### PR TITLE
Expand Studio site-build prompt corpus

### DIFF
--- a/Automattic/studio/bench/prompts/site-build/artist-music.md
+++ b/Automattic/studio/bench/prompts/site-build/artist-music.md
@@ -1,0 +1,5 @@
+I need a site for Mara Vale, an independent singer-songwriter releasing a new EP and booking a small run of house shows and listening-room dates.
+
+The site should introduce the artist, feature the new release, list tour dates, include a press quote, embed or describe music links, offer merch, collect fan emails, and make booking or press contact easy to find.
+
+Please build it in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/course-education.md
+++ b/Automattic/studio/bench/prompts/site-build/course-education.md
@@ -1,0 +1,5 @@
+Please build a course website for Practical Grant Writing, a six-week online class for nonprofit staff who need to write clearer proposals and budgets.
+
+The site should explain who the course is for, what students will learn each week, who teaches it, how live sessions and recordings work, pricing, scholarships, student outcomes, and how to enroll.
+
+Please build it in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/documentation-knowledge-base.md
+++ b/Automattic/studio/bench/prompts/site-build/documentation-knowledge-base.md
@@ -1,0 +1,5 @@
+I need a documentation and support site for PocketRoute, a route planning app used by small delivery teams.
+
+The homepage should help customers find answers fast. Include a search-focused hero, getting started links, grouped help topics, a few popular troubleshooting articles, release notes, contact support details, and a small section for developer API docs.
+
+Please build it in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/editorial-magazine.md
+++ b/Automattic/studio/bench/prompts/site-build/editorial-magazine.md
@@ -1,0 +1,5 @@
+I need a homepage for The Ledger Room, a small independent magazine covering city politics, food, arts, and neighborhood history in Milwaukee.
+
+Make it feel like a real publication people would return to every week. It should have a strong lead story, a few article sections, contributor bylines, newsletter signup, a simple membership ask, and space for a podcast or events listing.
+
+Please build it in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/event-conference.md
+++ b/Automattic/studio/bench/prompts/site-build/event-conference.md
@@ -1,0 +1,5 @@
+I am organizing Field Notes Live, a two-day conference for outdoor educators, trail groups, park staff, and conservation nonprofits.
+
+I need a site that explains the theme, makes the dates and location obvious, shows a practical schedule, highlights speakers, covers ticket options, answers basic travel questions, and gives sponsors a reason to get involved.
+
+Please build it in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/local-service-business.md
+++ b/Automattic/studio/bench/prompts/site-build/local-service-business.md
@@ -1,0 +1,5 @@
+Please build a website for Northline Plumbing & Heating, a family-run company that handles emergency repairs, water heaters, boiler maintenance, and bathroom rough-ins around Grand Rapids.
+
+The site needs to help a homeowner quickly understand what we do, where we work, why we are trustworthy, and how to call or request a visit. Include service areas, common services, reviews, emergency availability, licensing info, and a contact form section.
+
+Please build it in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/membership-community.md
+++ b/Automattic/studio/bench/prompts/site-build/membership-community.md
@@ -1,0 +1,5 @@
+Can you build a website for Common Table, a neighborhood membership club for people who host potlucks, skill shares, reading groups, and volunteer days?
+
+The site should explain what members get, show upcoming gatherings, introduce the organizers, include a few member stories, list membership levels, and make it easy to join or ask questions.
+
+Please build it in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/nonprofit-campaign.md
+++ b/Automattic/studio/bench/prompts/site-build/nonprofit-campaign.md
@@ -1,0 +1,5 @@
+We need a campaign site for Keep the Library Open, a local effort asking residents to support a library funding measure before the June vote.
+
+The page should explain what is at stake, give a few clear facts, show who supports the campaign, answer common voter questions, include volunteer and donation actions, and make the election date impossible to miss.
+
+Please build it in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/product-catalog.md
+++ b/Automattic/studio/bench/prompts/site-build/product-catalog.md
@@ -1,0 +1,5 @@
+I need a simple catalog website for Hollow & Grain, a small workshop selling handmade cutting boards, serving trays, spice racks, and custom kitchen pieces.
+
+Please show product categories, a few featured products with prices and short descriptions, custom order information, shipping or pickup notes, care instructions, customer photos, and a way to inquire about an item.
+
+Please build it in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/realistic-small-business.md
+++ b/Automattic/studio/bench/prompts/site-build/realistic-small-business.md
@@ -1,0 +1,5 @@
+I need a website for Juniper Lane, a small plant shop and gift store that also hosts repotting clinics and seasonal wreath workshops.
+
+Please make the site useful for real customers: hours, location, what we sell, upcoming workshops, a few staff picks, plant care advice, private event info, and a clear way to call or sign up for the newsletter.
+
+Please build it in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -13,6 +13,25 @@ const PROMPT_VARIANT_SETTING = 'studio_site_build_prompt_variant';
 const PROMPT_FILE_SETTING = 'studio_site_build_prompt_file';
 const DEFAULT_PROMPT_VARIANT = 'studio-code';
 const PROMPT_CATEGORY = 'site-build';
+const PROMPT_VARIANTS = [
+  'artist-music',
+  'course-education',
+  'documentation-knowledge-base',
+  'editorial-magazine',
+  'event-conference',
+  'local-service-business',
+  'membership-community',
+  'nonprofit',
+  'nonprofit-campaign',
+  'portfolio',
+  'product-catalog',
+  'radical-speed-month',
+  'restaurant',
+  'saas',
+  'realistic-small-business',
+  'studio-code',
+  'wordpress-is-dead',
+];
 const SYSTEM_PROMPT_FILES = ['apps/cli/ai/system-prompt.ts'];
 const requireFromBench = createRequire(import.meta.url);
 const VISUAL_VIEWPORT = { width: 1440, height: 1100 };
@@ -119,13 +138,32 @@ function promptVariant() {
   return setting(PROMPT_VARIANT_SETTING) || DEFAULT_PROMPT_VARIANT;
 }
 
-async function availablePromptVariants() {
+export async function availablePromptVariants() {
+  await validatePromptVariantCatalog();
+  return [...PROMPT_VARIANTS];
+}
+
+export async function validatePromptVariantCatalog() {
   const promptsDir = new URL('./prompts/site-build/', import.meta.url);
   const entries = await readdir(promptsDir, { withFileTypes: true });
-  return entries
+  const files = entries
     .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
     .map((entry) => entry.name.replace(/\.md$/, ''))
     .sort();
+
+  const registered = [...PROMPT_VARIANTS].sort();
+  const missingFiles = registered.filter((variantName) => !files.includes(variantName));
+  const unregisteredFiles = files.filter((variantName) => !registered.includes(variantName));
+
+  if (missingFiles.length || unregisteredFiles.length) {
+    throw new Error(
+      `Studio site-build prompt catalog mismatch. Missing files: ${
+        missingFiles.join(', ') || 'none'
+      }. Unregistered files: ${unregisteredFiles.join(', ') || 'none'}.`
+    );
+  }
+
+  return registered;
 }
 
 async function promptTemplatePath() {
@@ -138,11 +176,15 @@ async function promptTemplatePath() {
   if (!/^[a-z0-9][a-z0-9-]*$/.test(variantName)) {
     throw new Error(`Invalid ${PROMPT_VARIANT_SETTING}: ${variantName}`);
   }
+  if (!PROMPT_VARIANTS.includes(variantName)) {
+    const variants = await availablePromptVariants();
+    throw new Error(`Unknown ${PROMPT_VARIANT_SETTING}: ${variantName}. Available variants: ${variants.join(', ')}.`);
+  }
 
   return new URL(`./prompts/site-build/${variantName}.md`, import.meta.url);
 }
 
-async function siteBuildPrompt(sitePath) {
+export async function siteBuildPrompt(sitePath) {
   const promptPath = await promptTemplatePath();
   let template;
   try {


### PR DESCRIPTION
## Summary
- Add 10 realistic Studio site-build prompt variants covering editorial, service business, events, docs, membership, catalog, music, campaign, course, and small-business sites.
- Register site-build prompt variants in the benchmark harness instead of relying only on directory discovery.
- Add lightweight catalog validation so selected variants must be registered and backed by prompt files.

## Validation
- `node --check Automattic/studio/bench/studio-agent-site-build.bench.mjs`
- `HOMEBOY_COMPONENT_PATH=/tmp node --input-type=module -e "const mod = await import('./Automattic/studio/bench/studio-agent-site-build.bench.mjs'); const variants = await mod.availablePromptVariants(); for (const variant of variants) { process.env.HOMEBOY_SETTINGS_JSON = JSON.stringify({ studio_site_build_prompt_variant: variant }); const prompt = await mod.siteBuildPrompt('/tmp/studio-site'); if (!prompt.includes('/tmp/studio-site')) throw new Error('site path not substituted for ' + variant); } console.log('validated prompt variants:', variants.join(', '));"`

Closes #30.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the prompt corpus additions, benchmark harness registration, lightweight validation, and PR description; Chris remains responsible for review and merge.