### PR TITLE
bench(studio): add block-editor visual parity gate (#70)

### DIFF
--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
+import zlib from 'node:zlib';
 
 const STUDIO_PATH = process.env.HOMEBOY_COMPONENT_PATH;
 const SHARED_STATE = process.env.HOMEBOY_BENCH_SHARED_STATE || os.tmpdir();
@@ -49,6 +50,8 @@ const SYSTEM_PROMPT_FILES = ['apps/cli/ai/system-prompt.ts'];
 const requireFromBench = createRequire(import.meta.url);
 const VISUAL_VIEWPORT = { width: 1440, height: 1100 };
 const VISUAL_SCREENSHOT_DIAGNOSTIC_LIMIT = 5;
+const VISUAL_EDITOR_PIXEL_DIFF_THRESHOLD = 0.05;
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
 if (!STUDIO_PATH) {
   throw new Error('HOMEBOY_COMPONENT_PATH is required');
@@ -674,6 +677,24 @@ function surfaceUrl(target, surface, reportPath, sitePath) {
     return configured || target?.wordpress_url || '';
   }
 
+  if (surface === 'wordpress_editor') {
+    if (configured) {
+      return configured;
+    }
+
+    const postId = Number(target?.wordpress_page_id || target?.home_page_id || target?.front_page_id || 0);
+    const frontendUrl = surfaceUrl(target, 'wordpress_frontend', reportPath, sitePath);
+    if (!postId || !frontendUrl) {
+      return '';
+    }
+
+    const url = new URL(frontendUrl);
+    url.pathname = '/studio-auto-login';
+    url.search = '';
+    url.searchParams.set('redirect_to', `/wp-admin/post.php?post=${postId}&action=edit`);
+    return url.toString();
+  }
+
   return configured;
 }
 
@@ -742,9 +763,80 @@ function visualProbeGroups(target) {
 }
 
 async function loadVisualSurface(page, url) {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
   await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 45_000 });
   await page.waitForLoadState('networkidle', { timeout: 5_000 }).catch(() => {});
   await page.waitForTimeout(300);
+}
+
+async function loadEditorSurface(page, url) {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 45_000 });
+  await page.waitForSelector('iframe[name="editor-canvas"]', { timeout: 30_000 });
+
+  const frameHandle = await page.locator('iframe[name="editor-canvas"]').elementHandle();
+  const frame = await frameHandle?.contentFrame();
+  if (!frame) {
+    throw new Error('Editor canvas iframe did not expose a content frame.');
+  }
+
+  await frame.waitForFunction(
+    () => {
+      const layout = document.querySelector('.block-editor-block-list__layout');
+      if (!layout) {
+        return false;
+      }
+
+      const rect = layout.getBoundingClientRect();
+      const isLoading =
+        layout.matches('.is-loading, [aria-busy="true"]') ||
+        layout.querySelector('.is-loading, [aria-busy="true"], .components-spinner');
+      const blockCount = layout.querySelectorAll('.block-editor-block-list__block, [data-block]').length;
+      return rect.width > 0 && rect.height > 0 && !isLoading && blockCount > 0;
+    },
+    { timeout: 30_000 }
+  );
+
+  await frame.addStyleTag({
+    content: `
+      *, *::before, *::after {
+        animation-delay: 0s !important;
+        animation-duration: 0.001ms !important;
+        caret-color: transparent !important;
+        transition-delay: 0s !important;
+        transition-duration: 0.001ms !important;
+      }
+      .block-editor-block-list__block,
+      .block-editor-block-list__block::before,
+      .block-editor-block-list__block::after,
+      .is-selected,
+      .is-highlighted,
+      .has-child-selected {
+        box-shadow: none !important;
+        outline: 0 !important;
+      }
+      .block-editor-block-contextual-toolbar,
+      .block-editor-block-list__insertion-point,
+      .block-editor-block-list__breadcrumb,
+      .block-editor-inserter,
+      .block-editor-inserter__quick-inserter,
+      .block-editor-rich-text__editable::after,
+      .components-popover,
+      .components-toolbar,
+      .components-toolbar-group,
+      .is-root-container > .block-list-appender {
+        display: none !important;
+      }
+    `,
+  });
+  await frame.waitForTimeout(300);
+  return frame;
+}
+
+async function captureEditorScreenshot(page, url, screenshotPath) {
+  const frame = await loadEditorSurface(page, url);
+  const layout = frame.locator('.block-editor-block-list__layout').first();
+  await layout.screenshot({ path: screenshotPath, timeout: 30_000 });
 }
 
 async function evaluateVisualSurface(page, groups) {
@@ -981,6 +1073,229 @@ async function captureSelectorScreenshot(page, selector, screenshotPath) {
   }
 }
 
+function crc32(buffer) {
+  if (!crc32.table) {
+    crc32.table = Array.from({ length: 256 }, (_, index) => {
+      let value = index;
+      for (let bit = 0; bit < 8; bit++) {
+        value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+      }
+      return value >>> 0;
+    });
+  }
+
+  let crc = 0xffffffff;
+  for (const byte of buffer) {
+    crc = crc32.table[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type, data = Buffer.alloc(0)) {
+  const typeBuffer = Buffer.from(type, 'ascii');
+  const chunk = Buffer.concat([typeBuffer, data]);
+  const output = Buffer.alloc(12 + data.length);
+  output.writeUInt32BE(data.length, 0);
+  typeBuffer.copy(output, 4);
+  data.copy(output, 8);
+  output.writeUInt32BE(crc32(chunk), 8 + data.length);
+  return output;
+}
+
+function decodePng(buffer) {
+  if (!buffer.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)) {
+    throw new Error('Unsupported PNG signature.');
+  }
+
+  let offset = PNG_SIGNATURE.length;
+  let width = 0;
+  let height = 0;
+  let bitDepth = 0;
+  let colorType = 0;
+  const idat = [];
+
+  while (offset < buffer.length) {
+    const length = buffer.readUInt32BE(offset);
+    const type = buffer.toString('ascii', offset + 4, offset + 8);
+    const data = buffer.subarray(offset + 8, offset + 8 + length);
+    offset += 12 + length;
+
+    if (type === 'IHDR') {
+      width = data.readUInt32BE(0);
+      height = data.readUInt32BE(4);
+      bitDepth = data[8];
+      colorType = data[9];
+    } else if (type === 'IDAT') {
+      idat.push(data);
+    } else if (type === 'IEND') {
+      break;
+    }
+  }
+
+  if (bitDepth !== 8 || ![0, 2, 4, 6].includes(colorType)) {
+    throw new Error(`Unsupported PNG format: bitDepth=${bitDepth} colorType=${colorType}.`);
+  }
+
+  const channels = { 0: 1, 2: 3, 4: 2, 6: 4 }[colorType];
+  const bytesPerPixel = channels;
+  const stride = width * channels;
+  const inflated = zlib.inflateSync(Buffer.concat(idat));
+  const data = new Uint8ClampedArray(width * height * 4);
+  let inputOffset = 0;
+  let previous = Buffer.alloc(stride);
+
+  for (let y = 0; y < height; y++) {
+    const filter = inflated[inputOffset++];
+    const row = Buffer.from(inflated.subarray(inputOffset, inputOffset + stride));
+    inputOffset += stride;
+
+    for (let x = 0; x < stride; x++) {
+      const left = x >= bytesPerPixel ? row[x - bytesPerPixel] : 0;
+      const up = previous[x] || 0;
+      const upperLeft = x >= bytesPerPixel ? previous[x - bytesPerPixel] || 0 : 0;
+      let value = row[x];
+
+      if (filter === 1) {
+        value += left;
+      } else if (filter === 2) {
+        value += up;
+      } else if (filter === 3) {
+        value += Math.floor((left + up) / 2);
+      } else if (filter === 4) {
+        const p = left + up - upperLeft;
+        const pa = Math.abs(p - left);
+        const pb = Math.abs(p - up);
+        const pc = Math.abs(p - upperLeft);
+        value += pa <= pb && pa <= pc ? left : pb <= pc ? up : upperLeft;
+      } else if (filter !== 0) {
+        throw new Error(`Unsupported PNG row filter: ${filter}.`);
+      }
+
+      row[x] = value & 0xff;
+    }
+
+    for (let x = 0; x < width; x++) {
+      const source = x * channels;
+      const target = (y * width + x) * 4;
+      if (colorType === 0) {
+        data[target] = row[source];
+        data[target + 1] = row[source];
+        data[target + 2] = row[source];
+        data[target + 3] = 255;
+      } else if (colorType === 2) {
+        data[target] = row[source];
+        data[target + 1] = row[source + 1];
+        data[target + 2] = row[source + 2];
+        data[target + 3] = 255;
+      } else if (colorType === 4) {
+        data[target] = row[source];
+        data[target + 1] = row[source];
+        data[target + 2] = row[source];
+        data[target + 3] = row[source + 1];
+      } else {
+        data[target] = row[source];
+        data[target + 1] = row[source + 1];
+        data[target + 2] = row[source + 2];
+        data[target + 3] = row[source + 3];
+      }
+    }
+
+    previous = row;
+  }
+
+  return { width, height, data };
+}
+
+function encodePng({ width, height, data }) {
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(width, 0);
+  header.writeUInt32BE(height, 4);
+  header[8] = 8;
+  header[9] = 6;
+
+  const rows = Buffer.alloc((width * 4 + 1) * height);
+  for (let y = 0; y < height; y++) {
+    const rowOffset = y * (width * 4 + 1);
+    rows[rowOffset] = 0;
+    Buffer.from(data.buffer, data.byteOffset + y * width * 4, width * 4).copy(rows, rowOffset + 1);
+  }
+
+  return Buffer.concat([
+    PNG_SIGNATURE,
+    pngChunk('IHDR', header),
+    pngChunk('IDAT', zlib.deflateSync(rows)),
+    pngChunk('IEND'),
+  ]);
+}
+
+function normalizePng(image, width, height) {
+  if (image.width === width && image.height === height) {
+    return image.data;
+  }
+
+  const normalized = new Uint8ClampedArray(width * height * 4);
+  normalized.fill(255);
+  for (let y = 0; y < image.height; y++) {
+    for (let x = 0; x < image.width; x++) {
+      const source = (y * image.width + x) * 4;
+      const target = (y * width + x) * 4;
+      normalized[target] = image.data[source];
+      normalized[target + 1] = image.data[source + 1];
+      normalized[target + 2] = image.data[source + 2];
+      normalized[target + 3] = image.data[source + 3];
+    }
+  }
+  return normalized;
+}
+
+function comparePixels(sourceData, targetData, diffData) {
+  let mismatched = 0;
+  for (let index = 0; index < sourceData.length; index += 4) {
+    const delta = Math.max(
+      Math.abs(sourceData[index] - targetData[index]),
+      Math.abs(sourceData[index + 1] - targetData[index + 1]),
+      Math.abs(sourceData[index + 2] - targetData[index + 2]),
+      Math.abs(sourceData[index + 3] - targetData[index + 3])
+    );
+
+    if (delta > 26) {
+      mismatched++;
+      diffData[index] = 255;
+      diffData[index + 1] = 0;
+      diffData[index + 2] = 0;
+      diffData[index + 3] = 255;
+    } else {
+      const gray = Math.round((sourceData[index] + sourceData[index + 1] + sourceData[index + 2]) / 3);
+      diffData[index] = gray;
+      diffData[index + 1] = gray;
+      diffData[index + 2] = gray;
+      diffData[index + 3] = 80;
+    }
+  }
+  return mismatched;
+}
+
+async function comparePngScreenshots(sourcePath, targetPath, diffPath) {
+  const sourceImage = decodePng(await readFile(sourcePath));
+  const targetImage = decodePng(await readFile(targetPath));
+  const width = Math.max(sourceImage.width, targetImage.width);
+  const height = Math.max(sourceImage.height, targetImage.height);
+  const sourceData = normalizePng(sourceImage, width, height);
+  const targetData = normalizePng(targetImage, width, height);
+  const diffData = new Uint8ClampedArray(width * height * 4);
+  const mismatchedPixels = comparePixels(sourceData, targetData, diffData);
+
+  await writeFile(diffPath, encodePng({ width, height, data: diffData }));
+  return {
+    diff_path: diffPath,
+    height,
+    mismatched_pixels: mismatchedPixels,
+    pixel_count: width * height,
+    ratio: width > 0 && height > 0 ? mismatchedPixels / (width * height) : 1,
+    width,
+  };
+}
+
 async function captureVisualMismatchScreenshots(browser, result, mismatches, visualDir, targetSlug) {
   if (!mismatches.length) {
     return;
@@ -1196,6 +1511,10 @@ async function emptyVisualComparison(artifactDir, error = '') {
     target_count: 0,
     checked_target_count: 0,
     error_count: error ? 1 : 0,
+    visual_editor_vs_source_pixel_diff_ratio: 0,
+    visual_editor_vs_frontend_pixel_diff_ratio: 0,
+    visual_source_vs_frontend_pixel_diff_ratio_diagnostic: 0,
+    visual_editor_parity_error_count: error ? 1 : 0,
     missing_selector_count: 0,
     visibility_mismatch_count: 0,
     nonzero_bounding_box_count: 0,
@@ -1204,7 +1523,7 @@ async function emptyVisualComparison(artifactDir, error = '') {
     nav_probe_parity_mismatch_count: 0,
     footer_probe_parity_mismatch_count: 0,
     hero_probe_parity_mismatch_count: 0,
-    surfaces: ['source_static', 'wordpress_frontend'],
+    surfaces: ['source_static', 'wordpress_frontend', 'wordpress_editor'],
     editor_surface_ready: true,
     artifact_dir: visualDir,
     diagnostics_artifact: diagnosticsPath,
@@ -1274,6 +1593,61 @@ export async function compareVisualFidelity(importReport, artifactDir, sitePath)
         }
       }
 
+      const editorUrl = surfaceUrl(target, 'wordpress_editor', importReport.reportPath, sitePath);
+      const editorScreenshotPath = path.join(visualDir, `${targetSlug}-wordpress_editor.png`);
+      const editorPage = await browser.newPage({ ignoreHTTPSErrors: true, viewport: VISUAL_VIEWPORT });
+
+      try {
+        if (!editorUrl) {
+          throw new Error('Missing wordpress_editor render URL.');
+        }
+        await captureEditorScreenshot(editorPage, editorUrl, editorScreenshotPath);
+        result.surfaces.wordpress_editor = {
+          url: editorUrl,
+          screenshot: editorScreenshotPath,
+          probes: [],
+          totals: visualSurfaceTotals([]),
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        result.errors.push(`wordpress_editor: ${message}`);
+        result.surfaces.wordpress_editor = {
+          url: editorUrl,
+          screenshot: '',
+          probes: [],
+          totals: visualSurfaceTotals([]),
+          error: message,
+        };
+      } finally {
+        await editorPage.close();
+      }
+
+      result.pixel_diffs = {};
+      const sourceScreenshot = result.surfaces.source_static?.screenshot || '';
+      const frontendScreenshot = result.surfaces.wordpress_frontend?.screenshot || '';
+      const editorScreenshot = result.surfaces.wordpress_editor?.screenshot || '';
+      if (sourceScreenshot && editorScreenshot) {
+        result.pixel_diffs.editor_vs_source = await comparePngScreenshots(
+          sourceScreenshot,
+          editorScreenshot,
+          path.join(visualDir, `${targetSlug}-wordpress_editor-vs-source_static-diff.png`)
+        );
+      }
+      if (frontendScreenshot && editorScreenshot) {
+        result.pixel_diffs.editor_vs_frontend = await comparePngScreenshots(
+          frontendScreenshot,
+          editorScreenshot,
+          path.join(visualDir, `${targetSlug}-wordpress_editor-vs-wordpress_frontend-diff.png`)
+        );
+      }
+      if (sourceScreenshot && frontendScreenshot) {
+        result.pixel_diffs.source_vs_frontend_diagnostic = await comparePngScreenshots(
+          sourceScreenshot,
+          frontendScreenshot,
+          path.join(visualDir, `${targetSlug}-source_static-vs-wordpress_frontend-diagnostic-diff.png`)
+        );
+      }
+
       result.parity = visualParity(
         result.surfaces.source_static?.probes || [],
         result.surfaces.wordpress_frontend?.probes || []
@@ -1302,6 +1676,24 @@ export async function compareVisualFidelity(importReport, artifactDir, sitePath)
       const sourceTotals = result.surfaces.source_static?.totals || visualSurfaceTotals([]);
       const frontendTotals = result.surfaces.wordpress_frontend?.totals || visualSurfaceTotals([]);
       const parity = result.parity || visualParity([], []);
+      summary.visual_editor_vs_source_pixel_diff_ratio = Math.max(
+        summary.visual_editor_vs_source_pixel_diff_ratio,
+        Number(result.pixel_diffs?.editor_vs_source?.ratio || 0)
+      );
+      summary.visual_editor_vs_frontend_pixel_diff_ratio = Math.max(
+        summary.visual_editor_vs_frontend_pixel_diff_ratio,
+        Number(result.pixel_diffs?.editor_vs_frontend?.ratio || 0)
+      );
+      summary.visual_source_vs_frontend_pixel_diff_ratio_diagnostic = Math.max(
+        summary.visual_source_vs_frontend_pixel_diff_ratio_diagnostic,
+        Number(result.pixel_diffs?.source_vs_frontend_diagnostic?.ratio || 0)
+      );
+      if (!result.pixel_diffs?.editor_vs_source) {
+        summary.visual_editor_parity_error_count++;
+      }
+      if (!result.pixel_diffs?.editor_vs_frontend) {
+        summary.visual_editor_parity_error_count++;
+      }
       summary.error_count += result.errors.length;
       summary.checked_target_count += result.errors.length === 0 ? 1 : 0;
       summary.missing_selector_count += sourceTotals.missing_selector_count + frontendTotals.missing_selector_count;
@@ -1319,6 +1711,10 @@ export async function compareVisualFidelity(importReport, artifactDir, sitePath)
       target_count: targets.length,
       checked_target_count: 0,
       error_count: 0,
+      visual_editor_vs_source_pixel_diff_ratio: 0,
+      visual_editor_vs_frontend_pixel_diff_ratio: 0,
+      visual_source_vs_frontend_pixel_diff_ratio_diagnostic: 0,
+      visual_editor_parity_error_count: 0,
       missing_selector_count: 0,
       visibility_mismatch_count: 0,
       nonzero_bounding_box_count: 0,
@@ -1335,7 +1731,7 @@ export async function compareVisualFidelity(importReport, artifactDir, sitePath)
 
   return {
     ...totals,
-    surfaces: ['source_static', 'wordpress_frontend'],
+    surfaces: ['source_static', 'wordpress_frontend', 'wordpress_editor'],
     editor_surface_ready: true,
     artifact_dir: visualDir,
     diagnostics_artifact: diagnosticsPath,
@@ -3153,9 +3549,73 @@ export function importerBlockQualityFailureDetails(importerBlockQuality) {
   ];
 }
 
-export function agentSuccessGate(result, semanticComparison, importReport) {
+function visualRatio(value) {
+  const ratio = metric(value);
+  return Number.isFinite(ratio) ? ratio : 1;
+}
+
+function formatVisualRatio(value) {
+  return visualRatio(value).toFixed(2);
+}
+
+export function visualEditorParityMetrics(visualComparison) {
+  return {
+    visualEditorVsSourcePixelDiffRatio: visualRatio(visualComparison?.visual_editor_vs_source_pixel_diff_ratio),
+    visualEditorVsFrontendPixelDiffRatio: visualRatio(visualComparison?.visual_editor_vs_frontend_pixel_diff_ratio),
+    visualSourceVsFrontendPixelDiffRatio: visualRatio(
+      visualComparison?.visual_pixel_diff_ratio ?? visualComparison?.visual_source_vs_frontend_pixel_diff_ratio_diagnostic
+    ),
+    visualEditorParityErrorCount: metric(visualComparison?.visual_editor_parity_error_count),
+  };
+}
+
+export function visualEditorParityFailureDetails(visualEditorParity) {
+  const {
+    visualEditorVsSourcePixelDiffRatio,
+    visualEditorVsFrontendPixelDiffRatio,
+    visualSourceVsFrontendPixelDiffRatio,
+    visualEditorParityErrorCount,
+  } = visualEditorParity;
+  const editorFailedSource = visualEditorVsSourcePixelDiffRatio > VISUAL_EDITOR_PIXEL_DIFF_THRESHOLD;
+  const editorFailedFrontend = visualEditorVsFrontendPixelDiffRatio > VISUAL_EDITOR_PIXEL_DIFF_THRESHOLD;
+
+  if (visualEditorParityErrorCount > 0) {
+    return [`editor visual parity could not be measured (${visualEditorParityErrorCount} capture/diff errors)`];
+  }
+
+  if (!editorFailedSource && !editorFailedFrontend) {
+    return [];
+  }
+
+  if (editorFailedFrontend && visualSourceVsFrontendPixelDiffRatio <= VISUAL_EDITOR_PIXEL_DIFF_THRESHOLD) {
+    return [
+      `editor render diverges from frontend (editor diff: ${formatVisualRatio(
+        visualEditorVsSourcePixelDiffRatio
+      )}, frontend diff: ${formatVisualRatio(
+        visualSourceVsFrontendPixelDiffRatio
+      )}) - likely block-validation or unscoped CSS`,
+    ];
+  }
+
+  if (editorFailedSource && visualSourceVsFrontendPixelDiffRatio > VISUAL_EDITOR_PIXEL_DIFF_THRESHOLD) {
+    return [
+      `editor and frontend both diverge from source (editor: ${formatVisualRatio(
+        visualEditorVsSourcePixelDiffRatio
+      )}, frontend: ${formatVisualRatio(visualSourceVsFrontendPixelDiffRatio)}) - conversion failed before editor concern`,
+    ];
+  }
+
+  return [
+    `editor visual parity failed (editor vs source: ${formatVisualRatio(
+      visualEditorVsSourcePixelDiffRatio
+    )}, editor vs frontend: ${formatVisualRatio(visualEditorVsFrontendPixelDiffRatio)})`,
+  ];
+}
+
+export function agentSuccessGate(result, semanticComparison, importReport, visualComparison) {
   const semanticMismatchCount = metric(semanticComparison?.mismatch_count);
   const importerBlockQuality = importerBlockQualityMetrics(importReport);
+  const visualEditorParity = visualEditorParityMetrics(visualComparison);
   const agentTimedOut = result?.timedOut === true;
   const agentSucceeded =
     result?.success === true &&
@@ -3164,7 +3624,10 @@ export function agentSuccessGate(result, semanticComparison, importReport) {
     semanticMismatchCount === 0 &&
     importerBlockQuality.importerCoreHtmlBlockCount === 0 &&
     importerBlockQuality.importerFreeformBlockCount === 0 &&
-    importerBlockQuality.importerFallbackCount === 0;
+    importerBlockQuality.importerFallbackCount === 0 &&
+    visualEditorParity.visualEditorParityErrorCount === 0 &&
+    visualEditorParity.visualEditorVsSourcePixelDiffRatio <= VISUAL_EDITOR_PIXEL_DIFF_THRESHOLD &&
+    visualEditorParity.visualEditorVsFrontendPixelDiffRatio <= VISUAL_EDITOR_PIXEL_DIFF_THRESHOLD;
 
   return {
     agentSucceeded,
@@ -3172,6 +3635,8 @@ export function agentSuccessGate(result, semanticComparison, importReport) {
     semanticFailureDetails: semanticMismatchCount > 0 ? semanticMismatchFailureDetails(semanticComparison) : [],
     importerBlockQuality,
     importerBlockQualityFailureDetails: importerBlockQualityFailureDetails(importerBlockQuality),
+    visualEditorParity,
+    visualEditorFailureDetails: visualEditorParityFailureDetails(visualEditorParity),
     metrics: {
       success_rate: agentSucceeded ? 1 : 0,
       agent_error_rate: agentSucceeded ? 0 : 1,
@@ -3231,10 +3696,14 @@ export default async function studioAgentSiteBuildBench() {
   const nativeBlockQuality = nativeBlockQualityMetrics(quality, authoredBlocks, editorValidation, importReport);
   const designFingerprint = await collectDesignFingerprint(sitePath);
   const designMetrics = designFingerprintMetrics(designFingerprint);
-  const gate = agentSuccessGate(result, semanticComparison, importReport);
+  const gate = agentSuccessGate(result, semanticComparison, importReport, visualComparison);
   const semanticMismatchCount = gate.semanticMismatchCount;
   const semanticOptionalSelectorAbsentCount = semanticTargetMetric(semanticComparison, 'optional_selector_absent_count');
-  const failureDetails = [...gate.semanticFailureDetails, ...gate.importerBlockQualityFailureDetails];
+  const failureDetails = [
+    ...gate.semanticFailureDetails,
+    ...gate.importerBlockQualityFailureDetails,
+    ...gate.visualEditorFailureDetails,
+  ];
   const { importerCoreHtmlBlockCount, importerFreeformBlockCount, importerFallbackCount } = gate.importerBlockQuality;
 
   const artifactFile = path.join(artifactDir, `result-${runId}.json`);
@@ -3357,6 +3826,9 @@ export default async function studioAgentSiteBuildBench() {
       visual_comparison_target_count: Number(visualComparison.target_count || 0),
       visual_comparison_checked_target_count: Number(visualComparison.checked_target_count || 0),
       visual_comparison_error_count: Number(visualComparison.error_count || 0),
+      visual_editor_vs_source_pixel_diff_ratio: metric(visualComparison.visual_editor_vs_source_pixel_diff_ratio),
+      visual_editor_vs_frontend_pixel_diff_ratio: metric(visualComparison.visual_editor_vs_frontend_pixel_diff_ratio),
+      visual_editor_parity_error_count: Number(visualComparison.visual_editor_parity_error_count || 0),
       visual_missing_selector_count: Number(visualComparison.missing_selector_count || 0),
       visual_visibility_mismatch_count: Number(visualComparison.visibility_mismatch_count || 0),
       visual_nonzero_bounding_box_count: Number(visualComparison.nonzero_bounding_box_count || 0),

--- a/Automattic/studio/bench/studio-agent-site-build.test.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.test.mjs
@@ -10,6 +10,8 @@ const {
   importerBlockQualityMetrics,
   semanticTargetMetric,
   structuralSelectorDriftDiagnostics,
+  visualEditorParityFailureDetails,
+  visualEditorParityMetrics,
 } = await import('./studio-agent-site-build.bench.mjs');
 
 test('semantic-fidelity mismatches hard-fail the agent success gate', () => {
@@ -94,6 +96,45 @@ test('importer block-quality metrics use zero as the clean threshold', () => {
     agentSuccessGate({ success: true, error: null, timedOut: false }, { mismatch_count: 0 }, importReport).agentSucceeded,
     true
   );
+});
+
+test('editor visual parity metrics hard-fail the agent success gate', () => {
+  const visualComparison = {
+    visual_editor_vs_source_pixel_diff_ratio: 0.15,
+    visual_editor_vs_frontend_pixel_diff_ratio: 0.14,
+    visual_source_vs_frontend_pixel_diff_ratio_diagnostic: 0.03,
+  };
+  const gate = agentSuccessGate(
+    { success: true, error: null, timedOut: false },
+    { mismatch_count: 0 },
+    { report: { quality: {} } },
+    visualComparison
+  );
+
+  assert.equal(gate.agentSucceeded, false);
+  assert.equal(gate.metrics.success_rate, 0);
+  assert.equal(gate.metrics.agent_error_rate, 1);
+  assert.deepEqual(gate.visualEditorParity, {
+    visualEditorVsSourcePixelDiffRatio: 0.15,
+    visualEditorVsFrontendPixelDiffRatio: 0.14,
+    visualSourceVsFrontendPixelDiffRatio: 0.03,
+    visualEditorParityErrorCount: 0,
+  });
+  assert.deepEqual(gate.visualEditorFailureDetails, [
+    'editor render diverges from frontend (editor diff: 0.15, frontend diff: 0.03) - likely block-validation or unscoped CSS',
+  ]);
+});
+
+test('editor visual parity failure details distinguish upstream conversion failures', () => {
+  const visualEditorParity = visualEditorParityMetrics({
+    visual_editor_vs_source_pixel_diff_ratio: 0.15,
+    visual_editor_vs_frontend_pixel_diff_ratio: 0.04,
+    visual_source_vs_frontend_pixel_diff_ratio_diagnostic: 0.12,
+  });
+
+  assert.deepEqual(visualEditorParityFailureDetails(visualEditorParity), [
+    'editor and frontend both diverge from source (editor: 0.15, frontend: 0.12) - conversion failed before editor concern',
+  ]);
 });
 
 test('semantic target metrics sum artifact target details for top-level output', () => {


### PR DESCRIPTION
## Summary
- Fixes #70 by adding `wordpress_editor` as a third visual-comparison capture surface for the Studio site-build bench.
- Captures the block editor iframe via auto-login, hides editor chrome, writes `*-wordpress_editor.png`, and emits `visual_editor_vs_source_pixel_diff_ratio` plus `visual_editor_vs_frontend_pixel_diff_ratio`.
- Gates `agentSucceeded` on both editor pixel-diff ratios staying under `0.05`, alongside companion gates from #67 and the planned frontend pixel-diff gate from #68.

## Discriminator logic
- If editor diverges while frontend remains close to source, the failure detail names an editor-specific likely cause: block validation or unscoped CSS.
- If both editor and frontend diverge from source, the failure detail points at upstream conversion failure before editor-specific concerns.
- Editor capture/diff failures also fail the gate with an explicit measurement-error detail.

## Verification
- `node --check Automattic/studio/bench/studio-agent-site-build.bench.mjs`
- `node --test Automattic/studio/bench/studio-agent-site-build.test.mjs`
- Ran current worktree `compareVisualFidelity()` against a generated Studio/BFB site and confirmed artifacts were written under `/tmp/studio-bfb-bench/current-worktree-editor-parity-validation/visual-comparisons`, including `index-html-wordpress_editor.png` and both editor diff overlays.

## Notes
- A full `homeboy bench --rig studio-bfb --scenario studio-agent-site-build --iterations 1` invocation resolved the workload from a different registered `homeboy-rigs` worktree and the default baseline rig hit `EADDRINUSE`; the candidate rig completed, but that run did not validate this checkout's modified bench file.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Implemented the editor capture, PNG diff/gate logic, tests, and local verification commands; Chris remains responsible for review and merge.