### PR TITLE
Preserve local Studio rig defaults

### DIFF
--- a/Automattic/studio/bench/studio-agent-site-info.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-info.bench.mjs
@@ -61,7 +61,7 @@ function metric(value) {
 }
 
 export default async function studioAgentSiteInfoBench() {
-  const siteName = process.env.STUDIO_SITE_INFO_BENCH_SITE || 'homeboy-bench-site';
+  const siteName = process.env.STUDIO_SITE_INFO_BENCH_SITE || 'intelligence-chubes4';
   const prompt = `Use only the Studio site_info tool for the site named ${siteName}, then answer with its running status in one sentence. Do not use any other tools.`;
   const started = Date.now();
   const { result, resultFile, exitCode, stderr } = await runEval(prompt, {

--- a/Automattic/studio/rigs/studio/rig.json
+++ b/Automattic/studio/rigs/studio/rig.json
@@ -356,6 +356,12 @@
             "file_mtime": "${components.studio.path}/apps/cli/dist/cli/main.mjs"
           }
         }
+      },
+      {
+        "kind": "check",
+        "label": "Live proc_open end-to-end (the truth)",
+        "command": "site_path=${STUDIO_PROC_OPEN_CHECK_SITE_PATH:-$HOME/Studio/intelligence-chubes4}; rm -f /tmp/_studio_rig_check_marker && out=$(studio wp --path \"$site_path\" eval '$h = proc_open(\"touch /tmp/_studio_rig_check_marker && echo ok\", [1=>[\"pipe\",\"w\"]], $p); if (is_resource($h)) { echo stream_get_contents($p[1]); proc_close($h); } sleep(1);' 2>&1 | tail -1) && test -f /tmp/_studio_rig_check_marker && echo \"$out\" | grep -q ok",
+        "expect_exit": 0
       }
     ],
 


### PR DESCRIPTION
## Summary
- Restore the Studio proc_open check removed during public-surface cleanup, while making its site path overrideable with `STUDIO_PROC_OPEN_CHECK_SITE_PATH`.
- Keep the existing `studio-agent-site-info` bench default site name so Chris's current local benchmark workflow remains unchanged, while preserving the `STUDIO_SITE_INFO_BENCH_SITE` override for other environments.

## Verification
- `node -e "const fs=require('fs'); for (const f of ['Automattic/studio/rigs/studio/rig.json','Automattic/studio/rigs/studio-bfb/rig.json','Automattic/studio/rigs/studio-agent-sdk/rig.json','Automattic/studio/rigs/studio-agent-pi/rig.json','WordPress/wordpress-playground/stacks/playground-combined.json','chubes4/isolated-block-editor/rigs/isolated-block-editor/rig.json']) JSON.parse(fs.readFileSync(f,'utf8')); console.log('json ok')"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Adjusting the cleanup follow-up to preserve existing local Studio rig defaults while adding public-friendly env overrides, validating JSON, and drafting this PR.