### PR TITLE
Add Studio browser performance probes

### DIFF
--- a/Automattic/studio/bench/studio-dashboard-browser.bench.mjs
+++ b/Automattic/studio/bench/studio-dashboard-browser.bench.mjs
@@ -22,7 +22,7 @@ const { runBrowserBench } = await import(BROWSER_HELPER);
 
 async function createSite(sitePath) {
   return createStudioSite(sitePath, {
-    name: `Studio Bench ${variant()} Add Themes Browser ${process.pid}`,
+    name: `Studio Bench ${variant()} Dashboard Browser ${process.pid}`,
     timeoutMs: 420000,
   });
 }
@@ -33,12 +33,6 @@ async function siteStatus(sitePath) {
 
 async function stopSite(sitePath) {
   return stopStudioSite(sitePath, { timeoutMs: 90000 });
-}
-
-function autoLoginUrl(siteUrl, relativePath) {
-  const url = new URL('/studio-auto-login', siteUrl);
-  url.searchParams.set('redirect_to', new URL(relativePath, siteUrl).pathname);
-  return url.toString();
 }
 
 async function sanitizeNetworkArtifact(artifact) {
@@ -56,10 +50,10 @@ async function firstContentfulPaint(page) {
   });
 }
 
-export default async function studioAdminThemePageBrowserBench() {
+export default async function studioDashboardBrowserBench() {
   const currentVariant = variant();
-  const runId = `${currentVariant}-admin-theme-page-browser-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  const artifactDir = path.join(studioArtifactDir('studio-admin-theme-page-browser-artifacts'), runId);
+  const runId = `${currentVariant}-dashboard-browser-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const artifactDir = path.join(studioArtifactDir('studio-dashboard-browser-artifacts'), runId);
   const sitePath = path.join(artifactDir, 'site');
   await mkdir(artifactDir, { recursive: true });
 
@@ -82,26 +76,23 @@ export default async function studioAdminThemePageBrowserBench() {
     }
 
     browserResult = await runBrowserBench({
-      id: 'studio-admin-theme-page-browser',
+      id: 'studio-dashboard-browser',
       artifactsDir: artifactDir,
       trace: true,
       screenshot: true,
       action: async ({ page, mark }) => {
-        const response = await page.goto(autoLoginUrl(status.siteUrl, 'wp-admin/theme-install.php'), {
-          waitUntil: 'domcontentloaded',
-          timeout: 120000,
-        });
+        const response = await page.goto(status.autoLoginUrl, { waitUntil: 'domcontentloaded', timeout: 120000 });
         finalStatus = response ? response.status() : 0;
-        await mark('browser_theme_install_domcontentloaded');
+        await mark('dashboard_domcontentloaded');
 
         const loginForm = page.locator('#loginform');
         loginFormSeen = await loginForm.count();
 
-        await page.getByRole('heading', { name: /add themes/i }).waitFor({ timeout: 120000 });
-        await mark('add_themes_heading_visible');
+        await page.getByRole('heading', { name: /^dashboard$/i }).waitFor({ timeout: 120000 });
+        await mark('dashboard_heading_visible');
 
-        await page.locator('.theme-browser, .wp-filter, .theme-install-php').first().waitFor({ timeout: 120000 });
-        await mark('theme_browser_visible');
+        await page.locator('#dashboard-widgets, .index-php').first().waitFor({ timeout: 120000 });
+        await mark('dashboard_widgets_visible');
 
         firstContentfulPaintMs = await firstContentfulPaint(page);
       },
@@ -138,7 +129,7 @@ export default async function studioAdminThemePageBrowserBench() {
     );
 
     if (finalStatus < 200 || finalStatus >= 400) {
-      throw new Error(`Add Themes returned HTTP status ${finalStatus}; raw_result=${artifactFile}`);
+      throw new Error(`Dashboard returned HTTP status ${finalStatus}; raw_result=${artifactFile}`);
     }
     if (loginFormSeen > 0) {
       throw new Error(`Login form remained visible after auto-login; raw_result=${artifactFile}`);
@@ -154,7 +145,7 @@ export default async function studioAdminThemePageBrowserBench() {
         site_create_ms: metric(create.elapsedMs),
         site_status_ms: metric(statusResult.elapsedMs),
         browser_first_contentful_paint_ms: metric(firstContentfulPaintMs),
-        add_themes_status: metric(finalStatus),
+        dashboard_status: metric(finalStatus),
         login_form_seen: metric(loginFormSeen),
         total_elapsed_ms: totalElapsedMs,
         ...browserResult.metrics,

--- a/Automattic/studio/bench/studio-site-editor-browser.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-browser.bench.mjs
@@ -1,0 +1,220 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import {
+  artifactDir as studioArtifactDir,
+  createStudioSite,
+  metric,
+  parseStudioSiteStatus,
+  redact,
+  safeResult,
+  stopStudioSite,
+  studioSiteStatus,
+  variant,
+} from './lib/studio-bench.mjs';
+
+const BROWSER_HELPER = process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER;
+
+if (!BROWSER_HELPER) {
+  throw new Error('HOMEBOY_NODEJS_BROWSER_BENCH_HELPER is required');
+}
+
+const { runBrowserBench } = await import(BROWSER_HELPER);
+
+async function createSite(sitePath) {
+  return createStudioSite(sitePath, {
+    name: `Studio Bench ${variant()} Site Editor Browser ${process.pid}`,
+    timeoutMs: 420000,
+  });
+}
+
+async function siteStatus(sitePath) {
+  return studioSiteStatus(sitePath, { timeoutMs: 90000 });
+}
+
+async function stopSite(sitePath) {
+  return stopStudioSite(sitePath, { timeoutMs: 90000 });
+}
+
+function siteAdminUrl(siteUrl, relativePath = '') {
+  const base = siteUrl.endsWith('/') ? siteUrl : `${siteUrl}/`;
+  return new URL(`wp-admin/${relativePath}`, base).toString();
+}
+
+async function sanitizeNetworkArtifact(artifact) {
+  if (!artifact || typeof artifact.path !== 'string') {
+    return;
+  }
+  const raw = await readFile(artifact.path, 'utf8');
+  await writeFile(artifact.path, redact(raw));
+}
+
+async function waitForSiteEditorReady(page) {
+  const timings = {};
+  const started = performance.now();
+  const elapsed = () => performance.now() - started;
+
+  const response = await page.goto(siteAdminUrl(page.__studioSiteUrl, 'site-editor.php'), {
+    waitUntil: 'commit',
+    timeout: 120000,
+  });
+  timings.commit_ms = elapsed();
+  timings.status = response ? response.status() : 0;
+
+  await page.waitForSelector('iframe[name="editor-canvas"]', {
+    state: 'visible',
+    timeout: 120000,
+  });
+  timings.editor_canvas_iframe_visible_ms = elapsed();
+
+  const frame = page.frame({ name: 'editor-canvas' });
+  if (!frame) {
+    throw new Error('Site Editor canvas frame not found');
+  }
+
+  await frame.waitForLoadState('domcontentloaded', { timeout: 120000 });
+  timings.editor_canvas_domcontentloaded_ms = elapsed();
+
+  await frame.waitForSelector('[data-block]', { timeout: 60000 });
+  timings.first_data_block_ms = elapsed();
+
+  await frame.waitForFunction(
+    () => {
+      return (
+        document.querySelectorAll('[data-block]').length > 0 &&
+        !document.querySelector('.components-spinner') &&
+        !document.querySelector('.is-loading') &&
+        !document.querySelector('.wp-block-editor__loading')
+      );
+    },
+    { timeout: 60000 }
+  );
+  timings.site_editor_ready_ms = elapsed();
+
+  return timings;
+}
+
+export default async function studioSiteEditorBrowserBench() {
+  const currentVariant = variant();
+  const runId = `${currentVariant}-site-editor-browser-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const artifactDir = path.join(studioArtifactDir('studio-site-editor-browser-artifacts'), runId);
+  const sitePath = path.join(artifactDir, 'site');
+  await mkdir(artifactDir, { recursive: true });
+
+  const totalStarted = Date.now();
+  let create;
+  let statusResult;
+  let stop;
+  let status;
+  let browserResult;
+  let warmupTimings = {};
+  let measureTimings = {};
+  let loginFormSeen = 0;
+
+  try {
+    create = await createSite(sitePath);
+    statusResult = await siteStatus(sitePath);
+    status = parseStudioSiteStatus(statusResult.stdout);
+    if (!status.siteUrl || !status.autoLoginUrl) {
+      throw new Error(`site status missing siteUrl/autoLoginUrl: ${redact(statusResult.stdout).slice(0, 1000)}`);
+    }
+
+    browserResult = await runBrowserBench({
+      id: 'studio-site-editor-browser',
+      artifactsDir: artifactDir,
+      trace: true,
+      screenshot: true,
+      action: async ({ page, mark }) => {
+        page.__studioSiteUrl = status.siteUrl;
+
+        await page.goto(status.autoLoginUrl, { waitUntil: 'domcontentloaded', timeout: 120000 });
+        await page.waitForLoadState('networkidle', { timeout: 120000 });
+        await mark('browser_auto_login_networkidle');
+
+        loginFormSeen = await page.locator('#loginform').count();
+
+        warmupTimings = await waitForSiteEditorReady(page);
+        await mark('warmup_site_editor_ready');
+
+        await page.goto(siteAdminUrl(status.siteUrl), { waitUntil: 'domcontentloaded', timeout: 120000 });
+        await page.waitForLoadState('networkidle', { timeout: 120000 });
+        await mark('browser_admin_networkidle_between_runs');
+
+        measureTimings = await waitForSiteEditorReady(page);
+        await mark('measure_site_editor_ready');
+      },
+    });
+
+    await sanitizeNetworkArtifact(browserResult.artifacts?.network);
+    stop = await stopSite(sitePath);
+
+    const totalElapsedMs = Date.now() - totalStarted;
+    const artifactFile = path.join(artifactDir, `result-${runId}.json`);
+    await writeFile(
+      artifactFile,
+      JSON.stringify(
+        {
+          variant: currentVariant,
+          sitePath,
+          siteUrl: status.siteUrl,
+          timings: {
+            site_create_ms: create.elapsedMs,
+            site_status_ms: statusResult.elapsedMs,
+            total_elapsed_ms: totalElapsedMs,
+          },
+          siteEditorTimings: {
+            warmup: warmupTimings,
+            measure: measureTimings,
+          },
+          commands: {
+            create: safeResult(create),
+            status: safeResult(statusResult),
+            stop: safeResult(stop),
+          },
+          browserMetrics: browserResult.metrics,
+          browserArtifacts: browserResult.artifacts,
+        },
+        null,
+        2
+      )
+    );
+
+    if (measureTimings.status < 200 || measureTimings.status >= 400) {
+      throw new Error(`Site Editor returned HTTP status ${measureTimings.status}; raw_result=${artifactFile}`);
+    }
+    if (loginFormSeen > 0) {
+      throw new Error(`Login form remained visible after auto-login; raw_result=${artifactFile}`);
+    }
+    if (!browserResult.artifacts?.trace || !browserResult.artifacts?.screenshot) {
+      throw new Error(`Browser trace/screenshot artifacts missing; raw_result=${artifactFile}`);
+    }
+
+    return {
+      metrics: {
+        success_rate: 1,
+        elapsed_ms: totalElapsedMs,
+        site_create_ms: metric(create.elapsedMs),
+        site_status_ms: metric(statusResult.elapsedMs),
+        login_form_seen: metric(loginFormSeen),
+        site_editor_status: metric(measureTimings.status),
+        site_editor_commit_ms: metric(measureTimings.commit_ms),
+        site_editor_iframe_visible_ms: metric(measureTimings.editor_canvas_iframe_visible_ms),
+        site_editor_iframe_domcontentloaded_ms: metric(measureTimings.editor_canvas_domcontentloaded_ms),
+        site_editor_first_data_block_ms: metric(measureTimings.first_data_block_ms),
+        site_editor_ready_ms: metric(measureTimings.site_editor_ready_ms),
+        site_editor_warmup_ready_ms: metric(warmupTimings.site_editor_ready_ms),
+        total_elapsed_ms: totalElapsedMs,
+        ...browserResult.metrics,
+      },
+      artifacts: {
+        raw_result: artifactFile,
+        site_path: sitePath,
+        ...browserResult.artifacts,
+      },
+    };
+  } finally {
+    if (!stop) {
+      stop = await stopSite(sitePath);
+    }
+  }
+}

--- a/Automattic/studio/rigs/studio-combined/rig.json
+++ b/Automattic/studio/rigs/studio-combined/rig.json
@@ -55,7 +55,9 @@
     "nodejs": [
       "${package.root}/bench/studio-site-create.bench.mjs",
       "${package.root}/bench/studio-admin-theme-page.bench.mjs",
-      "${package.root}/bench/studio-admin-theme-page-browser.bench.mjs"
+      "${package.root}/bench/studio-admin-theme-page-browser.bench.mjs",
+      "${package.root}/bench/studio-dashboard-browser.bench.mjs",
+      "${package.root}/bench/studio-site-editor-browser.bench.mjs"
     ]
   },
 
@@ -449,7 +451,7 @@
       {
         "kind": "command",
         "label": "Stage compiled artifacts into dist",
-        "command": "for variant in jspi asyncify; do cp packages/php-wasm/node-builds/8-3/$variant/php_8_3.js dist/packages/php-wasm/node-builds/8-3/$variant/php_8_3.js && cp packages/php-wasm/node-builds/8-3/$variant/8_3_30/php_8_3.wasm dist/packages/php-wasm/node-builds/8-3/$variant/8_3_30/php_8_3.wasm; done",
+        "command": "for variant in jspi asyncify; do src_dir=packages/php-wasm/node-builds/8-3/$variant; dst_dir=dist/packages/php-wasm/node-builds/8-3/$variant; cp \"$src_dir/php_8_3.js\" \"$dst_dir/php_8_3.js\"; wasm_src=$(find \"$src_dir\" -path '*/php_8_3.wasm' -type f | head -1); wasm_rel=${wasm_src#$src_dir/}; mkdir -p \"$dst_dir/$(dirname \"$wasm_rel\")\"; cp \"$wasm_src\" \"$dst_dir/$wasm_rel\"; done",
         "cwd": "${components.wordpress-playground.path}"
       },
       {


### PR DESCRIPTION
## Summary
- Add a dedicated Studio dashboard browser benchmark for the user-visible WP Admin open path.
- Add a Site Editor browser benchmark that captures the Studio PR-style editor-ready window plus phase timings.
- Make the Add Themes browser benchmark auto-login directly to `theme-install.php` instead of loading the dashboard first.
- Make `studio-combined` stage PHP-WASM 8.3 artifacts by discovering the generated patch-version directory instead of hardcoding `8_3_30`.

## Why
Studio performance work needs probes that separate user-visible dashboard slowness from route-specific admin/editor load. The previous Add Themes browser probe mixed dashboard auto-login cost into the Add Themes measurement, and the rig could break whenever PHP 8.3 patch releases advanced the wasm output directory.

## Validation
- `node --check Automattic/studio/bench/studio-admin-theme-page-browser.bench.mjs`
- `node --check Automattic/studio/bench/studio-dashboard-browser.bench.mjs`
- `node --check Automattic/studio/bench/studio-site-editor-browser.bench.mjs`
- `node -e "JSON.parse(require('fs').readFileSync('Automattic/studio/rigs/studio-combined/rig.json','utf8')); console.log('rig-json-ok')"`
- `homeboy bench list studio --rig studio-combined`
- `homeboy bench studio --rig studio-combined --scenario studio-dashboard-browser --iterations 1 --warmup 0 --ignore-baseline --json-summary --force-hot`
- `homeboy bench studio --rig studio-combined --scenario studio-admin-theme-page-browser --scenario studio-site-editor-browser --iterations 1 --ignore-baseline --json-summary --force-hot`

Note: a combined three-scenario smoke with default warmup hit an existing Studio site-create flake before the dashboard browser workload ran. Re-running the dashboard workload with `--warmup 0` passed, and the other two workloads passed in the combined run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the benchmark workloads and rig update, running local validation, and drafting the PR summary. Chris directed the performance-probe scope and reviewed the investigation path.