### PR TITLE
Add Switchback WooCommerce benchmark prompt

### DIFF
--- a/Automattic/studio/bench/prompts/site-build/switchback-woocommerce-extra-hard.md
+++ b/Automattic/studio/bench/prompts/site-build/switchback-woocommerce-extra-hard.md
@@ -1,0 +1,101 @@
+Create a complete WooCommerce storefront concept for "Switchback," a specialist outdoor outfitter for dogs and their people.
+
+This is an extra-hard benchmark prompt. Do not treat it as a generic design-only landing page. Act like a cracked WordPress developer who can plan and build the right WordPress/WooCommerce substrate: homepage structure, product catalog shape, collections, attributes, navigation, reusable content sections, and editable block output. Use design as one part of the implementation, not the whole job.
+
+Brand concept:
+Switchback sells terrain-aware and weather-aware trail gear for dog owners who hike, camp, visit lakes, and road-trip with their dogs. The store helps shoppers confidently outfit their dog for outdoor days with the right mix of safety, comfort, hydration, paw care, cleanup, and recovery products.
+
+Visual direction:
+Use rugged, clean, utility-forward design. Favor believable outdoor dog photography, durable typography, earth-and-sky palette accents, and practical shopping guidance. Avoid cartoon styling, novelty pet language, overly cute icons, generic pet-shop energy, hunting-brand aesthetics, or a survivalist look. The mood should be competent, calm, prepared, and in motion.
+
+Required homepage sections:
+
+1. Hero
+- Strong dog-outdoors image.
+- Concise value proposition around outfitting real outings.
+- Primary CTA: Shop Trail Kits.
+- Secondary CTA: Find Your Outing.
+
+2. Scenario-led shopping tiles
+- Day Hike
+- Beach Day
+- Weekend Camp
+- Road Trip
+
+3. Featured bundle row
+Create 3-4 hero kits with names, short descriptions, prices, and practical utility metadata.
+Example bundle types:
+- Hot Trail Starter Kit
+- Muddy Ride Home Kit
+- Weekend Camp Dog Kit
+- Night Visibility Kit
+
+4. Shop by condition
+- Hot Weather
+- Mud and Rain
+- Night Visibility
+- Senior Dog Comfort
+
+5. Trust strip
+Include concise trust points:
+- Field-tested feel
+- Fit and sizing guidance
+- Curated bundles
+- Trail-ready essentials
+
+6. Seasonal feature
+Use a seasonal angle such as summer trails, lake weekends, or fall mud season. Include product and collection links.
+
+7. Giftable kits
+Help non-expert gift buyers choose confidently. Include price-banded recommendations and cues like "best for new dog hikers."
+
+8. Trail Notes preview
+Include 3 commerce-adjacent article cards:
+- How to pack for a dog-friendly day hike
+- What changes in hot weather
+- How to clean up after a muddy trail day
+
+Navigation:
+Top nav:
+- Shop All
+- By Outing
+- By Condition
+- Bundles
+- Travel
+- Gifts
+
+Utility nav:
+- Size Guide
+- Trail Notes
+- Help
+
+Catalog and merchandising expectations:
+- Lead with bundles as hero products.
+- Make bundles feel editorially curated, not upsell-heavy.
+- Explain why each kit exists and what outing it supports.
+- Include product-grid-ready cards with compact utility metadata such as best-for condition, dog size, trip type, or season.
+- Use condition-based cross-sells instead of generic "you may also like."
+- Keep the catalog intentionally edited, not massive.
+- Imply product attributes through copy and structure: outing, condition, dog size, season, terrain, and trip length.
+
+WooCommerce-specific expectations:
+- Include product-grid-ready sections and bundle-like product modules.
+- Include collection links by outing and condition.
+- Include a lightweight guided-selector teaser with inputs for outing type, weather, dog size, and dog age or mobility.
+- The output should be maintainable in WordPress and WooCommerce. Avoid fragile custom app logic.
+- Prefer semantic HTML and CSS that Studio can import into clean editable WordPress blocks through the Static Site Importer workflow.
+
+Tone:
+Use plain outdoor language: heat, trail length, mud, night visibility, recovery, hydration, paw care, cleanup, fit, terrain, lake weekends, campouts, and car rides home.
+
+Avoid:
+- generic "premium products for your pet"
+- cartoon dogs
+- novelty pet puns
+- long brand manifesto sections
+- fake app dashboards that would not belong in a WooCommerce store
+- a flat accessory catalog with no bundle or collection strategy
+
+The page should prioritize directional shopping and conversion over long-form storytelling, while still proving that the generated WordPress site understands the underlying commerce model.
+
+Work in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -30,6 +30,7 @@ const PROMPT_VARIANTS = [
   'saas',
   'realistic-small-business',
   'studio-code',
+  'switchback-woocommerce-extra-hard',
   'wordpress-is-dead',
 ];
 const SYSTEM_PROMPT_FILES = ['apps/cli/ai/system-prompt.ts'];


### PR DESCRIPTION
## Summary
- Add the extra-hard Switchback WooCommerce site-build benchmark prompt.
- Register `switchback-woocommerce-extra-hard` in the Studio site-build prompt catalog.

## Why
This gives Studio Code a pressure-test prompt that is explicitly more than a design-only landing page: it asks for WooCommerce-oriented IA, merchandising, product-grid-ready sections, bundles, attributes, and navigation. Output shape (HTML/CSS → editable WordPress blocks) is intentionally not constrained — the Static Site Importer pipeline handles that downstream.

## Testing
- `HOMEBOY_COMPONENT_PATH=/Users/chubes/Developer/studio node -e "import('./Automattic/studio/bench/studio-agent-site-build.bench.mjs').then(m => m.validatePromptVariantCatalog()).then(v => console.log(v.includes('switchback-woocommerce-extra-hard') ? 'catalog-ok' : 'missing')).catch(e => { console.error(e); process.exit(1); })"` → `catalog-ok`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Opus 4.7)
- **Used for:** Resolved merge conflict against `main` (kept both `switchback-woocommerce-extra-hard` and `wp-coding-agents` in the prompt variant catalog) and dropped editable-WordPress-output language from the Switchback prompt since SSI handles that concern. Chris remains responsible for review and merge.