### PR TITLE
Expose Studio benchmark site URLs

### DIFF
--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -678,6 +678,8 @@ export default async function studioAgentSiteBuildBench() {
         variant: currentVariant,
         prompt,
         sitePath,
+        siteUrl: status.siteUrl,
+        autoLoginUrl: status.autoLoginUrl,
         exitCode,
         stderr,
         resultFile,
@@ -768,6 +770,8 @@ export default async function studioAgentSiteBuildBench() {
     artifacts: {
       raw_result: artifactFile,
       site_path: sitePath,
+      frontend_url: status.siteUrl,
+      admin_auto_login_url: status.autoLoginUrl,
     },
   };
 }


### PR DESCRIPTION
## Summary
- Include `siteUrl` and `autoLoginUrl` in the raw Studio site-build benchmark artifact.
- Return `frontend_url` and `admin_auto_login_url` as first-class Homeboy artifacts for immediate viewing after a run.

## Verification
- `node --check Automattic/studio/bench/studio-agent-site-build.bench.mjs`
- `git diff --check -- Automattic/studio/bench/studio-agent-site-build.bench.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small benchmark artifact update; Chris remains responsible for review and final acceptance.