### PR TITLE
feat(studio): extend create-site trace diagnostics

### DIFF
--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -275,32 +275,7 @@ async function siteStatus(sitePath) {
 }
 
 async function collectThemeBlockDocuments(sitePath) {
-  const themesRoot = path.join(sitePath, 'wp-content/themes');
-  let themeEntries = [];
-  try {
-    themeEntries = await readdir(themesRoot, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-
-  const generatedThemes = [];
-  for (const entry of themeEntries) {
-    if (!entry.isDirectory()) {
-      continue;
-    }
-    const themeRoot = path.join(themesRoot, entry.name);
-    const reportPath = path.join(themeRoot, 'import-report.json');
-    try {
-      const reportStat = await stat(reportPath);
-      generatedThemes.push({ themeRoot, mtimeMs: reportStat.mtimeMs });
-    } catch {
-      // Only validate importer-generated themes. Default themes can contain
-      // historical/core patterns that are irrelevant to this benchmark.
-    }
-  }
-
-  generatedThemes.sort((a, b) => b.mtimeMs - a.mtimeMs);
-  const themeRoot = generatedThemes[0]?.themeRoot;
+  const { themeRoot } = await collectLatestGeneratedTheme(sitePath);
   if (!themeRoot) {
     return [];
   }
@@ -341,33 +316,38 @@ async function collectThemeBlockDocuments(sitePath) {
   return documents;
 }
 
-async function collectLatestImportReport(sitePath) {
+async function collectLatestGeneratedTheme(sitePath) {
   const themesRoot = path.join(sitePath, 'wp-content/themes');
   let themeEntries = [];
   try {
     themeEntries = await readdir(themesRoot, { withFileTypes: true });
   } catch {
-    return { report: null, reportPath: '', error: 'Themes directory not found.' };
+    return { themeRoot: '', themeSlug: '', reportPath: '', error: 'Themes directory not found.' };
   }
 
-  const reports = [];
+  const generatedThemes = [];
   for (const entry of themeEntries) {
     if (!entry.isDirectory()) {
       continue;
     }
-    const reportPath = path.join(themesRoot, entry.name, 'import-report.json');
+    const themeRoot = path.join(themesRoot, entry.name);
+    const reportPath = path.join(themeRoot, 'import-report.json');
     try {
       const reportStat = await stat(reportPath);
-      reports.push({ reportPath, mtimeMs: reportStat.mtimeMs });
+      generatedThemes.push({ themeRoot, themeSlug: entry.name, reportPath, mtimeMs: reportStat.mtimeMs });
     } catch {
       // Ignore non-importer themes.
     }
   }
 
-  reports.sort((a, b) => b.mtimeMs - a.mtimeMs);
-  const reportPath = reports[0]?.reportPath || '';
+  generatedThemes.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return generatedThemes[0] || { themeRoot: '', themeSlug: '', reportPath: '', error: 'No Static Site Importer report found.' };
+}
+
+async function collectLatestImportReport(sitePath) {
+  const { reportPath, error } = await collectLatestGeneratedTheme(sitePath);
   if (!reportPath) {
-    return { report: null, reportPath: '', error: 'No Static Site Importer report found.' };
+    return { report: null, reportPath: '', error };
   }
 
   try {
@@ -756,6 +736,210 @@ async function compareVisualFidelity(importReport, artifactDir) {
   };
 }
 
+async function readIfExists(file) {
+  try {
+    return await readFile(file, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+async function collectCssFiles(root, maxFiles = 40) {
+  const files = [];
+
+  async function visit(dir) {
+    if (files.length >= maxFiles) {
+      return;
+    }
+    let entries = [];
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (files.length >= maxFiles) {
+        return;
+      }
+      if (entry.name === 'node_modules' || entry.name === '.git') {
+        continue;
+      }
+      const absolute = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await visit(absolute);
+      } else if (entry.isFile() && entry.name.endsWith('.css')) {
+        files.push(absolute);
+      }
+    }
+  }
+
+  await visit(root);
+  return files;
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values.filter(Boolean))].sort((a, b) => a.localeCompare(b));
+}
+
+function countRegex(value, pattern) {
+  return typeof value === 'string' ? (value.match(pattern) || []).length : 0;
+}
+
+function normalizeFontFamily(value) {
+  return value
+    .replace(/\\["']/g, '')
+    .replace(/["']/g, '')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+function extractFontFamilies(text) {
+  const families = [];
+  for (const match of text.matchAll(/fonts\.googleapis\.com\/css2?[^"')\s]+/gi)) {
+    try {
+      const url = new URL(match[0].startsWith('http') ? match[0] : `https://${match[0]}`);
+      for (const family of url.searchParams.getAll('family')) {
+        families.push(normalizeFontFamily(family.split(':')[0].replaceAll('+', ' ')));
+      }
+    } catch {
+      // Keep parsing local font-family declarations even if an import URL is malformed.
+    }
+  }
+
+  for (const match of text.matchAll(/font-family\s*:\s*([^;}]+)/gi)) {
+    const declaration = match[1] || '';
+    for (const family of declaration.split(',')) {
+      const normalized = normalizeFontFamily(family);
+      if (!/^(sans-serif|serif|monospace|system-ui|inherit|initial|unset)$/i.test(normalized)) {
+        families.push(normalized);
+      }
+    }
+  }
+
+  return uniqueSorted(families);
+}
+
+function extractColors(text) {
+  const hexColors = [...text.matchAll(/#[0-9a-f]{3,8}\b/gi)].map((match) => match[0].toLowerCase());
+  const functionalColors = [...text.matchAll(/\b(?:rgb|rgba|hsl|hsla)\([^)]*\)/gi)].map((match) =>
+    match[0].toLowerCase().replace(/\s+/g, '')
+  );
+  return uniqueSorted([...hexColors, ...functionalColors]);
+}
+
+function includesAny(text, patterns) {
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+function extractMotifs(text) {
+  const motifs = [];
+  const checks = {
+    bento_grid: [/\bbento\b/i],
+    cards_grid: [/\bcard(s)?\b/i, /grid-template-columns/i],
+    code_preview: [/code-window/i, /code-preview/i, /<pre\b/i, /<code\b/i],
+    dashboard_mockup: [/dashboard/i, /metric-card/i, /analytics/i],
+    glow_overlay: [/\bglow\b/i, /blur\(/i, /radial-gradient\(/i],
+    marquee: [/\bmarquee\b/i, /ticker/i],
+    pricing: [/\bpricing\b/i, /\bplans?\b/i],
+    social_proof: [/testimonial/i, /customer/i, /trusted by/i],
+    split_hero: [/split-hero/i, /hero-grid/i],
+    terminal_window: [/terminal/i, /traffic-light/i, /window-chrome/i, /code-window/i],
+  };
+
+  for (const [motif, patterns] of Object.entries(checks)) {
+    if (includesAny(text, patterns)) {
+      motifs.push(motif);
+    }
+  }
+
+  return motifs.sort();
+}
+
+function extractPaletteLabels(text, colors) {
+  const labels = [];
+  const lower = text.toLowerCase();
+  const colorText = colors.join(' ');
+  if (/purple|violet|indigo|#6|#7|#8|#9|#a/i.test(`${lower} ${colorText}`) && /lime|chartreuse|#bef|#a3e|#ccff|#d9f99d/i.test(`${lower} ${colorText}`)) {
+    labels.push('purple_lime');
+  }
+  if (/orange|amber|coral|#f59|#fb7|#ff8/i.test(`${lower} ${colorText}`)) {
+    labels.push('warm_orange');
+  }
+  if (/cyan|teal|aqua|#06b6|#14b8|#22d3/i.test(`${lower} ${colorText}`)) {
+    labels.push('cyan_teal');
+  }
+  if (/black|charcoal|slate|#0[0-9a-f]{2,6}|#111|#18181b/i.test(`${lower} ${colorText}`)) {
+    labels.push('dark_base');
+  }
+  return labels.sort();
+}
+
+async function collectDesignFingerprint(sitePath) {
+  const { themeRoot, themeSlug } = await collectLatestGeneratedTheme(sitePath);
+  const sourceHtml = await readIfExists(path.join(sitePath, 'tmp/static-site/index.html'));
+  const cssFiles = themeRoot ? await collectCssFiles(themeRoot) : [];
+  const cssParts = [];
+  for (const file of cssFiles) {
+    cssParts.push(await readIfExists(file));
+  }
+
+  const text = [sourceHtml, ...cssParts].join('\n');
+  const lower = text.toLowerCase();
+  const fontFamilies = extractFontFamilies(text);
+  const colors = extractColors(text);
+  const cssVariables = uniqueSorted([...text.matchAll(/--([a-z0-9-]+)\s*:/gi)].map((match) => match[1].toLowerCase()));
+  const motifs = extractMotifs(text);
+  const paletteLabels = extractPaletteLabels(lower, colors);
+
+  return {
+    theme_slug: themeSlug,
+    source_html_present: sourceHtml ? true : false,
+    css_file_count: cssFiles.length,
+    font_families: fontFamilies,
+    dominant_font_family: fontFamilies[0] || '',
+    color_values: colors,
+    css_variables: cssVariables,
+    motifs,
+    palette_labels: paletteLabels,
+    gradient_count: countRegex(text, /(?:linear|radial|conic)-gradient\(/gi),
+    animation_count: countRegex(text, /@keyframes\b|\banimation(?:-[a-z]+)?\s*:/gi),
+    transition_count: countRegex(text, /\btransition(?:-[a-z]+)?\s*:/gi),
+    dark_theme: /#0[0-9a-f]{2,6}|#111|#18181b|#020617|background(?:-color)?\s*:\s*(?:black|rgb\(0[,\s]+0[,\s]+0\))/i.test(text),
+  };
+}
+
+function designFingerprintMetrics(fingerprint) {
+  const motifs = new Set(fingerprint?.motifs || []);
+  const paletteLabels = new Set(fingerprint?.palette_labels || []);
+  const fonts = (fingerprint?.font_families || []).map((font) => font.toLowerCase());
+
+  return {
+    design_source_html_present: fingerprint?.source_html_present ? 1 : 0,
+    design_css_file_count: Number(fingerprint?.css_file_count || 0),
+    design_font_unique_count: Number(fingerprint?.font_families?.length || 0),
+    design_color_unique_count: Number(fingerprint?.color_values?.length || 0),
+    design_css_variable_count: Number(fingerprint?.css_variables?.length || 0),
+    design_motif_count: Number(fingerprint?.motifs?.length || 0),
+    design_palette_label_count: Number(fingerprint?.palette_labels?.length || 0),
+    design_gradient_count: Number(fingerprint?.gradient_count || 0),
+    design_animation_count: Number(fingerprint?.animation_count || 0),
+    design_transition_count: Number(fingerprint?.transition_count || 0),
+    design_uses_inter: fonts.includes('inter') ? 1 : 0,
+    design_uses_syne: fonts.includes('syne') ? 1 : 0,
+    design_uses_space_grotesk: fonts.includes('space grotesk') ? 1 : 0,
+    design_uses_purple_lime: paletteLabels.has('purple_lime') ? 1 : 0,
+    design_uses_dark_base: paletteLabels.has('dark_base') || fingerprint?.dark_theme ? 1 : 0,
+    design_uses_bento_grid: motifs.has('bento_grid') ? 1 : 0,
+    design_uses_cards_grid: motifs.has('cards_grid') ? 1 : 0,
+    design_uses_code_preview: motifs.has('code_preview') ? 1 : 0,
+    design_uses_dashboard_mockup: motifs.has('dashboard_mockup') ? 1 : 0,
+    design_uses_glow_overlay: motifs.has('glow_overlay') ? 1 : 0,
+    design_uses_marquee: motifs.has('marquee') ? 1 : 0,
+    design_uses_terminal_window: motifs.has('terminal_window') ? 1 : 0,
+  };
+}
+
 async function validateThemeBlocks(sitePath, siteUrl) {
   const documents = await collectThemeBlockDocuments(sitePath);
   if (documents.length === 0) {
@@ -1086,6 +1270,8 @@ export default async function studioAgentSiteBuildBench() {
   const validation = validationMetrics(result);
   const authoredBlocks = agentAuthoredBlockMetrics(result);
   const nativeBlockQuality = nativeBlockQualityMetrics(quality, authoredBlocks, editorValidation, importReport);
+  const designFingerprint = await collectDesignFingerprint(sitePath);
+  const designMetrics = designFingerprintMetrics(designFingerprint);
 
   const artifactFile = path.join(artifactDir, `result-${runId}.json`);
   await writeFile(
@@ -1116,6 +1302,7 @@ export default async function studioAgentSiteBuildBench() {
         importReport,
         visualComparison,
         editorValidation,
+        designFingerprint,
         authoredBlocks,
         nativeBlockQuality,
         validation,
@@ -1183,6 +1370,7 @@ export default async function studioAgentSiteBuildBench() {
       visual_nav_probe_parity_mismatch_count: Number(visualComparison.nav_probe_parity_mismatch_count || 0),
       visual_footer_probe_parity_mismatch_count: Number(visualComparison.footer_probe_parity_mismatch_count || 0),
       visual_hero_probe_parity_mismatch_count: Number(visualComparison.hero_probe_parity_mismatch_count || 0),
+      ...designMetrics,
       posts_seen: Number(quality.posts_seen || 0),
       posts_with_blocks: Number(quality.posts_with_blocks || 0),
       pages_seen: Number(quality.pages_seen || 0),
@@ -1213,6 +1401,7 @@ export default async function studioAgentSiteBuildBench() {
       prompt_variant: selectedPromptVariant,
       prompt_file: selectedPromptFile,
       prompt_category: PROMPT_CATEGORY,
+      design: designFingerprint,
     },
   };
 }

--- a/Automattic/studio/bench/studio-app-create-site.trace.mjs
+++ b/Automattic/studio/bench/studio-app-create-site.trace.mjs
@@ -379,6 +379,33 @@ async function pollSiteDetailsRunning(mainWindow, siteName, timeoutMs, getFailur
   throw new Error(failureMessage || `Site details never reported running for ${siteName}`);
 }
 
+async function assertHttpEndpoint(port, pathName, label, acceptStatus = (status) => status >= 200 && status < 400) {
+  const url = `http://${HTTP_PROBE_HOST}:${port}${pathName}`;
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(HTTP_REQUEST_TIMEOUT_MS),
+  });
+  event('probe', 'http_endpoint_checked', {
+    label,
+    path: pathName,
+    status: response.status,
+    finalUrl: response.url,
+  });
+  if (!acceptStatus(response.status)) {
+    throw new Error(`${label} returned HTTP ${response.status}`);
+  }
+}
+
+async function assertSiteHttpSurface(site) {
+  const port = site?.port;
+  if (!port) {
+    throw new Error('Cannot validate site HTTP surface without a known port');
+  }
+
+  await assertHttpEndpoint(port, '/', 'frontend');
+  await assertHttpEndpoint(port, '/wp-json/', 'REST API');
+  await assertHttpEndpoint(port, '/wp-admin/', 'wp-admin');
+}
+
 async function captureSeedDatabase(site) {
   if (!CAPTURE_SEED_DB_PATH || !site?.path) {
     return;
@@ -609,6 +636,7 @@ async function main() {
       .or(siteContent.getByRole('button', { name: 'Running' }))
       .waitFor({ state: 'attached', timeout: SITE_READY_TIMEOUT_MS });
     event('ui', 'site.running_visible');
+    await assertSiteHttpSurface(runningSite);
     await captureSeedDatabase(runningSite);
 
     await captureArtifacts(mainWindow, mainProcessLog);

--- a/Automattic/studio/bench/studio-app-create-site.trace.mjs
+++ b/Automattic/studio/bench/studio-app-create-site.trace.mjs
@@ -1,8 +1,9 @@
-import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, copyFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const STUDIO_PATH = process.env.HOMEBOY_COMPONENT_PATH;
@@ -11,6 +12,8 @@ const ARTIFACT_DIR = process.env.HOMEBOY_TRACE_ARTIFACT_DIR || path.join(tmpdir(
 const SCENARIO_ID = process.env.HOMEBOY_TRACE_SCENARIO || 'studio-app-create-site';
 const COMPONENT_ID = process.env.HOMEBOY_COMPONENT_ID || 'studio';
 const SITE_READY_TIMEOUT_MS = Number(process.env.STUDIO_TRACE_SITE_READY_TIMEOUT_MS || 300_000);
+const CAPTURE_SEED_DB_PATH = process.env.STUDIO_TRACE_CAPTURE_SEED_DB_PATH;
+const HELPER_DIR = process.env.HOMEBOY_TRACE_HELPER_DIR;
 
 if (!STUDIO_PATH) {
   throw new Error('HOMEBOY_COMPONENT_PATH is required');
@@ -23,6 +26,9 @@ const playwright = require(require.resolve('playwright', { paths: [STUDIO_PATH] 
 const { findLatestBuild, parseElectronApp } = require(
   require.resolve('electron-playwright-helpers', { paths: [STUDIO_PATH] })
 );
+const { pollHttp: helperPollHttp } = HELPER_DIR
+  ? await import(pathToFileURL(`${HELPER_DIR}/probes.mjs`).href)
+  : { pollHttp: null };
 
 const timeline = [];
 const assertions = [];
@@ -51,15 +57,20 @@ function eventNameFromCliMessage(message) {
 }
 
 function captureCliEvents(chunk) {
-  for (const line of chunk.toString().split(/\r?\n/)) {
-    const match = line.match(
-      /^\[CLI - ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\]\s+(.*)$/i
-    );
+	for (const line of chunk.toString().split(/\r?\n/)) {
+		captureHarnessEvent(line);
+		const match = line.match(
+			/^\[CLI - ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\]\s+(.*)$/i
+		);
     if (!match) {
       continue;
     }
-    const [, commandId, message] = match;
-    const eventName = eventNameFromCliMessage(message);
+		const [, commandId, message] = match;
+		if (message.startsWith('[HOMEBOY_TRACE] ')) {
+			captureHarnessEvent(message);
+			continue;
+		}
+		const eventName = eventNameFromCliMessage(message);
     const key = `${commandId}:${eventName}`;
     if (!eventName || seenCliMessages.has(key)) {
       continue;
@@ -141,14 +152,122 @@ async function installIpcProbe(mainWindow) {
   });
 }
 
+async function installRendererStateProbe(mainWindow, siteName) {
+  const result = await mainWindow.evaluate((name) => {
+    if (window.__homeboyRendererStateProbeInstalled) {
+      return { installed: true, alreadyInstalled: true };
+    }
+
+    const emit = (eventName, data = {}) => {
+      console.log(`[HOMEBOY_TRACE] ${JSON.stringify({ source: 'renderer', event: eventName, data })}`);
+    };
+
+    window.ipcListener?.subscribe?.('site-event', (_event, siteEvent) => {
+      const site = siteEvent?.site;
+      if (site?.name === name || siteEvent?.running) {
+        emit('site_event_received', {
+          event: siteEvent?.event,
+          siteId: siteEvent?.siteId,
+          name: site?.name,
+          running: siteEvent?.running,
+          isAddingSite: site?.isAddingSite,
+        });
+      }
+      if (siteEvent?.running) {
+        emit('site_running_event_received', {
+          event: siteEvent?.event,
+          siteId: siteEvent?.siteId,
+          name: site?.name,
+          running: siteEvent?.running,
+          isAddingSite: site?.isAddingSite,
+        });
+      }
+    });
+
+    const observer = new MutationObserver(() => {
+      if (document.querySelector('[data-testid="site-status-running"]')) {
+        emit('dom_status_running_seen');
+        observer.disconnect();
+      }
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true, attributes: true });
+
+    window.__homeboyRendererStateProbeInstalled = true;
+    return { installed: true, alreadyInstalled: false };
+  }, siteName);
+  event('probe', 'renderer_state_probe_installed', result);
+}
+
 async function wait(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function pollHttp(port, timeoutMs) {
+async function withTimeout(promise, timeoutMs) {
+  let timeout;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((resolve) => {
+        timeout = setTimeout(resolve, timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function extractStudioFailureMessage(log) {
+  const startServerFailure = log.match(/Failed to start WordPress server: ([^\n]+)/);
+  const createSiteFailure = log.match(/Error occurred in handler for 'createSite': \[CliCommandError: ([\s\S]*?)\n\s*\[Exit code\]/);
+  const exitCode = log.match(/\[Exit code\] (\d+)/);
+
+  if (startServerFailure) {
+    return `${startServerFailure[0]}${exitCode ? ` (${exitCode[0]})` : ''}`;
+  }
+  if (createSiteFailure) {
+    return `${createSiteFailure[1].replace(/\s+/g, ' ').trim()}${exitCode ? ` (${exitCode[0]})` : ''}`;
+  }
+  return null;
+}
+
+async function pollHttp(port, timeoutMs, getFailureMessage = () => null) {
+  if (helperPollHttp) {
+    const result = await Promise.race([
+      helperPollHttp(`http://127.0.0.1:${port}/`, {
+        source: 'probe',
+        intervalMs: 250,
+        readyStatus: 200,
+        requestTimeoutMs: 500,
+        timeoutMs,
+        onEvent: (source, name, data) => {
+          event(source, name, data);
+          if (source === 'probe' && name === 'http.first_response') {
+            event('probe', 'http_first_response', { port, status: data.status });
+          }
+          if (source === 'probe' && name === 'http.ready') {
+            event('probe', 'http_ready', { port, status: data.status });
+          }
+          if (source === 'probe' && name === 'http.timeout') {
+            event('probe', 'http_timeout', { port });
+          }
+        },
+      }),
+      waitForStudioFailure(getFailureMessage, timeoutMs),
+    ]);
+    if (result.status !== 'ready') {
+      throw new Error(`HTTP did not become ready on port ${port}`);
+    }
+    return result;
+  }
+
   const deadline = Date.now() + timeoutMs;
   let sawResponse = false;
   while (Date.now() < deadline) {
+    const failureMessage = getFailureMessage();
+    if (failureMessage) {
+      event('probe', 'studio_failure_detected', { message: failureMessage });
+      throw new Error(failureMessage);
+    }
     try {
       const response = await fetch(`http://127.0.0.1:${port}/`, {
         signal: AbortSignal.timeout(500),
@@ -167,6 +286,21 @@ async function pollHttp(port, timeoutMs) {
     }
   }
   event('probe', 'http_timeout', { port });
+  const failureMessage = getFailureMessage();
+  throw new Error(failureMessage || `HTTP did not become ready on port ${port}`);
+}
+
+async function waitForStudioFailure(getFailureMessage, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const failureMessage = getFailureMessage();
+    if (failureMessage) {
+      event('probe', 'studio_failure_detected', { message: failureMessage });
+      throw new Error(failureMessage);
+    }
+    await wait(100);
+  }
+  return { status: 'timeout' };
 }
 
 async function pollSiteDetailsSeen(mainWindow, siteName, timeoutMs) {
@@ -203,16 +337,32 @@ async function pollSiteDetailsSeen(mainWindow, siteName, timeoutMs) {
   return null;
 }
 
-async function pollSiteDetailsRunning(mainWindow, siteName, timeoutMs) {
+async function pollSiteDetailsRunning(mainWindow, siteName, timeoutMs, getFailureMessage = () => null) {
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {
-    const site = await mainWindow.evaluate((name) => {
-      return window.ipcApi
-        .getSiteDetails()
-        .then((sites) => sites.find((candidate) => candidate.name === name) || null)
-        .catch(() => null);
-    }, siteName);
+    const failureMessage = getFailureMessage();
+    if (failureMessage) {
+      event('probe', 'studio_failure_detected', { message: failureMessage });
+      throw new Error(failureMessage);
+    }
+
+    let site;
+    try {
+      site = await mainWindow.evaluate((name) => {
+        return window.ipcApi
+          .getSiteDetails()
+          .then((sites) => sites.find((candidate) => candidate.name === name) || null)
+          .catch(() => null);
+      }, siteName);
+    } catch (error) {
+      const message = getFailureMessage();
+      if (message) {
+        event('probe', 'studio_failure_detected', { message });
+        throw new Error(message);
+      }
+      throw error;
+    }
 
     if (site?.running) {
       event('probe', 'site_details_running_true', { id: site.id, port: site.port });
@@ -223,7 +373,19 @@ async function pollSiteDetailsRunning(mainWindow, siteName, timeoutMs) {
   }
 
   event('probe', 'site_details_running_timeout', { site_name: siteName });
-  return null;
+  const failureMessage = getFailureMessage();
+  throw new Error(failureMessage || `Site details never reported running for ${siteName}`);
+}
+
+async function captureSeedDatabase(site) {
+  if (!CAPTURE_SEED_DB_PATH || !site?.path) {
+    return;
+  }
+
+  const source = path.join(site.path, 'wp-content', 'database', '.ht.sqlite');
+  await mkdir(path.dirname(CAPTURE_SEED_DB_PATH), { recursive: true });
+  await copyFile(source, CAPTURE_SEED_DB_PATH);
+  event('probe', 'seed_database_captured', { source, target: CAPTURE_SEED_DB_PATH });
 }
 
 async function pollCliConfig(cliConfigPath, siteName, timeoutMs) {
@@ -409,6 +571,7 @@ async function main() {
     await mainWindow.context().tracing.start({ screenshots: true, snapshots: true, sources: true });
     mainWindow.on('console', (message) => captureHarnessEvent(message.text()));
     await installIpcProbe(mainWindow);
+    await installRendererStateProbe(mainWindow, siteName);
 
     await waitFor(mainWindow.getByTestId('onboarding-welcome-title'), 'onboarding');
     await mainWindow.getByTestId('onboarding').getByRole('button', { name: 'Skip' }).click();
@@ -423,21 +586,28 @@ async function main() {
     await mainWindow.getByTestId('stepper-action-button').click();
     event('ui', 'create_site.submit_clicked');
     const siteDetailsSeenProbe = pollSiteDetailsSeen(mainWindow, siteName, SITE_READY_TIMEOUT_MS).catch(() => {});
-    const httpProbe = pollCliConfig(cliConfigPath, siteName, SITE_READY_TIMEOUT_MS)
-      .then((site) => (site?.port > 0 ? pollHttp(site.port, 60_000) : undefined))
-      .catch(() => {});
+    const currentStudioFailure = () => extractStudioFailureMessage(mainProcessLog);
+    const httpProbe = pollCliConfig(cliConfigPath, siteName, SITE_READY_TIMEOUT_MS).then((site) =>
+      site?.port > 0 ? pollHttp(site.port, 60_000, currentStudioFailure) : undefined
+    );
 
     await waitFor(mainWindow.getByText(siteName, { exact: true }).first(), 'site_shell');
 
     const siteContent = mainWindow.getByTestId('site-content');
     await siteDetailsSeenProbe;
     await httpProbe;
-    await pollSiteDetailsRunning(mainWindow, siteName, SITE_READY_TIMEOUT_MS);
+    const runningSite = await pollSiteDetailsRunning(
+      mainWindow,
+      siteName,
+      SITE_READY_TIMEOUT_MS,
+      currentStudioFailure
+    );
     await siteContent
       .getByTestId('site-status-running')
       .or(siteContent.getByRole('button', { name: 'Running' }))
       .waitFor({ state: 'attached', timeout: SITE_READY_TIMEOUT_MS });
     event('ui', 'site.running_visible');
+    await captureSeedDatabase(runningSite);
 
     await captureArtifacts(mainWindow, mainProcessLog);
 
@@ -454,17 +624,20 @@ async function main() {
   } finally {
     if (electronApp) {
       try {
-        await electronApp.evaluate(({ app }) => app.quit());
+        await withTimeout(electronApp.evaluate(({ app }) => app.quit()), 5_000);
       } catch {
         // Process may already be gone.
       }
       try {
-        await electronApp.close();
+        await withTimeout(electronApp.close(), 5_000);
       } catch {
         // Playwright close can race with app quit.
       }
     }
     await rm(sessionPath, { recursive: true, force: true }).catch(() => {});
+    if (process.env.STUDIO_TRACE_FORCE_EXIT_AFTER_RESULTS === '1') {
+      process.exit(0);
+    }
   }
 }
 

--- a/Automattic/studio/bench/studio-app-create-site.trace.mjs
+++ b/Automattic/studio/bench/studio-app-create-site.trace.mjs
@@ -14,6 +14,8 @@ const COMPONENT_ID = process.env.HOMEBOY_COMPONENT_ID || 'studio';
 const SITE_READY_TIMEOUT_MS = Number(process.env.STUDIO_TRACE_SITE_READY_TIMEOUT_MS || 300_000);
 const CAPTURE_SEED_DB_PATH = process.env.STUDIO_TRACE_CAPTURE_SEED_DB_PATH;
 const HELPER_DIR = process.env.HOMEBOY_TRACE_HELPER_DIR;
+const HTTP_PROBE_HOST = process.env.STUDIO_TRACE_HTTP_PROBE_HOST || '127.0.0.1';
+const HTTP_REQUEST_TIMEOUT_MS = Number(process.env.STUDIO_TRACE_HTTP_REQUEST_TIMEOUT_MS || 500);
 
 if (!STUDIO_PATH) {
   throw new Error('HOMEBOY_COMPONENT_PATH is required');
@@ -233,11 +235,11 @@ function extractStudioFailureMessage(log) {
 async function pollHttp(port, timeoutMs, getFailureMessage = () => null) {
   if (helperPollHttp) {
     const result = await Promise.race([
-      helperPollHttp(`http://127.0.0.1:${port}/`, {
+      helperPollHttp(`http://${HTTP_PROBE_HOST}:${port}/`, {
         source: 'probe',
         intervalMs: 250,
         readyStatus: 200,
-        requestTimeoutMs: 500,
+        requestTimeoutMs: HTTP_REQUEST_TIMEOUT_MS,
         timeoutMs,
         onEvent: (source, name, data) => {
           event(source, name, data);
@@ -269,8 +271,8 @@ async function pollHttp(port, timeoutMs, getFailureMessage = () => null) {
       throw new Error(failureMessage);
     }
     try {
-      const response = await fetch(`http://127.0.0.1:${port}/`, {
-        signal: AbortSignal.timeout(500),
+      const response = await fetch(`http://${HTTP_PROBE_HOST}:${port}/`, {
+        signal: AbortSignal.timeout(HTTP_REQUEST_TIMEOUT_MS),
       });
       if (!sawResponse) {
         event('probe', 'http_first_response', { port, status: response.status });

--- a/Automattic/studio/overlays/studio/add-mail-disable-function.patch
+++ b/Automattic/studio/overlays/studio/add-mail-disable-function.patch
@@ -1,0 +1,12 @@
+diff --git a/apps/studio/out/Studio-darwin-arm64/Studio.app/Contents/Resources/cli/node_modules/@wp-playground/wordpress/index.js b/apps/studio/out/Studio-darwin-arm64/Studio.app/Contents/Resources/cli/node_modules/@wp-playground/wordpress/index.js
+--- a/apps/studio/out/Studio-darwin-arm64/Studio.app/Contents/Resources/cli/node_modules/@wp-playground/wordpress/index.js
++++ b/apps/studio/out/Studio-darwin-arm64/Studio.app/Contents/Resources/cli/node_modules/@wp-playground/wordpress/index.js
+@@ -3131,6 +3131,6 @@ async function O(e) {
+   const t = await N(
+     e,
+     {
+-      disable_functions: "fsockopen,pfsockopen,curl_init,curl_exec,curl_multi_exec",
++      disable_functions: "fsockopen,pfsockopen,curl_init,curl_exec,curl_multi_exec,mail",
+       allow_url_fopen: "0"
+     },
+     async () => await e.request({

--- a/Automattic/studio/overlays/studio/fresh-install-mode.patch
+++ b/Automattic/studio/overlays/studio/fresh-install-mode.patch
@@ -1,0 +1,13 @@
+diff --git a/apps/studio/out/Studio-darwin-arm64/Studio.app/Contents/Resources/cli/playground-server-child.mjs b/apps/studio/out/Studio-darwin-arm64/Studio.app/Contents/Resources/cli/playground-server-child.mjs
+index 0000000..0000000 100644
+--- a/apps/studio/out/Studio-darwin-arm64/Studio.app/Contents/Resources/cli/playground-server-child.mjs
++++ b/apps/studio/out/Studio-darwin-arm64/Studio.app/Contents/Resources/cli/playground-server-child.mjs
+@@ -194,7 +194,7 @@ async function getWordPressInstallMode(sitePath) {
+     return "download-and-install";
+   }
+   if (hasSqlite) {
+-    return "install-from-existing-files-if-needed";
++    return "install-from-existing-files";
+   }
+   return "do-not-attempt-installing";
+ }

--- a/Automattic/studio/rigs/studio/rig.json
+++ b/Automattic/studio/rigs/studio/rig.json
@@ -63,7 +63,42 @@
     "nodejs": [
       {
         "path": "${package.root}/bench/studio-app-create-site.trace.mjs",
-        "check_groups": []
+        "check_groups": [],
+        "trace_default_phase_preset": "create-site",
+        "trace_phase_presets": {
+          "create-site": [
+            "start:scenario.start",
+            "launch:desktop.app_launch_start",
+            "window:desktop.first_window.ready",
+            "submit:ui.create_site.submit_clicked",
+            "copy_wp:cli.copying_bundled_wordpress",
+            "sqlite:cli.setting_up_sqlite_integration",
+            "daemon:cli.starting_process_daemon",
+            "pg_start:playground.run_cli.start",
+            "pg_bound:playground.server.bound",
+            "workers_ready:playground.workers.all.await.ready",
+            "wp_boot_start:playground.wordpress.boot.start",
+            "wp_boot_ready:playground.wordpress.boot.ready",
+            "blueprint_ready:playground.blueprint.run.ready",
+            "pg_ready:playground.run_cli.ready",
+            "running_event:renderer.site_running_event_received",
+            "dom_running:renderer.dom_status_running_seen",
+            "http_ready:probe.http_ready",
+            "running_state:probe.site_details_running_true",
+            "ui_running:ui.site.running_visible"
+          ],
+          "wordpress-boot": [
+            "boot_start:wordpress_boot.boot_wordpress.start",
+            "wp_config:wordpress_boot.wp_config.ensure.ready",
+            "db_prereqs:wordpress_boot.database.prerequisites.ready",
+            "installed_check:wordpress_boot.wordpress.installed_check.ready",
+            "install_request:wordpress_boot.install.request.ready",
+            "install_verify:wordpress_boot.install.verify.ready",
+            "install_permalink:wordpress_boot.install.permalink.ready",
+            "db_validate:wordpress_boot.database.validate.ready",
+            "boot_ready:wordpress_boot.boot_wordpress.ready"
+          ]
+        }
       }
     ]
   },

--- a/Automattic/studio/rigs/studio/rig.json
+++ b/Automattic/studio/rigs/studio/rig.json
@@ -97,10 +97,191 @@
             "install_permalink:wordpress_boot.install.permalink.ready",
             "db_validate:wordpress_boot.database.validate.ready",
             "boot_ready:wordpress_boot.boot_wordpress.ready"
+          ],
+          "wordpress-boot-steps": [
+            "wp_config_start:wordpress_boot.wp_config.ensure.start",
+            "wp_config_ready:wordpress_boot.wp_config.ensure.ready",
+            "db_prereqs_start:wordpress_boot.database.prerequisites.start",
+            "db_prereqs_ready:wordpress_boot.database.prerequisites.ready",
+            "installed_check_start:wordpress_boot.wordpress.installed_check.start",
+            "installed_check_ready:wordpress_boot.wordpress.installed_check.ready",
+            "install_request_start:wordpress_boot.install.request.start",
+            "install_request_ready:wordpress_boot.install.request.ready",
+            "install_verify_start:wordpress_boot.install.verify.start",
+            "install_verify_ready:wordpress_boot.install.verify.ready",
+            "install_permalink_start:wordpress_boot.install.permalink.start",
+            "install_permalink_ready:wordpress_boot.install.permalink.ready",
+            "db_validate_start:wordpress_boot.database.validate.start",
+            "db_validate_ready:wordpress_boot.database.validate.ready"
           ]
-        }
+        },
+        "trace_span_metadata": {
+          "phase.launch_to_window": {
+            "critical": true,
+            "blocking": true,
+            "prewarmable": true,
+            "blocks": "first_window_ready",
+            "category": "app_launch"
+          },
+          "phase.submit_to_copy_wp": {
+            "critical": true,
+            "blocking": true,
+            "cacheable": true,
+            "blocks": "site_running_visible",
+            "category": "site_materialization"
+          },
+          "phase.copy_wp_to_sqlite": {
+            "critical": true,
+            "blocking": true,
+            "cacheable": true,
+            "blocks": "site_running_visible",
+            "category": "site_materialization"
+          },
+          "phase.sqlite_to_daemon": {
+            "critical": true,
+            "blocking": true,
+            "prewarmable": true,
+            "blocks": "site_running_visible",
+            "category": "daemon_start"
+          },
+          "phase.daemon_to_pg_start": {
+            "critical": true,
+            "blocking": true,
+            "prewarmable": true,
+            "blocks": "site_running_visible",
+            "category": "daemon_start"
+          },
+          "phase.pg_bound_to_workers_ready": {
+            "critical": true,
+            "blocking": true,
+            "prewarmable": true,
+            "blocks": "site_running_visible",
+            "category": "playground_runtime"
+          },
+          "phase.wp_boot_start_to_wp_boot_ready": {
+            "critical": true,
+            "blocking": true,
+            "cacheable": true,
+            "blocks": "site_running_visible",
+            "category": "wordpress_boot"
+          },
+          "phase.wp_boot_ready_to_blueprint_ready": {
+            "critical": true,
+            "blocking": true,
+            "deferrable": true,
+            "blocks": "site_running_visible",
+            "category": "blueprint_finalize"
+          },
+          "phase.pg_ready_to_running_event": {
+            "critical": true,
+            "blocking": true,
+            "deferrable": true,
+            "blocks": "site_running_visible",
+            "category": "state_propagation"
+          },
+          "phase.total": {
+            "critical": true,
+            "blocking": true,
+            "blocks": "site_running_visible",
+            "category": "wordpress_boot"
+          },
+          "phase.wp_config_start_to_wp_config_ready": {
+            "critical": true,
+            "blocking": true,
+            "cacheable": true,
+            "blocks": "wordpress_boot_ready",
+            "category": "wordpress_config"
+          },
+          "phase.installed_check_start_to_installed_check_ready": {
+            "critical": true,
+            "blocking": true,
+            "cacheable": true,
+            "blocks": "wordpress_boot_ready",
+            "category": "install_state"
+          },
+          "phase.install_request_start_to_install_request_ready": {
+            "critical": true,
+            "blocking": true,
+            "cacheable": true,
+            "blocks": "wordpress_boot_ready",
+            "category": "wordpress_install"
+          },
+          "phase.install_verify_start_to_install_verify_ready": {
+            "critical": true,
+            "blocking": true,
+            "deferrable": true,
+            "blocks": "wordpress_boot_ready",
+            "category": "install_verification"
+          },
+          "phase.install_permalink_start_to_install_permalink_ready": {
+            "critical": true,
+            "blocking": true,
+            "deferrable": true,
+            "blocks": "wordpress_boot_ready",
+            "category": "permalink_setup"
+          },
+          "phase.db_validate_start_to_db_validate_ready": {
+            "critical": true,
+            "blocking": true,
+            "deferrable": true,
+            "blocks": "wordpress_boot_ready",
+            "category": "database_validation"
+          }
+        },
+        "trace_guardrails": [
+          {
+            "label": "packaged Studio app exists",
+            "file": "${components.studio.path}/apps/studio/out/Studio-darwin-arm64/Studio.app/Contents/Resources/cli/playground-server-child.mjs"
+          },
+          {
+            "label": "packaged Playground bundle exists",
+            "file": "${components.studio.path}/apps/studio/out/Studio-darwin-arm64/Studio.app/Contents/Resources/cli/node_modules/@wp-playground/wordpress/index.js"
+          }
+        ]
       }
     ]
+  },
+
+  "trace_variants": {
+    "fresh-install-mode": {
+      "component": "studio",
+      "overlay": "overlays/studio/fresh-install-mode.patch"
+    },
+    "add-mail-disable-function": {
+      "component": "studio",
+      "overlay": "overlays/studio/add-mail-disable-function.patch"
+    },
+    "combined-fast-create-site": {
+      "overlays": [
+        {
+          "component": "studio",
+          "overlay": "overlays/studio/fresh-install-mode.patch"
+        },
+        {
+          "component": "studio",
+          "overlay": "overlays/studio/add-mail-disable-function.patch"
+        }
+      ]
+    }
+  },
+
+  "trace_experiments": {
+    "diagnostic-seeded-sqlite-db": {
+      "setup": [
+        {
+          "command": "test -f /tmp/studio-template-probe/seed.ht.sqlite"
+        }
+      ],
+      "env": {
+        "STUDIO_TRACE_SEED_DB_PATH": "/tmp/studio-template-probe/seed.ht.sqlite"
+      },
+      "artifacts": [
+        {
+          "label": "diagnostic seed SQLite DB",
+          "path": "/tmp/studio-template-probe/seed.ht.sqlite"
+        }
+      ]
+    }
   },
 
   "pipeline": {


### PR DESCRIPTION
## Summary
- Expand Studio create-site trace capture with renderer state events, Studio failure detection, HTTP surface checks, and optional seed database capture.
- Add trace phase presets, span metadata, guardrails, and trace variants for packaged Studio create-site experiments.
- Add design fingerprint metrics to the Studio site-build benchmark for prompt/design distribution analysis.

## Validation
- Not rerun for this PR; these were existing local commits being surfaced as requested.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Preparing the PR from existing local commits and drafting this description; Chris remains responsible for review and validation.