### PR TITLE
fix(studio): ignore benign site-build detector drift

### DIFF
--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -680,6 +680,9 @@ function visualMismatchReason(sourceSelector, frontendSelector) {
   if (sourceSelector?.error || frontendSelector?.error) {
     return 'selector_error';
   }
+  if (sourceSelector.visible_count === 0 && frontendSelector.visible_count === 0) {
+    return 'missing_on_both_surfaces';
+  }
   if (sourceSelector.count === 0 && frontendSelector.count === 0) {
     return 'missing_on_both_surfaces';
   }
@@ -1499,6 +1502,20 @@ function semanticHasMaterialRepeatedDelta(sourceCount, frontendCount) {
   return Math.abs(sourceCount - frontendCount) >= Math.max(3, Math.ceil(sourceCount * 0.35));
 }
 
+function semanticAllowsNavigationClassRoleChange(sourceOwner, frontendOwner) {
+  const sourceRole = semanticRole(sourceOwner);
+  const frontendRole = semanticRole(frontendOwner);
+  const key = semanticPrimaryClassKey(sourceOwner);
+  if (!/nav|menu/i.test(key) || !['group', 'list'].includes(sourceRole) || frontendRole !== 'nav') {
+    return false;
+  }
+
+  return (
+    Number(sourceOwner.clickable_descendant_count || 0) === Number(frontendOwner.clickable_descendant_count || 0) &&
+    semanticTextTokens(sourceOwner.text).every((token) => new Set(semanticTextTokens(frontendOwner.text)).has(token))
+  );
+}
+
 function semanticMismatch(type, reason, source, frontend, extra = {}) {
   return {
     type,
@@ -1577,7 +1594,11 @@ function compareSemanticFingerprints(source, frontend) {
       continue;
     }
 
-    if (roleChanged && (sourceInteractive || frontendInteractive || sourceOwner.concept || frontendOwner.concept)) {
+    if (
+      roleChanged &&
+      !semanticAllowsNavigationClassRoleChange(sourceOwner, frontendOwner) &&
+      (sourceInteractive || frontendInteractive || sourceOwner.concept || frontendOwner.concept)
+    ) {
       counts.role_mismatch_count++;
       counts.class_owner_changed_count++;
       mismatches.push(


### PR DESCRIPTION
## Summary
- Treat non-visible selector matches on both visual comparison surfaces as absent rather than visual mismatches.
- Allow static `nav`/`menu` list wrappers to become WordPress navigation blocks when link count and text are preserved.

## Why
The Studio Static Site Importer benchmark was flagging detector noise as fidelity drift: `ul.nav-links` becoming `core/navigation`, zero-height generated `header` wrappers, and hidden structural code selectors. These are not evidence of lost content or broken conversion when the visible output and interactions are preserved.

## Evidence
- Before the semantic adjustment, the RSM site-build run reported `semantic_dom_mismatch_count=1`, `semantic_role_mismatch_count=1`, and `semantic_class_owner_changed_count=1` for a preserved navigation link group.
- After the semantic adjustment, rerun `e1680f98-b1c0-4914-b588-62603f539086` reported all three semantic mismatch metrics as `0`.
- The final visual-comparator rerun was interrupted before completion, so the visual adjustment still needs a clean follow-up bench run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (`openai/gpt-5.5`)
- **Used for:** Diagnosed the benchmark artifact drift, drafted the detector calibration, and prepared this PR under Chris's direction.