### PR TITLE
Add Studio Site Editor bootstrap timeline diagnostics

### DIFF
--- a/Automattic/studio/bench/lib/wordpress-bootstrap-timeline.mjs
+++ b/Automattic/studio/bench/lib/wordpress-bootstrap-timeline.mjs
@@ -1,0 +1,236 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const MARKER = 'HOMEBOY_BOOTSTRAP_TIMELINE';
+const ARTIFACT_RELATIVE_PATH = 'wp-content/homeboy-bootstrap-timeline.jsonl';
+const BACKUP_DIR_RELATIVE_PATH = 'wp-content/homeboy-bootstrap-timeline-backups';
+
+const BOOTSTRAP_MARKS = [
+  {
+    search: "require_wp_db();",
+    event: 'wp-settings.after_require_wp_db',
+  },
+  {
+    search: "wp_start_object_cache();",
+    event: 'wp-settings.after_object_cache',
+  },
+  {
+    search: "require ABSPATH . WPINC . '/default-filters.php';",
+    event: 'wp-settings.after_default_filters',
+  },
+  {
+    search: "register_shutdown_function( 'shutdown_action_hook' );",
+    event: 'wp-settings.after_shutdown_hook',
+  },
+  {
+    search: "require_once ABSPATH . WPINC . '/class-wp-locale-switcher.php';",
+    event: 'wp-settings.after_l10n_library',
+  },
+  {
+    search: 'wp_not_installed();',
+    event: 'wp-settings.after_not_installed_check',
+  },
+  {
+    search: '// Load most of WordPress.',
+    event: 'wp-settings.before_load_most',
+    before: true,
+  },
+  {
+    search: "require ABSPATH . WPINC . '/post.php';",
+    event: 'wp-settings.after_post_core',
+  },
+  {
+    search: "require ABSPATH . WPINC . '/rest-api.php';",
+    event: 'wp-settings.after_rest_api_base',
+  },
+  {
+    search: "require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-navigation-fallback-controller.php';",
+    event: 'wp-settings.after_rest_controllers',
+  },
+  {
+    search: "require ABSPATH . WPINC . '/blocks/index.php';",
+    event: 'wp-settings.after_blocks_index',
+  },
+  {
+    search: "require ABSPATH . WPINC . '/speculative-loading.php';",
+    event: 'wp-settings.after_load_most',
+  },
+  {
+    search: 'wp_plugin_directory_constants();',
+    event: 'wp-settings.after_plugin_directory_constants',
+  },
+  {
+    search: 'unset( $mu_plugin, $_wp_plugin_file );',
+    event: 'wp-settings.after_mu_plugins_included',
+  },
+  {
+    search: "do_action( 'muplugins_loaded' );",
+    event: 'wp-settings.after_muplugins_loaded',
+  },
+];
+
+function bootstrapArtifactPath(sitePath) {
+  return path.join(sitePath, ARTIFACT_RELATIVE_PATH);
+}
+
+function backupPath(sitePath, fileName) {
+  return path.join(sitePath, BACKUP_DIR_RELATIVE_PATH, `${fileName}.bak`);
+}
+
+function indexInstrumentation() {
+  return `
+/* ${MARKER}: begin */
+$GLOBALS['homeboy_bootstrap_timeline_start'] = microtime( true );
+$GLOBALS['homeboy_bootstrap_timeline_id'] = function_exists( 'random_bytes' ) ? bin2hex( random_bytes( 8 ) ) : uniqid( '', true );
+$GLOBALS['homeboy_bootstrap_timeline_uri'] = $_SERVER['REQUEST_URI'] ?? '';
+$GLOBALS['homeboy_bootstrap_timeline_method'] = $_SERVER['REQUEST_METHOD'] ?? '';
+$GLOBALS['homeboy_bootstrap_timeline_file'] = __DIR__ . '/${ARTIFACT_RELATIVE_PATH}';
+if ( ! function_exists( 'homeboy_bootstrap_timeline_record' ) ) {
+	function homeboy_bootstrap_timeline_record( $event ) {
+		$start = $GLOBALS['homeboy_bootstrap_timeline_start'] ?? null;
+		$file = $GLOBALS['homeboy_bootstrap_timeline_file'] ?? null;
+		if ( ! $start || ! $file ) {
+			return;
+		}
+		file_put_contents(
+			$file,
+			json_encode(
+				array(
+					'event'      => $event,
+					'request_id' => $GLOBALS['homeboy_bootstrap_timeline_id'] ?? '',
+					'uri'        => $GLOBALS['homeboy_bootstrap_timeline_uri'] ?? '',
+					'method'     => $GLOBALS['homeboy_bootstrap_timeline_method'] ?? '',
+					't_ms'       => ( microtime( true ) - $start ) * 1000,
+					'time'       => microtime( true ),
+				)
+			) . "\\n",
+			FILE_APPEND | LOCK_EX
+		);
+	}
+}
+homeboy_bootstrap_timeline_record( 'entry.start' );
+register_shutdown_function( static function () {
+	homeboy_bootstrap_timeline_record( 'entry.shutdown' );
+} );
+/* ${MARKER}: end */
+`;
+}
+
+function wpSettingsInstrumentation() {
+  return `
+/* ${MARKER}: begin */
+if ( ! function_exists( 'homeboy_bootstrap_timeline_mark' ) ) {
+	function homeboy_bootstrap_timeline_mark( $event ) {
+		if ( function_exists( 'homeboy_bootstrap_timeline_record' ) ) {
+			homeboy_bootstrap_timeline_record( $event );
+		}
+	}
+}
+homeboy_bootstrap_timeline_mark( 'wp-settings.start' );
+/* ${MARKER}: end */
+`;
+}
+
+export function instrumentIndexPhp(source) {
+  if (source.includes(MARKER)) {
+    return source;
+  }
+  return source.replace('<?php', `<?php${indexInstrumentation()}`);
+}
+
+export function instrumentWpSettingsPhp(source) {
+  if (source.includes(MARKER)) {
+    return source;
+  }
+  let instrumented = source.replace('<?php', `<?php${wpSettingsInstrumentation()}`);
+  for (const mark of BOOTSTRAP_MARKS) {
+    const markerCall = `homeboy_bootstrap_timeline_mark( '${mark.event}' );`;
+    if (!instrumented.includes(mark.search) || instrumented.includes(markerCall)) {
+      continue;
+    }
+    instrumented = mark.before
+      ? instrumented.replace(mark.search, `${markerCall}\n${mark.search}`)
+      : instrumented.replace(mark.search, `${mark.search}\n${markerCall}`);
+  }
+  return instrumented;
+}
+
+async function backupAndWrite(sitePath, fileName, transform) {
+  const filePath = path.join(sitePath, fileName);
+  const backup = backupPath(sitePath, fileName);
+  const source = await readFile(filePath, 'utf8');
+  if (!existsSync(backup)) {
+    await writeFile(backup, source);
+  }
+  await writeFile(filePath, transform(source));
+}
+
+export async function installWordPressBootstrapTimeline(sitePath, options = {}) {
+  const artifactPath = bootstrapArtifactPath(sitePath);
+  await mkdir(path.dirname(artifactPath), { recursive: true });
+  await mkdir(path.join(sitePath, BACKUP_DIR_RELATIVE_PATH), { recursive: true });
+  if (options.clearArtifact !== false) {
+    await writeFile(artifactPath, '');
+  }
+  await backupAndWrite(sitePath, 'index.php', instrumentIndexPhp);
+  await backupAndWrite(sitePath, 'wp-settings.php', instrumentWpSettingsPhp);
+  return { artifactPath };
+}
+
+export async function uninstallWordPressBootstrapTimeline(sitePath) {
+  for (const fileName of ['index.php', 'wp-settings.php']) {
+    const backup = backupPath(sitePath, fileName);
+    if (existsSync(backup)) {
+      await writeFile(path.join(sitePath, fileName), await readFile(backup, 'utf8'));
+    }
+  }
+  await rm(path.join(sitePath, BACKUP_DIR_RELATIVE_PATH), { recursive: true, force: true });
+}
+
+export async function collectWordPressBootstrapTimeline(sitePath) {
+  const artifactPath = bootstrapArtifactPath(sitePath);
+  if (!existsSync(artifactPath)) {
+    return [];
+  }
+  const raw = await readFile(artifactPath, 'utf8');
+  return raw
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+export function summarizeWordPressBootstrapTimeline(rows, options = {}) {
+  const limit = Math.max(1, Number(options.limit ?? 40));
+  const byRequest = new Map();
+  for (const row of rows || []) {
+    const id = row.request_id || 'unknown';
+    if (!byRequest.has(id)) {
+      byRequest.set(id, []);
+    }
+    byRequest.get(id).push(row);
+  }
+
+  return [...byRequest.values()]
+    .map((events) => {
+      events.sort((a, b) => (a.t_ms || 0) - (b.t_ms || 0));
+      const last = events[events.length - 1] || {};
+      let previous = 0;
+      return {
+        uri: last.uri || '',
+        method: last.method || '',
+        duration_ms: last.t_ms || 0,
+        events: events.map((event) => {
+          const delta = (event.t_ms || 0) - previous;
+          previous = event.t_ms || 0;
+          return {
+            event: event.event,
+            t_ms: event.t_ms || 0,
+            delta_from_previous_ms: delta,
+          };
+        }),
+      };
+    })
+    .sort((a, b) => b.duration_ms - a.duration_ms)
+    .slice(0, limit);
+}

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
@@ -21,6 +21,12 @@ import {
   loadTimingCorrelator,
   requestProfilerPath,
 } from './lib/site-editor-timing-deltas.mjs';
+import {
+  collectWordPressBootstrapTimeline,
+  installWordPressBootstrapTimeline,
+  summarizeWordPressBootstrapTimeline,
+  uninstallWordPressBootstrapTimeline,
+} from './lib/wordpress-bootstrap-timeline.mjs';
 
 const BROWSER_HELPER = process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER;
 
@@ -232,6 +238,8 @@ export default async function studioSiteEditorDiagnosticsBench() {
   let measureTimings = {};
   let loginFormSeen = 0;
   let wordpressRequests = [];
+  let wordpressBootstrapTimeline = [];
+  let bootstrapTimelineArtifactPath = '';
   const network = [];
   const startedRequests = new Map();
   let phase = 'setup';
@@ -244,6 +252,8 @@ export default async function studioSiteEditorDiagnosticsBench() {
       throw new Error(`site status missing siteUrl/autoLoginUrl: ${redact(statusResult.stdout).slice(0, 1000)}`);
     }
 
+    const bootstrapTimeline = await installWordPressBootstrapTimeline(sitePath, { clearArtifact: true });
+    bootstrapTimelineArtifactPath = bootstrapTimeline.artifactPath;
     profiler?.installWordPressRequestProfiler?.(sitePath);
 
     browserResult = await runBrowserBench({
@@ -309,6 +319,8 @@ export default async function studioSiteEditorDiagnosticsBench() {
     await sanitizeNetworkArtifact(browserResult.artifacts?.network);
     wordpressRequests = profiler?.collectWordPressRequestProfiles?.(sitePath) || [];
     profiler?.uninstallWordPressRequestProfiler?.(sitePath);
+    wordpressBootstrapTimeline = await collectWordPressBootstrapTimeline(sitePath);
+    await uninstallWordPressBootstrapTimeline(sitePath);
     stop = await stopSite(sitePath);
 
     const totalElapsedMs = Date.now() - totalStarted;
@@ -339,6 +351,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
           profilerAvailable: Boolean(profiler),
           correlatorPath,
           correlatorAvailable: Boolean(correlator),
+          bootstrapTimelineArtifactPath,
           // Effective Studio checkout that produced this artifact. The bench
           // run envelope itself now records the same path under
           // rig_state.components.studio.path (Homeboy PR #2364), but we
@@ -370,6 +383,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
             measureSiteEditor: summarizeNetwork(network, 'measure-site-editor'),
           },
           wordpressRequests: summarizeWordPressRequests(wordpressRequests),
+          wordpressBootstrapTimeline: summarizeWordPressBootstrapTimeline(wordpressBootstrapTimeline),
           timingDeltas,
           commands: {
             create: safeResult(create),
@@ -395,6 +409,12 @@ export default async function studioSiteEditorDiagnosticsBench() {
     }
 
     const slowestResource = measureResourceTimingSummary[0] || {};
+    const bootstrapTimelineSummary = summarizeWordPressBootstrapTimeline(wordpressBootstrapTimeline);
+    const slowestBootstrapRequest = bootstrapTimelineSummary[0] || {};
+    const slowestBootstrapEvents = slowestBootstrapRequest.events || [];
+    const slowestBootstrapSlice = slowestBootstrapEvents
+      .slice()
+      .sort((a, b) => (b.delta_from_previous_ms || 0) - (a.delta_from_previous_ms || 0))[0] || {};
     const overallDelta = timingDeltas?.overall || {};
     const largestTransport = overallDelta.largest_transport_delta || {};
     return {
@@ -427,12 +447,16 @@ export default async function studioSiteEditorDiagnosticsBench() {
         site_editor_largest_delta_browser_ttfb_ms: metric(largestTransport.browser_ttfb_ms),
         site_editor_largest_delta_browser_duration_ms: metric(largestTransport.browser_duration_ms),
         site_editor_largest_delta_wordpress_duration_ms: metric(largestTransport.wordpress_duration_ms),
+        site_editor_bootstrap_timeline_request_count: metric(bootstrapTimelineSummary.length),
+        site_editor_slowest_bootstrap_request_ms: metric(slowestBootstrapRequest.duration_ms),
+        site_editor_slowest_bootstrap_slice_ms: metric(slowestBootstrapSlice.delta_from_previous_ms),
         total_elapsed_ms: totalElapsedMs,
         ...browserResult.metrics,
       },
       artifacts: {
         raw_result: artifactFile,
         site_path: sitePath,
+        bootstrap_timeline: bootstrapTimelineArtifactPath,
         ...browserResult.artifacts,
       },
     };
@@ -440,6 +464,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
     if (profiler) {
       profiler.uninstallWordPressRequestProfiler?.(sitePath);
     }
+    await uninstallWordPressBootstrapTimeline(sitePath);
     if (!stop) {
       stop = await stopSite(sitePath);
     }

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -14,6 +14,11 @@ const {
   requestProfilerPath,
   timingCorrelatorPath,
 } = await import('./lib/site-editor-timing-deltas.mjs');
+const {
+  instrumentIndexPhp,
+  instrumentWpSettingsPhp,
+  summarizeWordPressBootstrapTimeline,
+} = await import('./lib/wordpress-bootstrap-timeline.mjs');
 
 function withEnv(values, callback) {
   const previous = {};
@@ -292,4 +297,57 @@ test('buildTimingDeltaSummary forwards unmatched buckets into preview slices', (
   assert.equal(summary.unmatched_browser_preview[0].url, '/missing-from-wp');
   assert.equal(summary.unmatched_wordpress_preview[0].uri, '/wp-cron.php');
   assert.equal(summary.unmatched_wordpress_preview[0].request_id, 'wp-only');
+});
+
+// --- WordPress bootstrap timeline -----------------------------------------
+
+test('instrumentIndexPhp adds entry and shutdown timeline hooks once', () => {
+  const source = "<?php\ndefine( 'WP_USE_THEMES', true );\nrequire __DIR__ . '/wp-blog-header.php';\n";
+  const instrumented = instrumentIndexPhp(source);
+  assert.match(instrumented, /HOMEBOY_BOOTSTRAP_TIMELINE/);
+  assert.match(instrumented, /entry\.start/);
+  assert.match(instrumented, /entry\.shutdown/);
+  assert.equal(instrumentIndexPhp(instrumented), instrumented);
+});
+
+test('instrumentWpSettingsPhp adds early WordPress bootstrap marks once', () => {
+  const source = `<?php
+define( 'WPINC', 'wp-includes' );
+require_wp_db();
+wp_start_object_cache();
+require ABSPATH . WPINC . '/default-filters.php';
+register_shutdown_function( 'shutdown_action_hook' );
+require_once ABSPATH . WPINC . '/class-wp-locale-switcher.php';
+wp_not_installed();
+// Load most of WordPress.
+require ABSPATH . WPINC . '/post.php';
+require ABSPATH . WPINC . '/rest-api.php';
+require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-navigation-fallback-controller.php';
+require ABSPATH . WPINC . '/blocks/index.php';
+require ABSPATH . WPINC . '/speculative-loading.php';
+wp_plugin_directory_constants();
+unset( $mu_plugin, $_wp_plugin_file );
+do_action( 'muplugins_loaded' );
+`;
+  const instrumented = instrumentWpSettingsPhp(source);
+  assert.match(instrumented, /wp-settings\.start/);
+  assert.match(instrumented, /wp-settings\.after_require_wp_db/);
+  assert.match(instrumented, /wp-settings\.before_load_most/);
+  assert.match(instrumented, /wp-settings\.after_blocks_index/);
+  assert.match(instrumented, /wp-settings\.after_muplugins_loaded/);
+  assert.equal(instrumentWpSettingsPhp(instrumented), instrumented);
+});
+
+test('summarizeWordPressBootstrapTimeline groups requests and reports per-event deltas', () => {
+  const summary = summarizeWordPressBootstrapTimeline([
+    { request_id: 'fast', uri: '/wp-json/fast', method: 'GET', event: 'entry.start', t_ms: 0 },
+    { request_id: 'fast', uri: '/wp-json/fast', method: 'GET', event: 'entry.shutdown', t_ms: 20 },
+    { request_id: 'slow', uri: '/wp-json/slow', method: 'GET', event: 'entry.start', t_ms: 0 },
+    { request_id: 'slow', uri: '/wp-json/slow', method: 'GET', event: 'wp-settings.start', t_ms: 2 },
+    { request_id: 'slow', uri: '/wp-json/slow', method: 'GET', event: 'entry.shutdown', t_ms: 75 },
+  ]);
+  assert.equal(summary.length, 2);
+  assert.equal(summary[0].uri, '/wp-json/slow');
+  assert.equal(summary[0].duration_ms, 75);
+  assert.equal(summary[0].events[2].delta_from_previous_ms, 73);
 });


### PR DESCRIPTION
## Summary
- Adds a Studio Site Editor bootstrap timeline helper that temporarily instruments generated WordPress `index.php` and `wp-settings.php`, records early bootstrap milestones, and restores the files after the workload.
- Embeds the summarized bootstrap timeline in the Site Editor diagnostics raw artifact and exposes headline metrics for request count, slowest request, and slowest bootstrap slice.
- Covers instrumentation idempotency and timeline summarization in the existing diagnostics unit test.

## Validation
- `node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- Direct patched workload run against `/Users/chubes/Developer/studio@test-site-editor-load-investigation` completed successfully and produced bootstrap metrics: `site_editor_bootstrap_timeline_request_count=30`, `site_editor_slowest_bootstrap_request_ms=1052.9999732971191`, `site_editor_slowest_bootstrap_slice_ms=256.0000419616699`.
- Verified the temporary generated site no longer contained `HOMEBOY_BOOTSTRAP_TIMELINE` markers after cleanup.

Closes #105

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the bootstrap timeline helper, workload integration, tests, and local validation commands; Chris remains responsible for review and merge.