### PR TITLE
feat(studio): add Add Themes browser benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 # Each rig writes its state to <id>.state/ alongside <id>.json. Not portable
 # across machines.
 *.state/
+
+# Local benchmark outputs and artifacts.
+.bench-output/

--- a/Automattic/studio/bench/studio-admin-theme-page-browser.bench.mjs
+++ b/Automattic/studio/bench/studio-admin-theme-page-browser.bench.mjs
@@ -1,0 +1,279 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+const STUDIO_PATH = process.env.HOMEBOY_COMPONENT_PATH;
+const SHARED_STATE = process.env.HOMEBOY_BENCH_SHARED_STATE || os.tmpdir();
+const BROWSER_HELPER = process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER;
+
+if (!STUDIO_PATH) {
+  throw new Error('HOMEBOY_COMPONENT_PATH is required');
+}
+if (!BROWSER_HELPER) {
+  throw new Error('HOMEBOY_NODEJS_BROWSER_BENCH_HELPER is required');
+}
+
+const { runBrowserBench } = await import(BROWSER_HELPER);
+
+function setting(key) {
+  try {
+    const settings = JSON.parse(process.env.HOMEBOY_SETTINGS_JSON || '{}');
+    if (settings && typeof settings[key] === 'string') {
+      return settings[key];
+    }
+  } catch {
+    // Ignore malformed settings and fall back to direct env/debug defaults.
+  }
+
+  return process.env[`HOMEBOY_SETTINGS_${key.toUpperCase()}`] || '';
+}
+
+function variant() {
+  return setting('studio_bench_variant') || path.basename(STUDIO_PATH);
+}
+
+function run(args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    let settled = false;
+    let stdout = '';
+    let stderr = '';
+    const child = spawn(process.execPath, args, {
+      cwd: options.cwd || STUDIO_PATH,
+      env: { ...process.env, ...(options.env || {}) },
+    });
+
+    const timer = options.timeoutMs
+      ? setTimeout(() => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          child.kill('SIGKILL');
+          reject(
+            new Error(
+              `${args.join(' ')} timed out after ${options.timeoutMs}ms; stdout=${redact(stdout).slice(-1000)}; stderr=${redact(stderr).slice(-1000)}`
+            )
+          );
+        }, options.timeoutMs)
+      : undefined;
+
+    child.stdout.on('data', (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      const elapsedMs = Date.now() - started;
+      if (code !== 0 && options.allowFailure !== true) {
+        reject(new Error(`${args.join(' ')} exited ${code}; stderr=${redact(stderr).slice(0, 1500)}`));
+        return;
+      }
+      resolve({ code, stdout, stderr, elapsedMs });
+    });
+  });
+}
+
+async function runCli(args, options = {}) {
+  const cliPath = path.join(STUDIO_PATH, 'apps/cli/dist/cli/main.mjs');
+  return run([cliPath, ...args], options);
+}
+
+async function createSite(sitePath) {
+  return runCli([
+    'site',
+    'create',
+    '--name',
+    `Studio Bench ${variant()} Add Themes Browser ${process.pid}`,
+    '--path',
+    sitePath,
+    '--skip-browser',
+    '--skip-log-details',
+  ], { timeoutMs: 420000 });
+}
+
+async function siteStatus(sitePath) {
+  return runCli(['site', 'status', '--path', sitePath, '--format', 'json'], { timeoutMs: 90000 });
+}
+
+async function stopSite(sitePath) {
+  return runCli(['site', 'stop', '--path', sitePath], { allowFailure: true, timeoutMs: 90000 });
+}
+
+function metric(value) {
+  const number = Number(value ?? 0);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function redact(text) {
+  return String(text || '')
+    .replace(/("adminPassword"\s*:\s*")[^"]+(")/g, '$1[redacted]$2')
+    .replace(/("autoLoginUrl"\s*:\s*")[^"]+(")/g, '$1[redacted]$2')
+    .replace(/([?&](?:token|password|key|nonce)=[^&\s"']+)/gi, '[redacted-query]');
+}
+
+function safeResult(result) {
+  if (!result) {
+    return result;
+  }
+  return {
+    code: result.code,
+    elapsedMs: result.elapsedMs,
+    stdout: redact(result.stdout),
+    stderr: redact(result.stderr),
+  };
+}
+
+function parseStatus(stdout) {
+  const parsed = JSON.parse(stdout);
+  if (!parsed.siteUrl || !parsed.autoLoginUrl) {
+    throw new Error(`site status missing siteUrl/autoLoginUrl: ${redact(stdout).slice(0, 1000)}`);
+  }
+  return parsed;
+}
+
+function siteAdminUrl(siteUrl, relativePath) {
+  const base = siteUrl.endsWith('/') ? siteUrl : `${siteUrl}/`;
+  return new URL(relativePath, base).toString();
+}
+
+async function sanitizeNetworkArtifact(artifact) {
+  if (!artifact || typeof artifact.path !== 'string') {
+    return;
+  }
+  const raw = await readFile(artifact.path, 'utf8');
+  await writeFile(artifact.path, redact(raw));
+}
+
+async function firstContentfulPaint(page) {
+  return page.evaluate(() => {
+    const paint = performance.getEntriesByType('paint').find((entry) => entry.name === 'first-contentful-paint');
+    return paint && Number.isFinite(paint.startTime) ? paint.startTime : 0;
+  });
+}
+
+export default async function studioAdminThemePageBrowserBench() {
+  const currentVariant = variant();
+  const runId = `${currentVariant}-admin-theme-page-browser-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const artifactDir = path.join(SHARED_STATE, 'studio-admin-theme-page-browser-artifacts', runId);
+  const sitePath = path.join(artifactDir, 'site');
+  await mkdir(artifactDir, { recursive: true });
+
+  const totalStarted = Date.now();
+  let create;
+  let statusResult;
+  let stop;
+  let status;
+  let browserResult;
+  let loginFormSeen = 0;
+  let firstContentfulPaintMs = 0;
+  let finalStatus = 0;
+
+  try {
+    create = await createSite(sitePath);
+    statusResult = await siteStatus(sitePath);
+    status = parseStatus(statusResult.stdout);
+
+    browserResult = await runBrowserBench({
+      id: 'studio-admin-theme-page-browser',
+      artifactsDir: artifactDir,
+      trace: true,
+      screenshot: true,
+      action: async ({ page, mark }) => {
+        await page.goto(status.autoLoginUrl, { waitUntil: 'domcontentloaded', timeout: 120000 });
+        await mark('browser_auto_login_domcontentloaded');
+
+        const loginForm = page.locator('#loginform');
+        loginFormSeen = await loginForm.count();
+
+        const response = await page.goto(siteAdminUrl(status.siteUrl, 'wp-admin/theme-install.php'), {
+          waitUntil: 'domcontentloaded',
+          timeout: 120000,
+        });
+        finalStatus = response ? response.status() : 0;
+        await mark('browser_theme_install_domcontentloaded');
+
+        await page.getByRole('heading', { name: /add themes/i }).waitFor({ timeout: 120000 });
+        await mark('add_themes_heading_visible');
+
+        await page.locator('.theme-browser, .wp-filter, .theme-install-php').first().waitFor({ timeout: 120000 });
+        await mark('theme_browser_visible');
+
+        firstContentfulPaintMs = await firstContentfulPaint(page);
+      },
+    });
+
+    await sanitizeNetworkArtifact(browserResult.artifacts?.network);
+    stop = await stopSite(sitePath);
+
+    const totalElapsedMs = Date.now() - totalStarted;
+    const artifactFile = path.join(artifactDir, `result-${runId}.json`);
+    await writeFile(
+      artifactFile,
+      JSON.stringify(
+        {
+          variant: currentVariant,
+          sitePath,
+          siteUrl: status.siteUrl,
+          timings: {
+            site_create_ms: create.elapsedMs,
+            site_status_ms: statusResult.elapsedMs,
+            total_elapsed_ms: totalElapsedMs,
+          },
+          commands: {
+            create: safeResult(create),
+            status: safeResult(statusResult),
+            stop: safeResult(stop),
+          },
+          browserMetrics: browserResult.metrics,
+          browserArtifacts: browserResult.artifacts,
+        },
+        null,
+        2
+      )
+    );
+
+    if (finalStatus < 200 || finalStatus >= 400) {
+      throw new Error(`Add Themes returned HTTP status ${finalStatus}; raw_result=${artifactFile}`);
+    }
+    if (loginFormSeen > 0) {
+      throw new Error(`Login form remained visible after auto-login; raw_result=${artifactFile}`);
+    }
+    if (!browserResult.artifacts?.trace || !browserResult.artifacts?.screenshot) {
+      throw new Error(`Browser trace/screenshot artifacts missing; raw_result=${artifactFile}`);
+    }
+
+    return {
+      metrics: {
+        success_rate: 1,
+        elapsed_ms: totalElapsedMs,
+        site_create_ms: metric(create.elapsedMs),
+        site_status_ms: metric(statusResult.elapsedMs),
+        browser_first_contentful_paint_ms: metric(firstContentfulPaintMs),
+        add_themes_status: metric(finalStatus),
+        login_form_seen: metric(loginFormSeen),
+        total_elapsed_ms: totalElapsedMs,
+        ...browserResult.metrics,
+      },
+      artifacts: {
+        raw_result: artifactFile,
+        site_path: sitePath,
+        ...browserResult.artifacts,
+      },
+    };
+  } finally {
+    if (!stop) {
+      stop = await stopSite(sitePath);
+    }
+  }
+}

--- a/Automattic/studio/bench/studio-admin-theme-page-browser.bench.mjs
+++ b/Automattic/studio/bench/studio-admin-theme-page-browser.bench.mjs
@@ -119,7 +119,7 @@ function redact(text) {
   return String(text || '')
     .replace(/("adminPassword"\s*:\s*")[^"]+(")/g, '$1[redacted]$2')
     .replace(/("autoLoginUrl"\s*:\s*")[^"]+(")/g, '$1[redacted]$2')
-    .replace(/([?&](?:token|password|key|nonce)=[^&\s"']+)/gi, '[redacted-query]');
+    .replace(/([?&](?:token|password|key|nonce|_ajax_nonce|_wpnonce)=)[^&\s"']+/gi, '$1[redacted]');
 }
 
 function safeResult(result) {

--- a/Automattic/studio/bench/studio-admin-theme-page.bench.mjs
+++ b/Automattic/studio/bench/studio-admin-theme-page.bench.mjs
@@ -1,0 +1,291 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import http from 'node:http';
+import https from 'node:https';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+const STUDIO_PATH = process.env.HOMEBOY_COMPONENT_PATH;
+const SHARED_STATE = process.env.HOMEBOY_BENCH_SHARED_STATE || os.tmpdir();
+
+if (!STUDIO_PATH) {
+  throw new Error('HOMEBOY_COMPONENT_PATH is required');
+}
+
+function setting(key) {
+  try {
+    const settings = JSON.parse(process.env.HOMEBOY_SETTINGS_JSON || '{}');
+    if (settings && typeof settings[key] === 'string') {
+      return settings[key];
+    }
+  } catch {
+    // Ignore malformed settings and fall back to direct env/debug defaults.
+  }
+
+  return process.env[`HOMEBOY_SETTINGS_${key.toUpperCase()}`] || '';
+}
+
+function variant() {
+  return setting('studio_bench_variant') || path.basename(STUDIO_PATH);
+}
+
+function run(args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    let settled = false;
+    let stdout = '';
+    let stderr = '';
+    const child = spawn(process.execPath, args, {
+      cwd: options.cwd || STUDIO_PATH,
+      env: { ...process.env, ...(options.env || {}) },
+    });
+
+    const timer = options.timeoutMs
+      ? setTimeout(() => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          child.kill('SIGKILL');
+          reject(
+            new Error(
+              `${args.join(' ')} timed out after ${options.timeoutMs}ms; stdout=${stdout.slice(-1000)}; stderr=${stderr.slice(-1000)}`
+            )
+          );
+        }, options.timeoutMs)
+      : undefined;
+
+    child.stdout.on('data', (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      const elapsedMs = Date.now() - started;
+      if (code !== 0 && options.allowFailure !== true) {
+        reject(new Error(`${args.join(' ')} exited ${code}; stderr=${stderr.slice(0, 1500)}`));
+        return;
+      }
+      resolve({ code, stdout, stderr, elapsedMs });
+    });
+  });
+}
+
+async function runCli(args, options = {}) {
+  const cliPath = path.join(STUDIO_PATH, 'apps/cli/dist/cli/main.mjs');
+  return run([cliPath, ...args], options);
+}
+
+async function createSite(sitePath) {
+  return runCli([
+    'site',
+    'create',
+    '--name',
+    `Studio Bench ${variant()} Theme Page ${process.pid}`,
+    '--path',
+    sitePath,
+    '--skip-browser',
+    '--skip-log-details',
+  ], { timeoutMs: 420000 });
+}
+
+async function siteStatus(sitePath) {
+  return runCli(['site', 'status', '--path', sitePath, '--format', 'json'], { timeoutMs: 90000 });
+}
+
+async function stopSite(sitePath) {
+  return runCli(['site', 'stop', '--path', sitePath], { allowFailure: true, timeoutMs: 90000 });
+}
+
+function metric(value) {
+  const number = Number(value ?? 0);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function redact(text) {
+  return String(text || '').replace(/("adminPassword"\s*:\s*")[^"]+(")/g, '$1[redacted]$2');
+}
+
+function safeResult(result) {
+  if (!result) {
+    return result;
+  }
+  return {
+    code: result.code,
+    elapsedMs: result.elapsedMs,
+    stdout: redact(result.stdout),
+    stderr: redact(result.stderr),
+  };
+}
+
+function parseStatus(stdout) {
+  const parsed = JSON.parse(stdout);
+  if (!parsed.siteUrl || !parsed.autoLoginUrl) {
+    throw new Error(`site status missing siteUrl/autoLoginUrl: ${stdout.slice(0, 1000)}`);
+  }
+  return parsed;
+}
+
+function cookieHeader(jar) {
+  return Object.entries(jar)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('; ');
+}
+
+function absorbCookies(headers, jar) {
+  for (const cookie of headers['set-cookie'] || []) {
+    const pair = cookie.split(';', 1)[0];
+    const eq = pair.indexOf('=');
+    if (eq > 0) {
+      jar[pair.slice(0, eq)] = pair.slice(eq + 1);
+    }
+  }
+}
+
+function fetchTimed(url, jar, redirects = 0) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const client = parsed.protocol === 'https:' ? https : http;
+    const started = Date.now();
+    let ttfbMs = 0;
+    let bytes = 0;
+    let bodyHead = '';
+    const req = client.request(
+      parsed,
+      {
+        method: 'GET',
+        headers: {
+          Accept: 'text/html,application/xhtml+xml',
+          'User-Agent': 'homeboy-studio-admin-theme-page-bench/1.0',
+          ...(Object.keys(jar).length ? { Cookie: cookieHeader(jar) } : {}),
+        },
+      },
+      (res) => {
+        ttfbMs = Date.now() - started;
+        absorbCookies(res.headers, jar);
+
+        const location = res.headers.location;
+        if (location && [301, 302, 303, 307, 308].includes(res.statusCode || 0) && redirects < 8) {
+          res.resume();
+          const nextUrl = new URL(location, parsed).toString();
+          fetchTimed(nextUrl, jar, redirects + 1).then(resolve, reject);
+          return;
+        }
+
+        res.on('data', (chunk) => {
+          bytes += chunk.length;
+          if (bodyHead.length < 4000) {
+            bodyHead += chunk.toString('utf8');
+          }
+        });
+        res.on('end', () => {
+          resolve({
+            url,
+            final_url: parsed.toString(),
+            status: res.statusCode || 0,
+            redirects,
+            ttfb_ms: ttfbMs,
+            total_ms: Date.now() - started,
+            bytes,
+            title: bodyHead.match(/<title[^>]*>([^<]*)<\/title>/i)?.[1]?.trim() || '',
+            login_form_seen: /id=["']loginform["']/.test(bodyHead) ? 1 : 0,
+          });
+        });
+      }
+    );
+    req.setTimeout(120000, () => {
+      req.destroy(new Error(`GET ${url} timed out after 120000ms`));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+async function loadAdminPages(status) {
+  const jar = {};
+  const login = await fetchTimed(status.autoLoginUrl, jar);
+  const siteUrl = status.siteUrl.endsWith('/') ? status.siteUrl : `${status.siteUrl}/`;
+  const themes = await fetchTimed(new URL('wp-admin/themes.php', siteUrl).toString(), jar);
+  const addThemes = await fetchTimed(new URL('wp-admin/theme-install.php', siteUrl).toString(), jar);
+  const addThemesWarm = await fetchTimed(new URL('wp-admin/theme-install.php', siteUrl).toString(), jar);
+
+  return { login, themes, addThemes, addThemesWarm };
+}
+
+export default async function studioAdminThemePageBench() {
+  const currentVariant = variant();
+  const runId = `${currentVariant}-admin-theme-page-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const artifactDir = path.join(SHARED_STATE, 'studio-admin-theme-page-artifacts');
+  const sitePath = path.join(artifactDir, 'sites', runId);
+  await mkdir(path.dirname(sitePath), { recursive: true });
+
+  const totalStarted = Date.now();
+  const create = await createSite(sitePath);
+  const statusResult = await siteStatus(sitePath);
+  const status = parseStatus(statusResult.stdout);
+  const pageLoads = await loadAdminPages(status);
+  const stop = await stopSite(sitePath);
+  const totalElapsedMs = Date.now() - totalStarted;
+
+  const artifactFile = path.join(artifactDir, `result-${runId}.json`);
+  await mkdir(artifactDir, { recursive: true });
+  await writeFile(
+    artifactFile,
+    JSON.stringify(
+      {
+        variant: currentVariant,
+        sitePath,
+        siteUrl: status.siteUrl,
+        timings: {
+          site_create_ms: create.elapsedMs,
+          site_status_ms: statusResult.elapsedMs,
+          total_elapsed_ms: totalElapsedMs,
+        },
+        commands: {
+          create: safeResult(create),
+          status: safeResult(statusResult),
+          stop: safeResult(stop),
+        },
+        pageLoads,
+      },
+      null,
+      2
+    )
+  );
+
+  return {
+    metrics: {
+      success_rate: 1,
+      elapsed_ms: totalElapsedMs,
+      site_create_ms: metric(create.elapsedMs),
+      site_status_ms: metric(statusResult.elapsedMs),
+      themes_status: metric(pageLoads.themes.status),
+      themes_ttfb_ms: metric(pageLoads.themes.ttfb_ms),
+      themes_total_ms: metric(pageLoads.themes.total_ms),
+      themes_bytes: metric(pageLoads.themes.bytes),
+      add_themes_status: metric(pageLoads.addThemes.status),
+      add_themes_ttfb_ms: metric(pageLoads.addThemes.ttfb_ms),
+      add_themes_total_ms: metric(pageLoads.addThemes.total_ms),
+      add_themes_bytes: metric(pageLoads.addThemes.bytes),
+      add_themes_warm_status: metric(pageLoads.addThemesWarm.status),
+      add_themes_warm_ttfb_ms: metric(pageLoads.addThemesWarm.ttfb_ms),
+      add_themes_warm_total_ms: metric(pageLoads.addThemesWarm.total_ms),
+      add_themes_warm_bytes: metric(pageLoads.addThemesWarm.bytes),
+      login_form_seen: metric(pageLoads.themes.login_form_seen + pageLoads.addThemes.login_form_seen),
+      total_elapsed_ms: totalElapsedMs,
+    },
+    artifacts: {
+      raw_result: artifactFile,
+      site_path: sitePath,
+    },
+  };
+}

--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -25,11 +25,24 @@ function expandHome(value) {
 }
 
 function variant() {
-  return process.env.HOMEBOY_SETTINGS_STUDIO_BENCH_VARIANT || path.basename(STUDIO_PATH);
+  return setting('studio_bench_variant') || path.basename(STUDIO_PATH);
+}
+
+function setting(key) {
+  try {
+    const settings = JSON.parse(process.env.HOMEBOY_SETTINGS_JSON || '{}');
+    if (settings && typeof settings[key] === 'string') {
+      return settings[key];
+    }
+  } catch {
+    // Ignore malformed settings and fall back to direct env/debug defaults.
+  }
+
+  return process.env[`HOMEBOY_SETTINGS_${key.toUpperCase()}`] || '';
 }
 
 function cliEnv(extra = {}) {
-  const bfbPath = expandHome(process.env.HOMEBOY_SETTINGS_STUDIO_BFB_PLUGIN_PATH || '');
+  const bfbPath = expandHome(setting('studio_bfb_plugin_path') || '');
   return {
     ...process.env,
     ...(bfbPath ? { STUDIO_BFB_MU_PLUGIN_PATH: bfbPath } : {}),
@@ -99,7 +112,10 @@ Requirements:
 - Include a hero section, three product highlights, one customer quote, hours/location details, and a clear call-to-action.
 - Keep the content concise but visually complete.
 - Use the normal Studio WordPress tools available to you.
-- Validate the final stored block content with validate_blocks.
+- Provide a raw HTML body fragment for page content; block conversion happens automatically when WordPress stores it.
+- Put CSS in the theme stylesheet if styling is needed.
+- Do not create additional pages, plugins, screenshots, SEO audits, or performance audits.
+- This is a benchmark: write the single page, then stop.
 - Do not ask the user questions; make reasonable choices and finish.`;
 }
 
@@ -135,11 +151,22 @@ function bench_count_blocks( $blocks, &$counts ) {
 $counts = array(
     'posts_seen' => 0,
     'posts_with_blocks' => 0,
+    'pages_seen' => 0,
+    'templates_seen' => 0,
+    'template_parts_seen' => 0,
+    'target_pages_seen' => 0,
+    'target_posts_with_blocks' => 0,
+    'target_raw_html_unconverted' => 0,
+    'target_total_blocks' => 0,
+    'target_core_html_blocks' => 0,
+    'target_serialized_block_comments' => 0,
     'total_blocks' => 0,
     'core_html_blocks' => 0,
     'serialized_block_comments' => 0,
     'bfb_fallback_count' => (int) get_option( 'studio_bfb_unsupported_fallback_count', 0 ),
 );
+
+$front_page_id = (int) get_option( 'page_on_front', 0 );
 
 $posts = get_posts( array(
     'post_type' => array( 'page', 'wp_template', 'wp_template_part' ),
@@ -153,12 +180,40 @@ foreach ( $posts as $post ) {
         continue;
     }
     $counts['posts_seen']++;
+    if ( 'page' === $post->post_type ) {
+        $counts['pages_seen']++;
+    }
+    if ( 'wp_template' === $post->post_type ) {
+        $counts['templates_seen']++;
+    }
+    if ( 'wp_template_part' === $post->post_type ) {
+        $counts['template_parts_seen']++;
+    }
     $counts['serialized_block_comments'] += substr_count( $content, '<!-- wp:' );
     if ( false !== strpos( $content, '<!-- wp:' ) ) {
         $counts['posts_with_blocks']++;
     }
+    $before_total     = $counts['total_blocks'];
+    $before_core_html = $counts['core_html_blocks'];
     bench_count_blocks( parse_blocks( $content ), $counts );
+
+    $is_target_page = 'page' === $post->post_type && ( (int) $post->ID === $front_page_id || 'Salt & Star' === $post->post_title );
+    if ( $is_target_page ) {
+        $counts['target_pages_seen']++;
+        $counts['target_serialized_block_comments'] += substr_count( $content, '<!-- wp:' );
+        if ( false !== strpos( $content, '<!-- wp:' ) ) {
+            $counts['target_posts_with_blocks']++;
+        }
+        if ( false === strpos( $content, '<!-- wp:' ) && preg_match( '/<\/?[a-z][\s>]/i', $content ) ) {
+            $counts['target_raw_html_unconverted']++;
+        }
+        $counts['target_total_blocks'] += $counts['total_blocks'] - $before_total;
+        $counts['target_core_html_blocks'] += $counts['core_html_blocks'] - $before_core_html;
+    }
 }
+
+$counts['core_html_without_bfb_fallback'] = max( 0, $counts['core_html_blocks'] - $counts['bfb_fallback_count'] );
+$counts['target_core_html_without_bfb_fallback'] = max( 0, $counts['target_core_html_blocks'] - $counts['bfb_fallback_count'] );
 
 echo wp_json_encode( $counts, JSON_PRETTY_PRINT ) . PHP_EOL;
 `;
@@ -187,6 +242,39 @@ function validationMetrics(result) {
   return { validateCallCount, validateErrorCount, validatedAllCount };
 }
 
+function metric(value) {
+  const number = Number(value ?? 0);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function toolMetrics(result) {
+  const toolEvents = Array.isArray(result.toolEvents) ? result.toolEvents : [];
+  const names = ['site_info', 'wp_cli', 'validate_blocks', 'take_screenshot', 'Write', 'Edit'];
+  const metrics = {
+    tool_event_count: toolEvents.length,
+    max_tool_duration_ms: 0,
+  };
+
+  for (const event of toolEvents) {
+    const duration = metric(event?.durationMs);
+    if (duration > metrics.max_tool_duration_ms) {
+      metrics.max_tool_duration_ms = duration;
+    }
+  }
+
+  for (const name of names) {
+    const events = toolEvents.filter((event) => event && event.toolName === name);
+    const durations = events.map((event) => metric(event?.durationMs)).filter((value) => value > 0);
+    const key = name.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+    metrics[`${key}_tool_count`] = events.length;
+    metrics[`${key}_error_count`] = events.filter((event) => event.isError === true).length;
+    metrics[`${key}_duration_ms`] = durations.reduce((sum, value) => sum + value, 0);
+    metrics[`${key}_max_duration_ms`] = durations.length ? Math.max(...durations) : 0;
+  }
+
+  return metrics;
+}
+
 export default async function studioAgentSiteBuildBench() {
   const currentVariant = variant();
   const runId = `${currentVariant}-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
@@ -194,7 +282,10 @@ export default async function studioAgentSiteBuildBench() {
   const sitePath = path.join(artifactDir, 'sites', runId);
   await mkdir(path.dirname(sitePath), { recursive: true });
 
+  const totalStarted = Date.now();
+  const siteCreateStarted = Date.now();
   await createFreshSite(sitePath);
+  const siteCreateMs = Date.now() - siteCreateStarted;
 
   const prompt = siteBuildPrompt(sitePath);
   const agentStarted = Date.now();
@@ -203,41 +294,84 @@ export default async function studioAgentSiteBuildBench() {
     timeoutMs: 420000,
   });
   const agentElapsedMs = Date.now() - agentStarted;
+  const qualityProbeStarted = Date.now();
   const quality = await probeQuality(sitePath);
+  const qualityProbeMs = Date.now() - qualityProbeStarted;
+  const totalElapsedMs = Date.now() - totalStarted;
   const validation = validationMetrics(result);
 
   await mkdir(artifactDir, { recursive: true });
   const artifactFile = path.join(artifactDir, `result-${runId}.json`);
   await writeFile(
     artifactFile,
-    JSON.stringify({ variant: currentVariant, prompt, sitePath, exitCode, stderr, resultFile, result, quality }, null, 2)
+    JSON.stringify(
+      {
+        variant: currentVariant,
+        prompt,
+        sitePath,
+        exitCode,
+        stderr,
+        resultFile,
+        result,
+        timings: {
+          site_create_ms: siteCreateMs,
+          agent_elapsed_ms: agentElapsedMs,
+          quality_probe_ms: qualityProbeMs,
+          total_elapsed_ms: totalElapsedMs,
+        },
+        quality,
+        validation,
+      },
+      null,
+      2
+    )
   );
-
-  if (result.success !== true) {
-    const detail = typeof result.error === 'string' ? result.error : `exit=${exitCode}`;
-    throw new Error(`Studio site-build eval failed: ${detail}; raw_result=${artifactFile}`);
-  }
 
   const toolCalls = Array.isArray(result.toolCalls) ? result.toolCalls : [];
   const toolResults = Array.isArray(result.toolResults) ? result.toolResults : [];
   const turnDurations = Array.isArray(result.turnDurationsMs) ? result.turnDurationsMs : [];
+  const phaseTimings = result.phaseTimingsMs && typeof result.phaseTimingsMs === 'object' ? result.phaseTimingsMs : {};
+  const toolBreakdown = toolMetrics(result);
 
   return {
     metrics: {
-      success_rate: 1,
+      success_rate: result.success === true ? 1 : 0,
+      agent_error_rate: result.success === true ? 0 : 1,
+      elapsed_ms: totalElapsedMs,
+      site_create_ms: siteCreateMs,
       agent_elapsed_ms: agentElapsedMs,
+      quality_probe_ms: qualityProbeMs,
+      total_elapsed_ms: totalElapsedMs,
+      phase_resolve_initial_provider_ms: metric(phaseTimings.resolve_initial_provider_ms),
+      phase_resolve_unavailable_provider_ms: metric(phaseTimings.resolve_unavailable_provider_ms),
+      phase_resolve_ai_environment_ms: metric(phaseTimings.resolve_ai_environment_ms),
+      phase_start_ai_agent_ms: metric(phaseTimings.start_ai_agent_ms),
+      phase_first_assistant_message_ms: metric(phaseTimings.first_assistant_message_ms),
+      phase_total_eval_ms: metric(phaseTimings.total_eval_ms),
       turn_count: Number(result.numTurns ?? turnDurations.length ?? 0),
       assistant_message_count: turnDurations.length,
       max_turn_ms: turnDurations.length ? Math.max(...turnDurations) : 0,
       tool_call_count: toolCalls.length,
       tool_error_count: toolResults.filter((item) => item && item.isError === true).length,
+      ...toolBreakdown,
       validate_call_count: validation.validateCallCount,
       validate_error_count: validation.validateErrorCount,
       validated_all_count: validation.validatedAllCount,
       posts_seen: Number(quality.posts_seen || 0),
       posts_with_blocks: Number(quality.posts_with_blocks || 0),
+      pages_seen: Number(quality.pages_seen || 0),
+      templates_seen: Number(quality.templates_seen || 0),
+      template_parts_seen: Number(quality.template_parts_seen || 0),
+      target_pages_seen: Number(quality.target_pages_seen || 0),
+      target_posts_with_blocks: Number(quality.target_posts_with_blocks || 0),
+      target_raw_html_unconverted: Number(quality.target_raw_html_unconverted || 0),
+      target_total_blocks: Number(quality.target_total_blocks || 0),
+      target_core_html_blocks: Number(quality.target_core_html_blocks || 0),
+      target_serialized_block_comments: Number(quality.target_serialized_block_comments || 0),
       total_blocks: Number(quality.total_blocks || 0),
       core_html_blocks: Number(quality.core_html_blocks || 0),
+      core_html_without_bfb_fallback: Number(quality.core_html_without_bfb_fallback || 0),
+      target_core_html_without_bfb_fallback: Number(quality.target_core_html_without_bfb_fallback || 0),
       serialized_block_comments: Number(quality.serialized_block_comments || 0),
       bfb_fallback_count: Number(quality.bfb_fallback_count || 0),
     },

--- a/Automattic/studio/bench/studio-bfb-write-path.bench.mjs
+++ b/Automattic/studio/bench/studio-bfb-write-path.bench.mjs
@@ -269,9 +269,6 @@ export default async function studioBfbWritePathBench() {
     artifacts: {
       raw_result: artifactFile,
       site_path: sitePath,
-      page_id: writeResult.page_id,
-      stored_content_hash: quality.stored_content_hash,
-      stored_content_bytes: quality.stored_content_bytes,
     },
   };
 }

--- a/Automattic/studio/bench/studio-site-create.bench.mjs
+++ b/Automattic/studio/bench/studio-site-create.bench.mjs
@@ -1,0 +1,222 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+const STUDIO_PATH = process.env.HOMEBOY_COMPONENT_PATH;
+const SHARED_STATE = process.env.HOMEBOY_BENCH_SHARED_STATE || os.tmpdir();
+
+if (!STUDIO_PATH) {
+  throw new Error('HOMEBOY_COMPONENT_PATH is required');
+}
+
+function setting(key) {
+  try {
+    const settings = JSON.parse(process.env.HOMEBOY_SETTINGS_JSON || '{}');
+    if (settings && typeof settings[key] === 'string') {
+      return settings[key];
+    }
+  } catch {
+    // Ignore malformed settings and fall back to direct env/debug defaults.
+  }
+
+  return process.env[`HOMEBOY_SETTINGS_${key.toUpperCase()}`] || '';
+}
+
+function variant() {
+  return setting('studio_bench_variant') || path.basename(STUDIO_PATH);
+}
+
+function run(args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    let settled = false;
+    const child = spawn(process.execPath, args, {
+      cwd: options.cwd || STUDIO_PATH,
+      env: { ...process.env, ...(options.env || {}) },
+    });
+
+    const timer = options.timeoutMs
+      ? setTimeout(() => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          child.kill('SIGKILL');
+          reject(
+            new Error(
+              `${args.join(' ')} timed out after ${options.timeoutMs}ms; stdout=${stdout.slice(-1000)}; stderr=${stderr.slice(-1000)}`
+            )
+          );
+        }, options.timeoutMs)
+      : undefined;
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      const elapsedMs = Date.now() - started;
+      if (code !== 0 && options.allowFailure !== true) {
+        reject(new Error(`${args.join(' ')} exited ${code}; stderr=${stderr.slice(0, 1500)}`));
+        return;
+      }
+      resolve({ code, stdout, stderr, elapsedMs });
+    });
+  });
+}
+
+async function runCli(args, options = {}) {
+  const cliPath = path.join(STUDIO_PATH, 'apps/cli/dist/cli/main.mjs');
+  return run([cliPath, ...args], options);
+}
+
+async function createSite(sitePath, start) {
+  return runCli([
+    'site',
+    'create',
+    '--name',
+    `Studio Bench ${variant()} Site Create ${process.pid}`,
+    '--path',
+    sitePath,
+    ...(start ? [] : ['--no-start']),
+    '--skip-browser',
+    '--skip-log-details',
+  ], { timeoutMs: start ? 420000 : 240000 });
+}
+
+async function stopSite(sitePath) {
+  return runCli(['site', 'stop', '--path', sitePath], { allowFailure: true, timeoutMs: 90000 });
+}
+
+async function siteStatus(sitePath) {
+  return runCli(['site', 'status', '--path', sitePath, '--format', 'json'], { allowFailure: true, timeoutMs: 90000 });
+}
+
+function metric(value) {
+  const number = Number(value ?? 0);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function redact(text) {
+  return String(text || '').replace(/("adminPassword"\s*:\s*")[^"]+(")/g, '$1[redacted]$2');
+}
+
+function safeResult(result) {
+  if (!result) {
+    return result;
+  }
+  return {
+    code: result.code,
+    elapsedMs: result.elapsedMs,
+    stdout: redact(result.stdout),
+    stderr: redact(result.stderr),
+  };
+}
+
+export default async function studioSiteCreateBench() {
+  const currentVariant = variant();
+  const runId = `${currentVariant}-site-create-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const artifactDir = path.join(SHARED_STATE, 'studio-site-create-artifacts');
+  const sitesDir = path.join(artifactDir, 'sites');
+  const noStartSitePath = path.join(sitesDir, `${runId}-no-start`);
+  const startSitePath = path.join(sitesDir, `${runId}-start`);
+  await mkdir(sitesDir, { recursive: true });
+
+  const progressFile = path.join(artifactDir, `progress-${runId}.json`);
+  const progress = {
+    variant: currentVariant,
+    sites: {
+      no_start: noStartSitePath,
+      start: startSitePath,
+    },
+    steps: [],
+  };
+  async function recordStep(name, result) {
+    progress.steps.push({
+      name,
+      elapsed_ms: metric(result?.elapsedMs),
+      exit_code: result?.code ?? null,
+      stdout_tail: redact(result?.stdout).slice(-1000),
+      stderr_tail: redact(result?.stderr).slice(-1000),
+      recorded_at: new Date().toISOString(),
+    });
+    await writeFile(progressFile, JSON.stringify(progress, null, 2));
+  }
+
+  const totalStarted = Date.now();
+
+  const noStartCreate = await createSite(noStartSitePath, false);
+  await recordStep('site_create_no_start', noStartCreate);
+  const startCreate = await createSite(startSitePath, true);
+  await recordStep('site_create_start', startCreate);
+  const startStatus = await siteStatus(startSitePath);
+  await recordStep('site_status_started', startStatus);
+  const stopStarted = Date.now();
+  const stopResult = await stopSite(startSitePath);
+  const stopMs = Date.now() - stopStarted;
+  await recordStep('site_stop_started', { ...stopResult, elapsedMs: stopMs });
+
+  const totalElapsedMs = Date.now() - totalStarted;
+
+  const artifactFile = path.join(artifactDir, `result-${runId}.json`);
+  await mkdir(artifactDir, { recursive: true });
+  await writeFile(
+    artifactFile,
+    JSON.stringify(
+      {
+        variant: currentVariant,
+        sites: {
+          no_start: noStartSitePath,
+          start: startSitePath,
+        },
+        timings: {
+          site_create_no_start_ms: noStartCreate.elapsedMs,
+          site_create_start_ms: startCreate.elapsedMs,
+          site_status_started_ms: startStatus.elapsedMs,
+          site_stop_started_ms: stopMs,
+          total_elapsed_ms: totalElapsedMs,
+        },
+        commands: {
+          noStartCreate: safeResult(noStartCreate),
+          startCreate: safeResult(startCreate),
+          startStatus: safeResult(startStatus),
+          stopResult: safeResult(stopResult),
+        },
+        progressFile,
+      },
+      null,
+      2
+    )
+  );
+
+  return {
+    metrics: {
+      success_rate: 1,
+      elapsed_ms: totalElapsedMs,
+      site_create_no_start_ms: metric(noStartCreate.elapsedMs),
+      site_create_start_ms: metric(startCreate.elapsedMs),
+      site_status_started_ms: metric(startStatus.elapsedMs),
+      site_stop_started_ms: metric(stopMs),
+      total_elapsed_ms: totalElapsedMs,
+    },
+    artifacts: {
+      raw_result: artifactFile,
+      progress: progressFile,
+      no_start_site_path: noStartSitePath,
+      start_site_path: startSitePath,
+    },
+  };
+}

--- a/Automattic/studio/rigs/studio-agent-pi/rig.json
+++ b/Automattic/studio/rigs/studio-agent-pi/rig.json
@@ -15,7 +15,9 @@
   },
   "bench_workloads": {
     "nodejs": [
-      "${package.root}/bench/studio-agent-runtime.bench.mjs"
+      "${package.root}/bench/studio-agent-runtime.bench.mjs",
+      "${package.root}/bench/studio-agent-site-build.bench.mjs",
+      "${package.root}/bench/studio-bfb-write-path.bench.mjs"
     ]
   },
   "pipeline": {

--- a/Automattic/studio/rigs/studio-agent-sdk/rig.json
+++ b/Automattic/studio/rigs/studio-agent-sdk/rig.json
@@ -18,6 +18,7 @@
   "bench_workloads": {
     "nodejs": [
       "${package.root}/bench/studio-agent-runtime.bench.mjs",
+      "${package.root}/bench/studio-agent-site-build.bench.mjs",
       "${package.root}/bench/studio-bfb-write-path.bench.mjs"
     ]
   },

--- a/Automattic/studio/rigs/studio-bfb/rig.json
+++ b/Automattic/studio/rigs/studio-bfb/rig.json
@@ -44,6 +44,7 @@
   "bench_workloads": {
     "nodejs": [
       "${package.root}/bench/studio-agent-runtime.bench.mjs",
+      "${package.root}/bench/studio-agent-site-build.bench.mjs",
       "${package.root}/bench/studio-bfb-write-path.bench.mjs"
     ]
   },
@@ -73,9 +74,9 @@
       },
       {
         "kind": "check",
-        "label": "Studio prompt asks for semantic raw HTML",
+        "label": "Studio prompt asks for raw HTML",
         "file": "${components.studio.path}/apps/cli/ai/system-prompt.ts",
-        "contains": "semantic raw HTML"
+        "contains": "Block conversion happens automatically"
       },
       {
         "kind": "check",

--- a/Automattic/studio/rigs/studio/rig.json
+++ b/Automattic/studio/rigs/studio/rig.json
@@ -54,7 +54,8 @@
   "bench_workloads": {
     "nodejs": [
       "${package.root}/bench/studio-site-create.bench.mjs",
-      "${package.root}/bench/studio-admin-theme-page.bench.mjs"
+      "${package.root}/bench/studio-admin-theme-page.bench.mjs",
+      "${package.root}/bench/studio-admin-theme-page-browser.bench.mjs"
     ]
   },
 

--- a/Automattic/studio/rigs/studio/rig.json
+++ b/Automattic/studio/rigs/studio/rig.json
@@ -53,7 +53,8 @@
 
   "bench_workloads": {
     "nodejs": [
-      "${package.root}/bench/studio-site-create.bench.mjs"
+      "${package.root}/bench/studio-site-create.bench.mjs",
+      "${package.root}/bench/studio-admin-theme-page.bench.mjs"
     ]
   },
 

--- a/Automattic/studio/rigs/studio/rig.json
+++ b/Automattic/studio/rigs/studio/rig.json
@@ -5,7 +5,12 @@
   "components": {
     "studio": {
       "path": "~/Developer/studio",
-      "branch": "dev/combined-fixes"
+      "branch": "dev/combined-fixes",
+      "extensions": {
+        "nodejs": {
+          "studio_bench_variant": "combined-fixes"
+        }
+      }
     },
     "wordpress-playground": {
       "path": "~/Developer/wordpress-playground",
@@ -41,6 +46,16 @@
       "target": "../../packages/playground/wordpress-builds"
     }
   ],
+
+  "bench": {
+    "default_component": "studio"
+  },
+
+  "bench_workloads": {
+    "nodejs": [
+      "${package.root}/bench/studio-site-create.bench.mjs"
+    ]
+  },
 
   "pipeline": {
     "check": [
@@ -118,7 +133,7 @@
       {
         "kind": "check",
         "label": "Live proc_open end-to-end (the truth)",
-        "command": "rm -f /tmp/_studio_rig_check_marker && out=$(studio wp eval '$h = proc_open(\"touch /tmp/_studio_rig_check_marker && echo ok\", [1=>[\"pipe\",\"w\"]], $p); if (is_resource($h)) { echo stream_get_contents($p[1]); proc_close($h); } sleep(1);' 2>&1 | tail -1) && test -f /tmp/_studio_rig_check_marker && echo \"$out\" | grep -q ok",
+        "command": "rm -f /tmp/_studio_rig_check_marker && out=$(studio wp --path ~/Studio/intelligence-chubes4 eval '$h = proc_open(\"touch /tmp/_studio_rig_check_marker && echo ok\", [1=>[\"pipe\",\"w\"]], $p); if (is_resource($h)) { echo stream_get_contents($p[1]); proc_close($h); } sleep(1);' 2>&1 | tail -1) && test -f /tmp/_studio_rig_check_marker && echo \"$out\" | grep -q ok",
         "expect_exit": 0
       }
     ],

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ homeboy rig up studio
 homeboy rig down studio
 ```
 
+`rigs/studio/rig.json` also declares the `studio-site-create` bench workload for timing fresh Studio site provisioning through the combined-fixes dev copy.
+
+```bash
+homeboy bench --rig studio --scenario studio-site-create --iterations 1 --shared-state /tmp/studio-site-create-bench
+```
+
+The workload creates one `--no-start` site and one normally-started site per iteration, then reports create, started-site status, stop, and total timings. Artifacts are written below the shared-state directory for inspection.
+
 `rigs/studio-bfb/rig.json` is the local Studio/BFB mu-plugin playground rig. It verifies raw HTML writes store native blocks through the BFB substrate and declares `studio-agent-sdk` as its default benchmark baseline for trunk-vs-BFB agent site-build comparisons.
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds Studio benchmark coverage for site creation and server-side admin theme page loading.
- Adds a browser-level Add Themes benchmark using the Node browser helper from homeboy-extensions.
- Wires the browser workload into the Studio rig bench workload list.

## Validation
- node --check Automattic/studio/bench/studio-admin-theme-page-browser.bench.mjs
- git diff --check
- homeboy bench list --rig studio discovered 3 scenarios with the branch rig config temporarily installed
- Ran one browser benchmark iteration against /Users/chubes/Developer/studio using the helper from homeboy-extensions origin/main; it created/stopped a fresh site, loaded Add Themes, and produced screenshot/network/console/trace artifacts

## Notes
- This branch includes two prerequisite local main commits that had not yet reached origin/main but define the existing Studio bench files referenced by issue #8.
- Runtime status output is redacted for adminPassword and autoLoginUrl before being written to the raw result artifact; the network JSON artifact is also redacted after capture.

Closes #8

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the benchmark workload, wired the rig, ran focused validation, and drafted this PR body. Chris remains responsible for review and merge.