### PR TITLE
Split Studio agent rigs by model

### DIFF
--- a/Automattic/studio/rigs/studio-agent-claude-ssi/rig.json
+++ b/Automattic/studio/rigs/studio-agent-claude-ssi/rig.json
@@ -1,12 +1,15 @@
 {
-  "id": "studio-agent-pi",
-  "description": "Studio agent runtime candidate: Automattic/studio PR #3246 / pi-agent-core unified runtime. Compared against studio-agent-sdk via Homeboy bench.",
+  "id": "studio-agent-claude-ssi",
+  "description": "Studio Claude Sonnet 4.6 on the active Static Site Importer draft branch. Pairs with studio-agent-gpt55-ssi so the same SSI substrate can be compared across models.",
   "components": {
     "studio": {
-      "path": "~/Developer/studio@pi-runtime-candidate",
-      "branch": "pi-runtime-candidate",
+      "path": "~/Developer/studio@bfb-mu-plugin-agent-output",
+      "branch": "bfb-mu-plugin-agent-output-draft",
       "extensions": {
-        "nodejs": {}
+        "nodejs": {
+          "studio_bench_variant": "claude-sonnet-4-6-ssi",
+          "studio_agent_model": "claude-sonnet-4-6"
+        }
       }
     }
   },

--- a/Automattic/studio/rigs/studio-agent-claude-trunk/rig.json
+++ b/Automattic/studio/rigs/studio-agent-claude-trunk/rig.json
@@ -1,13 +1,14 @@
 {
-  "id": "studio-agent-sdk",
-  "description": "Studio agent runtime baseline: Automattic/studio trunk with the Claude Agent SDK runtime. Used as the reference rig for Homeboy bench A/B runs against pi-agent-core.",
+  "id": "studio-agent-claude-trunk",
+  "description": "Studio Claude Sonnet 4.6 on current Automattic/studio trunk. Used as the reference rig for trunk-vs-SSI comparisons.",
   "components": {
     "studio": {
       "path": "~/Developer/studio@agent-sdk-baseline",
       "branch": "agent-sdk-baseline",
       "extensions": {
         "nodejs": {
-          "studio_bench_variant": "trunk"
+          "studio_bench_variant": "claude-sonnet-4-6-trunk",
+          "studio_agent_model": "claude-sonnet-4-6"
         }
       }
     }

--- a/Automattic/studio/rigs/studio-agent-gpt55-ssi/rig.json
+++ b/Automattic/studio/rigs/studio-agent-gpt55-ssi/rig.json
@@ -1,0 +1,54 @@
+{
+  "id": "studio-agent-gpt55-ssi",
+  "description": "Studio GPT 5.5 / pi-agent-core runtime on the active Static Site Importer draft branch. Pairs with studio-agent-claude-ssi so the same SSI substrate can be compared across models.",
+  "components": {
+    "studio": {
+      "path": "~/Developer/studio@bfb-mu-plugin-agent-output",
+      "branch": "bfb-mu-plugin-agent-output-draft",
+      "extensions": {
+        "nodejs": {
+          "studio_bench_variant": "gpt-5.5-ssi",
+          "studio_agent_model": "gpt-5.5"
+        }
+      }
+    }
+  },
+  "bench": {
+    "default_component": "studio"
+  },
+  "bench_workloads": {
+    "nodejs": [
+      "${package.root}/bench/studio-agent-runtime.bench.mjs",
+      "${package.root}/bench/studio-agent-site-build.bench.mjs",
+      "${package.root}/bench/studio-bfb-write-path.bench.mjs"
+    ]
+  },
+  "pipeline": {
+    "up": [
+      {
+        "kind": "command",
+        "label": "Install Studio dependencies",
+        "cwd": "${components.studio.path}",
+        "command": "npm install"
+      },
+      {
+        "kind": "command",
+        "label": "Build Studio CLI",
+        "cwd": "${components.studio.path}",
+        "command": "npm run cli:build --silent"
+      }
+    ],
+    "check": [
+      {
+        "kind": "check",
+        "label": "Studio CLI eval runner built",
+        "file": "${components.studio.path}/apps/cli/dist/cli/eval-runner.mjs"
+      },
+      {
+        "kind": "check",
+        "label": "Studio package dependencies installed",
+        "file": "${components.studio.path}/node_modules"
+      }
+    ]
+  }
+}

--- a/Automattic/studio/rigs/studio-bfb/rig.json
+++ b/Automattic/studio/rigs/studio-bfb/rig.json
@@ -39,7 +39,7 @@
   },
   "bench": {
     "default_component": "studio",
-    "default_baseline_rig": "studio-agent-sdk"
+    "default_baseline_rig": "studio-agent-claude-ssi"
   },
   "bench_workloads": {
     "nodejs": [

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Canonical Studio create-site trace spans, pending Homeboy's trace span summary s
 | `state_to_ui` | `probe.site_details_running_true` | `ui.site.running_visible` |
 | `submit_to_running` | `ui.create_site.submit_clicked` | `ui.site.running_visible` |
 
-`rigs/studio-bfb/rig.json` is the local Studio/BFB mu-plugin playground rig. It verifies raw HTML writes store native blocks through the BFB substrate and declares `studio-agent-sdk` as its default benchmark baseline for trunk-vs-BFB agent site-build comparisons.
+`rigs/studio-bfb/rig.json` is the local Studio/BFB mu-plugin playground rig. It verifies raw HTML writes store native blocks through the BFB substrate and declares `studio-agent-claude-ssi` as its default benchmark baseline for same-substrate agent site-build comparisons.
 
 ```bash
 homeboy rig up studio-bfb
@@ -139,7 +139,7 @@ The deterministic write-path workload is `bench/studio-bfb-write-path.bench.mjs`
 
 `bench/studio-ssi-woo-fixture-validation.bench.mjs` carries a disabled fixture scaffold for Static Site Importer WooCommerce primitives. It records the static store fixture and `products.json` manifest, then reports a skip until SSI implements manifest validation, product seeding, and product context forwarding. Enable it with `HOMEBOY_ENABLE_SSI_WOO_FIXTURE=1` only against an SSI branch that exposes those primitives; the rig must not seed WooCommerce products itself.
 
-`rigs/studio-agent-sdk/rig.json` and `rigs/studio-agent-pi/rig.json` are paired bench rigs for Studio agent-runtime A/B checks. They share `bench/studio-agent-runtime.bench.mjs`.
+`rigs/studio-agent-claude-ssi/rig.json` and `rigs/studio-agent-gpt55-ssi/rig.json` are paired bench rigs for Studio agent-runtime and SSI site-build A/B checks across models. `rigs/studio-agent-claude-trunk/rig.json` remains available for trunk-vs-SSI comparisons. They share `bench/studio-agent-runtime.bench.mjs`.
 
 `stacks/studio-combined.json` rebuilds `fork/dev/combined-fixes` from `origin/trunk` plus Chris's active Automattic/studio local-dev PRs.
 


### PR DESCRIPTION
## Summary
- Rename the stale Studio agent SDK/PI rigs around the model/scenario they represent: Claude trunk and GPT 5.5 SSI.
- Add a Claude SSI rig so the Static Site Importer bridge can be compared across Claude Sonnet 4.6 and GPT 5.5 on the same substrate.
- Point the Studio BFB rig's default baseline at the Claude SSI rig for same-substrate comparisons.

## Verification
- `node -e \"for (const f of ['Automattic/studio/rigs/studio-agent-claude-ssi/rig.json','Automattic/studio/rigs/studio-agent-claude-trunk/rig.json','Automattic/studio/rigs/studio-agent-gpt55-ssi/rig.json','Automattic/studio/rigs/studio-bfb/rig.json']) JSON.parse(require('fs').readFileSync(f,'utf8'))\"`
- `homeboy rig install /Users/chubes/Developer/homeboy-rigs@studio-agent-model-matrix/Automattic/studio --all`
- `homeboy rig check studio-agent-claude-ssi`
- `homeboy rig check studio-agent-gpt55-ssi`
- `homeboy rig check studio-agent-claude-trunk`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Isolated the rig-matrix changes from in-flight work, renamed/added Studio agent rig specs, and verified the installed rig checks.