### PR TITLE
fix(studio): make site-build prompts natural client briefs

### DIFF
--- a/Automattic/studio/bench/prompts/site-build/static-markdown/astro-docs-content-collection.md
+++ b/Automattic/studio/bench/prompts/site-build/static-markdown/astro-docs-content-collection.md
@@ -1,23 +1,5 @@
-Build an importable mixed-source documentation site for SignalForge, a developer tool that monitors API reliability for small platform teams.
+I need a documentation site for SignalForge, a developer tool that helps small platform teams monitor API reliability and respond to incidents before customers start filing support tickets.
 
-This benchmark is specifically for the Static Site Importer mixed-source capability. Create a source tree that the importer can consume directly, with an HTML shell for shared chrome and plain Markdown content files for individual pages.
+The site should feel like a serious developer docs hub, not a generic SaaS landing page. Include a clear homepage, product overview, getting started path, incident workflow guidance, API reference preview, changelog or launch notes, support links, and practical examples that make the tool feel real.
 
-Required source shape:
-
-```text
-site/
-  index.html
-  styles.css
-  content/
-    about.md
-    docs/getting-started.md
-    docs/incident-workflows.md
-    docs/api-reference.md
-    changelog/launch-notes.markdown
-```
-
-Use `index.html` for the visual system, navigation, footer, homepage sections, and links into the Markdown pages. Use `styles.css` for all site styling. Give every Markdown file frontmatter with `title` and `slug`, and include internal links between the homepage and nested content pages.
-
-The Markdown pages should exercise rich GFM content: headings, ordered and unordered lists, tables, blockquotes, fenced code examples, task lists, and at least one image or downloadable-file link placeholder where the importer supports it.
-
-Import the source tree into this Studio site using the mixed HTML shell plus Markdown content importer path: {{sitePath}}
+Please build it in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/static-markdown/markdown-blog-launch-site.md
+++ b/Automattic/studio/bench/prompts/site-build/static-markdown/markdown-blog-launch-site.md
@@ -1,23 +1,5 @@
-Build an importable mixed-source launch site for Northstar Pantry, a new subscription meal-planning service for busy families.
+I need a launch website for Northstar Pantry, a new subscription meal-planning service for busy families who want practical weekly dinners without turning cooking into another project.
 
-This prompt is intended to validate Static Site Importer support for a handoff where the marketing shell is HTML/CSS and the article content is Markdown. Produce a source tree for import with plain Markdown article files.
+The site should include a welcoming homepage, clear product promise, pricing teaser, launch story, sample weekly menu, founder note, pantry staples guide, newsletter signup, and links between the main pages or articles so visitors can explore naturally.
 
-Required source shape:
-
-```text
-site/
-  index.html
-  styles.css
-  content/
-    about.md
-    blog/launch-story.md
-    blog/weekly-menu-preview.markdown
-    blog/founder-note.md
-    guides/pantry-staples.markdown
-```
-
-Use `index.html` as the homepage and shared shell: distinctive hero, product promise, pricing teaser, article cards, newsletter call to action, and footer navigation. Use `styles.css` for a polished responsive visual direction. Link homepage article cards to the Markdown files and include cross-links between articles.
-
-Every Markdown file needs frontmatter with `title` and `slug`. Include rich Markdown/GFM content across the files: nested headings, lists, comparison tables, blockquotes, fenced recipe or config-style code blocks, and image/file link placeholders where supported.
-
-Import this mixed HTML/CSS/Markdown source tree into the Studio site through the importer capability: {{sitePath}}
+Please build it in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/static-markdown/static-content-library.md
+++ b/Automattic/studio/bench/prompts/site-build/static-markdown/static-content-library.md
@@ -1,23 +1,5 @@
-Build an importable mixed-source resource library for Civic Signal, a nonprofit publishing toolkits for neighborhood organizers.
+I need a resource library website for Civic Signal, a nonprofit publishing practical toolkits for neighborhood organizers who run outreach, public meetings, grant prep, and community improvement projects.
 
-This benchmark should depend on Static Site Importer mixed-source support: one HTML shell plus multiple plain Markdown resources. Generate a source tree that can be imported as-is.
+The site should include a useful homepage, resource index, topic groupings, an about page, outreach checklist, meeting agenda template, grant readiness guide, case study, calls to action, and enough cross-linking that the library feels connected instead of like isolated pages.
 
-Required source shape:
-
-```text
-site/
-  index.html
-  styles.css
-  content/
-    about.md
-    resources/outreach-checklist.md
-    resources/meeting-agenda-template.markdown
-    resources/grant-readiness.md
-    case-studies/park-cleanup.md
-```
-
-Use `index.html` for the shared design system, homepage, resource index, topic filters or groupings, calls to action, and footer. Use `styles.css` for all responsive layout and visual styling. The homepage must link to the Markdown resources, and the resources should link back to the index and to at least one related resource.
-
-Every Markdown or `.markdown` file must include frontmatter with `title` and `slug`. Use rich Markdown/GFM content: headings, numbered steps, unordered checklists, data tables, blockquotes, fenced code or plain-text templates, and image/file link placeholders where supported by the importer.
-
-Import the resulting HTML shell plus Markdown content tree into this Studio site: {{sitePath}}
+Please build it in this Studio site: {{sitePath}}

--- a/Automattic/studio/bench/prompts/site-build/store/switchback-woocommerce-extra-hard.md
+++ b/Automattic/studio/bench/prompts/site-build/store/switchback-woocommerce-extra-hard.md
@@ -1,6 +1,6 @@
 Create a complete WooCommerce storefront concept for "Switchback," a specialist outdoor outfitter for dogs and their people.
 
-This is an extra-hard benchmark prompt. Act like a cracked WordPress developer who can plan and build the right WordPress/WooCommerce substrate: homepage structure, product catalog shape, collections, attributes, navigation, reusable content sections, and visual design as one coordinated implementation.
+This needs to be more than a generic design-only landing page. Plan the storefront like a real outdoor retail business: homepage structure, product catalog shape, collections, attributes, navigation, reusable content sections, and visual design as one coordinated store experience.
 
 Brand concept:
 Switchback sells terrain-aware and weather-aware trail gear for dog owners who hike, camp, visit lakes, and road-trip with their dogs. The store helps shoppers confidently outfit their dog for outdoor days with the right mix of safety, comfort, hydration, paw care, cleanup, and recovery products.
@@ -87,6 +87,6 @@ WooCommerce-specific expectations:
 Tone:
 Use plain outdoor language: heat, trail length, mud, night visibility, recovery, hydration, paw care, cleanup, fit, terrain, lake weekends, campouts, and car rides home.
 
-The page should prioritize directional shopping and conversion over long-form storytelling, while still proving that the generated WordPress site understands the underlying commerce model.
+The page should prioritize directional shopping and conversion over long-form storytelling, with enough merchandising detail to make the underlying commerce model clear.
 
 Work in this Studio site: {{sitePath}}


### PR DESCRIPTION
## Summary
- Rewrites static-markdown site-build prompts as natural client briefs instead of importer fixture specifications.
- Removes self-aware benchmark language from the Switchback WooCommerce prompt while preserving its storefront requirements.

## Why
The site-build benchmark should measure how the Studio agent behaves under realistic client requests. Prompting literal source shapes, frontmatter, HTML shell structure, or benchmark intent leaks implementation details that should be controlled by the Studio system prompt and runtime workflow.

## Tests
- `HOMEBOY_COMPONENT_PATH=/Users/chubes/Developer/studio node --input-type=module -e "const bench = await import('./Automattic/studio/bench/studio-agent-site-build.bench.mjs'); console.log((await bench.availablePromptVariants()).join('\\n'))"`
- `node --test "Automattic/studio/bench/studio-agent-site-build.test.mjs"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Rewriting benchmark prompts to remove implementation-format leakage, validating prompt catalog discovery, and running targeted unit tests. Chris reviewed and directed the change.