### PR TITLE
feat(studio): add project site-build prompts

### DIFF
--- a/Automattic/studio/bench/prompts/site-build/data-machine.md
+++ b/Automattic/studio/bench/prompts/site-build/data-machine.md
@@ -1,0 +1,7 @@
+Build a one-page landing page for Data Machine, a WordPress operations engine for AI-powered content workflows, site health checks, automation pipelines, agent memory, chat, email, and WP-CLI orchestration.
+
+Make the page feel like WordPress grew an operating layer: pipelines that schedule themselves, handlers that process real content, memory that persists across agents, dashboards for queue health, and tools for SEO, images, links, analytics, and system diagnostics. Include a hero, workflow diagram section, capability grid, automation examples, reliability/evidence section, and a final call to action for site owners and developers.
+
+Use normal semantic HTML and CSS. Studio should import the result into clean editable WordPress blocks through the Static Site Importer workflow.
+
+Work in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/homeboy.md
+++ b/Automattic/studio/bench/prompts/site-build/homeboy.md
@@ -1,0 +1,7 @@
+Build a sharp one-page landing page for Homeboy, a developer operations system that turns local repos, rigs, benchmarks, traces, reviews, dependency updates, and release workflows into one repeatable command surface.
+
+Make it feel like a serious engineering power tool, not a generic SaaS template. Show how a solo engineer with AI coding agents can operate like a much larger team: reproducible rigs, benchmark evidence, trace diagnostics, structured observations, safer git workflows, and PR-ready reports. Include sections for the command surface, automation loop, evidence artifacts, team leverage, and a confident call to action.
+
+Use normal semantic HTML and CSS. Studio should import the result into clean editable WordPress blocks through the Static Site Importer workflow.
+
+Work in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/intelligence.md
+++ b/Automattic/studio/bench/prompts/site-build/intelligence.md
@@ -1,0 +1,7 @@
+Build a one-page landing page for Intelligence, a personal WordPress-based work intelligence agent that turns memory, wiki knowledge, Slack, GitHub, Linear, YouTube, and source repositories into a searchable second brain.
+
+Make the page feel thoughtful, fast, and personal: an agent that remembers context, finds answers across work systems, builds wiki pages, creates briefings, tracks unresolved asks, and helps a human navigate a complex workday. Include a hero, source map, wiki/second-brain section, daily briefing section, automation examples, privacy/control section, and a warm call to action.
+
+Use normal semantic HTML and CSS. Studio should import the result into clean editable WordPress blocks through the Static Site Importer workflow.
+
+Work in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/wp-coding-agents.md
+++ b/Automattic/studio/bench/prompts/site-build/wp-coding-agents.md
@@ -1,0 +1,7 @@
+Build a one-page landing page for WP Coding Agents, a self-hostable WordPress + coding-agent environment that gives developers isolated worktrees, agent instructions, GitHub workflows, PR review loops, persistent memory, and Discord-based collaboration.
+
+Make it feel like a practical workshop for shipping WordPress code with AI teammates. Show the path from a live Studio or VPS install to cloned workspaces, focused worktree sessions, evidence capture, commits, PRs, and cleanup. Include sections for setup, isolated workspaces, minion sessions, GitHub integration, safety rules, and examples of parallel agent work.
+
+Use normal semantic HTML and CSS. Studio should import the result into clean editable WordPress blocks through the Static Site Importer workflow.
+
+Work in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -16,9 +16,12 @@ const PROMPT_CATEGORY = 'site-build';
 const PROMPT_VARIANTS = [
   'artist-music',
   'course-education',
+  'data-machine',
   'documentation-knowledge-base',
   'editorial-magazine',
   'event-conference',
+  'homeboy',
+  'intelligence',
   'local-service-business',
   'membership-community',
   'nonprofit',
@@ -30,6 +33,7 @@ const PROMPT_VARIANTS = [
   'saas',
   'realistic-small-business',
   'studio-code',
+  'wp-coding-agents',
   'wordpress-is-dead',
 ];
 const SYSTEM_PROMPT_FILES = ['apps/cli/ai/system-prompt.ts'];
@@ -1008,7 +1012,21 @@ function visualParity(sourceGroups, frontendGroups) {
   };
 }
 
-function emptyVisualComparison(error = '') {
+async function emptyVisualComparison(artifactDir, error = '') {
+  const visualDir = path.join(artifactDir, 'visual-comparisons');
+  await mkdir(visualDir, { recursive: true });
+  const diagnosticsPath = path.join(visualDir, 'visual-comparison-mismatches.json');
+  const diagnostics = {
+    artifact: diagnosticsPath,
+    mismatch_count: 0,
+    optional_probe_absent_count: 0,
+    top_failing_groups: [],
+    targets: [],
+    mismatches: [],
+    optional_probe_absences: [],
+  };
+  await writeFile(diagnosticsPath, JSON.stringify(diagnostics, null, 2));
+
   return {
     target_count: 0,
     checked_target_count: 0,
@@ -1023,24 +1041,18 @@ function emptyVisualComparison(error = '') {
     hero_probe_parity_mismatch_count: 0,
     surfaces: ['source_static', 'wordpress_frontend'],
     editor_surface_ready: true,
+    artifact_dir: visualDir,
+    diagnostics_artifact: diagnosticsPath,
     error,
     results: [],
-    diagnostics: {
-      artifact: '',
-      mismatch_count: 0,
-      optional_probe_absent_count: 0,
-      top_failing_groups: [],
-      targets: [],
-      mismatches: [],
-      optional_probe_absences: [],
-    },
+    diagnostics,
   };
 }
 
 async function compareVisualFidelity(importReport, artifactDir, sitePath) {
   const targets = comparisonTargets(importReport);
   if (!targets.length) {
-    return emptyVisualComparison(importReport?.error || 'No visual fidelity comparison targets found.');
+    return emptyVisualComparison(artifactDir, importReport?.error || 'No visual fidelity comparison targets found.');
   }
 
   const playwrightPackage = path.join(STUDIO_PATH, 'node_modules/@playwright/test');
@@ -1113,7 +1125,7 @@ async function compareVisualFidelity(importReport, artifactDir, sitePath) {
       results.push(result);
     }
   } catch (error) {
-    return emptyVisualComparison(`Visual comparison failed: ${error instanceof Error ? error.message : String(error)}`);
+    return emptyVisualComparison(artifactDir, `Visual comparison failed: ${error instanceof Error ? error.message : String(error)}`);
   } finally {
     if (browser) {
       await browser.close();


### PR DESCRIPTION
## Summary
- Adds Data Machine, Homeboy, Intelligence, and WP Coding Agents site-build prompt variants.
- Registers the new variants in the Studio site-build benchmark prompt list.
- Writes an empty visual diagnostics artifact when visual comparison cannot run, so downstream artifact consumers still have a stable file path and shape.

## Notes
- This packages the remaining dirty rig work from the Studio Static Site Importer benchmark iteration.
- The earlier detector calibration was split into and merged via #40.

## Tests
- Not run; packaging existing dirty rig work as requested.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (`openai/gpt-5.5`)
- **Used for:** Packaged the existing dirty rig changes, reviewed the diff for secrets, committed, and drafted this PR body under Chris's direction.