### PR TITLE
feat(studio): consume eval-runner failure-capture fields

### DIFF
--- a/Automattic/studio/bench/studio-agent-runtime.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-runtime.bench.mjs
@@ -60,12 +60,14 @@ function runEval(prompt, vars) {
   });
 }
 
+const RUNTIME_TIMEOUT_MS = 60000;
+
 export default async function studioAgentRuntimeBench() {
   const prompt = 'In one short sentence, tell me who you are. Do not call any tools.';
   const started = Date.now();
   const { result, resultFile, exitCode, stderr } = await runEval(prompt, {
     maxTurns: 12,
-    timeoutMs: 60000,
+    timeoutMs: RUNTIME_TIMEOUT_MS,
     askUserPolicy: 'allow_all',
   });
   const elapsedMs = Date.now() - started;
@@ -79,8 +81,12 @@ export default async function studioAgentRuntimeBench() {
   );
 
   if (result.success !== true) {
-    const detail = typeof result.error === 'string' ? result.error : `exit=${exitCode}`;
-    throw new Error(`Studio eval failed: ${detail}; raw_result=${artifactFile}`);
+    const reason = result.timedOut === true
+      ? `timed out after ${RUNTIME_TIMEOUT_MS}ms (eval-runner reported timedOut)`
+      : typeof result.error === 'string'
+        ? `exception: ${result.error}`
+        : `exit=${exitCode}`;
+    throw new Error(`Studio eval failed: ${reason}; raw_result=${artifactFile}`);
   }
 
   const toolCalls = Array.isArray(result.toolCalls) ? result.toolCalls : [];

--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -3036,12 +3036,23 @@ export default async function studioAgentSiteBuildBench() {
   const turnDurations = Array.isArray(result.turnDurationsMs) ? result.turnDurationsMs : [];
   const phaseTimings = result.phaseTimingsMs && typeof result.phaseTimingsMs === 'object' ? result.phaseTimingsMs : {};
   const toolBreakdown = toolMetrics(result);
-  const agentSucceeded = result.success === true && !result.error;
+  // result.error and result.timedOut land in the eval-runner JSON via
+  // Automattic/studio#3330. Both are nullish on Studio versions older than
+  // that PR, which collapses the AND to result.success === true (the same
+  // gate the bench had before). On versions with #3330, the bench correctly
+  // distinguishes successful runs from runs that finished with a runner-side
+  // exception, and from runs that timed out. timed_out is surfaced as its
+  // own metric so timeout regressions are visible separately from agent
+  // failures.
+  const agentTimedOut = result.timedOut === true;
+  const agentSucceeded = result.success === true && !result.error && !agentTimedOut;
 
   return {
     metrics: {
       success_rate: agentSucceeded ? 1 : 0,
       agent_error_rate: agentSucceeded ? 0 : 1,
+      timed_out: agentTimedOut ? 1 : 0,
+      agent_runner_error: typeof result.error === 'string' ? 1 : 0,
       elapsed_ms: totalElapsedMs,
       site_create_ms: siteCreateMs,
       agent_elapsed_ms: agentElapsedMs,

--- a/Automattic/studio/bench/studio-agent-site-info.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-info.bench.mjs
@@ -60,13 +60,15 @@ function metric(value) {
   return Number.isFinite(number) ? number : 0;
 }
 
+const SITE_INFO_TIMEOUT_MS = 60000;
+
 export default async function studioAgentSiteInfoBench() {
   const siteName = process.env.STUDIO_SITE_INFO_BENCH_SITE || 'intelligence-chubes4';
   const prompt = `Use only the Studio site_info tool for the site named ${siteName}, then answer with its running status in one sentence. Do not use any other tools.`;
   const started = Date.now();
   const { result, resultFile, exitCode, stderr } = await runEval(prompt, {
     maxTurns: 5,
-    timeoutMs: 60000,
+    timeoutMs: SITE_INFO_TIMEOUT_MS,
   });
   const elapsedMs = Date.now() - started;
 
@@ -76,8 +78,12 @@ export default async function studioAgentSiteInfoBench() {
   await writeFile(artifactFile, JSON.stringify({ prompt, exitCode, stderr, resultFile, result }, null, 2));
 
   if (result.success !== true) {
-    const detail = typeof result.error === 'string' ? result.error : `exit=${exitCode}`;
-    throw new Error(`Studio eval failed: ${detail}; raw_result=${artifactFile}`);
+    const reason = result.timedOut === true
+      ? `timed out after ${SITE_INFO_TIMEOUT_MS}ms (eval-runner reported timedOut)`
+      : typeof result.error === 'string'
+        ? `exception: ${result.error}`
+        : `exit=${exitCode}`;
+    throw new Error(`Studio eval failed: ${reason}; raw_result=${artifactFile}`);
   }
 
   const phaseTimings = result.phaseTimingsMs && typeof result.phaseTimingsMs === 'object' ? result.phaseTimingsMs : {};


### PR DESCRIPTION
## Summary

Pairs with [Automattic/studio#3330](https://github.com/Automattic/studio/pull/3330), which adds two new fields to the eval-runner result JSON:

- `result.error: string | null` — set when an exception is caught inside the message loop (auth blip, MCP crash, network error, SDK throw, etc.)
- `result.timedOut: boolean` — set when the timeout callback fires before `query.interrupt()`

This PR teaches the Studio bench scripts to consume both fields.

## Why

Today the bench gate is `result.success === true && !result.error`. On current trunk Studio, `result.error` is `undefined` outside the rare top-level catch path, so the AND degenerates to `result.success === true`. Timeouts are indistinguishable from clean model failures — both surface as `success: false` with no other differentiator.

After Studio#3330, the eval-runner emits both fields consistently, and the bench can:

- **Distinguish timeouts from agent failures.** A timed-out 5-minute run and a model that gave up at turn 3 today look identical in metrics. With this PR, `timed_out` is a separate metric.
- **Distinguish runner-side exceptions from agent failures.** A run where the model finished cleanly but the runner caught a recoverable exception today degrades to a stripped-down `{ success: false, error }` JSON, losing all timings and tool history. After Studio#3330 the structured result is preserved with `error` set, and this PR's `agent_runner_error` metric makes it visible.
- **Show the actual failure mode in error messages.** `studio-agent-runtime` and `studio-agent-site-info` now print `timed out after Nms` / `exception: ...` / `exit=N` instead of always falling back to `exit=N`.

## Diff

Three bench files, ~30 lines:

- `studio-agent-runtime.bench.mjs` and `studio-agent-site-info.bench.mjs`: failure-detail message branches on `result.timedOut` and `result.error`. Lifts the timeout literal into a named constant so the message stays in sync with the actual budget.
- `studio-agent-site-build.bench.mjs`: `agentSucceeded` gate now requires `!result.timedOut`. Adds `timed_out` and `agent_runner_error` metrics so timeout regressions are visible separately from agent failures.

## Backwards compatibility

On Studio versions older than #3330, both `result.error` and `result.timedOut` are nullish (or absent). The new gates degrade safely: `agentTimedOut` resolves to `false`, `!result.error` resolves to `true`, and the bench behaves exactly as it did before. New metrics emit `0` instead of misleading values.

This means the rig PR can land independently of Studio#3330 — it's strictly additive on old Studio, fully active on new Studio.

## Refs

- [Automattic/studio#3330](https://github.com/Automattic/studio/pull/3330) — the upstream eval-runner change this consumes
- [Automattic/studio#3262](https://github.com/Automattic/studio/issues/3262) — the umbrella ask for structured eval diagnostics
- [Automattic/studio#3273](https://github.com/Automattic/studio/pull/3273) — the previous installment (`firstToolError`, `toolEvents`, `phaseTimingsMs`)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Sonnet 4.5)
- **Used for:** Drafted the gate-tightening, named-constant refactor, and failure-detail messages under Chris's direction.
