### PR TITLE
feat(studio): add mixed-source site-build prompts

### DIFF
--- a/Automattic/studio/bench/prompts/site-build/astro-docs-content-collection.md
+++ b/Automattic/studio/bench/prompts/site-build/astro-docs-content-collection.md
@@ -1,0 +1,23 @@
+Build an importable mixed-source documentation site for SignalForge, a developer tool that monitors API reliability for small platform teams.
+
+This benchmark is specifically for the Static Site Importer mixed-source capability. Create a source tree that the importer can consume directly, with an HTML shell for shared chrome and plain Markdown content files for individual pages. Do not build an Astro project, do not generate MDX, and do not collapse the content into one generated HTML file.
+
+Required source shape:
+
+```text
+site/
+  index.html
+  styles.css
+  content/
+    about.md
+    docs/getting-started.md
+    docs/incident-workflows.md
+    docs/api-reference.md
+    changelog/launch-notes.markdown
+```
+
+Use `index.html` for the visual system, navigation, footer, homepage sections, and links into the Markdown pages. Use `styles.css` for all site styling. Give every Markdown file frontmatter with `title` and `slug`, and include internal links between the homepage and nested content pages.
+
+The Markdown pages should exercise rich GFM content: headings, ordered and unordered lists, tables, blockquotes, fenced code examples, task lists, and at least one image or downloadable-file link placeholder where the importer supports it.
+
+Import the source tree into this Studio site using the mixed HTML shell plus Markdown content importer path: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/markdown-blog-launch-site.md
+++ b/Automattic/studio/bench/prompts/site-build/markdown-blog-launch-site.md
@@ -1,0 +1,23 @@
+Build an importable mixed-source launch site for Northstar Pantry, a new subscription meal-planning service for busy families.
+
+This prompt is intended to validate Static Site Importer support for a handoff where the marketing shell is HTML/CSS and the article content is Markdown. Produce a source tree for import, not a built framework bundle. Do not use MDX or any `.mdx` files.
+
+Required source shape:
+
+```text
+site/
+  index.html
+  styles.css
+  content/
+    about.md
+    blog/launch-story.md
+    blog/weekly-menu-preview.markdown
+    blog/founder-note.md
+    guides/pantry-staples.markdown
+```
+
+Use `index.html` as the homepage and shared shell: distinctive hero, product promise, pricing teaser, article cards, newsletter call to action, and footer navigation. Use `styles.css` for a polished responsive visual direction. Link homepage article cards to the Markdown files and include cross-links between articles.
+
+Every Markdown file needs frontmatter with `title` and `slug`. Include rich Markdown/GFM content across the files: nested headings, lists, comparison tables, blockquotes, fenced recipe or config-style code blocks, and image/file link placeholders where supported.
+
+Import this mixed HTML/CSS/Markdown source tree into the Studio site through the importer capability: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/static-content-library.md
+++ b/Automattic/studio/bench/prompts/site-build/static-content-library.md
@@ -1,0 +1,23 @@
+Build an importable mixed-source resource library for Civic Signal, a nonprofit publishing toolkits for neighborhood organizers.
+
+This benchmark should depend on Static Site Importer mixed-source support: one HTML shell plus multiple plain Markdown resources. Generate a source tree that can be imported as-is. Do not use MDX, front-end framework build output, or a single flattened HTML export.
+
+Required source shape:
+
+```text
+site/
+  index.html
+  styles.css
+  content/
+    about.md
+    resources/outreach-checklist.md
+    resources/meeting-agenda-template.markdown
+    resources/grant-readiness.md
+    case-studies/park-cleanup.md
+```
+
+Use `index.html` for the shared design system, homepage, resource index, topic filters or groupings, calls to action, and footer. Use `styles.css` for all responsive layout and visual styling. The homepage must link to the Markdown resources, and the resources should link back to the index and to at least one related resource.
+
+Every Markdown or `.markdown` file must include frontmatter with `title` and `slug`. Use rich Markdown/GFM content: headings, numbered steps, unordered checklists, data tables, blockquotes, fenced code or plain-text templates, and image/file link placeholders where supported by the importer.
+
+Import the resulting HTML shell plus Markdown content tree into this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -20,6 +20,7 @@ const DEFAULT_PROMPT_VARIANT = 'studio-code';
 const PROMPT_CATEGORY = 'site-build';
 const PROMPT_VARIANTS = [
   'artist-music',
+  'astro-docs-content-collection',
   'course-education',
   'data-machine',
   'documentation-knowledge-base',
@@ -28,6 +29,7 @@ const PROMPT_VARIANTS = [
   'homeboy',
   'intelligence',
   'local-service-business',
+  'markdown-blog-launch-site',
   'membership-community',
   'nonprofit',
   'nonprofit-campaign',
@@ -37,6 +39,7 @@ const PROMPT_VARIANTS = [
   'restaurant',
   'saas',
   'realistic-small-business',
+  'static-content-library',
   'studio-code',
   'switchback-woocommerce-extra-hard',
   'wp-coding-agents',

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ wait
 
 The site-build workload also emits generated-theme UX gates in `generated-theme-ux-gates.json`. This first slice catches serialized `wp:freeform` count drift against the Static Site Importer report and CSS-hidden reveal content that lacks an editor override, which can make the Site Editor canvas appear blank even when the frontend looks acceptable. Remaining gates to automate are Site Editor above-the-fold visible text, footer utility links converted into responsive navigation overlays, and fixed/sticky chrome overlapping the WordPress admin bar.
 
+Mixed-source prompt variants such as `astro-docs-content-collection`, `markdown-blog-launch-site`, and `static-content-library` intentionally depend on Static Site Importer support for importing a source tree with `index.html`, `styles.css`, and plain `.md`/`.markdown` content files. They should be used against SSI branches that implement that mixed HTML shell plus Markdown content path; the prompts explicitly exclude MDX and do not require Studio changes.
+
 ### Cross-run design repetition
 
 Use Homeboy's persisted run store, not bench-side scanning, to detect when repeated `studio-agent-site-build` runs of the same `prompt_variant` are cooking the same visual recipe. Every bench run already records the design fingerprint (`design_repetition_signature`, motifs, palette labels, recipe flags, type pairing) under `results.scenarios[].metadata.*` and `results.scenarios[].metrics.*` in the run record, so `homeboy runs distribution` can aggregate them across runs by component, rig, and scenario.


### PR DESCRIPTION
## Summary
- Adds three Studio BFB site-build prompt variants for mixed-source imports: `astro-docs-content-collection`, `markdown-blog-launch-site`, and `static-content-library`.
- Registers the variants in `PROMPT_VARIANTS` so `studio_site_build_prompt_variant` can target them.
- Documents that these prompts intentionally depend on Static Site Importer mixed HTML shell plus Markdown content support and exclude MDX.

## Tests
- `HOMEBOY_COMPONENT_PATH=/tmp node --input-type=module -e 'import("./Automattic/studio/bench/studio-agent-site-build.bench.mjs").then(async (mod) => { await mod.validatePromptVariantCatalog(); for (const variant of ["astro-docs-content-collection", "markdown-blog-launch-site", "static-content-library"]) { process.env.HOMEBOY_SETTINGS_STUDIO_SITE_BUILD_PROMPT_VARIANT = variant; const prompt = await mod.siteBuildPrompt("/tmp/studio-site"); if (!prompt.includes("/tmp/studio-site")) throw new Error(variant + " did not render site path"); if (!/do not .*mdx|exclude MDX|Do not use MDX|Do not build .*MDX/i.test(prompt)) throw new Error(variant + " does not clearly exclude MDX"); } console.log("prompt catalog and templates valid"); })'`

## Blockers / dependencies
- No Homeboy Rigs blocker found.
- Full benchmark execution depends on Static Site Importer mixed-source support for importing `index.html`, `styles.css`, and `.md`/`.markdown` content trees.
- Related: static-site-importer#136, static-site-importer#137, static-site-importer#138, static-site-importer#139, block-format-bridge#96.

Closes #58.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the prompt variants, catalog registration, README note, validation command, and PR text; Chris remains responsible for review and merge.