### PR TITLE
fix(studio): restore agent benchmark rigs

### DIFF
--- a/Automattic/studio/rigs/studio-agent-claude-ssi/rig.json
+++ b/Automattic/studio/rigs/studio-agent-claude-ssi/rig.json
@@ -1,0 +1,54 @@
+{
+  "id": "studio-agent-claude-ssi",
+  "description": "Studio Claude Sonnet 4.6 on the active Static Site Importer draft branch. Pairs with studio-agent-gpt55-ssi so the same SSI substrate can be compared across models.",
+  "components": {
+    "studio": {
+      "path": "~/Developer/studio@bfb-mu-plugin-agent-output",
+      "branch": "bfb-mu-plugin-agent-output-draft",
+      "extensions": {
+        "nodejs": {
+          "studio_bench_variant": "claude-sonnet-4-6-ssi",
+          "studio_agent_model": "claude-sonnet-4-6"
+        }
+      }
+    }
+  },
+  "bench": {
+    "default_component": "studio"
+  },
+  "bench_workloads": {
+    "nodejs": [
+      "${package.root}/bench/studio-agent-runtime.bench.mjs",
+      "${package.root}/bench/studio-agent-site-build.bench.mjs",
+      "${package.root}/bench/studio-bfb-write-path.bench.mjs"
+    ]
+  },
+  "pipeline": {
+    "up": [
+      {
+        "kind": "command",
+        "label": "Install Studio dependencies",
+        "cwd": "${components.studio.path}",
+        "command": "npm install"
+      },
+      {
+        "kind": "command",
+        "label": "Build Studio CLI",
+        "cwd": "${components.studio.path}",
+        "command": "npm run cli:build --silent"
+      }
+    ],
+    "check": [
+      {
+        "kind": "check",
+        "label": "Studio CLI eval runner built",
+        "file": "${components.studio.path}/apps/cli/dist/cli/eval-runner.mjs"
+      },
+      {
+        "kind": "check",
+        "label": "Studio package dependencies installed",
+        "file": "${components.studio.path}/node_modules"
+      }
+    ]
+  }
+}

--- a/Automattic/studio/rigs/studio-agent-claude-trunk/rig.json
+++ b/Automattic/studio/rigs/studio-agent-claude-trunk/rig.json
@@ -1,0 +1,54 @@
+{
+  "id": "studio-agent-claude-trunk",
+  "description": "Studio Claude Sonnet 4.6 on current Automattic/studio trunk. Used as the reference rig for trunk-vs-SSI comparisons.",
+  "components": {
+    "studio": {
+      "path": "~/Developer/studio@agent-sdk-baseline",
+      "branch": "agent-sdk-baseline",
+      "extensions": {
+        "nodejs": {
+          "studio_bench_variant": "claude-sonnet-4-6-trunk",
+          "studio_agent_model": "claude-sonnet-4-6"
+        }
+      }
+    }
+  },
+  "bench": {
+    "default_component": "studio"
+  },
+  "bench_workloads": {
+    "nodejs": [
+      "${package.root}/bench/studio-agent-runtime.bench.mjs",
+      "${package.root}/bench/studio-agent-site-build.bench.mjs",
+      "${package.root}/bench/studio-bfb-write-path.bench.mjs"
+    ]
+  },
+  "pipeline": {
+    "up": [
+      {
+        "kind": "command",
+        "label": "Install Studio dependencies",
+        "cwd": "${components.studio.path}",
+        "command": "npm install"
+      },
+      {
+        "kind": "command",
+        "label": "Build Studio CLI",
+        "cwd": "${components.studio.path}",
+        "command": "npm run cli:build --silent"
+      }
+    ],
+    "check": [
+      {
+        "kind": "check",
+        "label": "Studio CLI eval runner built",
+        "file": "${components.studio.path}/apps/cli/dist/cli/eval-runner.mjs"
+      },
+      {
+        "kind": "check",
+        "label": "Studio package dependencies installed",
+        "file": "${components.studio.path}/node_modules"
+      }
+    ]
+  }
+}

--- a/Automattic/studio/rigs/studio-agent-gpt55-ssi/rig.json
+++ b/Automattic/studio/rigs/studio-agent-gpt55-ssi/rig.json
@@ -1,0 +1,54 @@
+{
+  "id": "studio-agent-gpt55-ssi",
+  "description": "Studio GPT 5.5 / pi-agent-core runtime on the active Static Site Importer draft branch. Pairs with studio-agent-claude-ssi so the same SSI substrate can be compared across models.",
+  "components": {
+    "studio": {
+      "path": "~/Developer/studio@bfb-mu-plugin-agent-output",
+      "branch": "bfb-mu-plugin-agent-output-draft",
+      "extensions": {
+        "nodejs": {
+          "studio_bench_variant": "gpt-5.5-ssi",
+          "studio_agent_model": "gpt-5.5"
+        }
+      }
+    }
+  },
+  "bench": {
+    "default_component": "studio"
+  },
+  "bench_workloads": {
+    "nodejs": [
+      "${package.root}/bench/studio-agent-runtime.bench.mjs",
+      "${package.root}/bench/studio-agent-site-build.bench.mjs",
+      "${package.root}/bench/studio-bfb-write-path.bench.mjs"
+    ]
+  },
+  "pipeline": {
+    "up": [
+      {
+        "kind": "command",
+        "label": "Install Studio dependencies",
+        "cwd": "${components.studio.path}",
+        "command": "npm install"
+      },
+      {
+        "kind": "command",
+        "label": "Build Studio CLI",
+        "cwd": "${components.studio.path}",
+        "command": "npm run cli:build --silent"
+      }
+    ],
+    "check": [
+      {
+        "kind": "check",
+        "label": "Studio CLI eval runner built",
+        "file": "${components.studio.path}/apps/cli/dist/cli/eval-runner.mjs"
+      },
+      {
+        "kind": "check",
+        "label": "Studio package dependencies installed",
+        "file": "${components.studio.path}/node_modules"
+      }
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ The deterministic write-path workload is `bench/studio-bfb-write-path.bench.mjs`
 
 `bench/studio-ssi-woo-fixture-validation.bench.mjs` carries a disabled fixture scaffold for Static Site Importer WooCommerce primitives. It records the static store fixture and `products.json` manifest, then reports a skip until SSI implements manifest validation, product seeding, and product context forwarding. Enable it with `HOMEBOY_ENABLE_SSI_WOO_FIXTURE=1` only against an SSI branch that exposes those primitives; the rig must not seed WooCommerce products itself.
 
-`rigs/studio-agent-claude-ssi/rig.json` and `rigs/studio-agent-gpt55-ssi/rig.json` are paired bench rigs for Studio agent-runtime and SSI site-build A/B checks across models. `rigs/studio-agent-claude-trunk/rig.json` remains available for trunk-vs-SSI comparisons. They share `bench/studio-agent-runtime.bench.mjs`.
+`rigs/studio-agent-claude-ssi/rig.json` and `rigs/studio-agent-gpt55-ssi/rig.json` are paired bench rigs for Studio agent-runtime and SSI site-build A/B checks across models. `rigs/studio-agent-claude-trunk/rig.json` remains available for trunk-vs-SSI comparisons. They share `bench/studio-agent-runtime.bench.mjs`, `bench/studio-agent-site-build.bench.mjs`, and `bench/studio-bfb-write-path.bench.mjs`.
 
 `stacks/studio-combined.json` rebuilds `fork/dev/combined-fixes` from `origin/trunk` plus Chris's active Automattic/studio local-dev PRs.
 


### PR DESCRIPTION
## Summary
- Restores the Studio agent benchmark rigs that were stranded on the old model-matrix branch:
  - `studio-agent-claude-ssi`
  - `studio-agent-claude-trunk`
  - `studio-agent-gpt55-ssi`
- Updates the README note to document the shared site-build/write-path workloads used by those rigs.

## Why
The prompt cleanup PR merged before this follow-up commit was applied. Without a separate PR, `main` still only has `studio` and the outdated `studio-bfb` rig in the current package, while the model comparison rigs remain installed locally from an old worktree but absent from the source package.

## Tests
- `node --test "Automattic/studio/bench/studio-agent-site-build.test.mjs"`
- `homeboy rig install --all /Users/chubes/Developer/homeboy-rigs@prompt-natural-client-briefs/Automattic/studio && homeboy rig list`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Restoring the missing rig JSON files from the stranded model-matrix worktree and validating local rig installation/listing under Chris's direction.