### PR TITLE
fix(studio): read BFB bench settings from JSON

### DIFF
--- a/Automattic/studio/bench/studio-bfb-write-path.bench.mjs
+++ b/Automattic/studio/bench/studio-bfb-write-path.bench.mjs
@@ -92,12 +92,25 @@ function expandHome(value) {
 }
 
 function variant() {
-  return process.env.HOMEBOY_SETTINGS_STUDIO_BENCH_VARIANT || path.basename(STUDIO_PATH);
+  return setting('studio_bench_variant') || path.basename(STUDIO_PATH);
+}
+
+function setting(key) {
+  try {
+    const settings = JSON.parse(process.env.HOMEBOY_SETTINGS_JSON || '{}');
+    if (settings && typeof settings[key] === 'string') {
+      return settings[key];
+    }
+  } catch {
+    // Ignore malformed settings and fall back to direct env/debug defaults.
+  }
+  const envKey = `HOMEBOY_SETTINGS_${key.toUpperCase()}`;
+  return process.env[envKey] || '';
 }
 
 function cliEnv(extra = {}) {
   const bfbPath = expandHome(
-    process.env.HOMEBOY_SETTINGS_STUDIO_BFB_PLUGIN_PATH || process.env.STUDIO_BFB_MU_PLUGIN_PATH || ''
+    setting('studio_bfb_plugin_path') || process.env.STUDIO_BFB_MU_PLUGIN_PATH || ''
   );
   return {
     ...process.env,


### PR DESCRIPTION
## Summary
- Read rig-provided bench settings from `HOMEBOY_SETTINGS_JSON`, which is the capability-script contract Homeboy actually exports.
- Keep the individual env-var and direct `STUDIO_BFB_MU_PLUGIN_PATH` fallbacks for manual/debug runs.

## Verification
- Ran `homeboy bench --rig=studio-bfb-json --warmup=0 --iterations=1 --shared-state=/tmp/studio-bfb-write-path-settings-json` with temporary rigs pointing at this branch.
- Result: baseline stored raw HTML (`total_blocks=0`); BFB stored native blocks (`total_blocks=19`, `core_html_blocks=0`, `bfb_fallback_count=0`) without direct env injection.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the settings-env mismatch, editing the workload, and running verification.