### PR TITLE
fix(studio): keep BFB write-path bench on conversion path

### DIFF
--- a/Automattic/studio/bench/studio-bfb-write-path.bench.mjs
+++ b/Automattic/studio/bench/studio-bfb-write-path.bench.mjs
@@ -20,20 +20,11 @@ const RAW_HTML = `
   </section>
   <section class="highlights">
     <h2>Bakery favorites</h2>
-    <div class="cards">
-      <article>
-        <h3>Sea Salt Croissants</h3>
-        <p>Layered butter pastry finished with a quiet sparkle of Atlantic salt.</p>
-      </article>
-      <article>
-        <h3>Brown Sugar Morning Buns</h3>
-        <p>Soft spirals with citrus, cinnamon, and a caramelized edge.</p>
-      </article>
-      <article>
-        <h3>Harbor Sourdough</h3>
-        <p>A slow-fermented loaf with a blistered crust and tender crumb.</p>
-      </article>
-    </div>
+    <ul>
+      <li><strong>Sea Salt Croissants</strong> — layered butter pastry finished with Atlantic salt.</li>
+      <li><strong>Brown Sugar Morning Buns</strong> — soft spirals with citrus, cinnamon, and caramelized edges.</li>
+      <li><strong>Harbor Sourdough</strong> — a slow-fermented loaf with a blistered crust and tender crumb.</li>
+    </ul>
   </section>
   <blockquote>
     <p>"The kind of neighborhood bakery that makes Saturday feel planned by someone who loves you."</p>
@@ -105,7 +96,9 @@ function variant() {
 }
 
 function cliEnv(extra = {}) {
-  const bfbPath = expandHome(process.env.HOMEBOY_SETTINGS_STUDIO_BFB_PLUGIN_PATH || '');
+  const bfbPath = expandHome(
+    process.env.HOMEBOY_SETTINGS_STUDIO_BFB_PLUGIN_PATH || process.env.STUDIO_BFB_MU_PLUGIN_PATH || ''
+  );
   return {
     ...process.env,
     ...(bfbPath ? { STUDIO_BFB_MU_PLUGIN_PATH: bfbPath } : {}),
@@ -157,6 +150,10 @@ async function createFreshSite(sitePath) {
   ]);
 }
 
+async function stopSite(sitePath) {
+  await runCli(['site', 'stop', '--path', sitePath], { allowFailure: true });
+}
+
 async function writeRawHtmlPage(sitePath) {
   const encodedContent = Buffer.from(RAW_HTML).toString('base64');
   const insertCode = `
@@ -203,6 +200,7 @@ export default async function studioBfbWritePathBench() {
   const started = Date.now();
   const siteCreateStarted = Date.now();
   await createFreshSite(sitePath);
+  await stopSite(sitePath);
   const siteCreateMs = Date.now() - siteCreateStarted;
 
   const writeStarted = Date.now();


### PR DESCRIPTION
## Summary
- Stop freshly-created Studio bench sites before the WP-CLI write/probe steps so they use the in-process path that sees `STUDIO_BFB_MU_PLUGIN_PATH`.
- Let the workload fall back to a directly-provided `STUDIO_BFB_MU_PLUGIN_PATH` when rig extension settings are unavailable.
- Simplify the fixture HTML to conservative no-fallback markup, keeping the benchmark focused on native block conversion rather than unsupported HTML fallback behavior.

## Verification
- Ran `homeboy bench --rig=studio-bfb-origin --warmup=0 --iterations=1 --shared-state=/tmp/studio-bfb-write-path-no-fallback` with the latest Homeboy binary and explicit BFB env.
- Result: baseline stored raw HTML (`total_blocks=0`); BFB stored native blocks (`total_blocks=19`, `core_html_blocks=0`, `bfb_fallback_count=0`).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the benchmark path mismatch, editing the workload, and running verification.