### PR TITLE
fix(studio): resolve SSI source static file URLs

### DIFF
--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -438,7 +438,24 @@ function comparisonTargets(importReport) {
   );
 }
 
-function surfaceUrl(target, surface, reportPath) {
+export function resolveSourceStaticFile(sourceFile, reportPath, sitePath) {
+  if (!sourceFile) {
+    return '';
+  }
+
+  if (path.isAbsolute(sourceFile)) {
+    const wordpressRoot = '/wordpress';
+    if (sitePath && (sourceFile === wordpressRoot || sourceFile.startsWith(`${wordpressRoot}/`))) {
+      return path.join(sitePath, sourceFile.slice(wordpressRoot.length));
+    }
+
+    return sourceFile;
+  }
+
+  return path.resolve(path.dirname(reportPath), sourceFile);
+}
+
+function surfaceUrl(target, surface, reportPath, sitePath) {
   const surfaces = target?.comparison_hooks?.render_surfaces || {};
   const configured = surfaces[surface]?.url || '';
   if (surface === 'source_static') {
@@ -446,7 +463,7 @@ function surfaceUrl(target, surface, reportPath) {
     if (!sourceFile) {
       return '';
     }
-    const absoluteSource = path.isAbsolute(sourceFile) ? sourceFile : path.resolve(path.dirname(reportPath), sourceFile);
+    const absoluteSource = resolveSourceStaticFile(sourceFile, reportPath, sitePath);
     return pathToFileURL(absoluteSource).toString();
   }
 
@@ -455,6 +472,44 @@ function surfaceUrl(target, surface, reportPath) {
   }
 
   return configured;
+}
+
+async function restoreMissingSourceStaticFiles(importReport, sitePath, result) {
+  const writes = new Map();
+  for (const call of Array.isArray(result?.toolCalls) ? result.toolCalls : []) {
+    if (call?.name !== 'Write' || typeof call?.input?.file_path !== 'string' || typeof call?.input?.content !== 'string') {
+      continue;
+    }
+    writes.set(path.resolve(call.input.file_path), call.input.content);
+  }
+
+  if (!writes.size) {
+    return;
+  }
+
+  for (const target of comparisonTargets(importReport)) {
+    const surfaces = target?.comparison_hooks?.render_surfaces || {};
+    const sourceFile = surfaces.source_static?.url || target?.source_file || '';
+    const hostPath = resolveSourceStaticFile(sourceFile, importReport.reportPath, sitePath);
+    if (!hostPath) {
+      continue;
+    }
+
+    try {
+      await stat(hostPath);
+      continue;
+    } catch {
+      // Restore only files the agent authored during this benchmark run.
+    }
+
+    const content = writes.get(path.resolve(hostPath));
+    if (typeof content !== 'string') {
+      continue;
+    }
+
+    await mkdir(path.dirname(hostPath), { recursive: true });
+    await writeFile(hostPath, content);
+  }
 }
 
 function visualProbeGroups(target) {
@@ -674,7 +729,7 @@ function emptyVisualComparison(error = '') {
   };
 }
 
-async function compareVisualFidelity(importReport, artifactDir) {
+async function compareVisualFidelity(importReport, artifactDir, sitePath) {
   const targets = comparisonTargets(importReport);
   if (!targets.length) {
     return emptyVisualComparison(importReport?.error || 'No visual fidelity comparison targets found.');
@@ -708,7 +763,7 @@ async function compareVisualFidelity(importReport, artifactDir) {
       };
 
       for (const surface of ['source_static', 'wordpress_frontend']) {
-        const url = surfaceUrl(target, surface, importReport.reportPath);
+        const url = surfaceUrl(target, surface, importReport.reportPath, sitePath);
         const screenshotPath = path.join(visualDir, `${targetSlug}-${surface}.png`);
         const page = await browser.newPage({ ignoreHTTPSErrors: true, viewport: VISUAL_VIEWPORT });
 
@@ -1111,8 +1166,9 @@ export default async function studioAgentSiteBuildBench() {
   const status = await siteStatus(sitePath);
   const importReport = await collectLatestImportReport(sitePath);
   await mkdir(artifactDir, { recursive: true });
+  await restoreMissingSourceStaticFiles(importReport, sitePath, result);
   const visualComparisonStarted = Date.now();
-  const visualComparison = await compareVisualFidelity(importReport, artifactDir);
+  const visualComparison = await compareVisualFidelity(importReport, artifactDir, sitePath);
   const visualComparisonMs = Date.now() - visualComparisonStarted;
   const editorValidationStarted = Date.now();
   const editorValidation = await validateThemeBlocks(sitePath, status.siteUrl);


### PR DESCRIPTION
## Summary
- Map Static Site Importer `/wordpress/...` source-static report paths back onto the benchmark host `sitePath` before building `file://` render URLs.
- Preserve source/frontend visual comparison screenshots and metrics by passing `sitePath` through the visual comparison harness.
- Restore missing source-static files from the benchmark run's own `Write` tool output when the importer/report path points at an authored temp file that no longer exists.

Fixes #20.

## Evidence
- `node --check Automattic/studio/bench/studio-agent-site-build.bench.mjs`
- Focused helper assertions via `HOMEBOY_COMPONENT_PATH=/tmp node --input-type=module -e "... resolveSourceStaticFile(...) ..."`
- `homeboy rig check studio-bfb`
- `homeboy bench --rig studio-bfb --scenario studio-agent-site-build --iterations 1 --shared-state /tmp/studio-ssi-source-url-smoke --ignore-default-baseline --json-summary`

## Known limits
- The Homeboy bench smoke exercised the installed rig package path, which reproduced the original `file:///wordpress/tmp/static-site/index.html` failure before this branch was pushed.
- A direct run of the changed benchmark module was started after the fix but was aborted before completion, so the PR relies on syntax/helper validation plus the rig smoke evidence above rather than a completed changed-branch full agent benchmark.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the benchmark URL mapping/restoration fix, ran local validation, and drafted this PR description. Chris remains responsible for review and merge.