### PR TITLE
Refactor Studio shared bench helpers

### DIFF
--- a/Automattic/studio/bench/lib/fidelity-targets.mjs
+++ b/Automattic/studio/bench/lib/fidelity-targets.mjs
@@ -1,0 +1,86 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+export function stringArray(value) {
+  return asArray(value).filter((item) => typeof item === 'string' && item.trim() !== '');
+}
+
+export function safeSlug(value, fallback) {
+  const slug = String(value || fallback || 'target')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+  return slug || 'target';
+}
+
+export function comparisonTargets(importReport) {
+  return asArray(importReport?.report?.visual_fidelity?.comparison_targets).filter(
+    (target) => target && typeof target === 'object'
+  );
+}
+
+export function semanticComparisonTargets(importReport) {
+  const semanticTargets = asArray(importReport?.report?.semantic_fidelity?.comparison_targets).filter(
+    (target) => target && typeof target === 'object'
+  );
+  return semanticTargets.length ? semanticTargets : comparisonTargets(importReport);
+}
+
+export function resolveSourceStaticFile(sourceFile, reportPath, sitePath) {
+  if (!sourceFile) {
+    return '';
+  }
+
+  if (path.isAbsolute(sourceFile)) {
+    const wordpressRoot = '/wordpress';
+    if (sitePath && (sourceFile === wordpressRoot || sourceFile.startsWith(`${wordpressRoot}/`))) {
+      return path.join(sitePath, sourceFile.slice(wordpressRoot.length));
+    }
+
+    return sourceFile;
+  }
+
+  return path.resolve(path.dirname(reportPath), sourceFile);
+}
+
+export function surfaceUrl(target, surface, reportPath, sitePath) {
+  const surfaces = target?.comparison_hooks?.render_surfaces || {};
+  const configured = surfaces[surface]?.url || '';
+  if (surface === 'source_static') {
+    const sourceFile = configured || target?.source_file || '';
+    if (!sourceFile) {
+      return '';
+    }
+    const absoluteSource = resolveSourceStaticFile(sourceFile, reportPath, sitePath);
+    return pathToFileURL(absoluteSource).toString();
+  }
+
+  if (surface === 'wordpress_frontend') {
+    return configured || target?.wordpress_url || '';
+  }
+
+  if (surface === 'wordpress_editor') {
+    if (configured) {
+      return configured;
+    }
+
+    const postId = Number(target?.wordpress_page_id || target?.home_page_id || target?.front_page_id || 0);
+    const frontendUrl = surfaceUrl(target, 'wordpress_frontend', reportPath, sitePath);
+    if (!postId || !frontendUrl) {
+      return '';
+    }
+
+    const url = new URL(frontendUrl);
+    url.pathname = '/studio-auto-login';
+    url.search = '';
+    url.searchParams.set('redirect_to', `/wp-admin/post.php?post=${postId}&action=edit`);
+    return url.toString();
+  }
+
+  return configured;
+}

--- a/Automattic/studio/bench/lib/semantic-fidelity.mjs
+++ b/Automattic/studio/bench/lib/semantic-fidelity.mjs
@@ -1,80 +1,16 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
+
+import { safeSlug, semanticComparisonTargets, stringArray, surfaceUrl } from './fidelity-targets.mjs';
 
 const requireFromSemanticFidelity = createRequire(import.meta.url);
-
-function asArray(value) {
-  return Array.isArray(value) ? value : [];
-}
-
-function stringArray(value) {
-  return asArray(value).filter((item) => typeof item === 'string' && item.trim() !== '');
-}
-
-function safeSlug(value, fallback) {
-  const slug = String(value || fallback || 'target')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 80);
-  return slug || 'target';
-}
 
 function metric(value) {
   const number = Number(value ?? 0);
   return Number.isFinite(number) ? number : 0;
 }
 
-function comparisonTargets(importReport) {
-  return asArray(importReport?.report?.visual_fidelity?.comparison_targets).filter(
-    (target) => target && typeof target === 'object'
-  );
-}
-
-function semanticComparisonTargets(importReport) {
-  const semanticTargets = asArray(importReport?.report?.semantic_fidelity?.comparison_targets).filter(
-    (target) => target && typeof target === 'object'
-  );
-  return semanticTargets.length ? semanticTargets : comparisonTargets(importReport);
-}
-
-export function resolveSourceStaticFile(sourceFile, reportPath, sitePath) {
-  if (!sourceFile) {
-    return '';
-  }
-
-  if (path.isAbsolute(sourceFile)) {
-    const wordpressRoot = '/wordpress';
-    if (sitePath && (sourceFile === wordpressRoot || sourceFile.startsWith(`${wordpressRoot}/`))) {
-      return path.join(sitePath, sourceFile.slice(wordpressRoot.length));
-    }
-
-    return sourceFile;
-  }
-
-  return path.resolve(path.dirname(reportPath), sourceFile);
-}
-
-function surfaceUrl(target, surface, reportPath, sitePath) {
-  const surfaces = target?.comparison_hooks?.render_surfaces || {};
-  const configured = surfaces[surface]?.url || '';
-  if (surface === 'source_static') {
-    const sourceFile = configured || target?.source_file || '';
-    if (!sourceFile) {
-      return '';
-    }
-    const absoluteSource = resolveSourceStaticFile(sourceFile, reportPath, sitePath);
-    return pathToFileURL(absoluteSource).toString();
-  }
-
-  if (surface === 'wordpress_frontend') {
-    return configured || target?.wordpress_url || '';
-  }
-
-  return configured;
-}
 
 async function loadSemanticSurface(page, url) {
   await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 45_000 });

--- a/Automattic/studio/bench/lib/studio-bench.mjs
+++ b/Automattic/studio/bench/lib/studio-bench.mjs
@@ -131,6 +131,45 @@ export async function runCli(args, options = {}) {
   return run([cliPath, ...args], options);
 }
 
+export async function createStudioSite(sitePath, options = {}) {
+  const name = options.name || `Studio Bench ${variant()} ${options.nameSuffix || 'Site'} ${process.pid}`;
+  return runCli(
+    [
+      'site',
+      'create',
+      '--name',
+      name,
+      '--path',
+      sitePath,
+      ...(options.start === false ? ['--no-start'] : []),
+      '--skip-browser',
+      '--skip-log-details',
+    ],
+    options
+  );
+}
+
+export async function stopStudioSite(sitePath, options = {}) {
+  return runCli(['site', 'stop', '--path', sitePath], { allowFailure: true, ...options });
+}
+
+export async function studioSiteStatus(sitePath, options = {}) {
+  return runCli(['site', 'status', '--path', sitePath, '--format', 'json'], options);
+}
+
+export function parseStudioSiteStatus(stdout) {
+  const jsonStart = String(stdout || '').indexOf('{');
+  if (jsonStart === -1) {
+    throw new Error(`site status did not emit JSON: ${redact(stdout).slice(0, 1000)}`);
+  }
+  return JSON.parse(String(stdout).slice(jsonStart));
+}
+
+export async function studioSiteStatusJson(sitePath, options = {}) {
+  const { stdout } = await studioSiteStatus(sitePath, options);
+  return parseStudioSiteStatus(stdout);
+}
+
 export async function runEval(prompt, vars, options = {}) {
   const evalRunner = path.join(STUDIO_PATH, 'apps/cli/dist/cli/eval-runner.mjs');
   const { code, stdout, stderr } = await run(

--- a/Automattic/studio/bench/lib/visual-fidelity.mjs
+++ b/Automattic/studio/bench/lib/visual-fidelity.mjs
@@ -1,93 +1,16 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { createRequire } from 'node:module';
-import { pathToFileURL } from 'node:url';
 import zlib from 'node:zlib';
 
 import { STUDIO_PATH } from './studio-bench.mjs';
+import { asArray, comparisonTargets, safeSlug, stringArray, surfaceUrl } from './fidelity-targets.mjs';
 
 const requireFromBench = createRequire(import.meta.url);
 export const VISUAL_VIEWPORT = { width: 1440, height: 1100 };
 const VISUAL_SCREENSHOT_DIAGNOSTIC_LIMIT = 5;
 const VISUAL_PIXELMATCH_THRESHOLD = 0.1;
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-
-function asArray(value) {
-  return Array.isArray(value) ? value : [];
-}
-
-function stringArray(value) {
-  return asArray(value).filter((item) => typeof item === 'string' && item.trim() !== '');
-}
-
-function safeSlug(value, fallback) {
-  const slug = String(value || fallback || 'target')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 80);
-  return slug || 'target';
-}
-
-function comparisonTargets(importReport) {
-  return asArray(importReport?.report?.visual_fidelity?.comparison_targets).filter(
-    (target) => target && typeof target === 'object'
-  );
-}
-
-function resolveSourceStaticFile(sourceFile, reportPath, sitePath) {
-  if (!sourceFile) {
-    return '';
-  }
-
-  if (path.isAbsolute(sourceFile)) {
-    const wordpressRoot = '/wordpress';
-    if (sitePath && (sourceFile === wordpressRoot || sourceFile.startsWith(`${wordpressRoot}/`))) {
-      return path.join(sitePath, sourceFile.slice(wordpressRoot.length));
-    }
-
-    return sourceFile;
-  }
-
-  return path.resolve(path.dirname(reportPath), sourceFile);
-}
-
-function surfaceUrl(target, surface, reportPath, sitePath) {
-  const surfaces = target?.comparison_hooks?.render_surfaces || {};
-  const configured = surfaces[surface]?.url || '';
-  if (surface === 'source_static') {
-    const sourceFile = configured || target?.source_file || '';
-    if (!sourceFile) {
-      return '';
-    }
-    const absoluteSource = resolveSourceStaticFile(sourceFile, reportPath, sitePath);
-    return pathToFileURL(absoluteSource).toString();
-  }
-
-  if (surface === 'wordpress_frontend') {
-    return configured || target?.wordpress_url || '';
-  }
-
-  if (surface === 'wordpress_editor') {
-    if (configured) {
-      return configured;
-    }
-
-    const postId = Number(target?.wordpress_page_id || target?.home_page_id || target?.front_page_id || 0);
-    const frontendUrl = surfaceUrl(target, 'wordpress_frontend', reportPath, sitePath);
-    if (!postId || !frontendUrl) {
-      return '';
-    }
-
-    const url = new URL(frontendUrl);
-    url.pathname = '/studio-auto-login';
-    url.search = '';
-    url.searchParams.set('redirect_to', `/wp-admin/post.php?post=${postId}&action=edit`);
-    return url.toString();
-  }
-
-  return configured;
-}
 
 function visualProbeGroups(target) {
   const hooks = target?.comparison_hooks || {};

--- a/Automattic/studio/bench/studio-admin-theme-page-browser.bench.mjs
+++ b/Automattic/studio/bench/studio-admin-theme-page-browser.bench.mjs
@@ -1,6 +1,16 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { artifactDir as studioArtifactDir, metric, redact, runCli, safeResult, variant } from './lib/studio-bench.mjs';
+import {
+  artifactDir as studioArtifactDir,
+  createStudioSite,
+  metric,
+  parseStudioSiteStatus,
+  redact,
+  safeResult,
+  stopStudioSite,
+  studioSiteStatus,
+  variant,
+} from './lib/studio-bench.mjs';
 
 const BROWSER_HELPER = process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER;
 
@@ -11,32 +21,18 @@ if (!BROWSER_HELPER) {
 const { runBrowserBench } = await import(BROWSER_HELPER);
 
 async function createSite(sitePath) {
-  return runCli([
-    'site',
-    'create',
-    '--name',
-    `Studio Bench ${variant()} Add Themes Browser ${process.pid}`,
-    '--path',
-    sitePath,
-    '--skip-browser',
-    '--skip-log-details',
-  ], { timeoutMs: 420000 });
+  return createStudioSite(sitePath, {
+    name: `Studio Bench ${variant()} Add Themes Browser ${process.pid}`,
+    timeoutMs: 420000,
+  });
 }
 
 async function siteStatus(sitePath) {
-  return runCli(['site', 'status', '--path', sitePath, '--format', 'json'], { timeoutMs: 90000 });
+  return studioSiteStatus(sitePath, { timeoutMs: 90000 });
 }
 
 async function stopSite(sitePath) {
-  return runCli(['site', 'stop', '--path', sitePath], { allowFailure: true, timeoutMs: 90000 });
-}
-
-function parseStatus(stdout) {
-  const parsed = JSON.parse(stdout);
-  if (!parsed.siteUrl || !parsed.autoLoginUrl) {
-    throw new Error(`site status missing siteUrl/autoLoginUrl: ${redact(stdout).slice(0, 1000)}`);
-  }
-  return parsed;
+  return stopStudioSite(sitePath, { timeoutMs: 90000 });
 }
 
 function siteAdminUrl(siteUrl, relativePath) {
@@ -79,7 +75,10 @@ export default async function studioAdminThemePageBrowserBench() {
   try {
     create = await createSite(sitePath);
     statusResult = await siteStatus(sitePath);
-    status = parseStatus(statusResult.stdout);
+    status = parseStudioSiteStatus(statusResult.stdout);
+    if (!status.siteUrl || !status.autoLoginUrl) {
+      throw new Error(`site status missing siteUrl/autoLoginUrl: ${redact(statusResult.stdout).slice(0, 1000)}`);
+    }
 
     browserResult = await runBrowserBench({
       id: 'studio-admin-theme-page-browser',

--- a/Automattic/studio/bench/studio-admin-theme-page.bench.mjs
+++ b/Automattic/studio/bench/studio-admin-theme-page.bench.mjs
@@ -2,31 +2,34 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import http from 'node:http';
 import https from 'node:https';
 import path from 'node:path';
-import { artifactDir as studioArtifactDir, metric, runCli, safeResult, variant } from './lib/studio-bench.mjs';
+import {
+  artifactDir as studioArtifactDir,
+  createStudioSite,
+  metric,
+  parseStudioSiteStatus,
+  safeResult,
+  stopStudioSite,
+  studioSiteStatus,
+  variant,
+} from './lib/studio-bench.mjs';
 
 async function createSite(sitePath) {
-  return runCli([
-    'site',
-    'create',
-    '--name',
-    `Studio Bench ${variant()} Theme Page ${process.pid}`,
-    '--path',
-    sitePath,
-    '--skip-browser',
-    '--skip-log-details',
-  ], { timeoutMs: 420000 });
+  return createStudioSite(sitePath, {
+    name: `Studio Bench ${variant()} Theme Page ${process.pid}`,
+    timeoutMs: 420000,
+  });
 }
 
 async function siteStatus(sitePath) {
-  return runCli(['site', 'status', '--path', sitePath, '--format', 'json'], { timeoutMs: 90000 });
+  return studioSiteStatus(sitePath, { timeoutMs: 90000 });
 }
 
 async function stopSite(sitePath) {
-  return runCli(['site', 'stop', '--path', sitePath], { allowFailure: true, timeoutMs: 90000 });
+  return stopStudioSite(sitePath, { timeoutMs: 90000 });
 }
 
 function parseStatus(stdout) {
-  const parsed = JSON.parse(stdout);
+  const parsed = parseStudioSiteStatus(stdout);
   if (!parsed.siteUrl || !parsed.autoLoginUrl) {
     throw new Error(`site status missing siteUrl/autoLoginUrl: ${stdout.slice(0, 1000)}`);
   }

--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -1,10 +1,7 @@
 import { mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
-import os from 'node:os';
 import path from 'node:path';
-import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
-import { pathToFileURL } from 'node:url';
 
 import {
   agentAuthoredBlockMetrics,
@@ -41,6 +38,21 @@ import {
 } from './lib/semantic-fidelity.mjs';
 export { semanticMismatchFailureDetails, semanticTargetMetric } from './lib/semantic-fidelity.mjs';
 
+import { comparisonTargets, resolveSourceStaticFile, safeSlug } from './lib/fidelity-targets.mjs';
+export { resolveSourceStaticFile } from './lib/fidelity-targets.mjs';
+
+import {
+  SHARED_STATE,
+  STUDIO_PATH,
+  createStudioSite,
+  expandHome,
+  runCli as sharedRunCli,
+  runEval as sharedRunEval,
+  setting,
+  studioSiteStatusJson,
+  variant,
+} from './lib/studio-bench.mjs';
+
 import {
   agentSuccessGate,
   importerBlockQualityMetrics,
@@ -61,9 +73,6 @@ export {
   visualPixelDiffFailureDetails,
 } from './lib/site-build-gates.mjs';
 
-const STUDIO_PATH = process.env.HOMEBOY_COMPONENT_PATH;
-const SHARED_STATE = process.env.HOMEBOY_BENCH_SHARED_STATE || os.tmpdir();
-const RESULT_PREFIX = 'EVAL_RUNNER_RESULT_FILE=';
 const DEFAULT_STUDIO_PORT = 8881;
 const NAMESPACE_PORT_RANGE_SIZE = 10;
 const NAMESPACE_PORT_RANGE_START = 8900;
@@ -76,26 +85,6 @@ const DEFAULT_PROMPT_VARIANT = 'studio-code';
 const PROMPT_CATEGORY = 'site-build';
 const SYSTEM_PROMPT_FILES = ['apps/cli/ai/system-prompt.ts'];
 const requireFromBench = createRequire(import.meta.url);
-if (!STUDIO_PATH) {
-  throw new Error('HOMEBOY_COMPONENT_PATH is required');
-}
-
-function expandHome(value) {
-  if (!value) {
-    return value;
-  }
-  if (value === '~') {
-    return os.homedir();
-  }
-  if (value.startsWith('~/')) {
-    return path.join(os.homedir(), value.slice(2));
-  }
-  return value;
-}
-
-function variant() {
-  return setting('studio_bench_variant') || path.basename(STUDIO_PATH);
-}
 
 function benchmarkNamespace() {
   return (
@@ -164,19 +153,6 @@ export function resolveBenchRuntime(namespace = benchmarkNamespace(), sharedStat
       TMPDIR: tmpDir,
     },
   };
-}
-
-function setting(key) {
-  try {
-    const settings = JSON.parse(process.env.HOMEBOY_SETTINGS_JSON || '{}');
-    if (settings && typeof settings[key] === 'string') {
-      return settings[key];
-    }
-  } catch {
-    // Ignore malformed settings and fall back to direct env/debug defaults.
-  }
-
-  return process.env[`HOMEBOY_SETTINGS_${key.toUpperCase()}`] || '';
 }
 
 function cliEnv(extra = {}) {
@@ -269,56 +245,12 @@ function assertNamespacedPort(status, runtime) {
   }
 }
 
-function run(args, options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, args, {
-      cwd: options.cwd || STUDIO_PATH,
-      env: cliEnv(options.env),
-    });
-
-    let stdout = '';
-    let stderr = '';
-    child.stdout.on('data', (chunk) => {
-      stdout += String(chunk);
-    });
-    child.stderr.on('data', (chunk) => {
-      stderr += String(chunk);
-    });
-    child.on('error', reject);
-    child.on('close', (code) => {
-      if (code !== 0 && options.allowFailure !== true) {
-        reject(new Error(`${args.join(' ')} exited ${code}; stderr=${stderr.slice(0, 1500)}`));
-        return;
-      }
-      resolve({ code, stdout, stderr });
-    });
-  });
-}
-
 async function runCli(args, options = {}) {
-  const cliPath = path.join(STUDIO_PATH, 'apps/cli/dist/cli/main.mjs');
-  return run([cliPath, ...args], options);
+  return sharedRunCli(args, { ...options, env: cliEnv(options.env) });
 }
 
 async function runEval(prompt, vars) {
-  const evalRunner = path.join(STUDIO_PATH, 'apps/cli/dist/cli/eval-runner.mjs');
-  const { code, stdout, stderr } = await run(
-    [evalRunner, prompt, 'unused-provider-slot', JSON.stringify({ vars: { prompt, ...vars } })],
-    { allowFailure: true }
-  );
-
-  const marker = stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .find((line) => line.startsWith(RESULT_PREFIX));
-
-  if (!marker) {
-    throw new Error(`eval runner did not emit result marker; exit=${code}; stderr=${stderr.slice(0, 1500)}`);
-  }
-
-  const resultFile = marker.slice(RESULT_PREFIX.length);
-  const result = JSON.parse(await readFile(resultFile, 'utf8'));
-  return { result, resultFile, exitCode: code, stderr };
+  return sharedRunEval(prompt, vars, { env: cliEnv() });
 }
 
 function promptVariant() {
@@ -451,103 +383,11 @@ export async function systemPromptFingerprint() {
 }
 
 async function createFreshSite(sitePath) {
-  await runCli([
-    'site',
-    'create',
-    '--name',
-    `Studio Bench ${variant()} ${process.pid}`,
-    '--path',
-    sitePath,
-    '--skip-browser',
-    '--skip-log-details',
-  ]);
+  await createStudioSite(sitePath, { name: `Studio Bench ${variant()} ${process.pid}`, env: cliEnv() });
 }
 
 async function siteStatus(sitePath) {
-  const { stdout } = await runCli(['site', 'status', '--path', sitePath, '--format', 'json']);
-  const jsonStart = stdout.indexOf('{');
-  if (jsonStart === -1) {
-    throw new Error(`site status did not emit JSON: ${stdout.slice(0, 1000)}`);
-  }
-  return JSON.parse(stdout.slice(jsonStart));
-}
-
-function asArray(value) {
-  return Array.isArray(value) ? value : [];
-}
-
-function stringArray(value) {
-  return asArray(value).filter((item) => typeof item === 'string' && item.trim() !== '');
-}
-
-function safeSlug(value, fallback) {
-  const slug = String(value || fallback || 'target')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 80);
-  return slug || 'target';
-}
-
-function comparisonTargets(importReport) {
-  return asArray(importReport?.report?.visual_fidelity?.comparison_targets).filter(
-    (target) => target && typeof target === 'object'
-  );
-}
-
-
-export function resolveSourceStaticFile(sourceFile, reportPath, sitePath) {
-  if (!sourceFile) {
-    return '';
-  }
-
-  if (path.isAbsolute(sourceFile)) {
-    const wordpressRoot = '/wordpress';
-    if (sitePath && (sourceFile === wordpressRoot || sourceFile.startsWith(`${wordpressRoot}/`))) {
-      return path.join(sitePath, sourceFile.slice(wordpressRoot.length));
-    }
-
-    return sourceFile;
-  }
-
-  return path.resolve(path.dirname(reportPath), sourceFile);
-}
-
-function surfaceUrl(target, surface, reportPath, sitePath) {
-  const surfaces = target?.comparison_hooks?.render_surfaces || {};
-  const configured = surfaces[surface]?.url || '';
-  if (surface === 'source_static') {
-    const sourceFile = configured || target?.source_file || '';
-    if (!sourceFile) {
-      return '';
-    }
-    const absoluteSource = resolveSourceStaticFile(sourceFile, reportPath, sitePath);
-    return pathToFileURL(absoluteSource).toString();
-  }
-
-  if (surface === 'wordpress_frontend') {
-    return configured || target?.wordpress_url || '';
-  }
-
-  if (surface === 'wordpress_editor') {
-    if (configured) {
-      return configured;
-    }
-
-    const postId = Number(target?.wordpress_page_id || target?.home_page_id || target?.front_page_id || 0);
-    const frontendUrl = surfaceUrl(target, 'wordpress_frontend', reportPath, sitePath);
-    if (!postId || !frontendUrl) {
-      return '';
-    }
-
-    const url = new URL(frontendUrl);
-    url.pathname = '/studio-auto-login';
-    url.search = '';
-    url.searchParams.set('redirect_to', `/wp-admin/post.php?post=${postId}&action=edit`);
-    return url.toString();
-  }
-
-  return configured;
+  return studioSiteStatusJson(sitePath, { env: cliEnv() });
 }
 
 async function restoreMissingSourceStaticFiles(importReport, sitePath, result) {

--- a/Automattic/studio/bench/studio-bfb-write-path.bench.mjs
+++ b/Automattic/studio/bench/studio-bfb-write-path.bench.mjs
@@ -1,6 +1,14 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { artifactDir as studioArtifactDir, expandHome, runCli, setting, variant } from './lib/studio-bench.mjs';
+import {
+  artifactDir as studioArtifactDir,
+  createStudioSite,
+  expandHome,
+  runCli,
+  setting,
+  stopStudioSite,
+  variant,
+} from './lib/studio-bench.mjs';
 import { probePageQuality } from './lib/wordpress-quality.mjs';
 
 const RAW_HTML = `
@@ -45,20 +53,14 @@ async function runStudioCli(args, options = {}) {
 }
 
 async function createFreshSite(sitePath) {
-  await runStudioCli([
-    'site',
-    'create',
-    '--name',
-    `Studio Bench ${variant()} Write Path ${process.pid}`,
-    '--path',
-    sitePath,
-    '--skip-browser',
-    '--skip-log-details',
-  ]);
+  await createStudioSite(sitePath, {
+    name: `Studio Bench ${variant()} Write Path ${process.pid}`,
+    env: cliEnv(),
+  });
 }
 
 async function stopSite(sitePath) {
-  await runStudioCli(['site', 'stop', '--path', sitePath], { allowFailure: true });
+  await stopStudioSite(sitePath, { env: cliEnv() });
 }
 
 async function writeRawHtmlPage(sitePath) {

--- a/Automattic/studio/bench/studio-site-create.bench.mjs
+++ b/Automattic/studio/bench/studio-site-create.bench.mjs
@@ -1,27 +1,30 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { artifactDir as studioArtifactDir, metric, redact, runCli, safeResult, variant } from './lib/studio-bench.mjs';
+import {
+  artifactDir as studioArtifactDir,
+  createStudioSite,
+  metric,
+  redact,
+  safeResult,
+  stopStudioSite,
+  studioSiteStatus,
+  variant,
+} from './lib/studio-bench.mjs';
 
 async function createSite(sitePath, start) {
-  return runCli([
-    'site',
-    'create',
-    '--name',
-    `Studio Bench ${variant()} Site Create ${process.pid}`,
-    '--path',
-    sitePath,
-    ...(start ? [] : ['--no-start']),
-    '--skip-browser',
-    '--skip-log-details',
-  ], { timeoutMs: start ? 420000 : 240000 });
+  return createStudioSite(sitePath, {
+    name: `Studio Bench ${variant()} Site Create ${process.pid}`,
+    start,
+    timeoutMs: start ? 420000 : 240000,
+  });
 }
 
 async function stopSite(sitePath) {
-  return runCli(['site', 'stop', '--path', sitePath], { allowFailure: true, timeoutMs: 90000 });
+  return stopStudioSite(sitePath, { timeoutMs: 90000 });
 }
 
 async function siteStatus(sitePath) {
-  return runCli(['site', 'status', '--path', sitePath, '--format', 'json'], { allowFailure: true, timeoutMs: 90000 });
+  return studioSiteStatus(sitePath, { allowFailure: true, timeoutMs: 90000 });
 }
 
 export default async function studioSiteCreateBench() {


### PR DESCRIPTION
## Summary
- Extract shared fidelity target helpers for visual, semantic, and site-build workloads.
- Promote common Studio site lifecycle helpers into `lib/studio-bench.mjs` and consume them from smaller workloads.
- Keep site-build namespace isolation local while trimming duplicate CLI/eval/site-status plumbing.

## Testing
- `node --check Automattic/studio/bench/lib/fidelity-targets.mjs`
- `node --check Automattic/studio/bench/lib/studio-bench.mjs`
- `node --check Automattic/studio/bench/lib/visual-fidelity.mjs`
- `node --check Automattic/studio/bench/lib/semantic-fidelity.mjs`
- `node --check Automattic/studio/bench/studio-agent-site-build.bench.mjs`
- `node --check Automattic/studio/bench/studio-bfb-write-path.bench.mjs`
- `node --check Automattic/studio/bench/studio-site-create.bench.mjs`
- `node --check Automattic/studio/bench/studio-admin-theme-page-browser.bench.mjs`
- `node --check Automattic/studio/bench/studio-admin-theme-page.bench.mjs`
- `node --test Automattic/studio/bench/studio-agent-site-build.test.mjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the helper extraction/refactor and ran syntax/test verification; Chris remains responsible for review and merge.