### PR TITLE
bench(studio): gate site-build success on semantic-fidelity report (#60)

### DIFF
--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -2934,6 +2934,26 @@ function optionalArtifactPath(name, value) {
   return typeof value === 'string' && value.length > 0 ? { [name]: value } : {};
 }
 
+function semanticTargetMetric(semanticComparison, key) {
+  return (semanticComparison?.diagnostics?.targets || semanticComparison?.targets || []).reduce(
+    (sum, target) => sum + metric(target?.[key]),
+    0
+  );
+}
+
+function semanticMismatchFailureDetails(semanticComparison) {
+  const mismatches = semanticComparison?.diagnostics?.mismatches || semanticComparison?.mismatches || [];
+  return mismatches.map((mismatch) => {
+    const concept = mismatch.concept || mismatch.type || 'unknown';
+    const sourceCount =
+      mismatch.source && Object.hasOwn(mismatch.source, 'count') ? ` source=${mismatch.source.count}` : '';
+    const generatedCount =
+      mismatch.generated && Object.hasOwn(mismatch.generated, 'count') ? ` generated=${mismatch.generated.count}` : '';
+    const reason = mismatch.reason ? ` reason=${mismatch.reason}` : '';
+    return `semantic mismatch: ${concept}${sourceCount}${generatedCount}${reason}`;
+  });
+}
+
 export default async function studioAgentSiteBuildBench() {
   const runtime = resolveBenchRuntime();
   const currentVariant = variant();
@@ -2984,6 +3004,9 @@ export default async function studioAgentSiteBuildBench() {
   const nativeBlockQuality = nativeBlockQualityMetrics(quality, authoredBlocks, editorValidation, importReport);
   const designFingerprint = await collectDesignFingerprint(sitePath);
   const designMetrics = designFingerprintMetrics(designFingerprint);
+  const semanticMismatchCount = metric(semanticComparison.mismatch_count);
+  const semanticOptionalSelectorAbsentCount = semanticTargetMetric(semanticComparison, 'optional_selector_absent_count');
+  const semanticFailureDetails = semanticMismatchCount > 0 ? semanticMismatchFailureDetails(semanticComparison) : [];
 
   const artifactFile = path.join(artifactDir, `result-${runId}.json`);
   await writeFile(
@@ -3045,7 +3068,11 @@ export default async function studioAgentSiteBuildBench() {
   // own metric so timeout regressions are visible separately from agent
   // failures.
   const agentTimedOut = result.timedOut === true;
-  const agentSucceeded = result.success === true && !result.error && !agentTimedOut;
+  // Issue #60: Static Site Importer can produce a syntactically valid theme
+  // while dropping meaningful source content. Any semantic-fidelity mismatch
+  // means the generated site no longer preserves the source fixture, so the
+  // correct threshold for this bench is zero mismatches rather than warnings.
+  const agentSucceeded = result.success === true && !result.error && !agentTimedOut && semanticMismatchCount === 0;
 
   return {
     metrics: {
@@ -3118,14 +3145,19 @@ export default async function studioAgentSiteBuildBench() {
       semantic_comparison_target_count: Number(semanticComparison.target_count || 0),
       semantic_comparison_checked_target_count: Number(semanticComparison.checked_target_count || 0),
       semantic_comparison_error_count: Number(semanticComparison.error_count || 0),
-      semantic_dom_mismatch_count: Number(semanticComparison.mismatch_count || 0),
+      semantic_mismatch_count: semanticMismatchCount,
+      semantic_dom_mismatch_count: semanticMismatchCount,
       semantic_role_mismatch_count: Number(semanticComparison.role_mismatch_count || 0),
       semantic_class_owner_changed_count: Number(semanticComparison.class_owner_changed_count || 0),
       semantic_interaction_group_split_count: Number(semanticComparison.interaction_group_split_count || 0),
       semantic_interaction_group_merged_count: Number(semanticComparison.interaction_group_merged_count || 0),
       semantic_link_text_delta_count: Number(semanticComparison.link_text_delta_count || 0),
-      semantic_region_link_count_delta: Number(semanticComparison.region_link_count_delta || 0),
-      semantic_clickable_area_delta_ratio: Number(semanticComparison.clickable_area_delta_ratio || 0),
+      semantic_region_link_count_delta: metric(semanticComparison.region_link_count_delta),
+      semantic_clickable_area_delta_ratio: metric(semanticComparison.clickable_area_delta_ratio),
+      semantic_optional_selector_absent_count: semanticOptionalSelectorAbsentCount,
+      region_link_count_delta: metric(semanticComparison.region_link_count_delta),
+      clickable_area_delta_ratio: metric(semanticComparison.clickable_area_delta_ratio),
+      optional_selector_absent_count: semanticOptionalSelectorAbsentCount,
       semantic_landmark_mismatch_count: Number(semanticComparison.landmark_mismatch_count || 0),
       semantic_repeated_count_delta_count: Number(semanticComparison.repeated_count_delta_count || 0),
       semantic_brand_logo_missing_count: Number(semanticComparison.brand_logo_missing_count || 0),
@@ -3159,6 +3191,7 @@ export default async function studioAgentSiteBuildBench() {
       ...optionalArtifactPath('semantic_comparison_dir', semanticComparison.artifact_dir),
       ...optionalArtifactPath('generated_theme_ux_gates', generatedThemeUxGates.artifact),
     },
+    errors: semanticFailureDetails,
     metadata: {
       benchmark_variant: currentVariant,
       bench_namespace: runtime.namespaceSlug,


### PR DESCRIPTION
## Summary
- Fixes #60 by requiring the Studio site-build bench success gate to have zero semantic-fidelity mismatches.
- Adds top-level semantic-fidelity metrics for mismatch count, region link delta, clickable-area delta ratio, and optional selector absences.
- Adds semantic failure detail entries such as `semantic mismatch: list_item source=12 generated=6 reason=repeated_structure_count_changed_materially`.

## Before/After
Using saved run `3261fd3e-d6b0-480b-8dee-625e9b538356`:

- Before: `result.success: true`, `success_rate: 1`, `agent_error_rate: 0` even though `semantic-fidelity.json` reported `mismatch_count: 1`.
- After: the same evidence gates as `agentSucceeded: false`, `success_rate: 0`, `agent_error_rate: 1`, with `errors: [\"semantic mismatch: list_item source=12 generated=6 reason=repeated_structure_count_changed_materially\"]`.

## Verification
- `node --check Automattic/studio/bench/studio-agent-site-build.bench.mjs`
- Emulated the new gate against `/Users/chubes/Developer/_bench-evidence/run-3261fd3e/reports/bench-result.json` plus `/Users/chubes/Developer/_bench-evidence/run-3261fd3e/reports/semantic-fidelity.json` and confirmed it would fail the previous false-pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the bench-side gate, metrics, failure-detail change, and verification snippet; Chris remains responsible for review and merge.