### PR TITLE
bench(studio): gate site-build success on importer block-quality counters (#67)

### DIFF
--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -3131,15 +3131,47 @@ export function semanticMismatchFailureDetails(semanticComparison) {
   });
 }
 
-export function agentSuccessGate(result, semanticComparison) {
+export function importerBlockQualityMetrics(importReport) {
+  const quality = importReport?.report?.quality || {};
+
+  return {
+    importerCoreHtmlBlockCount: metric(quality.core_html_block_count),
+    importerFreeformBlockCount: metric(quality.freeform_block_count),
+    importerFallbackCount: metric(quality.fallback_count),
+  };
+}
+
+export function importerBlockQualityFailureDetails(importerBlockQuality) {
+  const { importerCoreHtmlBlockCount, importerFreeformBlockCount, importerFallbackCount } = importerBlockQuality;
+
+  if (importerCoreHtmlBlockCount === 0 && importerFreeformBlockCount === 0 && importerFallbackCount === 0) {
+    return [];
+  }
+
+  return [
+    `importer block quality: core/html=${importerCoreHtmlBlockCount}, freeform=${importerFreeformBlockCount}, fallback=${importerFallbackCount}`,
+  ];
+}
+
+export function agentSuccessGate(result, semanticComparison, importReport) {
   const semanticMismatchCount = metric(semanticComparison?.mismatch_count);
+  const importerBlockQuality = importerBlockQualityMetrics(importReport);
   const agentTimedOut = result?.timedOut === true;
-  const agentSucceeded = result?.success === true && !result?.error && !agentTimedOut && semanticMismatchCount === 0;
+  const agentSucceeded =
+    result?.success === true &&
+    !result?.error &&
+    !agentTimedOut &&
+    semanticMismatchCount === 0 &&
+    importerBlockQuality.importerCoreHtmlBlockCount === 0 &&
+    importerBlockQuality.importerFreeformBlockCount === 0 &&
+    importerBlockQuality.importerFallbackCount === 0;
 
   return {
     agentSucceeded,
     semanticMismatchCount,
     semanticFailureDetails: semanticMismatchCount > 0 ? semanticMismatchFailureDetails(semanticComparison) : [],
+    importerBlockQuality,
+    importerBlockQualityFailureDetails: importerBlockQualityFailureDetails(importerBlockQuality),
     metrics: {
       success_rate: agentSucceeded ? 1 : 0,
       agent_error_rate: agentSucceeded ? 0 : 1,
@@ -3199,10 +3231,11 @@ export default async function studioAgentSiteBuildBench() {
   const nativeBlockQuality = nativeBlockQualityMetrics(quality, authoredBlocks, editorValidation, importReport);
   const designFingerprint = await collectDesignFingerprint(sitePath);
   const designMetrics = designFingerprintMetrics(designFingerprint);
-  const gate = agentSuccessGate(result, semanticComparison);
+  const gate = agentSuccessGate(result, semanticComparison, importReport);
   const semanticMismatchCount = gate.semanticMismatchCount;
   const semanticOptionalSelectorAbsentCount = semanticTargetMetric(semanticComparison, 'optional_selector_absent_count');
-  const semanticFailureDetails = gate.semanticFailureDetails;
+  const failureDetails = [...gate.semanticFailureDetails, ...gate.importerBlockQualityFailureDetails];
+  const { importerCoreHtmlBlockCount, importerFreeformBlockCount, importerFallbackCount } = gate.importerBlockQuality;
 
   const artifactFile = path.join(artifactDir, `result-${runId}.json`);
   await writeFile(
@@ -3314,8 +3347,9 @@ export default async function studioAgentSiteBuildBench() {
       editor_validation_invalid_blocks: Number(editorValidation.invalid_blocks || 0),
       editor_validation_error_count: editorValidation.error ? 1 : 0,
       importer_report_error_count: importReport.error ? 1 : 0,
-      importer_fallback_count: Number(importReport.report?.quality?.fallback_count || 0),
-      importer_core_html_block_count: Number(importReport.report?.quality?.core_html_block_count || 0),
+      importer_fallback_count: importerFallbackCount,
+      importer_core_html_block_count: importerCoreHtmlBlockCount,
+      importer_freeform_block_count: importerFreeformBlockCount,
       importer_invalid_block_count: Number(importReport.report?.quality?.invalid_block_count || 0),
       importer_invalid_block_document_count: Number(importReport.report?.quality?.invalid_block_document_count || 0),
       importer_generated_block_document_count: Number(importReport.report?.generated_theme?.block_documents?.length || 0),
@@ -3382,7 +3416,7 @@ export default async function studioAgentSiteBuildBench() {
       ...optionalArtifactPath('semantic_comparison_dir', semanticComparison.artifact_dir),
       ...optionalArtifactPath('generated_theme_ux_gates', generatedThemeUxGates.artifact),
     },
-    errors: semanticFailureDetails,
+    errors: failureDetails,
     metadata: {
       benchmark_variant: currentVariant,
       bench_namespace: runtime.namespaceSlug,

--- a/Automattic/studio/bench/studio-agent-site-build.test.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.test.mjs
@@ -6,6 +6,8 @@ process.env.HOMEBOY_COMPONENT_PATH ||= '/tmp/homeboy-rigs-test-component';
 const {
   agentSuccessGate,
   hiddenEditorContentDiagnostics,
+  importerBlockQualityFailureDetails,
+  importerBlockQualityMetrics,
   semanticTargetMetric,
   structuralSelectorDriftDiagnostics,
 } = await import('./studio-agent-site-build.bench.mjs');
@@ -44,6 +46,54 @@ test('zero semantic-fidelity mismatches keep successful agent runs green', () =>
   assert.equal(gate.metrics.agent_error_rate, 0);
   assert.equal(gate.semanticMismatchCount, 0);
   assert.deepEqual(gate.semanticFailureDetails, []);
+});
+
+test('importer block-quality counters hard-fail the agent success gate', () => {
+  const importReport = {
+    report: {
+      quality: {
+        core_html_block_count: 4,
+        freeform_block_count: 1,
+        fallback_count: 4,
+      },
+    },
+  };
+  const gate = agentSuccessGate({ success: true, error: null, timedOut: false }, { mismatch_count: 0 }, importReport);
+
+  assert.equal(gate.agentSucceeded, false);
+  assert.equal(gate.metrics.success_rate, 0);
+  assert.equal(gate.metrics.agent_error_rate, 1);
+  assert.deepEqual(gate.importerBlockQuality, {
+    importerCoreHtmlBlockCount: 4,
+    importerFreeformBlockCount: 1,
+    importerFallbackCount: 4,
+  });
+  assert.deepEqual(gate.importerBlockQualityFailureDetails, [
+    'importer block quality: core/html=4, freeform=1, fallback=4',
+  ]);
+});
+
+test('importer block-quality metrics use zero as the clean threshold', () => {
+  const importReport = {
+    report: {
+      quality: {
+        core_html_block_count: 0,
+        freeform_block_count: 0,
+        fallback_count: 0,
+      },
+    },
+  };
+
+  assert.deepEqual(importerBlockQualityMetrics(importReport), {
+    importerCoreHtmlBlockCount: 0,
+    importerFreeformBlockCount: 0,
+    importerFallbackCount: 0,
+  });
+  assert.deepEqual(importerBlockQualityFailureDetails(importerBlockQualityMetrics(importReport)), []);
+  assert.equal(
+    agentSuccessGate({ success: true, error: null, timedOut: false }, { mismatch_count: 0 }, importReport).agentSucceeded,
+    true
+  );
 });
 
 test('semantic target metrics sum artifact target details for top-level output', () => {


### PR DESCRIPTION
## Summary
- Fixes #67 by adding `core_html_block_count`, `freeform_block_count`, and `fallback_count` from SSI `import-report.json` to the site-build `agentSucceeded` gate.
- Surfaces `importer_freeform_block_count` as a top-level bench metric alongside the existing importer core/html and fallback metrics.
- Adds failure detail output in the shape `importer block quality: core/html=4, freeform=1, fallback=4` when any importer block-quality counter trips.

## Before / After
- Before: run `87d2f0c3-c053-457b-bc7c-808da37254c8` reported `passed: true` / `success_rate: 1.0` despite `4 core/html` blocks, `1 core/freeform` block, and `4 fallback` events.
- After: the saved `import-report.json` from that run makes `agentSucceeded === false` with failure detail `importer block quality: core/html=4, freeform=1, fallback=4`.

## Verification
- `node --check Automattic/studio/bench/studio-agent-site-build.bench.mjs`
- `node --test Automattic/studio/bench/studio-agent-site-build.test.mjs`
- Direct fixture probe against the saved run-87d2f0c3 import report confirmed the gate fails with `core/html=4, freeform=1, fallback=4`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode Build agent (GPT-5.5)
- **Used for:** Drafted the bench gate/test changes and ran local verification; Chris remains responsible for review and merge.