### PR TITLE
feat(studio): track cross-run design repetition in site-build bench

### DIFF
--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -2597,6 +2597,422 @@ async function collectDesignFingerprint(sitePath) {
   };
 }
 
+const DESIGN_NOVELTY_DEFAULT_THRESHOLD = 0.7;
+const DESIGN_NOVELTY_DEFAULT_MAX_PRIORS = 20;
+const DESIGN_NOVELTY_TOP_MATCHES = 5;
+const DESIGN_NOVELTY_RECIPE_FLAGS = [
+  'design_uses_dark_base',
+  'design_uses_purple_lime',
+  'design_uses_cards_grid',
+  'design_uses_bento_grid',
+  'design_uses_glow_overlay',
+  'design_uses_marquee',
+  'design_uses_terminal_window',
+  'design_uses_inter',
+  'design_uses_syne',
+  'design_uses_space_grotesk',
+  'design_hero_grid_background_present',
+];
+
+function jaccard(setA, setB) {
+  if (!(setA instanceof Set) || !(setB instanceof Set)) {
+    return 0;
+  }
+  if (setA.size === 0 && setB.size === 0) {
+    return 0;
+  }
+  let intersection = 0;
+  for (const value of setA) {
+    if (setB.has(value)) {
+      intersection += 1;
+    }
+  }
+  const union = setA.size + setB.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+function tokenizeRepetitionSignature(signature) {
+  if (typeof signature !== 'string' || signature.length === 0) {
+    return new Set();
+  }
+  return new Set(
+    signature
+      .split('|')
+      .map((token) => token.trim().toLowerCase())
+      .filter(Boolean)
+  );
+}
+
+function fingerprintRecipeFlags(metrics) {
+  const flags = new Set();
+  if (!metrics || typeof metrics !== 'object') {
+    return flags;
+  }
+  for (const flag of DESIGN_NOVELTY_RECIPE_FLAGS) {
+    if (Number(metrics[flag]) === 1) {
+      flags.add(flag);
+    }
+  }
+  return flags;
+}
+
+function fingerprintMotifSet(fingerprint) {
+  return new Set(
+    Array.isArray(fingerprint?.motifs)
+      ? fingerprint.motifs.map((motif) => String(motif).toLowerCase())
+      : []
+  );
+}
+
+function fingerprintPaletteSet(fingerprint) {
+  return new Set(
+    Array.isArray(fingerprint?.palette_labels)
+      ? fingerprint.palette_labels.map((label) => String(label).toLowerCase())
+      : []
+  );
+}
+
+function priorRecipeFlags(prior) {
+  if (prior?.metrics && typeof prior.metrics === 'object') {
+    return fingerprintRecipeFlags(prior.metrics);
+  }
+  // Backfill from raw fingerprint when prior artifacts predate the metrics block.
+  const flags = new Set();
+  const fingerprint = prior?.designFingerprint || {};
+  const motifs = fingerprintMotifSet(fingerprint);
+  const palette = fingerprintPaletteSet(fingerprint);
+  const patterns = fingerprint?.patterns || {};
+  if (palette.has('dark_base') || fingerprint?.dark_theme) {
+    flags.add('design_uses_dark_base');
+  }
+  if (palette.has('purple_lime')) {
+    flags.add('design_uses_purple_lime');
+  }
+  if (motifs.has('cards_grid')) {
+    flags.add('design_uses_cards_grid');
+  }
+  if (motifs.has('bento_grid')) {
+    flags.add('design_uses_bento_grid');
+  }
+  if (motifs.has('glow_overlay')) {
+    flags.add('design_uses_glow_overlay');
+  }
+  if (motifs.has('marquee')) {
+    flags.add('design_uses_marquee');
+  }
+  if (motifs.has('terminal_window')) {
+    flags.add('design_uses_terminal_window');
+  }
+  const fonts = (fingerprint?.font_families || []).map((font) => String(font).toLowerCase());
+  if (fonts.includes('inter')) {
+    flags.add('design_uses_inter');
+  }
+  if (fonts.includes('syne')) {
+    flags.add('design_uses_syne');
+  }
+  if (fonts.includes('space grotesk')) {
+    flags.add('design_uses_space_grotesk');
+  }
+  if (patterns.hero_grid_background_present) {
+    flags.add('design_hero_grid_background_present');
+  }
+  return flags;
+}
+
+export function scoreDesignFingerprintAgainstPrior({
+  currentSignatureTokens,
+  currentMotifs,
+  currentPalette,
+  currentRecipeFlags,
+  currentTypePairing,
+  prior,
+}) {
+  const priorFingerprint = prior?.designFingerprint || {};
+  const priorPatterns = priorFingerprint?.patterns || {};
+  const priorTokens = tokenizeRepetitionSignature(priorPatterns.repetition_signature);
+  const priorMotifs = fingerprintMotifSet(priorFingerprint);
+  const priorPalette = fingerprintPaletteSet(priorFingerprint);
+  const priorFlags = priorRecipeFlags(prior);
+  const priorTypePairing = String(priorPatterns.type_pairing_signature || '').toLowerCase();
+
+  const tokenScore = jaccard(currentSignatureTokens, priorTokens);
+  const motifScore = jaccard(currentMotifs, priorMotifs);
+  const paletteScore = jaccard(currentPalette, priorPalette);
+  const recipeScore = jaccard(currentRecipeFlags, priorFlags);
+  const typeMatch =
+    currentTypePairing && priorTypePairing && currentTypePairing === priorTypePairing ? 1 : 0;
+
+  // Weighted combination — repetition tokens dominate, recipe flags reinforce,
+  // motif/palette/type pairing add nuance. Stays bounded in [0, 1].
+  const score =
+    tokenScore * 0.45 +
+    recipeScore * 0.2 +
+    motifScore * 0.15 +
+    paletteScore * 0.1 +
+    typeMatch * 0.1;
+
+  const sharedTokens = [...currentSignatureTokens].filter((token) => priorTokens.has(token)).sort();
+  const sharedMotifs = [...currentMotifs].filter((motif) => priorMotifs.has(motif)).sort();
+  const sharedPalette = [...currentPalette].filter((label) => priorPalette.has(label)).sort();
+  const sharedFlags = [...currentRecipeFlags].filter((flag) => priorFlags.has(flag)).sort();
+
+  return {
+    score,
+    component_scores: {
+      repetition_tokens: tokenScore,
+      recipe_flags: recipeScore,
+      motifs: motifScore,
+      palette_labels: paletteScore,
+      type_pairing: typeMatch,
+    },
+    shared: {
+      repetition_tokens: sharedTokens,
+      recipe_flags: sharedFlags,
+      motifs: sharedMotifs,
+      palette_labels: sharedPalette,
+      type_pairing_signature: typeMatch ? currentTypePairing : '',
+    },
+  };
+}
+
+export function summarizeDesignNoveltyAgainstPriors({
+  currentFingerprint,
+  currentMetrics,
+  priors = [],
+  threshold = DESIGN_NOVELTY_DEFAULT_THRESHOLD,
+  topMatches = DESIGN_NOVELTY_TOP_MATCHES,
+} = {}) {
+  const currentPatterns = currentFingerprint?.patterns || {};
+  const currentSignatureTokens = tokenizeRepetitionSignature(currentPatterns.repetition_signature);
+  const currentMotifs = fingerprintMotifSet(currentFingerprint);
+  const currentPalette = fingerprintPaletteSet(currentFingerprint);
+  const currentRecipeFlags = fingerprintRecipeFlags(currentMetrics);
+  const currentTypePairing = String(currentPatterns.type_pairing_signature || '').toLowerCase();
+
+  const empty = {
+    metrics: {
+      design_repetition_prior_run_count: 0,
+      design_repetition_match_count: 0,
+      design_repetition_max_score: 0,
+      design_repetition_mean_score: 0,
+      design_repetition_signal: 0,
+      design_repetition_recurring_motif_count: 0,
+      design_repetition_recurring_palette_count: 0,
+      design_repetition_recurring_recipe_flag_count: 0,
+      design_repetition_recurring_token_count: 0,
+      design_repetition_threshold: threshold,
+    },
+    diagnostics: {
+      threshold,
+      prompt_variant: '',
+      current: {
+        repetition_signature: currentPatterns.repetition_signature || '',
+        type_pairing_signature: currentPatterns.type_pairing_signature || '',
+        motifs: [...currentMotifs].sort(),
+        palette_labels: [...currentPalette].sort(),
+        recipe_flags: [...currentRecipeFlags].sort(),
+        repetition_tokens: [...currentSignatureTokens].sort(),
+      },
+      prior_run_count: 0,
+      matches: [],
+      top_matches: [],
+      recurring: {
+        repetition_tokens: [],
+        motifs: [],
+        palette_labels: [],
+        recipe_flags: [],
+      },
+    },
+  };
+
+  if (!Array.isArray(priors) || priors.length === 0) {
+    return empty;
+  }
+
+  const matches = [];
+  let scoreSum = 0;
+  let maxScore = 0;
+  // Recurrence counts: how many priors share each value with the current run.
+  const tokenRecurrence = new Map();
+  const motifRecurrence = new Map();
+  const paletteRecurrence = new Map();
+  const flagRecurrence = new Map();
+
+  for (const prior of priors) {
+    const detail = scoreDesignFingerprintAgainstPrior({
+      currentSignatureTokens,
+      currentMotifs,
+      currentPalette,
+      currentRecipeFlags,
+      currentTypePairing,
+      prior,
+    });
+
+    scoreSum += detail.score;
+    if (detail.score > maxScore) {
+      maxScore = detail.score;
+    }
+
+    for (const token of detail.shared.repetition_tokens) {
+      tokenRecurrence.set(token, (tokenRecurrence.get(token) || 0) + 1);
+    }
+    for (const motif of detail.shared.motifs) {
+      motifRecurrence.set(motif, (motifRecurrence.get(motif) || 0) + 1);
+    }
+    for (const label of detail.shared.palette_labels) {
+      paletteRecurrence.set(label, (paletteRecurrence.get(label) || 0) + 1);
+    }
+    for (const flag of detail.shared.recipe_flags) {
+      flagRecurrence.set(flag, (flagRecurrence.get(flag) || 0) + 1);
+    }
+
+    matches.push({
+      artifact: prior.artifact || '',
+      site_url: prior.siteUrl || '',
+      mtime_ms: Number(prior.mtimeMs || 0),
+      prompt_variant: prior.prompt_variant || '',
+      score: detail.score,
+      component_scores: detail.component_scores,
+      shared: detail.shared,
+      prior_repetition_signature:
+        prior.designFingerprint?.patterns?.repetition_signature || '',
+      prior_type_pairing_signature:
+        prior.designFingerprint?.patterns?.type_pairing_signature || '',
+    });
+  }
+
+  matches.sort((a, b) => b.score - a.score || b.mtime_ms - a.mtime_ms);
+  const matchCount = matches.filter((entry) => entry.score >= threshold).length;
+  const recurringTokens = [...tokenRecurrence.entries()]
+    .filter(([, count]) => count >= 2)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([value, count]) => ({ value, prior_count: count }));
+  const recurringMotifs = [...motifRecurrence.entries()]
+    .filter(([, count]) => count >= 2)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([value, count]) => ({ value, prior_count: count }));
+  const recurringPalette = [...paletteRecurrence.entries()]
+    .filter(([, count]) => count >= 2)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([value, count]) => ({ value, prior_count: count }));
+  const recurringFlags = [...flagRecurrence.entries()]
+    .filter(([, count]) => count >= 2)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([value, count]) => ({ value, prior_count: count }));
+
+  return {
+    metrics: {
+      design_repetition_prior_run_count: priors.length,
+      design_repetition_match_count: matchCount,
+      design_repetition_max_score: Number(maxScore.toFixed(4)),
+      design_repetition_mean_score: Number((scoreSum / priors.length).toFixed(4)),
+      design_repetition_signal: maxScore >= threshold ? 1 : 0,
+      design_repetition_recurring_motif_count: recurringMotifs.length,
+      design_repetition_recurring_palette_count: recurringPalette.length,
+      design_repetition_recurring_recipe_flag_count: recurringFlags.length,
+      design_repetition_recurring_token_count: recurringTokens.length,
+      design_repetition_threshold: threshold,
+    },
+    diagnostics: {
+      threshold,
+      prompt_variant: priors[0]?.prompt_variant || '',
+      current: {
+        repetition_signature: currentPatterns.repetition_signature || '',
+        type_pairing_signature: currentPatterns.type_pairing_signature || '',
+        motifs: [...currentMotifs].sort(),
+        palette_labels: [...currentPalette].sort(),
+        recipe_flags: [...currentRecipeFlags].sort(),
+        repetition_tokens: [...currentSignatureTokens].sort(),
+      },
+      prior_run_count: priors.length,
+      matches,
+      top_matches: matches.slice(0, Math.max(1, topMatches)),
+      recurring: {
+        repetition_tokens: recurringTokens,
+        motifs: recurringMotifs,
+        palette_labels: recurringPalette,
+        recipe_flags: recurringFlags,
+      },
+    },
+  };
+}
+
+export async function loadDesignNoveltyPriors({
+  artifactDir,
+  currentArtifactPath,
+  promptVariant,
+  maxPriors = DESIGN_NOVELTY_DEFAULT_MAX_PRIORS,
+} = {}) {
+  if (!artifactDir || !promptVariant) {
+    return [];
+  }
+  let entries;
+  try {
+    entries = await readdir(artifactDir);
+  } catch {
+    return [];
+  }
+  const candidates = [];
+  for (const entry of entries) {
+    if (!entry.startsWith('result-') || !entry.endsWith('.json')) {
+      continue;
+    }
+    const fullPath = path.join(artifactDir, entry);
+    if (currentArtifactPath && fullPath === currentArtifactPath) {
+      continue;
+    }
+    let stats;
+    try {
+      stats = await stat(fullPath);
+    } catch {
+      continue;
+    }
+    if (!stats.isFile()) {
+      continue;
+    }
+    candidates.push({ path: fullPath, mtimeMs: stats.mtimeMs });
+  }
+  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  const priors = [];
+  // Walk newest-first; take up to maxPriors that match the prompt variant.
+  // We bound by *scanned* count too, so a backlog of unrelated variants can
+  // never balloon I/O on a one-off run.
+  const scanCap = Math.max(maxPriors * 4, 40);
+  for (const candidate of candidates) {
+    if (priors.length >= maxPriors) {
+      break;
+    }
+    if (priors.length === 0 && candidates.indexOf(candidate) >= scanCap) {
+      break;
+    }
+    let raw;
+    try {
+      raw = await readFile(candidate.path, 'utf8');
+    } catch {
+      continue;
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    if (parsed?.prompt_variant !== promptVariant) {
+      continue;
+    }
+    priors.push({
+      artifact: candidate.path,
+      mtimeMs: candidate.mtimeMs,
+      prompt_variant: parsed.prompt_variant || '',
+      siteUrl: parsed.siteUrl || '',
+      designFingerprint: parsed.designFingerprint || null,
+      metrics: parsed.metrics || null,
+    });
+  }
+  return priors;
+}
+
 function designFingerprintMetrics(fingerprint) {
   const motifs = new Set(fingerprint?.motifs || []);
   const paletteLabels = new Set(fingerprint?.palette_labels || []);
@@ -2933,6 +3349,36 @@ function optionalArtifactPath(name, value) {
   return typeof value === 'string' && value.length > 0 ? { [name]: value } : {};
 }
 
+function clampNoveltyThreshold(raw) {
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    return DESIGN_NOVELTY_DEFAULT_THRESHOLD;
+  }
+  if (value <= 0) {
+    return 0;
+  }
+  if (value >= 1) {
+    return 1;
+  }
+  return value;
+}
+
+function clampNoveltyMaxPriors(raw) {
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isFinite(value) || value <= 0) {
+    return DESIGN_NOVELTY_DEFAULT_MAX_PRIORS;
+  }
+  return Math.min(value, 200);
+}
+
+function parseBooleanSetting(raw) {
+  if (typeof raw !== 'string') {
+    return false;
+  }
+  const value = raw.trim().toLowerCase();
+  return value === '1' || value === 'true' || value === 'yes' || value === 'on';
+}
+
 export default async function studioAgentSiteBuildBench() {
   const runtime = resolveBenchRuntime();
   const currentVariant = variant();
@@ -3037,6 +3483,43 @@ export default async function studioAgentSiteBuildBench() {
   const toolBreakdown = toolMetrics(result);
   const agentSucceeded = result.success === true && !result.error;
 
+  const designNoveltyThreshold = clampNoveltyThreshold(setting('studio_site_build_design_novelty_threshold'));
+  const designNoveltyMaxPriors = clampNoveltyMaxPriors(setting('studio_site_build_design_novelty_max_priors'));
+  const designNoveltyGateEnabled = parseBooleanSetting(setting('studio_site_build_design_novelty_gate'));
+  const designNoveltyPriors = await loadDesignNoveltyPriors({
+    artifactDir,
+    currentArtifactPath: artifactFile,
+    promptVariant: selectedPromptVariant,
+    maxPriors: designNoveltyMaxPriors,
+  });
+  const designNovelty = summarizeDesignNoveltyAgainstPriors({
+    currentFingerprint: designFingerprint,
+    currentMetrics: designMetrics,
+    priors: designNoveltyPriors,
+    threshold: designNoveltyThreshold,
+  });
+  let designNoveltyArtifactPath = '';
+  if (designNoveltyPriors.length > 0) {
+    designNoveltyArtifactPath = path.join(artifactDir, `design-novelty-${runId}.json`);
+    try {
+      await writeFile(
+        designNoveltyArtifactPath,
+        JSON.stringify(
+          {
+            run_id: runId,
+            prompt_variant: selectedPromptVariant,
+            current_artifact: artifactFile,
+            ...designNovelty.diagnostics,
+          },
+          null,
+          2
+        )
+      );
+    } catch {
+      designNoveltyArtifactPath = '';
+    }
+  }
+
   return {
     metrics: {
       success_rate: agentSucceeded ? 1 : 0,
@@ -3135,6 +3618,10 @@ export default async function studioAgentSiteBuildBench() {
       target_core_html_without_bfb_fallback: Number(quality.target_core_html_without_bfb_fallback || 0),
       serialized_block_comments: Number(quality.serialized_block_comments || 0),
       bfb_fallback_count: Number(quality.bfb_fallback_count || 0),
+      ...designNovelty.metrics,
+      design_novelty_gate_enabled: designNoveltyGateEnabled ? 1 : 0,
+      design_novelty_gate_failed:
+        designNoveltyGateEnabled && designNovelty.metrics.design_repetition_signal === 1 ? 1 : 0,
     },
     artifacts: {
       raw_result: artifactFile,
@@ -3146,6 +3633,7 @@ export default async function studioAgentSiteBuildBench() {
       ...optionalArtifactPath('semantic_fidelity', semanticComparison.artifact),
       ...optionalArtifactPath('semantic_comparison_dir', semanticComparison.artifact_dir),
       ...optionalArtifactPath('generated_theme_ux_gates', generatedThemeUxGates.artifact),
+      ...optionalArtifactPath('design_novelty', designNoveltyArtifactPath),
     },
     metadata: {
       benchmark_variant: currentVariant,
@@ -3159,6 +3647,7 @@ export default async function studioAgentSiteBuildBench() {
       design_type_pairing_signature: designFingerprint.patterns?.type_pairing_signature || '',
       design_repetition_signature: designFingerprint.patterns?.repetition_signature || '',
       design: designFingerprint,
+      design_novelty: designNovelty.diagnostics,
       ...systemPrompt,
     },
   };

--- a/Automattic/studio/bench/studio-agent-site-build.test.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.test.mjs
@@ -1,9 +1,43 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 
 process.env.HOMEBOY_COMPONENT_PATH ||= '/tmp/homeboy-rigs-test-component';
 
-const { hiddenEditorContentDiagnostics } = await import('./studio-agent-site-build.bench.mjs');
+const {
+  hiddenEditorContentDiagnostics,
+  scoreDesignFingerprintAgainstPrior,
+  summarizeDesignNoveltyAgainstPriors,
+  loadDesignNoveltyPriors,
+} = await import('./studio-agent-site-build.bench.mjs');
+
+function makeFingerprint(overrides = {}) {
+  return {
+    motifs: ['cards_grid', 'pricing'],
+    palette_labels: ['dark_base', 'purple_lime'],
+    font_families: ['Playfair Display', 'Libre Baskerville'],
+    dark_theme: true,
+    patterns: {
+      hero_grid_background_present: true,
+      type_pairing_signature: 'Playfair Display / Libre Baskerville',
+      repetition_signature:
+        'hero-grid-background|eyebrow-title-labels|type:playfair display / libre baskerville',
+    },
+    ...overrides,
+  };
+}
+
+function makeMetrics(overrides = {}) {
+  return {
+    design_uses_dark_base: 1,
+    design_uses_purple_lime: 1,
+    design_uses_cards_grid: 1,
+    design_hero_grid_background_present: 1,
+    ...overrides,
+  };
+}
 
 test('generated-theme UX gate accepts broad .reveal editor override for .reveal.hidden', () => {
   const diagnostics = hiddenEditorContentDiagnostics([
@@ -64,4 +98,211 @@ test('generated-theme UX gate does not accept narrower editor overrides for comp
 
   assert.equal(diagnostics.editor_override_rule_count, 1);
   assert.equal(diagnostics.missing_editor_override_count, 1);
+});
+
+test('design novelty summary returns zeroed metrics when there are no priors', () => {
+  const summary = summarizeDesignNoveltyAgainstPriors({
+    currentFingerprint: makeFingerprint(),
+    currentMetrics: makeMetrics(),
+    priors: [],
+    threshold: 0.7,
+  });
+
+  assert.equal(summary.metrics.design_repetition_prior_run_count, 0);
+  assert.equal(summary.metrics.design_repetition_match_count, 0);
+  assert.equal(summary.metrics.design_repetition_max_score, 0);
+  assert.equal(summary.metrics.design_repetition_signal, 0);
+  assert.equal(summary.metrics.design_repetition_threshold, 0.7);
+  assert.deepEqual(summary.diagnostics.matches, []);
+  assert.deepEqual(summary.diagnostics.recurring.repetition_tokens, []);
+});
+
+test('design novelty signal triggers when a near-identical prior exists', () => {
+  const current = makeFingerprint();
+  const priorFingerprint = makeFingerprint();
+  const summary = summarizeDesignNoveltyAgainstPriors({
+    currentFingerprint: current,
+    currentMetrics: makeMetrics(),
+    priors: [
+      {
+        artifact: '/tmp/result-prior.json',
+        mtimeMs: 1,
+        prompt_variant: 'event-conference',
+        designFingerprint: priorFingerprint,
+        metrics: makeMetrics(),
+      },
+    ],
+    threshold: 0.7,
+  });
+
+  assert.equal(summary.metrics.design_repetition_prior_run_count, 1);
+  assert.equal(summary.metrics.design_repetition_match_count, 1);
+  assert.equal(summary.metrics.design_repetition_signal, 1);
+  assert.ok(summary.metrics.design_repetition_max_score >= 0.95);
+  assert.equal(summary.diagnostics.matches[0].artifact, '/tmp/result-prior.json');
+  assert.deepEqual(summary.diagnostics.matches[0].shared.motifs, ['cards_grid', 'pricing']);
+});
+
+test('design novelty signal stays silent when fingerprints diverge', () => {
+  const current = makeFingerprint();
+  const priorFingerprint = {
+    motifs: ['marquee'],
+    palette_labels: ['cyan_teal'],
+    font_families: ['Inter'],
+    dark_theme: false,
+    patterns: {
+      hero_grid_background_present: false,
+      type_pairing_signature: 'Inter / Inter',
+      repetition_signature: 'type:inter / inter',
+    },
+  };
+  const summary = summarizeDesignNoveltyAgainstPriors({
+    currentFingerprint: current,
+    currentMetrics: makeMetrics(),
+    priors: [
+      {
+        artifact: '/tmp/result-divergent.json',
+        mtimeMs: 1,
+        prompt_variant: 'event-conference',
+        designFingerprint: priorFingerprint,
+        metrics: { design_uses_inter: 1 },
+      },
+    ],
+    threshold: 0.7,
+  });
+
+  assert.equal(summary.metrics.design_repetition_match_count, 0);
+  assert.equal(summary.metrics.design_repetition_signal, 0);
+  assert.ok(summary.metrics.design_repetition_max_score < 0.5);
+});
+
+test('design novelty surfaces recurring tokens, motifs, and palette labels across priors', () => {
+  const current = makeFingerprint();
+  const priorA = makeFingerprint();
+  const priorB = makeFingerprint({
+    motifs: ['cards_grid'],
+    palette_labels: ['dark_base'],
+    patterns: {
+      hero_grid_background_present: true,
+      type_pairing_signature: 'Inter / Inter',
+      repetition_signature: 'hero-grid-background|eyebrow-title-labels|type:inter / inter',
+    },
+  });
+  const summary = summarizeDesignNoveltyAgainstPriors({
+    currentFingerprint: current,
+    currentMetrics: makeMetrics(),
+    priors: [
+      {
+        artifact: '/tmp/result-a.json',
+        mtimeMs: 2,
+        prompt_variant: 'event-conference',
+        designFingerprint: priorA,
+        metrics: makeMetrics(),
+      },
+      {
+        artifact: '/tmp/result-b.json',
+        mtimeMs: 1,
+        prompt_variant: 'event-conference',
+        designFingerprint: priorB,
+        metrics: makeMetrics({ design_uses_purple_lime: 0 }),
+      },
+    ],
+    threshold: 0.7,
+  });
+
+  const recurringTokens = summary.diagnostics.recurring.repetition_tokens.map((entry) => entry.value);
+  assert.ok(recurringTokens.includes('hero-grid-background'));
+  assert.ok(recurringTokens.includes('eyebrow-title-labels'));
+  const recurringMotifs = summary.diagnostics.recurring.motifs.map((entry) => entry.value);
+  assert.ok(recurringMotifs.includes('cards_grid'));
+  const recurringPalette = summary.diagnostics.recurring.palette_labels.map((entry) => entry.value);
+  assert.ok(recurringPalette.includes('dark_base'));
+  assert.equal(summary.diagnostics.matches.length, 2);
+  // Ordering: highest score first.
+  assert.ok(summary.diagnostics.matches[0].score >= summary.diagnostics.matches[1].score);
+});
+
+test('design novelty score component breakdown exposes per-axis Jaccard', () => {
+  const current = makeFingerprint();
+  const detail = scoreDesignFingerprintAgainstPrior({
+    currentSignatureTokens: new Set([
+      'hero-grid-background',
+      'eyebrow-title-labels',
+      'type:playfair display / libre baskerville',
+    ]),
+    currentMotifs: new Set(['cards_grid', 'pricing']),
+    currentPalette: new Set(['dark_base', 'purple_lime']),
+    currentRecipeFlags: new Set([
+      'design_uses_dark_base',
+      'design_uses_purple_lime',
+      'design_uses_cards_grid',
+      'design_hero_grid_background_present',
+    ]),
+    currentTypePairing: 'playfair display / libre baskerville',
+    prior: {
+      designFingerprint: current,
+      metrics: makeMetrics(),
+    },
+  });
+
+  assert.equal(detail.component_scores.repetition_tokens, 1);
+  assert.equal(detail.component_scores.motifs, 1);
+  assert.equal(detail.component_scores.palette_labels, 1);
+  assert.equal(detail.component_scores.recipe_flags, 1);
+  assert.equal(detail.component_scores.type_pairing, 1);
+  assert.equal(detail.score, 1);
+});
+
+test('loadDesignNoveltyPriors reads matching prompt-variant artifacts and skips the current run', async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'design-novelty-priors-'));
+  try {
+    const currentPath = path.join(tmpDir, 'result-current.json');
+    const matchingPath = path.join(tmpDir, 'result-matching.json');
+    const otherVariantPath = path.join(tmpDir, 'result-other.json');
+    const malformedPath = path.join(tmpDir, 'result-malformed.json');
+    const unrelatedPath = path.join(tmpDir, 'unrelated.txt');
+
+    await writeFile(
+      currentPath,
+      JSON.stringify({ prompt_variant: 'event-conference', designFingerprint: makeFingerprint() })
+    );
+    await writeFile(
+      matchingPath,
+      JSON.stringify({
+        prompt_variant: 'event-conference',
+        designFingerprint: makeFingerprint(),
+        siteUrl: 'http://localhost:9254/',
+      })
+    );
+    await writeFile(
+      otherVariantPath,
+      JSON.stringify({ prompt_variant: 'restaurant', designFingerprint: makeFingerprint() })
+    );
+    await writeFile(malformedPath, '{not-json');
+    await writeFile(unrelatedPath, 'noise');
+
+    const priors = await loadDesignNoveltyPriors({
+      artifactDir: tmpDir,
+      currentArtifactPath: currentPath,
+      promptVariant: 'event-conference',
+      maxPriors: 5,
+    });
+
+    assert.equal(priors.length, 1);
+    assert.equal(priors[0].artifact, matchingPath);
+    assert.equal(priors[0].prompt_variant, 'event-conference');
+    assert.equal(priors[0].siteUrl, 'http://localhost:9254/');
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('loadDesignNoveltyPriors returns empty array when artifact dir is missing', async () => {
+  const priors = await loadDesignNoveltyPriors({
+    artifactDir: '/tmp/__definitely_missing_homeboy_rigs__',
+    currentArtifactPath: '',
+    promptVariant: 'event-conference',
+    maxPriors: 5,
+  });
+  assert.deepEqual(priors, []);
 });

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ wait
 
 The site-build workload also emits generated-theme UX gates in `generated-theme-ux-gates.json`. This first slice catches serialized `wp:freeform` count drift against the Static Site Importer report and CSS-hidden reveal content that lacks an editor override, which can make the Site Editor canvas appear blank even when the frontend looks acceptable. Remaining gates to automate are Site Editor above-the-fold visible text, footer utility links converted into responsive navigation overlays, and fixed/sticky chrome overlapping the WordPress admin bar.
 
+The site-build workload also emits a non-fatal **design-novelty diagnostic** that scans persisted prior `result-*.json` artifacts in the same `artifactDir`, scoped to the current `prompt_variant`. It compares fingerprint axes (`repetition_signature` tokens, motifs, palette labels, recipe flags, type pairing) against the new run and surfaces:
+
+- `design_repetition_prior_run_count` / `design_repetition_match_count` / `design_repetition_max_score` / `design_repetition_mean_score` metrics
+- recurrence counts for repetition tokens, motifs, palette labels, and recipe flags shared across multiple priors
+- a `design-novelty-<run>.json` artifact with per-prior scores and the top matches
+
+Defaults are conservative: no priors means zero metrics (one-off runs do not require a baseline). Tune via `studio_site_build_design_novelty_threshold` (default `0.7`) and `studio_site_build_design_novelty_max_priors` (default `20`). Set `studio_site_build_design_novelty_gate=1` to flip an info-only `design_novelty_gate_failed` metric; the workload itself stays non-fatal.
+
 The deterministic write-path workload is `bench/studio-bfb-write-path.bench.mjs`. It creates a fresh Studio site per run, inserts one raw HTML page, and reports phase timings plus stored-block quality metrics (`core_html_blocks`, `bfb_fallback_count`, `serialized_block_comments`, etc.) scoped to that inserted page.
 
 `bench/studio-ssi-woo-fixture-validation.bench.mjs` carries a disabled fixture scaffold for Static Site Importer WooCommerce primitives. It records the static store fixture and `products.json` manifest, then reports a skip until SSI implements manifest validation, product seeding, and product context forwarding. Enable it with `HOMEBOY_ENABLE_SSI_WOO_FIXTURE=1` only against an SSI branch that exposes those primitives; the rig must not seed WooCommerce products itself.


### PR DESCRIPTION
Closes #52.

## Summary

Repeated `studio-agent-site-build` runs of the same `prompt_variant` were cooking the same visual recipe (e.g. event-conference: `hero-grid-background | eyebrow-title-labels | dark_base | cards_grid | purple_lime`) while the bench still reported success. The harness already captured rich design fingerprints — it just had no way to compare them across runs.

This PR adds a non-fatal **design-novelty diagnostic** that compares the current run's fingerprint against persisted prior `result-*.json` artifacts for the same prompt variant.

## What changed

- New helpers in `studio-agent-site-build.bench.mjs`:
  - `loadDesignNoveltyPriors()` — bounded scan of `result-*.json` in `artifactDir`, filtered to the same `prompt_variant`, newest-first, with hard caps and full error tolerance.
  - `scoreDesignFingerprintAgainstPrior()` — weighted similarity across repetition tokens, recipe flags, motifs, palette labels, and type pairing.
  - `summarizeDesignNoveltyAgainstPriors()` — aggregate metrics + diagnostic detail (top matches, recurrence counts).
- New bench metrics:
  - `design_repetition_prior_run_count`
  - `design_repetition_match_count`
  - `design_repetition_max_score`
  - `design_repetition_mean_score`
  - `design_repetition_signal` (1 when max score >= threshold)
  - `design_repetition_recurring_token_count`, `..._motif_count`, `..._palette_count`, `..._recipe_flag_count`
  - `design_repetition_threshold`
  - Optional info-only `design_novelty_gate_enabled` / `design_novelty_gate_failed`
- New artifact: `design-novelty-<run>.json` (only written when priors exist) with per-prior scores, shared axes, and recurring values.
- New optional settings:
  - `studio_site_build_design_novelty_threshold` (default `0.7`)
  - `studio_site_build_design_novelty_max_priors` (default `20`)
  - `studio_site_build_design_novelty_gate` (default off; flips the info-only metric only)
- Brief README entry under the `studio-bfb` rig section.

## Acceptance criteria

- ✅ The bench surfaces a clear diagnostic when a new run resembles recent runs.
- ✅ The diagnostic includes comparable fingerprint fields (per-axis Jaccard scores, shared tokens/motifs/palette labels, recurrence counts), not a vague pass/fail.
- ✅ Existing one-off runs remain usable without a baseline. When no priors are found, all metrics are zeroed and no artifact is written.

## Smoke-tested against the issue's evidence

Replayed the helpers against the artifact set referenced in #52 (latest run `result-bfb-17025-1777857554802-8ri6exwmm62.json`, prompt variant `event-conference`):

- `prior_run_count`: 5
- Top match score: ~0.585 (below the conservative 0.7 threshold because type pairings differ)
- **But the human-meaningful signal lands in the recurrence counts**:
  - `hero-grid-background` token: shared with 5/5 priors
  - `eyebrow-title-labels` token: shared with 5/5 priors
  - `cards_grid` motif: shared with 5/5 priors
  - `pricing` motif: shared with 4/5 priors
  - `dark_base` palette: shared with 5/5 priors
  - `purple_lime` palette: shared with 4/5 priors

That matches the human-review verdict: the latest site looks just like the prior generated ones. Reviewers can now see *why* without re-running anything.

## Tests

`node --test Automattic/studio/bench/studio-agent-site-build.test.mjs`

```
ℹ tests 11
ℹ pass 11
ℹ fail 0
```

Seven new tests cover:
- zeroed metrics with no priors,
- signal triggers on near-identical priors,
- signal stays silent on divergent priors,
- recurring token/motif/palette aggregation across multiple priors,
- per-axis component score breakdown,
- on-disk prior loading skipping the current run, malformed JSON, and other prompt variants,
- empty result when artifact dir is missing.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** drafting the cross-run repetition scoring helpers, wiring them into the bench, and writing the focused unit tests; Chris is reviewing and will validate against a live bench run.