### PR TITLE
Drop SSI/editable-block boilerplate from site-build benchmark prompts

### DIFF
--- a/Automattic/studio/bench/prompts/site-build/data-machine.md
+++ b/Automattic/studio/bench/prompts/site-build/data-machine.md
@@ -2,6 +2,4 @@ Build a one-page landing page for Data Machine, a WordPress operations engine fo
 
 Make the page feel like WordPress grew an operating layer: pipelines that schedule themselves, handlers that process real content, memory that persists across agents, dashboards for queue health, and tools for SEO, images, links, analytics, and system diagnostics. Include a hero, workflow diagram section, capability grid, automation examples, reliability/evidence section, and a final call to action for site owners and developers.
 
-Use normal semantic HTML and CSS. Studio should import the result into clean editable WordPress blocks through the Static Site Importer workflow.
-
 Work in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/homeboy.md
+++ b/Automattic/studio/bench/prompts/site-build/homeboy.md
@@ -2,6 +2,4 @@ Build a sharp one-page landing page for Homeboy, a developer operations system t
 
 Make it feel like a serious engineering power tool, not a generic SaaS template. Show how a solo engineer with AI coding agents can operate like a much larger team: reproducible rigs, benchmark evidence, trace diagnostics, structured observations, safer git workflows, and PR-ready reports. Include sections for the command surface, automation loop, evidence artifacts, team leverage, and a confident call to action.
 
-Use normal semantic HTML and CSS. Studio should import the result into clean editable WordPress blocks through the Static Site Importer workflow.
-
 Work in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/intelligence.md
+++ b/Automattic/studio/bench/prompts/site-build/intelligence.md
@@ -2,6 +2,4 @@ Build a one-page landing page for Intelligence, a personal WordPress-based work 
 
 Make the page feel thoughtful, fast, and personal: an agent that remembers context, finds answers across work systems, builds wiki pages, creates briefings, tracks unresolved asks, and helps a human navigate a complex workday. Include a hero, source map, wiki/second-brain section, daily briefing section, automation examples, privacy/control section, and a warm call to action.
 
-Use normal semantic HTML and CSS. Studio should import the result into clean editable WordPress blocks through the Static Site Importer workflow.
-
 Work in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/nonprofit.md
+++ b/Automattic/studio/bench/prompts/site-build/nonprofit.md
@@ -2,6 +2,4 @@ Build a polished one-page campaign site for Harbor Steps, a nonprofit helping co
 
 Use a credible, urgent, and human editorial direction. Include a strong hero, mission summary, impact metrics, program cards, story or quote from a participant, donation/volunteer section, partner strip, FAQ or transparency section, and a clear final call to action.
 
-Use normal semantic HTML and CSS. Studio should import the result into clean editable WordPress blocks through the Static Site Importer workflow.
-
 Work in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/portfolio.md
+++ b/Automattic/studio/bench/prompts/site-build/portfolio.md
@@ -2,6 +2,4 @@ Build a polished one-page portfolio site for Mira Vale, an independent creative 
 
 Use a high-end editorial portfolio direction with a strong point of view and varied page sections. Include a hero, selected work grid, featured case study, process section, client list or proof strip, short bio, testimonial quote, and contact call to action.
 
-Use normal semantic HTML and CSS. Studio should import the result into clean editable WordPress blocks through the Static Site Importer workflow.
-
 Work in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/restaurant.md
+++ b/Automattic/studio/bench/prompts/site-build/restaurant.md
@@ -2,6 +2,4 @@ Build a polished one-page marketing site for Ember & Rye, a neighborhood restaur
 
 Use a distinctive visual direction, not a generic template. Include a memorable hero, short restaurant story, menu highlights, chef or sourcing section, private dining or events section, hours/location details, testimonial or press quote, and a reservation call to action.
 
-Use normal semantic HTML and CSS. Studio should import the result into clean editable WordPress blocks through the Static Site Importer workflow.
-
 Work in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/saas.md
+++ b/Automattic/studio/bench/prompts/site-build/saas.md
@@ -2,6 +2,4 @@ Build a polished one-page SaaS marketing site for Relay Atlas, an operations pla
 
 Use modern software-brand polish and clear information architecture. Include a hero, product UI or workflow section, benefits grid, integrations or proof section, use cases, testimonial quote, pricing or packaging teaser, and final call to action.
 
-Use normal semantic HTML and CSS. Studio should import the result into clean editable WordPress blocks through the Static Site Importer workflow.
-
 Work in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/wp-coding-agents.md
+++ b/Automattic/studio/bench/prompts/site-build/wp-coding-agents.md
@@ -2,6 +2,4 @@ Build a one-page landing page for WP Coding Agents, a self-hostable WordPress + 
 
 Make it feel like a practical workshop for shipping WordPress code with AI teammates. Show the path from a live Studio or VPS install to cloned workspaces, focused worktree sessions, evidence capture, commits, PRs, and cleanup. Include sections for setup, isolated workspaces, minion sessions, GitHub integration, safety rules, and examples of parallel agent work.
 
-Use normal semantic HTML and CSS. Studio should import the result into clean editable WordPress blocks through the Static Site Importer workflow.
-
 Work in this Studio site: {{sitePath}}


### PR DESCRIPTION
## Summary
- Remove the line `Use normal semantic HTML and CSS. Studio should import the result into clean editable WordPress blocks through the Static Site Importer workflow.` from 8 site-build benchmark prompts: `data-machine`, `homeboy`, `intelligence`, `nonprofit`, `portfolio`, `restaurant`, `saas`, `wp-coding-agents`.

## Why
Site-build benchmark prompts should describe the site we want, not constrain the agent's output shape. The Static Site Importer pipeline handles HTML → editable WordPress block conversion downstream — the prompt does not need to mention it. Carrying that boilerplate biases the agent toward output-shape thinking when the bench is meant to evaluate site/IA/design quality.

This applies the same cleanup that was made to the Switchback prompt in #55 to every other prompt that carried the identical boilerplate line.

## Intentionally not touched
`radical-speed-month.md` and `wordpress-is-dead.md` mention the Static Site Importer as the *subject* of the landing page they describe (RSM is an SSI hackathon project; "WordPress is dead" positions SSI as the plot twist). Removing SSI references there would gut the prompt's content, so those references stay.

## Testing
- `HOMEBOY_COMPONENT_PATH=/Users/chubes/Developer/studio node -e "import('./Automattic/studio/bench/studio-agent-site-build.bench.mjs').then(m => m.validatePromptVariantCatalog()).then(v => { const need = ['data-machine','homeboy','intelligence','nonprofit','portfolio','restaurant','saas','wp-coding-agents']; const missing = need.filter(n => !v.includes(n)); console.log(missing.length === 0 ? 'catalog-ok' : 'missing: ' + missing.join(',')); })"` → `catalog-ok`
- `grep -rn "Static Site Importer\|editable WordPress block" Automattic/studio/bench/prompts/site-build/` → only `radical-speed-month.md` and `wordpress-is-dead.md` match (intentional)
- `git diff --stat` → 8 files changed, 16 deletions(-)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Identified the identical boilerplate line across the prompt corpus, removed it from the 8 prompts where it was pure framing (not subject content), preserved SSI references in the two prompts where SSI is the subject, ran catalog validation, drafted this PR. Chris remains responsible for review and merge.