### PR TITLE
chore: add combined-fixes stack specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # homeboy-rigs
 
-Personal `homeboy rig` specs. Lives at `~/.config/homeboy/rigs/` on every machine.
+Personal `homeboy rig` and `homeboy stack` specs. Lives at `~/.config/homeboy/rigs/` and `~/.config/homeboy/stacks/` on every machine.
 
 A **rig** is a declarative spec for a reproducible local dev environment — components, services, symlinks, patches, pipelines for `up` / `check` / `down`. Replaces multi-step bash runbooks with one command.
 
@@ -49,6 +49,33 @@ homeboy rig check isolated-block-editor   # npm run build + npm test -- --runInB
 ```
 
 Edit `components.isolated-block-editor.path` to point at a worktree such as `/var/lib/datamachine/workspace/isolated-block-editor@feature-branch` when validating a PR branch. The rig temporarily symlinks the primary checkout's `node_modules` if the worktree does not have its own install.
+
+## Stacks in this repo
+
+Stack specs live under `stacks/`. Install them by copying the JSON files into `~/.config/homeboy/stacks/` until Homeboy grows a package install verb for stacks.
+
+```bash
+mkdir -p ~/.config/homeboy/stacks
+cp stacks/*.json ~/.config/homeboy/stacks/
+```
+
+### `studio-combined`
+
+The PR stack for `~/Developer/studio` on `dev/combined-fixes`. It rebuilds `fork/dev/combined-fixes` from `origin/trunk` plus Chris's active Automattic/studio local-dev PRs.
+
+```bash
+homeboy stack status studio-combined
+homeboy stack sync --dry-run studio-combined
+```
+
+### `playground-combined`
+
+The PR stack for `~/Developer/wordpress-playground` on `dev/combined-fixes`. It rebuilds `origin/dev/combined-fixes` from `upstream/trunk` plus Chris's active WordPress/wordpress-playground PHP-WASM and worker-pool PRs.
+
+```bash
+homeboy stack status playground-combined
+homeboy stack sync --dry-run playground-combined
+```
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Edit `components.isolated-block-editor.path` to point at a worktree such as `/va
 
 ## Stacks in this repo
 
-Stack specs live under `stacks/`. Install them by copying the JSON files into `~/.config/homeboy/stacks/` until Homeboy grows a package install verb for stacks.
+Stack specs live under `stacks/`. Install them by copying the JSON files into `~/.config/homeboy/stacks/` until Homeboy's rig package lifecycle installs stack specs too (tracked in Extra-Chill/homeboy#1734).
 
 ```bash
 mkdir -p ~/.config/homeboy/stacks

--- a/stacks/playground-combined.json
+++ b/stacks/playground-combined.json
@@ -1,0 +1,31 @@
+{
+  "id": "playground-combined",
+  "description": "WordPress Playground dev/combined-fixes stack: upstream trunk plus Chris's active PHP-WASM and worker-pool PRs.",
+  "component": "wordpress-playground",
+  "component_path": "~/Developer/wordpress-playground",
+  "base": {
+    "remote": "upstream",
+    "branch": "trunk"
+  },
+  "target": {
+    "remote": "origin",
+    "branch": "dev/combined-fixes"
+  },
+  "prs": [
+    {
+      "repo": "WordPress/wordpress-playground",
+      "number": 3494,
+      "note": "Fix intermittent 500 errors from worker pool concurrency issues"
+    },
+    {
+      "repo": "WordPress/wordpress-playground",
+      "number": 3481,
+      "note": "Add nativeSpawn option to RunCLIArgs for host process spawning"
+    },
+    {
+      "repo": "WordPress/wordpress-playground",
+      "number": 3523,
+      "note": "Add stdin option to PHP.cli()"
+    }
+  ]
+}

--- a/stacks/studio-combined.json
+++ b/stacks/studio-combined.json
@@ -1,0 +1,41 @@
+{
+  "id": "studio-combined",
+  "description": "Studio dev/combined-fixes stack: Automattic/studio trunk plus Chris's active local-dev PRs.",
+  "component": "studio",
+  "component_path": "~/Developer/studio",
+  "base": {
+    "remote": "origin",
+    "branch": "trunk"
+  },
+  "target": {
+    "remote": "fork",
+    "branch": "dev/combined-fixes"
+  },
+  "prs": [
+    {
+      "repo": "Automattic/studio",
+      "number": 3095,
+      "note": "Preserve custom db.php drop-ins during SQLite integration updates"
+    },
+    {
+      "repo": "Automattic/studio",
+      "number": 3057,
+      "note": "Replace no-op spawn handler with native child_process.spawn bridge"
+    },
+    {
+      "repo": "Automattic/studio",
+      "number": 3099,
+      "note": "Auto-mount host directories referenced in wp-config.php"
+    },
+    {
+      "repo": "Automattic/studio",
+      "number": 3120,
+      "note": "Allow longer time-to-first-byte for AI API requests"
+    },
+    {
+      "repo": "Automattic/studio",
+      "number": 3211,
+      "note": "Forward host stdin to wp-cli through the server daemon"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add reproducible Homeboy stack specs for the Studio and WordPress Playground `dev/combined-fixes` branches.
- Document how to install the stack specs locally until Homeboy grows a stack package install verb.

## Specs

- `studio-combined`: rebuilds `fork/dev/combined-fixes` from `origin/trunk` plus Automattic/studio PRs #3095, #3057, #3099, #3120, and #3211.
- `playground-combined`: rebuilds `origin/dev/combined-fixes` from `upstream/trunk` plus WordPress/wordpress-playground PRs #3494, #3481, and #3523.

## Verification

- `homeboy stack list`
- `homeboy stack show studio-combined`
- `homeboy stack show playground-combined`
- `homeboy stack status studio-combined`
- `homeboy stack status playground-combined`
- `homeboy stack sync --dry-run studio-combined`
- `homeboy stack sync --dry-run playground-combined`

Refs Extra-Chill/homeboy#1715

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the stack specs from current local branch and GitHub PR state, running Homeboy verification commands, and preparing this PR. Chris remains responsible for review and merge.
