### PR TITLE
Collect SSI import timing metrics in Studio site-build benches

### DIFF
--- a/Automattic/studio/bench/lib/wordpress-quality.mjs
+++ b/Automattic/studio/bench/lib/wordpress-quality.mjs
@@ -243,6 +243,49 @@ export async function collectLatestImportReport(sitePath) {
   }
 }
 
+function numericMetric(value) {
+  const number = Number(value ?? 0);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function metricKeyPart(value) {
+  return String(value || '')
+    .replace(/[^a-zA-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toLowerCase();
+}
+
+export function importerTimingMetrics(importReport) {
+  const report = importReport?.report || {};
+  const performance = report.performance || {};
+  const timings = performance.timings && typeof performance.timings === 'object' ? performance.timings : {};
+  const fragments = report.conversion_fragments && typeof report.conversion_fragments === 'object'
+    ? report.conversion_fragments
+    : {};
+  const metrics = {
+    importer_performance_total_ms: numericMetric(performance.total_ms),
+  };
+
+  for (const [key, value] of Object.entries(timings)) {
+    metrics[`importer_phase_${metricKeyPart(key)}`] = numericMetric(value);
+  }
+
+  for (const [source, fragment] of Object.entries(fragments)) {
+    const sourceKey = metricKeyPart(source || 'fragment');
+    const fragmentTimings = fragment?.timings && typeof fragment.timings === 'object' ? fragment.timings : {};
+    metrics[`importer_fragment_${sourceKey}_html_bytes`] = numericMetric(fragment?.html_bytes);
+    metrics[`importer_fragment_${sourceKey}_block_bytes`] = numericMetric(fragment?.block_bytes);
+    metrics[`importer_fragment_${sourceKey}_fallback_count`] = numericMetric(fragment?.fallback_count);
+    metrics[`importer_fragment_${sourceKey}_content_loss_count`] = numericMetric(fragment?.content_loss_count);
+
+    for (const [key, value] of Object.entries(fragmentTimings)) {
+      metrics[`importer_fragment_${sourceKey}_${metricKeyPart(key)}`] = numericMetric(value);
+    }
+  }
+
+  return metrics;
+}
+
 async function readIfExists(file) {
   try {
     return await readFile(file, 'utf8');

--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -11,6 +11,7 @@ import {
   collectGeneratedThemeUxGates,
   collectLatestImportReport,
   collectThemeBlockDocuments,
+  importerTimingMetrics,
   nativeBlockQualityMetrics,
   probeQuality,
 } from './lib/wordpress-quality.mjs';
@@ -19,6 +20,7 @@ import { collectDesignFingerprint } from './lib/design-gates.mjs';
 
 export {
   agentAuthoredBlockMetrics,
+  importerTimingMetrics,
   nativeBlockQualityMetrics,
 } from './lib/wordpress-quality.mjs';
 
@@ -1008,6 +1010,7 @@ export default async function studioAgentSiteBuildBench() {
   const status = await siteStatus(sitePath);
   assertNamespacedPort(status, runtime);
   const importReport = await collectLatestImportReport(sitePath);
+  const importerTimings = importerTimingMetrics(importReport);
   await mkdir(artifactDir, { recursive: true });
   await restoreMissingSourceStaticFiles(importReport, sitePath, result);
   const visualComparisonStarted = Date.now();
@@ -1156,6 +1159,7 @@ export default async function studioAgentSiteBuildBench() {
       importer_invalid_block_count: Number(importReport.report?.quality?.invalid_block_count || 0),
       importer_invalid_block_document_count: Number(importReport.report?.quality?.invalid_block_document_count || 0),
       importer_generated_block_document_count: Number(importReport.report?.generated_theme?.block_documents?.length || 0),
+      ...importerTimings,
       system_prompt_size_bytes: systemPrompt.system_prompt_size_bytes,
       visual_comparison_target_count: Number(visualComparison.target_count || 0),
       visual_comparison_checked_target_count: Number(visualComparison.checked_target_count || 0),

--- a/Automattic/studio/bench/studio-agent-site-build.test.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.test.mjs
@@ -12,6 +12,7 @@ const {
   hiddenEditorContentDiagnostics,
   importerBlockQualityFailureDetails,
   importerBlockQualityMetrics,
+  importerTimingMetrics,
   promptVariantCatalog,
   semanticTargetMetric,
   siteBuildPrompt,
@@ -147,6 +148,44 @@ test('importer block-quality metrics use zero as the clean threshold', () => {
     agentSuccessGate({ success: true, error: null, timedOut: false }, { mismatch_count: 0 }, importReport).agentSucceeded,
     true
   );
+});
+
+test('importer timing metrics flatten SSI report performance fields', () => {
+  const importReport = {
+    report: {
+      performance: {
+        total_ms: 1234.5,
+        timings: {
+          convert_page_artifacts_ms: 900,
+          quality_and_fidelity_analysis_ms: 40,
+        },
+      },
+      conversion_fragments: {
+        main: {
+          html_bytes: 524288,
+          block_bytes: 120000,
+          fallback_count: 0,
+          content_loss_count: 1,
+          timings: {
+            bfb_convert_ms: 800,
+            finish_fragment_report_ms: 12,
+          },
+        },
+      },
+    },
+  };
+
+  assert.deepEqual(importerTimingMetrics(importReport), {
+    importer_performance_total_ms: 1234.5,
+    importer_phase_convert_page_artifacts_ms: 900,
+    importer_phase_quality_and_fidelity_analysis_ms: 40,
+    importer_fragment_main_html_bytes: 524288,
+    importer_fragment_main_block_bytes: 120000,
+    importer_fragment_main_fallback_count: 0,
+    importer_fragment_main_content_loss_count: 1,
+    importer_fragment_main_bfb_convert_ms: 800,
+    importer_fragment_main_finish_fragment_report_ms: 12,
+  });
 });
 
 test('editor visual parity metrics hard-fail the agent success gate', () => {


### PR DESCRIPTION
## Summary
- Flattens Static Site Importer report performance timings into Studio site-build benchmark metrics.
- Surfaces per-fragment metrics such as main HTML bytes, BFB convert time, fallback count, and content loss count.
- Adds unit coverage for the timing metric extraction helper.

## Testing
- `node --test Automattic/studio/bench/studio-agent-site-build.test.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the benchmark metric wiring and test coverage; Chris directed the need to capture SSI timings across prompt-variant eval runs.