### PR TITLE
fix(studio): discover site-build prompt variants

### DIFF
--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -19,33 +19,6 @@ const PROMPT_FILE_SETTING = 'studio_site_build_prompt_file';
 const BENCH_NAMESPACE_SETTING = 'studio_bench_namespace';
 const DEFAULT_PROMPT_VARIANT = 'studio-code';
 const PROMPT_CATEGORY = 'site-build';
-const PROMPT_VARIANTS = {
-  'artist-music': 'plain-site/artist-music.md',
-  'course-education': 'plain-site/course-education.md',
-  'data-machine': 'plain-site/data-machine.md',
-  'documentation-knowledge-base': 'plain-site/documentation-knowledge-base.md',
-  'editorial-magazine': 'plain-site/editorial-magazine.md',
-  'event-conference': 'plain-site/event-conference.md',
-  homeboy: 'plain-site/homeboy.md',
-  intelligence: 'plain-site/intelligence.md',
-  'local-service-business': 'plain-site/local-service-business.md',
-  'membership-community': 'plain-site/membership-community.md',
-  nonprofit: 'plain-site/nonprofit.md',
-  'nonprofit-campaign': 'plain-site/nonprofit-campaign.md',
-  portfolio: 'plain-site/portfolio.md',
-  'radical-speed-month': 'plain-site/radical-speed-month.md',
-  restaurant: 'plain-site/restaurant.md',
-  saas: 'plain-site/saas.md',
-  'realistic-small-business': 'plain-site/realistic-small-business.md',
-  'studio-code': 'plain-site/studio-code.md',
-  'wp-coding-agents': 'plain-site/wp-coding-agents.md',
-  'wordpress-is-dead': 'plain-site/wordpress-is-dead.md',
-  'product-catalog': 'store/product-catalog.md',
-  'switchback-woocommerce-extra-hard': 'store/switchback-woocommerce-extra-hard.md',
-  'astro-docs-content-collection': 'static-markdown/astro-docs-content-collection.md',
-  'markdown-blog-launch-site': 'static-markdown/markdown-blog-launch-site.md',
-  'static-content-library': 'static-markdown/static-content-library.md',
-};
 const SYSTEM_PROMPT_FILES = ['apps/cli/ai/system-prompt.ts'];
 const requireFromBench = createRequire(import.meta.url);
 const VISUAL_VIEWPORT = { width: 1440, height: 1100 };
@@ -299,30 +272,42 @@ function promptVariant() {
 }
 
 export async function availablePromptVariants() {
-  await validatePromptVariantCatalog();
-  return Object.keys(PROMPT_VARIANTS);
+  return validatePromptVariantCatalog();
 }
 
 export async function validatePromptVariantCatalog() {
   const promptsDir = new URL('./prompts/site-build/', import.meta.url);
   const files = await promptFiles(promptsDir);
-  const registeredEntries = Object.entries(PROMPT_VARIANTS);
-  const registered = registeredEntries.map(([variantName]) => variantName).sort();
-  const registeredFiles = registeredEntries.map(([, relativePath]) => relativePath).sort();
-  const missingFiles = registeredEntries
-    .filter(([, relativePath]) => !files.includes(relativePath))
-    .map(([variantName, relativePath]) => `${variantName} (${relativePath})`);
-  const unregisteredFiles = files.filter((relativePath) => !registeredFiles.includes(relativePath));
+  return Object.keys(promptVariantCatalog(files));
+}
 
-  if (missingFiles.length || unregisteredFiles.length) {
+export function promptVariantCatalog(files) {
+  const variants = {};
+  const duplicatePaths = new Map();
+
+  for (const relativePath of files) {
+    const variantName = path.posix.basename(relativePath, '.md');
+    if (variants[variantName]) {
+      if (!duplicatePaths.has(variantName)) {
+        duplicatePaths.set(variantName, [variants[variantName]]);
+      }
+      duplicatePaths.get(variantName).push(relativePath);
+      continue;
+    }
+
+    variants[variantName] = relativePath;
+  }
+
+  if (duplicatePaths.size) {
+    const duplicates = [...duplicatePaths.entries()]
+      .map(([variantName, paths]) => `${variantName} (${paths.join(', ')})`)
+      .join('; ');
     throw new Error(
-      `Studio site-build prompt catalog mismatch. Missing files: ${
-        missingFiles.join(', ') || 'none'
-      }. Unregistered files: ${unregisteredFiles.join(', ') || 'none'}.`
+      `Studio site-build prompt catalog has duplicate basename-derived variant IDs. Rename prompt files so each basename is unique. Duplicates: ${duplicates}.`
     );
   }
 
-  return registered;
+  return variants;
 }
 
 async function promptFiles(directoryUrl, prefix = '') {
@@ -351,7 +336,8 @@ async function promptTemplatePath() {
   if (!/^[a-z0-9][a-z0-9-]*$/.test(variantName)) {
     throw new Error(`Invalid ${PROMPT_VARIANT_SETTING}: ${variantName}`);
   }
-  const relativePromptPath = PROMPT_VARIANTS[variantName];
+  const promptsDir = new URL('./prompts/site-build/', import.meta.url);
+  const relativePromptPath = promptVariantCatalog(await promptFiles(promptsDir))[variantName];
   if (!relativePromptPath) {
     const variants = await availablePromptVariants();
     throw new Error(`Unknown ${PROMPT_VARIANT_SETTING}: ${variantName}. Available variants: ${variants.join(', ')}.`);

--- a/Automattic/studio/bench/studio-agent-site-build.test.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.test.mjs
@@ -1,18 +1,68 @@
 import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
 process.env.HOMEBOY_COMPONENT_PATH ||= '/tmp/homeboy-rigs-test-component';
 
 const {
   agentSuccessGate,
+  availablePromptVariants,
   hiddenEditorContentDiagnostics,
   importerBlockQualityFailureDetails,
   importerBlockQualityMetrics,
+  promptVariantCatalog,
   semanticTargetMetric,
+  siteBuildPrompt,
   structuralSelectorDriftDiagnostics,
+  validatePromptVariantCatalog,
   visualEditorParityFailureDetails,
   visualEditorParityMetrics,
 } = await import('./studio-agent-site-build.bench.mjs');
+
+test('site-build prompt variants are discovered from prompt files', async () => {
+  const variants = await availablePromptVariants();
+
+  assert.ok(variants.includes('restaurant'));
+  assert.ok(variants.includes('studio-code'));
+  assert.ok(variants.includes('static-content-library'));
+  assert.deepEqual(await validatePromptVariantCatalog(), variants);
+});
+
+test('site-build prompt catalog derives variant IDs from markdown basenames', () => {
+  assert.deepEqual(promptVariantCatalog(['plain-site/restaurant.md', 'static-markdown/static-content-library.md']), {
+    restaurant: 'plain-site/restaurant.md',
+    'static-content-library': 'static-markdown/static-content-library.md',
+  });
+});
+
+test('site-build prompt catalog fails clearly for duplicate basename-derived IDs', () => {
+  assert.throws(
+    () => promptVariantCatalog(['plain-site/restaurant.md', 'store/restaurant.md']),
+    /duplicate basename-derived variant IDs.*restaurant.*plain-site\/restaurant\.md.*store\/restaurant\.md/
+  );
+});
+
+test('site-build prompt file override bypasses discovered variants', async () => {
+  const previousSettings = process.env.HOMEBOY_SETTINGS_JSON;
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'studio-site-build-prompt-'));
+  const promptFile = path.join(tempDir, 'custom.md');
+
+  try {
+    await writeFile(promptFile, 'Build {{sitePath}} from ${sitePath}\n');
+    process.env.HOMEBOY_SETTINGS_JSON = JSON.stringify({ studio_site_build_prompt_file: promptFile });
+
+    assert.equal(await siteBuildPrompt('/tmp/example-site'), 'Build /tmp/example-site from /tmp/example-site');
+  } finally {
+    if (previousSettings === undefined) {
+      delete process.env.HOMEBOY_SETTINGS_JSON;
+    } else {
+      process.env.HOMEBOY_SETTINGS_JSON = previousSettings;
+    }
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
 
 test('semantic-fidelity mismatches hard-fail the agent success gate', () => {
   const gate = agentSuccessGate(


### PR DESCRIPTION
## Summary
- Discover Studio site-build prompt variants from `bench/prompts/site-build/**/*.md` instead of maintaining a hardcoded map.
- Preserve basename-derived variant IDs and explicit `studio_site_build_prompt_file` overrides.
- Add focused node tests for discovery, duplicate basename failures, and override behavior.

## Verification
- `node --test Automattic/studio/bench/studio-agent-site-build.test.mjs`
- `homeboy bench list --rig studio-bfb --scenario studio-agent-site-build`

Fixes #80.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the implementation and tests; Chris remains responsible for review and validation.