### PR TITLE
Persist Studio site-build prompt metadata

### DIFF
--- a/Automattic/studio/bench/prompts/site-build/nonprofit.md
+++ b/Automattic/studio/bench/prompts/site-build/nonprofit.md
@@ -1,0 +1,7 @@
+Build a polished one-page campaign site for Harbor Steps, a nonprofit helping coastal communities prepare for flooding, heat, and climate displacement.
+
+Use a credible, urgent, and human editorial direction. Include a strong hero, mission summary, impact metrics, program cards, story or quote from a participant, donation/volunteer section, partner strip, FAQ or transparency section, and a clear final call to action.
+
+Use normal semantic HTML and CSS. Studio should import the result into clean editable WordPress blocks through the Static Site Importer workflow.
+
+Work in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/portfolio.md
+++ b/Automattic/studio/bench/prompts/site-build/portfolio.md
@@ -1,0 +1,7 @@
+Build a polished one-page portfolio site for Mira Vale, an independent creative director who works across brand systems, editorial campaigns, and art-directed product launches.
+
+Use a high-end editorial portfolio direction with a strong point of view and varied page sections. Include a hero, selected work grid, featured case study, process section, client list or proof strip, short bio, testimonial quote, and contact call to action.
+
+Use normal semantic HTML and CSS. Studio should import the result into clean editable WordPress blocks through the Static Site Importer workflow.
+
+Work in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/radical-speed-month.md
+++ b/Automattic/studio/bench/prompts/site-build/radical-speed-month.md
@@ -1,0 +1,13 @@
+Build a polished one-page project site for Radical Speed Month at Automattic, presenting Static Site Importer as a month-long creative hackathon project.
+
+The page should explain the project clearly: Static Site Importer turns custom static HTML/CSS into an editable WordPress block theme, giving Studio a stronger answer for fast site generation and for customers who arrive with existing custom HTML templates and want a real WordPress site.
+
+Connect the work to broader trends. Developers and agencies increasingly reach for static sites because they feel fast, portable, customizable, and easy to generate. Static Site Importer gives WordPress and Studio a credible answer to that trend: keep the speed and flexibility of static HTML while ending with editable WordPress output.
+
+Include the data liberation angle. Many customers already have HTML exports, static templates, hand-built pages, or generated prototypes. This project gives those assets a path into WordPress without starting over, preserving more of the customer's existing work while making the final site maintainable in the Site Editor.
+
+Emphasize the Studio value-add: better one-shot site generation, fewer fragile block-format prompts, easier debugging, one reusable conversion pipeline, support for customer-provided templates, and cleaner handoff from agent output to editable WordPress sites.
+
+Include a strong hero, concise RSM context, problem/opportunity section, how the importer works, customer/developer use cases, Studio impact section, data liberation section, proof or metrics-style highlights, and final call to action.
+
+Work in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/restaurant.md
+++ b/Automattic/studio/bench/prompts/site-build/restaurant.md
@@ -1,0 +1,7 @@
+Build a polished one-page marketing site for Ember & Rye, a neighborhood restaurant with a live-fire kitchen, seasonal produce, and a strong natural wine program.
+
+Use a distinctive visual direction, not a generic template. Include a memorable hero, short restaurant story, menu highlights, chef or sourcing section, private dining or events section, hours/location details, testimonial or press quote, and a reservation call to action.
+
+Use normal semantic HTML and CSS. Studio should import the result into clean editable WordPress blocks through the Static Site Importer workflow.
+
+Work in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/saas.md
+++ b/Automattic/studio/bench/prompts/site-build/saas.md
@@ -1,0 +1,7 @@
+Build a polished one-page SaaS marketing site for Relay Atlas, an operations platform for distributed product teams that turns scattered decisions, tasks, and customer signals into a living launch map.
+
+Use modern software-brand polish and clear information architecture. Include a hero, product UI or workflow section, benefits grid, integrations or proof section, use cases, testimonial quote, pricing or packaging teaser, and final call to action.
+
+Use normal semantic HTML and CSS. Studio should import the result into clean editable WordPress blocks through the Static Site Importer workflow.
+
+Work in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/studio-code.md
+++ b/Automattic/studio/bench/prompts/site-build/studio-code.md
@@ -1,0 +1,9 @@
+Build a polished one-page marketing site for Studio Code, a Studio feature for Automattic and WordPress developers that makes custom site generation faster, simpler, and easier to maintain.
+
+The page should pitch the feature as a better developer workflow: agents can work with normal HTML/CSS or customer-provided raw HTML templates, Studio converts that output into clean WordPress blocks in PHP, and the final site still opens cleanly in the Site Editor.
+
+Create the product launch page for the Studio team. Emphasize the practical benefits: less block-format prompting, fewer fragile skills to maintain, one reusable conversion pipeline, faster one-shot site generation, easier debugging, and editable WordPress output.
+
+Include a strong hero, proof/benefits section, example use cases, workflow section, testimonial or quote, and final call to action.
+
+Work in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/wordpress-is-dead.md
+++ b/Automattic/studio/bench/prompts/site-build/wordpress-is-dead.md
@@ -1,0 +1,11 @@
+Build a polished one-page marketing site with the headline concept "WordPress is dead" as a tongue-in-cheek plot twist.
+
+The page should start with the familiar online gripe that WordPress is supposedly too slow, too old, too rigid, or too hard to customize. Then flip the argument: this static-looking custom marketing site was generated in under five minutes from normal HTML and CSS, imported into WordPress, and is still editable in the Site Editor. The reveal is: "Wait, this is WordPress?"
+
+Keep the tone sharp, sarcastic, and playful, but do not overdo it. Write it as a clever product-launch page, not a rant. The joke is that WordPress is "dead" because the old assumptions about WordPress are dead: slow build cycles, fragile block prompts, rigid templates, and hand-maintained conversion glue.
+
+Position Studio Code / Static Site Importer as the plot twist: agents can cook a custom static site quickly, Studio imports it through one reusable pipeline, and WordPress ends up as the editable final product. Emphasize practical benefits: speed, customization, normal HTML/CSS authoring, fewer prompt constraints, clean block output, and easier iteration.
+
+Include a strong hero, the "WordPress is dead" setup, a plot-twist reveal section, proof/benefits section, workflow section, short sarcastic testimonial or quote, and final call to action.
+
+Work in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -7,6 +7,10 @@ import { createRequire } from 'node:module';
 const STUDIO_PATH = process.env.HOMEBOY_COMPONENT_PATH;
 const SHARED_STATE = process.env.HOMEBOY_BENCH_SHARED_STATE || os.tmpdir();
 const RESULT_PREFIX = 'EVAL_RUNNER_RESULT_FILE=';
+const PROMPT_VARIANT_SETTING = 'studio_site_build_prompt_variant';
+const PROMPT_FILE_SETTING = 'studio_site_build_prompt_file';
+const DEFAULT_PROMPT_VARIANT = 'studio-code';
+const PROMPT_CATEGORY = 'site-build';
 const requireFromBench = createRequire(import.meta.url);
 
 if (!STUDIO_PATH) {
@@ -106,18 +110,49 @@ async function runEval(prompt, vars) {
   return { result, resultFile, exitCode: code, stderr };
 }
 
-function siteBuildPrompt(sitePath) {
-  return `Build a polished one-page marketing site for Studio Code, a new Studio feature for Automattic and WordPress developers that makes custom site generation faster, simpler, and easier to maintain.
+function promptVariant() {
+  return setting(PROMPT_VARIANT_SETTING) || DEFAULT_PROMPT_VARIANT;
+}
 
-The page should pitch the feature as a better developer workflow: agents can work with normal HTML/CSS or customer-provided raw HTML templates, Studio converts that output into clean WordPress blocks in PHP, and the final site still opens cleanly in the Site Editor.
+async function availablePromptVariants() {
+  const promptsDir = new URL('./prompts/site-build/', import.meta.url);
+  const entries = await readdir(promptsDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+    .map((entry) => entry.name.replace(/\.md$/, ''))
+    .sort();
+}
 
-Make it feel like a real product launch page for the Studio team. Emphasize the practical benefits: less block-format prompting, fewer fragile skills to maintain, one reusable conversion pipeline, faster one-shot site generation, easier debugging, and editable WordPress output.
+async function promptTemplatePath() {
+  const explicitPromptFile = expandHome(setting(PROMPT_FILE_SETTING) || '');
+  if (explicitPromptFile) {
+    return explicitPromptFile;
+  }
 
-Include a strong hero, proof/benefits section, example use cases, workflow section, testimonial or quote, and final call to action.
+  const variantName = promptVariant();
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(variantName)) {
+    throw new Error(`Invalid ${PROMPT_VARIANT_SETTING}: ${variantName}`);
+  }
 
-Work in this Studio site: ${sitePath}
+  return new URL(`./prompts/site-build/${variantName}.md`, import.meta.url);
+}
 
-Use the normal Studio WordPress tools available to you. This is a one-page benchmark, so make reasonable choices, build the page, and stop.`;
+async function siteBuildPrompt(sitePath) {
+  const promptPath = await promptTemplatePath();
+  let template;
+  try {
+    template = await readFile(promptPath, 'utf8');
+  } catch (error) {
+    const variants = await availablePromptVariants().catch(() => []);
+    const hint = variants.length ? ` Available variants: ${variants.join(', ')}.` : '';
+    throw new Error(
+      `Failed to read Studio site-build prompt for variant "${promptVariant()}" from ${String(promptPath)}.${hint} ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+
+  return template.trim().replaceAll('{{sitePath}}', sitePath).replaceAll('${sitePath}', sitePath);
 }
 
 async function createFreshSite(sitePath) {
@@ -649,7 +684,9 @@ export default async function studioAgentSiteBuildBench() {
   await createFreshSite(sitePath);
   const siteCreateMs = Date.now() - siteCreateStarted;
 
-  const prompt = siteBuildPrompt(sitePath);
+  const selectedPromptVariant = promptVariant();
+  const selectedPromptFile = String(await promptTemplatePath());
+  const prompt = await siteBuildPrompt(sitePath);
   const agentStarted = Date.now();
   const { result, resultFile, exitCode, stderr } = await runEval(prompt, {
     maxTurns: 40,
@@ -676,6 +713,9 @@ export default async function studioAgentSiteBuildBench() {
     JSON.stringify(
       {
         variant: currentVariant,
+        prompt_variant: selectedPromptVariant,
+        prompt_file: selectedPromptFile,
+        prompt_category: PROMPT_CATEGORY,
         prompt,
         sitePath,
         siteUrl: status.siteUrl,
@@ -772,6 +812,12 @@ export default async function studioAgentSiteBuildBench() {
       site_path: sitePath,
       frontend_url: status.siteUrl,
       admin_auto_login_url: status.autoLoginUrl,
+    },
+    metadata: {
+      benchmark_variant: currentVariant,
+      prompt_variant: selectedPromptVariant,
+      prompt_file: selectedPromptFile,
+      prompt_category: PROMPT_CATEGORY,
     },
   };
 }


### PR DESCRIPTION
## Summary
- Move Studio site-build benchmark prompts into named variant files.
- Add `studio_site_build_prompt_variant` and `studio_site_build_prompt_file` settings for distribution runs.
- Emit `benchmark_variant`, `prompt_variant`, `prompt_file`, and `prompt_category` as scenario metadata so Homeboy run storage can query generated style metrics by prompt context.

## Dependency
- Depends on Extra-Chill/homeboy-extensions#400 for Node.js bench metadata passthrough.

## Tests
- `node --check Automattic/studio/bench/studio-agent-site-build.bench.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Studio rig prompt metadata persistence change and prompt variant files; Chris remains responsible for review and validation.