### PR TITLE
fix(studio): restore authored SSI source files

### DIFF
--- a/Automattic/studio/bench/lib/design-gates.mjs
+++ b/Automattic/studio/bench/lib/design-gates.mjs
@@ -68,7 +68,7 @@ export async function collectLatestGeneratedTheme(sitePath) {
   }
 
   generatedThemes.sort((a, b) => b.mtimeMs - a.mtimeMs);
-  return generatedThemes[0] || { themeRoot: '', themeSlug: '', reportPath, error: 'No Static Site Importer report found.' };
+  return generatedThemes[0] || { themeRoot: '', themeSlug: '', reportPath: '', error: 'No Static Site Importer report found.' };
 }
 
 async function readIfExists(file) {

--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -355,13 +355,14 @@ async function siteStatus(sitePath) {
   return studioSiteStatusJson(sitePath, { env: cliEnv() });
 }
 
-async function restoreMissingSourceStaticFiles(importReport, sitePath, result) {
+export async function restoreMissingSourceStaticFiles(importReport, sitePath, result) {
   const writes = new Map();
   for (const call of Array.isArray(result?.toolCalls) ? result.toolCalls : []) {
-    if (call?.name !== 'Write' || typeof call?.input?.file_path !== 'string' || typeof call?.input?.content !== 'string') {
+    const filePath = call?.input?.file_path || call?.input?.path || '';
+    if (call?.name !== 'Write' || typeof filePath !== 'string' || typeof call?.input?.content !== 'string') {
       continue;
     }
-    writes.set(path.resolve(call.input.file_path), call.input.content);
+    writes.set(path.resolve(filePath), call.input.content);
   }
 
   if (!writes.size) {

--- a/Automattic/studio/bench/studio-agent-site-build.test.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -15,6 +15,7 @@ const {
   importerTimingMetrics,
   promptVariantCatalog,
   resolveBenchRuntime,
+  restoreMissingSourceStaticFiles,
   semanticTargetMetric,
   siteBuildPrompt,
   structuralSelectorDriftDiagnostics,
@@ -23,6 +24,8 @@ const {
   visualEditorParityFailureDetails,
   visualEditorParityMetrics,
 } = await import('./studio-agent-site-build.bench.mjs');
+
+const { collectLatestGeneratedTheme } = await import('./lib/design-gates.mjs');
 
 function withEnv(values, callback) {
   const previous = {};
@@ -145,6 +148,68 @@ test('bench runtime consumes Homeboy invocation env for isolated paths and ports
       });
     }
   );
+});
+
+test('bench restores missing SSI source files from Studio Write tool path input', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'studio-source-restore-'));
+  const sitePath = path.join(tempDir, 'site');
+  const sourcePath = path.join(sitePath, 'tmp/static-site/index.html');
+  const content = '<!doctype html><html><body><main>Source evidence</main></body></html>';
+
+  try {
+    await restoreMissingSourceStaticFiles(
+      {
+        reportPath: path.join(sitePath, 'wp-content/themes/demo/import-report.json'),
+        report: {
+          visual_fidelity: {
+            comparison_targets: [
+              {
+                source_file: '/wordpress/tmp/static-site/index.html',
+                comparison_hooks: {
+                  render_surfaces: {
+                    source_static: { url: '/wordpress/tmp/static-site/index.html' },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+      sitePath,
+      {
+        toolCalls: [
+          {
+            name: 'Write',
+            input: {
+              path: sourcePath,
+              content,
+            },
+          },
+        ],
+      }
+    );
+
+    assert.equal(await readFile(sourcePath, 'utf8'), content);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('generated-theme discovery reports missing SSI import instead of throwing', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'studio-no-import-report-'));
+
+  try {
+    await mkdir(path.join(tempDir, 'wp-content/themes'), { recursive: true });
+
+    assert.deepEqual(await collectLatestGeneratedTheme(tempDir), {
+      themeRoot: '',
+      themeSlug: '',
+      reportPath: '',
+      error: 'No Static Site Importer report found.',
+    });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
 });
 
 test('semantic-fidelity mismatches hard-fail the agent success gate', () => {


### PR DESCRIPTION
## Summary
- Restore missing Static Site Importer source files from Studio eval `Write` tool calls that use `input.path`.
- Keep SSI production cleanup behavior intact while allowing the bench to preserve source evidence for visual and semantic fidelity checks.
- Fix missing-import-report diagnostics so no-import runs report as bench failures instead of crashing on an undefined `reportPath` variable.

## Validation
- `node --test Automattic/studio/bench/studio-agent-site-build.test.mjs` passed: 24 / 24.
- Reran built-in prompt variants without prompt-level `--keep-source`; no-import runs now return diagnostic artifacts instead of harness exceptions.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing why source restoration missed Studio's `Write.input.path`, implementing the harness fix and regression tests, and running validation. Chris remains responsible for review and final acceptance.