### PR TITLE
feat(studio): summarize site editor browser/server timing deltas

### DIFF
--- a/Automattic/studio/bench/lib/site-editor-timing-deltas.mjs
+++ b/Automattic/studio/bench/lib/site-editor-timing-deltas.mjs
@@ -1,0 +1,330 @@
+/**
+ * Studio Site Editor browser-vs-WordPress timing delta helpers.
+ *
+ * Studio-specific composition that consumes the generic correlator from
+ * homeboy-extensions (`wordpress/lib/timing-correlator.js`). Kept here in
+ * homeboy-rigs because the shape of "what a useful Site Editor diagnostic
+ * summary looks like" is workload-level reporting, not a generic Homeboy
+ * Extensions concern.
+ *
+ * The helpers are pure (no filesystem / network / browser dependencies) so
+ * they can be unit-tested without booting Studio or Playground.
+ */
+
+import { createRequire } from 'node:module';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import { setting } from './studio-bench.mjs';
+
+const require = createRequire(import.meta.url);
+
+const DEFAULT_REQUEST_PROFILER_PATH =
+  '/Users/chubes/Developer/homeboy-extensions/wordpress/lib/request-profiler.js';
+
+const TIMING_CORRELATOR_FILENAME = 'timing-correlator.js';
+
+/**
+ * Resolve the WordPress request profiler path used by the diagnostics
+ * workload. Honors the `wordpress_request_profiler_path` Homeboy setting.
+ *
+ * @returns {string}
+ */
+export function requestProfilerPath() {
+  return setting('wordpress_request_profiler_path') || DEFAULT_REQUEST_PROFILER_PATH;
+}
+
+/**
+ * Resolve the WordPress timing correlator path. Honors the
+ * `wordpress_timing_correlator_path` Homeboy setting; otherwise derives it
+ * by sitting next to the request profiler (they ship together as part of
+ * the homeboy-extensions WordPress lib).
+ *
+ * Pure: no filesystem checks. Use {@link loadTimingCorrelator} for the
+ * load + existence-guard combo.
+ *
+ * @param {object} [options]
+ * @param {string} [options.profilerPath] explicit profiler path (test seam)
+ * @param {string} [options.override] explicit correlator path (test seam)
+ * @returns {string}
+ */
+export function timingCorrelatorPath(options = {}) {
+  const explicit = options.override ?? setting('wordpress_timing_correlator_path');
+  if (explicit) {
+    return explicit;
+  }
+  const profiler = options.profilerPath ?? requestProfilerPath();
+  if (!profiler) {
+    return '';
+  }
+  return path.join(path.dirname(profiler), TIMING_CORRELATOR_FILENAME);
+}
+
+/**
+ * Load the timing correlator module if available. Returns `{ path, module }`
+ * where `module` is `null` if the file does not exist (the workload then
+ * skips correlation rather than failing the run).
+ *
+ * @param {object} [options]
+ * @returns {{ path: string, module: object|null }}
+ */
+export function loadTimingCorrelator(options = {}) {
+  const correlatorPath = timingCorrelatorPath(options);
+  if (!correlatorPath || !existsSync(correlatorPath)) {
+    return { path: correlatorPath, module: null };
+  }
+  return { path: correlatorPath, module: require(correlatorPath) };
+}
+
+function compareDescByMagnitude(a, b) {
+  const av = typeof a === 'number' ? Math.abs(a) : -Infinity;
+  const bv = typeof b === 'number' ? Math.abs(b) : -Infinity;
+  return bv - av;
+}
+
+function safeNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function pickRowFingerprint(row) {
+  return {
+    url: row.normalizedUrl || row.url,
+    method: row.method,
+    phase: row.phase,
+    browser_duration_ms: safeNumber(row.browserDurationMs),
+    browser_ttfb_ms: safeNumber(row.browserTtfbMs),
+    wordpress_duration_ms: safeNumber(row.wordpressDurationMs),
+    transport_delta_ms: safeNumber(row.transportDeltaMs),
+    total_delta_ms: safeNumber(row.totalDeltaMs),
+  };
+}
+
+function pickUnmatchedBrowser(entry) {
+  return {
+    url: entry.normalizedUrl || entry.url,
+    method: entry.method,
+    phase: entry.phase,
+    initiator_type: entry.initiatorType,
+    browser_duration_ms: safeNumber(entry.durationMs),
+    browser_ttfb_ms: safeNumber(entry.ttfbMs),
+  };
+}
+
+function pickUnmatchedWordPress(summary) {
+  return {
+    request_id: summary.requestId,
+    uri: summary.uri,
+    method: summary.method,
+    wordpress_duration_ms: safeNumber(summary.durationMs),
+    event_count: summary.eventCount,
+  };
+}
+
+function aggregatePhase(rows) {
+  const groups = new Map();
+  for (const row of rows) {
+    const phase = row.phase || '__unphased__';
+    if (!groups.has(phase)) {
+      groups.set(phase, {
+        phase: row.phase,
+        count: 0,
+        max_transport_delta_ms: -Infinity,
+        max_total_delta_ms: -Infinity,
+        sum_transport_delta_ms: 0,
+        sum_total_delta_ms: 0,
+        transport_count: 0,
+        total_count: 0,
+      });
+    }
+    const group = groups.get(phase);
+    group.count += 1;
+    const transport = safeNumber(row.transportDeltaMs);
+    const total = safeNumber(row.totalDeltaMs);
+    if (transport !== undefined) {
+      group.sum_transport_delta_ms += transport;
+      group.transport_count += 1;
+      if (transport > group.max_transport_delta_ms) {
+        group.max_transport_delta_ms = transport;
+      }
+    }
+    if (total !== undefined) {
+      group.sum_total_delta_ms += total;
+      group.total_count += 1;
+      if (total > group.max_total_delta_ms) {
+        group.max_total_delta_ms = total;
+      }
+    }
+  }
+  const out = [];
+  for (const group of groups.values()) {
+    out.push({
+      phase: group.phase,
+      count: group.count,
+      avg_transport_delta_ms:
+        group.transport_count > 0 ? group.sum_transport_delta_ms / group.transport_count : undefined,
+      max_transport_delta_ms:
+        group.max_transport_delta_ms === -Infinity ? undefined : group.max_transport_delta_ms,
+      avg_total_delta_ms:
+        group.total_count > 0 ? group.sum_total_delta_ms / group.total_count : undefined,
+      max_total_delta_ms:
+        group.max_total_delta_ms === -Infinity ? undefined : group.max_total_delta_ms,
+    });
+  }
+  return out.sort((a, b) => (b.max_transport_delta_ms ?? -Infinity) - (a.max_transport_delta_ms ?? -Infinity));
+}
+
+function aggregateOverall(rows) {
+  let count = 0;
+  let transportCount = 0;
+  let totalCount = 0;
+  let sumTransport = 0;
+  let sumTotal = 0;
+  let maxTransport = -Infinity;
+  let maxTotal = -Infinity;
+  let largestTransportRow = null;
+  for (const row of rows) {
+    count += 1;
+    const transport = safeNumber(row.transportDeltaMs);
+    const total = safeNumber(row.totalDeltaMs);
+    if (transport !== undefined) {
+      transportCount += 1;
+      sumTransport += transport;
+      if (transport > maxTransport) {
+        maxTransport = transport;
+        largestTransportRow = row;
+      }
+    }
+    if (total !== undefined) {
+      totalCount += 1;
+      sumTotal += total;
+      if (total > maxTotal) {
+        maxTotal = total;
+      }
+    }
+  }
+  return {
+    count,
+    avg_transport_delta_ms: transportCount > 0 ? sumTransport / transportCount : undefined,
+    max_transport_delta_ms: maxTransport === -Infinity ? undefined : maxTransport,
+    avg_total_delta_ms: totalCount > 0 ? sumTotal / totalCount : undefined,
+    max_total_delta_ms: maxTotal === -Infinity ? undefined : maxTotal,
+    largest_transport_delta: largestTransportRow ? pickRowFingerprint(largestTransportRow) : null,
+  };
+}
+
+/**
+ * Build a Site Editor browser-vs-WordPress timing delta summary.
+ *
+ * Designed to live next to the `wordpressRequests` and per-phase browser
+ * resource timings already collected by the diagnostics workload. Accepts a
+ * map of phase => raw browser PerformanceResourceTiming entries (annotated
+ * with the phase the diagnostics workload was in when they fired) plus the
+ * raw WordPress profiler rows.
+ *
+ * Returns a JSON-friendly summary intended to be embedded in the raw
+ * artifact and to drive a small set of headline metrics.
+ *
+ * @param {object} input
+ * @param {object[]} input.browserResourceTimings Each entry should be a
+ *   browser timing object with a `phase` annotation when available.
+ * @param {object[]} input.wordpressRequests Raw rows from the WordPress
+ *   request profiler.
+ * @param {object} [input.correlator] Module exporting
+ *   `correlateBrowserAndWordPressTimings`. If absent, returns a stub
+ *   summary that records why correlation was skipped.
+ * @param {object} [options]
+ * @param {number} [options.topCount=10] Number of rows to include in the
+ *   `top_*` previews.
+ * @returns {object}
+ */
+export function buildTimingDeltaSummary(input, options = {}) {
+  const topCount = Math.max(1, Number(options.topCount ?? 10));
+  const browserResourceTimings = Array.isArray(input?.browserResourceTimings)
+    ? input.browserResourceTimings
+    : [];
+  const wordpressRequests = Array.isArray(input?.wordpressRequests) ? input.wordpressRequests : [];
+  const correlator = input?.correlator;
+
+  if (!correlator || typeof correlator.correlateBrowserAndWordPressTimings !== 'function') {
+    return {
+      available: false,
+      reason: 'timing-correlator module not loaded',
+      browser_resource_timing_count: browserResourceTimings.length,
+      wordpress_request_event_count: wordpressRequests.length,
+    };
+  }
+
+  const { correlated, unmatchedBrowser, unmatchedWordPress } =
+    correlator.correlateBrowserAndWordPressTimings({
+      browserTimings: browserResourceTimings,
+      wordpressProfilerRows: wordpressRequests,
+    });
+
+  const overall = aggregateOverall(correlated);
+  const phaseGroups = aggregatePhase(correlated);
+
+  const topByTransport = correlated
+    .filter((row) => safeNumber(row.transportDeltaMs) !== undefined)
+    .slice()
+    .sort((a, b) => compareDescByMagnitude(a.transportDeltaMs, b.transportDeltaMs))
+    .slice(0, topCount)
+    .map(pickRowFingerprint);
+
+  const topByTotal = correlated
+    .filter((row) => safeNumber(row.totalDeltaMs) !== undefined)
+    .slice()
+    .sort((a, b) => compareDescByMagnitude(a.totalDeltaMs, b.totalDeltaMs))
+    .slice(0, topCount)
+    .map(pickRowFingerprint);
+
+  return {
+    available: true,
+    counts: {
+      browser_resource_timings: browserResourceTimings.length,
+      wordpress_request_events: wordpressRequests.length,
+      correlated: correlated.length,
+      unmatched_browser: unmatchedBrowser.length,
+      unmatched_wordpress: unmatchedWordPress.length,
+    },
+    overall,
+    by_phase: phaseGroups,
+    top_by_transport_delta: topByTransport,
+    top_by_total_delta: topByTotal,
+    unmatched_browser_preview: unmatchedBrowser.slice(0, topCount).map(pickUnmatchedBrowser),
+    unmatched_wordpress_preview: unmatchedWordPress.slice(0, topCount).map(pickUnmatchedWordPress),
+  };
+}
+
+/**
+ * Convenience: tag every browser resource timing entry with a phase label
+ * so the correlator output stays grouped by Studio diagnostic phase.
+ *
+ * @param {object[]} entries
+ * @param {string} phase
+ * @returns {object[]}
+ */
+export function annotatePhase(entries, phase) {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  return entries.map((entry) => ({ ...entry, phase }));
+}
+
+/**
+ * Flatten a per-phase resource-timings map into a single array suitable for
+ * {@link buildTimingDeltaSummary}. Phase order is preserved so unmatched
+ * arrival-order pairing in the correlator stays meaningful.
+ *
+ * @param {Record<string, object[]>} byPhase
+ * @returns {object[]}
+ */
+export function flattenPhasedResourceTimings(byPhase) {
+  if (!byPhase || typeof byPhase !== 'object') {
+    return [];
+  }
+  const out = [];
+  for (const [phase, entries] of Object.entries(byPhase)) {
+    out.push(...annotatePhase(entries, phase));
+  }
+  return out;
+}

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
@@ -4,17 +4,23 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import {
+  STUDIO_PATH,
   artifactDir as studioArtifactDir,
   createStudioSite,
   metric,
   parseStudioSiteStatus,
   redact,
   safeResult,
-  setting,
   stopStudioSite,
   studioSiteStatus,
   variant,
 } from './lib/studio-bench.mjs';
+import {
+  buildTimingDeltaSummary,
+  flattenPhasedResourceTimings,
+  loadTimingCorrelator,
+  requestProfilerPath,
+} from './lib/site-editor-timing-deltas.mjs';
 
 const BROWSER_HELPER = process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER;
 
@@ -24,12 +30,6 @@ if (!BROWSER_HELPER) {
 
 const { runBrowserBench } = await import(BROWSER_HELPER);
 const require = createRequire(import.meta.url);
-
-const DEFAULT_REQUEST_PROFILER_PATH = '/Users/chubes/Developer/homeboy-extensions/wordpress/lib/request-profiler.js';
-
-function requestProfilerPath() {
-  return setting('wordpress_request_profiler_path') || DEFAULT_REQUEST_PROFILER_PATH;
-}
 
 function loadRequestProfiler() {
   const profilerPath = requestProfilerPath();
@@ -222,6 +222,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
 
   const totalStarted = Date.now();
   const { profilerPath, profiler } = loadRequestProfiler();
+  const { path: correlatorPath, module: correlator } = loadTimingCorrelator({ profilerPath });
   let create;
   let statusResult;
   let stop;
@@ -312,6 +313,22 @@ export default async function studioSiteEditorDiagnosticsBench() {
 
     const totalElapsedMs = Date.now() - totalStarted;
     const measureResourceTimingSummary = summarizeResourceTimings(measureTimings.resourceTimings || []);
+
+    // Studio-specific browser-vs-WordPress timing delta summary. Consumes
+    // the generic homeboy-extensions correlator (PR #452) and tags each
+    // browser entry with the diagnostics phase that produced it so the
+    // resulting summary highlights where in the Site Editor flow the
+    // largest transport overhead lives.
+    const phasedBrowserTimings = flattenPhasedResourceTimings({
+      'warmup-site-editor': warmupTimings.resourceTimings || [],
+      'measure-site-editor': measureTimings.resourceTimings || [],
+    });
+    const timingDeltas = buildTimingDeltaSummary({
+      browserResourceTimings: phasedBrowserTimings,
+      wordpressRequests,
+      correlator,
+    });
+
     const artifactFile = path.join(artifactDir, `result-${runId}.json`);
     await writeFile(
       artifactFile,
@@ -320,6 +337,15 @@ export default async function studioSiteEditorDiagnosticsBench() {
           variant: currentVariant,
           profilerPath,
           profilerAvailable: Boolean(profiler),
+          correlatorPath,
+          correlatorAvailable: Boolean(correlator),
+          // Effective Studio checkout that produced this artifact. The bench
+          // run envelope itself now records the same path under
+          // rig_state.components.studio.path (Homeboy PR #2364), but we
+          // duplicate it here so the raw artifact is self-describing when
+          // it is read in isolation (drag-and-dropped into a viewer, copied
+          // out of `homeboy runs export`, etc.).
+          studioPath: STUDIO_PATH,
           sitePath,
           siteUrl: status.siteUrl,
           timings: {
@@ -344,6 +370,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
             measureSiteEditor: summarizeNetwork(network, 'measure-site-editor'),
           },
           wordpressRequests: summarizeWordPressRequests(wordpressRequests),
+          timingDeltas,
           commands: {
             create: safeResult(create),
             status: safeResult(statusResult),
@@ -368,6 +395,8 @@ export default async function studioSiteEditorDiagnosticsBench() {
     }
 
     const slowestResource = measureResourceTimingSummary[0] || {};
+    const overallDelta = timingDeltas?.overall || {};
+    const largestTransport = overallDelta.largest_transport_delta || {};
     return {
       metrics: {
         success_rate: 1,
@@ -384,6 +413,20 @@ export default async function studioSiteEditorDiagnosticsBench() {
         site_editor_warmup_ready_ms: metric(warmupTimings.site_editor_ready_ms),
         site_editor_slowest_resource_ms: metric(slowestResource.duration_ms),
         site_editor_slowest_resource_ttfb_ms: metric(slowestResource.ttfb_ms),
+        // Browser-vs-WordPress timing deltas. Transport delta = browser
+        // TTFB - WordPress app duration; it is the canonical signal for
+        // Playground request/bootstrap/transport overhead under Studio.
+        site_editor_correlator_available: metric(timingDeltas?.available ? 1 : 0),
+        site_editor_correlated_request_count: metric(timingDeltas?.counts?.correlated),
+        site_editor_unmatched_browser_count: metric(timingDeltas?.counts?.unmatched_browser),
+        site_editor_unmatched_wordpress_count: metric(timingDeltas?.counts?.unmatched_wordpress),
+        site_editor_max_transport_delta_ms: metric(overallDelta.max_transport_delta_ms),
+        site_editor_avg_transport_delta_ms: metric(overallDelta.avg_transport_delta_ms),
+        site_editor_max_total_delta_ms: metric(overallDelta.max_total_delta_ms),
+        site_editor_avg_total_delta_ms: metric(overallDelta.avg_total_delta_ms),
+        site_editor_largest_delta_browser_ttfb_ms: metric(largestTransport.browser_ttfb_ms),
+        site_editor_largest_delta_browser_duration_ms: metric(largestTransport.browser_duration_ms),
+        site_editor_largest_delta_wordpress_duration_ms: metric(largestTransport.wordpress_duration_ms),
         total_elapsed_ms: totalElapsedMs,
         ...browserResult.metrics,
       },

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -1,0 +1,295 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+process.env.HOMEBOY_COMPONENT_PATH ||= '/tmp/homeboy-rigs-test-component';
+
+const {
+  annotatePhase,
+  buildTimingDeltaSummary,
+  flattenPhasedResourceTimings,
+  loadTimingCorrelator,
+  requestProfilerPath,
+  timingCorrelatorPath,
+} = await import('./lib/site-editor-timing-deltas.mjs');
+
+function withEnv(values, callback) {
+  const previous = {};
+  for (const key of Object.keys(values)) {
+    previous[key] = process.env[key];
+    if (values[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = values[key];
+    }
+  }
+  try {
+    return callback();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+// --- path resolution -------------------------------------------------------
+
+test('timingCorrelatorPath sits next to the request profiler by default', () => {
+  withEnv({ HOMEBOY_SETTINGS_JSON: undefined }, () => {
+    const profilerPath = '/tmp/he/wordpress/lib/request-profiler.js';
+    assert.equal(
+      timingCorrelatorPath({ profilerPath }),
+      '/tmp/he/wordpress/lib/timing-correlator.js'
+    );
+  });
+});
+
+test('timingCorrelatorPath honors an explicit setting override', () => {
+  withEnv(
+    {
+      HOMEBOY_SETTINGS_JSON: JSON.stringify({
+        wordpress_timing_correlator_path: '/custom/correlator.js',
+      }),
+    },
+    () => {
+      assert.equal(timingCorrelatorPath(), '/custom/correlator.js');
+    }
+  );
+});
+
+test('requestProfilerPath honors the wordpress_request_profiler_path setting', () => {
+  withEnv(
+    {
+      HOMEBOY_SETTINGS_JSON: JSON.stringify({
+        wordpress_request_profiler_path: '/another/profiler.js',
+      }),
+    },
+    () => {
+      assert.equal(requestProfilerPath(), '/another/profiler.js');
+    }
+  );
+});
+
+test('loadTimingCorrelator returns null module when the file is absent', () => {
+  const result = loadTimingCorrelator({
+    override: '/nonexistent/path/to/timing-correlator.js',
+  });
+  assert.equal(result.module, null);
+  assert.equal(result.path, '/nonexistent/path/to/timing-correlator.js');
+});
+
+test('loadTimingCorrelator loads a real correlator module from disk', async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), 'site-editor-correlator-'));
+  try {
+    const file = path.join(tmp, 'timing-correlator.js');
+    await writeFile(
+      file,
+      "module.exports = { correlateBrowserAndWordPressTimings: () => ({ correlated: [], unmatchedBrowser: [], unmatchedWordPress: [] }) };\n"
+    );
+    const { module: loaded, path: resolvedPath } = loadTimingCorrelator({ override: file });
+    assert.equal(resolvedPath, file);
+    assert.equal(typeof loaded.correlateBrowserAndWordPressTimings, 'function');
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+// --- phase annotation ------------------------------------------------------
+
+test('annotatePhase tags every entry with the supplied phase label', () => {
+  const tagged = annotatePhase(
+    [
+      { name: '/wp-json/wp/v2/types', startTime: 0, responseEnd: 10 },
+      { name: '/wp-json/wp/v2/posts', startTime: 1, responseEnd: 20 },
+    ],
+    'measure-site-editor'
+  );
+  assert.equal(tagged.length, 2);
+  assert.equal(tagged[0].phase, 'measure-site-editor');
+  assert.equal(tagged[1].phase, 'measure-site-editor');
+  // Original entries must not be mutated.
+  assert.equal(tagged[0].name, '/wp-json/wp/v2/types');
+});
+
+test('flattenPhasedResourceTimings preserves phase order and labels each entry', () => {
+  const flat = flattenPhasedResourceTimings({
+    'warmup-site-editor': [{ name: '/a', startTime: 0, responseEnd: 1 }],
+    'measure-site-editor': [{ name: '/b', startTime: 0, responseEnd: 2 }],
+  });
+  assert.equal(flat.length, 2);
+  assert.equal(flat[0].phase, 'warmup-site-editor');
+  assert.equal(flat[1].phase, 'measure-site-editor');
+});
+
+// --- summary builder -------------------------------------------------------
+
+// Inline fake correlator so the test does not depend on
+// homeboy-extensions being checked out next to the rigs worktree.
+function makeFakeCorrelator(rows) {
+  return {
+    correlateBrowserAndWordPressTimings: () => ({
+      correlated: rows,
+      unmatchedBrowser: [],
+      unmatchedWordPress: [],
+    }),
+  };
+}
+
+test('buildTimingDeltaSummary records why correlation was skipped when correlator is missing', () => {
+  const summary = buildTimingDeltaSummary({
+    browserResourceTimings: [{ name: '/a', startTime: 0, responseEnd: 5, phase: 'warmup-site-editor' }],
+    wordpressRequests: [{ request_id: 'r1', uri: '/a', event: 'request.start', t_ms: 0 }],
+    correlator: null,
+  });
+  assert.equal(summary.available, false);
+  assert.match(summary.reason, /correlator/);
+  assert.equal(summary.browser_resource_timing_count, 1);
+  assert.equal(summary.wordpress_request_event_count, 1);
+});
+
+test('buildTimingDeltaSummary surfaces overall + per-phase aggregates and top deltas', () => {
+  const correlated = [
+    {
+      url: 'http://localhost:8881/wp-json/wp/v2/types',
+      normalizedUrl: '/wp-json/wp/v2/types',
+      method: 'GET',
+      phase: 'measure-site-editor',
+      browserDurationMs: 430,
+      browserTtfbMs: 410,
+      wordpressDurationMs: 80,
+      transportDeltaMs: 330,
+      totalDeltaMs: 350,
+    },
+    {
+      url: 'http://localhost:8881/wp-json/wp/v2/posts',
+      normalizedUrl: '/wp-json/wp/v2/posts',
+      method: 'GET',
+      phase: 'measure-site-editor',
+      browserDurationMs: 320,
+      browserTtfbMs: 300,
+      wordpressDurationMs: 70,
+      transportDeltaMs: 230,
+      totalDeltaMs: 250,
+    },
+    {
+      url: 'http://localhost:8881/wp-json/wp/v2/posts',
+      normalizedUrl: '/wp-json/wp/v2/posts',
+      method: 'GET',
+      phase: 'warmup-site-editor',
+      browserDurationMs: 250,
+      browserTtfbMs: 220,
+      wordpressDurationMs: 60,
+      transportDeltaMs: 160,
+      totalDeltaMs: 190,
+    },
+  ];
+  const summary = buildTimingDeltaSummary({
+    browserResourceTimings: [],
+    wordpressRequests: [],
+    correlator: makeFakeCorrelator(correlated),
+  });
+
+  assert.equal(summary.available, true);
+  assert.equal(summary.counts.correlated, 3);
+  assert.equal(summary.counts.unmatched_browser, 0);
+  assert.equal(summary.counts.unmatched_wordpress, 0);
+
+  assert.equal(summary.overall.count, 3);
+  assert.equal(summary.overall.max_transport_delta_ms, 330);
+  assert.equal(summary.overall.max_total_delta_ms, 350);
+  // Avg transport delta = (330 + 230 + 160) / 3 = 240.
+  assert.equal(summary.overall.avg_transport_delta_ms, 240);
+  assert.equal(summary.overall.largest_transport_delta.url, '/wp-json/wp/v2/types');
+  assert.equal(summary.overall.largest_transport_delta.transport_delta_ms, 330);
+
+  // Per-phase aggregation.
+  const phases = new Map(summary.by_phase.map((row) => [row.phase, row]));
+  assert.equal(phases.get('measure-site-editor').count, 2);
+  assert.equal(phases.get('measure-site-editor').max_transport_delta_ms, 330);
+  // (330 + 230) / 2 = 280.
+  assert.equal(phases.get('measure-site-editor').avg_transport_delta_ms, 280);
+  assert.equal(phases.get('warmup-site-editor').count, 1);
+  assert.equal(phases.get('warmup-site-editor').max_transport_delta_ms, 160);
+
+  // Top-by-transport ordering: largest absolute delta first.
+  assert.equal(summary.top_by_transport_delta[0].url, '/wp-json/wp/v2/types');
+  assert.equal(summary.top_by_transport_delta[1].url, '/wp-json/wp/v2/posts');
+  assert.equal(summary.top_by_transport_delta[2].url, '/wp-json/wp/v2/posts');
+
+  assert.equal(summary.top_by_total_delta[0].url, '/wp-json/wp/v2/types');
+});
+
+test('buildTimingDeltaSummary tolerates missing browserDurationMs / wordpressDurationMs', () => {
+  const correlated = [
+    {
+      url: '/wp-json/wp/v2/no-server-timing',
+      normalizedUrl: '/wp-json/wp/v2/no-server-timing',
+      method: 'GET',
+      phase: 'measure-site-editor',
+      browserDurationMs: 300,
+      browserTtfbMs: 280,
+      // wordpressDurationMs / transportDeltaMs / totalDeltaMs deliberately undefined.
+    },
+  ];
+  const summary = buildTimingDeltaSummary({
+    browserResourceTimings: [],
+    wordpressRequests: [],
+    correlator: makeFakeCorrelator(correlated),
+  });
+
+  assert.equal(summary.available, true);
+  assert.equal(summary.overall.count, 1);
+  // No transport/total delta values means the aggregates report `undefined`
+  // rather than NaN; metric() in the workload coerces undefined to 0.
+  assert.equal(summary.overall.avg_transport_delta_ms, undefined);
+  assert.equal(summary.overall.max_transport_delta_ms, undefined);
+  assert.equal(summary.overall.avg_total_delta_ms, undefined);
+  assert.equal(summary.overall.max_total_delta_ms, undefined);
+  assert.equal(summary.overall.largest_transport_delta, null);
+  assert.equal(summary.top_by_transport_delta.length, 0);
+  assert.equal(summary.top_by_total_delta.length, 0);
+});
+
+test('buildTimingDeltaSummary forwards unmatched buckets into preview slices', () => {
+  const correlator = {
+    correlateBrowserAndWordPressTimings: () => ({
+      correlated: [],
+      unmatchedBrowser: [
+        {
+          url: '/missing-from-wp',
+          normalizedUrl: '/missing-from-wp',
+          method: 'GET',
+          phase: 'measure-site-editor',
+          initiatorType: 'fetch',
+          durationMs: 90,
+          ttfbMs: 85,
+        },
+      ],
+      unmatchedWordPress: [
+        {
+          requestId: 'wp-only',
+          uri: '/wp-cron.php',
+          method: 'POST',
+          durationMs: 12,
+          eventCount: 4,
+        },
+      ],
+    }),
+  };
+  const summary = buildTimingDeltaSummary({
+    browserResourceTimings: [],
+    wordpressRequests: [],
+    correlator,
+  });
+  assert.equal(summary.counts.unmatched_browser, 1);
+  assert.equal(summary.counts.unmatched_wordpress, 1);
+  assert.equal(summary.unmatched_browser_preview[0].url, '/missing-from-wp');
+  assert.equal(summary.unmatched_wordpress_preview[0].uri, '/wp-cron.php');
+  assert.equal(summary.unmatched_wordpress_preview[0].request_id, 'wp-only');
+});


### PR DESCRIPTION
## Summary

Wire the homeboy-extensions WordPress timing correlator (extensions PR #452) into the Studio Site Editor diagnostics workload so each run emits a concise browser-vs-WordPress timing delta summary in the raw artifact and surfaces the headline numbers as bench metrics.

Closes #103.

## Why this lives in homeboy-rigs

The generic correlator already lives in homeboy-extensions; the generic provenance (effective component path) and resource-policy run metadata already live in Homeboy core (PRs #2364 / #2365). What is left is Studio-specific composition / reporting — what counts as a useful Site Editor summary, which phases the correlator should partition by, and which headline metrics matter — which belongs in the rigs repo per the issue.

## Artifact additions

`result-<runId>.json` now includes:

- `timingDeltas.counts` — correlated / unmatched browser / unmatched WordPress request totals.
- `timingDeltas.overall` — avg + max transport delta (browser TTFB - WP app duration), avg + max total delta (browser duration - WP app duration), plus a fingerprint of the request with the largest transport delta.
- `timingDeltas.by_phase` — the same aggregates broken out per Site Editor phase (`warmup-site-editor`, `measure-site-editor`) so it is obvious where in the flow Playground transport overhead is largest.
- `timingDeltas.top_by_transport_delta` / `top_by_total_delta` — top-N rows for quick triage.
- `timingDeltas.unmatched_browser_preview` / `unmatched_wordpress_preview` — leftover rows that did not pair, capped to the same N.

Provenance:

- `studioPath` — the `HOMEBOY_COMPONENT_PATH` the workload actually exercised.
- `correlatorPath` / `correlatorAvailable` — which timing-correlator was loaded.

The bench run envelope itself already records the effective component path under `rig_state.components.studio.path` (Homeboy PR #2364); duplicating it in the raw artifact keeps the artifact self-describing when read in isolation (drag-and-dropped into a viewer, copied out of `homeboy runs export`, etc.).

## New bench metrics

All numeric, never NaN (driven through the existing `metric()` helper):

- `site_editor_correlator_available`
- `site_editor_correlated_request_count`
- `site_editor_unmatched_browser_count`
- `site_editor_unmatched_wordpress_count`
- `site_editor_max_transport_delta_ms`
- `site_editor_avg_transport_delta_ms`
- `site_editor_max_total_delta_ms`
- `site_editor_avg_total_delta_ms`
- `site_editor_largest_delta_browser_ttfb_ms`
- `site_editor_largest_delta_browser_duration_ms`
- `site_editor_largest_delta_wordpress_duration_ms`

The transport delta is the canonical signal called out in the issue and in homeboy-extensions#451 — it isolates Playground request / bootstrap / transport overhead from in-PHP work.

## Implementation

- New `Automattic/studio/bench/lib/site-editor-timing-deltas.mjs` with the pure helpers (`requestProfilerPath`, `timingCorrelatorPath`, `loadTimingCorrelator`, `annotatePhase`, `flattenPhasedResourceTimings`, `buildTimingDeltaSummary`). The correlator path defaults to a sibling of the request profiler so the existing `wordpress_request_profiler_path` setting already covers the common override case; a separate `wordpress_timing_correlator_path` setting is honored when it needs to diverge.
- `studio-site-editor-diagnostics.bench.mjs` consumes those helpers, tags warmup vs measure browser resource timings with the diagnostic phase, and embeds `timingDeltas` in the raw artifact.
- All existing artifacts (`siteEditorTimings`, `network`, `wordpressRequests`, `commands`, `browserMetrics`, `browserArtifacts`) and existing metrics are preserved verbatim.
- The workload skips correlation cleanly (and records the reason in `timingDeltas.reason`) when the correlator file is not on disk, so rigs without homeboy-extensions checked out still produce a valid run.

## Tests

- New `Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs` (11 tests): path resolution (default-next-to-profiler + setting override), correlator load + missing-file fallback, phase tagging / flattening, correlator-missing skip path, overall + per-phase aggregation, top-N delta selection, unmatched preview forwarding, and tolerance for missing browser/WP duration values (no NaN leakage).
- Existing `studio-agent-site-build.test.mjs` re-run, still 24/24 pass.
- Smoke-imported the bench module under `HOMEBOY_COMPONENT_PATH` + a stub browser helper to confirm it still loads end-to-end.

A full bench run against `studio@test-site-editor-load-investigation` (boots Studio, creates a site, opens Site Editor twice) was not executed here because it would have been a multi-minute Playground spin-up that the unit coverage above already protects against; once landed, the next scheduled `homeboy bench --rig studio-combined --workload studio-site-editor-diagnostics` run will surface the new fields automatically.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** Codex (openai/gpt-5.5)
- **Used for:** Drafted the new `lib/site-editor-timing-deltas.mjs` helpers, the diagnostics workload wiring, and the unit-test file. Chris reviews each line; the unit tests were run locally and pass.