### PR TITLE
Add Studio Site Editor preload comparison workload

### DIFF
--- a/Automattic/studio/bench/lib/site-editor-preload-harness.mjs
+++ b/Automattic/studio/bench/lib/site-editor-preload-harness.mjs
@@ -1,0 +1,88 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const PRELOAD_MARKER = 'HOMEBOY_SITE_EDITOR_PRELOAD_CANDIDATE';
+
+export function installSiteEditorPreloadCandidateSource(source) {
+  if (source.includes(PRELOAD_MARKER)) {
+    return source;
+  }
+
+  const needle = 'block_editor_rest_api_preload( $preload_paths, $block_editor_context );';
+  const patch = `
+// ${PRELOAD_MARKER}: begin
+foreach ( get_block_templates( array(), 'wp_template_part' ) as $homeboy_template_part ) {
+	if ( ! empty( $homeboy_template_part->id ) ) {
+		$preload_paths[] = '/wp/v2/template-parts/' . $homeboy_template_part->id . '?context=edit';
+	}
+}
+
+$homeboy_post_rest_route = rest_get_route_for_post_type_items( 'post' );
+foreach ( array( 10, 3 ) as $homeboy_per_page ) {
+	$preload_paths[] = add_query_arg(
+		array(
+			'context'       => 'edit',
+			'offset'        => 0,
+			'order'         => 'desc',
+			'orderby'       => 'date',
+			'per_page'      => $homeboy_per_page,
+			'ignore_sticky' => 'false',
+		),
+		$homeboy_post_rest_route
+	);
+}
+
+$preload_paths[] = '/wp/v2/taxonomies?context=view';
+// ${PRELOAD_MARKER}: end
+`;
+
+  if (!source.includes(needle)) {
+    throw new Error('site-editor.php preload call not found');
+  }
+
+  return source.replace(needle, `${patch}\n${needle}`);
+}
+
+export async function installSiteEditorPreloadCandidate(sitePath) {
+  const file = path.join(sitePath, 'wp-admin/site-editor.php');
+  const source = await readFile(file, 'utf8');
+  await writeFile(file, installSiteEditorPreloadCandidateSource(source));
+}
+
+function round(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.round(value) : 0;
+}
+
+function slowResourceFingerprint(resource) {
+  return {
+    url: resource.url,
+    duration_ms: round(resource.duration_ms),
+    ttfb_ms: round(resource.ttfb_ms),
+  };
+}
+
+export function buildSiteEditorPreloadComparison({ baseline, candidate }) {
+  const baselineMeasure = baseline?.measure?.duration_ms || 0;
+  const candidateMeasure = candidate?.measure?.duration_ms || 0;
+  const delta = candidateMeasure - baselineMeasure;
+  const deltaPct = baselineMeasure > 0 ? (delta / baselineMeasure) * 100 : 0;
+
+  return {
+    baseline_measure_ms: round(baselineMeasure),
+    candidate_measure_ms: round(candidateMeasure),
+    delta_ms: round(delta),
+    delta_pct: Math.round(deltaPct * 10) / 10,
+    baseline_warmup_ms: round(baseline?.warmup?.duration_ms),
+    candidate_warmup_ms: round(candidate?.warmup?.duration_ms),
+    baseline_measure_resource_count: baseline?.measure?.resourceTimings?.length || 0,
+    candidate_measure_resource_count: candidate?.measure?.resourceTimings?.length || 0,
+    baseline_slowest_measure_resources: (baseline?.measure?.resourceTimings || [])
+      .slice(0, 10)
+      .map(slowResourceFingerprint),
+    candidate_slowest_measure_resources: (candidate?.measure?.resourceTimings || [])
+      .slice(0, 10)
+      .map(slowResourceFingerprint),
+    baseline_status: baseline?.measure?.status || 0,
+    candidate_status: candidate?.measure?.status || 0,
+  };
+}

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -19,6 +19,10 @@ const {
   instrumentWpSettingsPhp,
   summarizeWordPressBootstrapTimeline,
 } = await import('./lib/wordpress-bootstrap-timeline.mjs');
+const {
+  buildSiteEditorPreloadComparison,
+  installSiteEditorPreloadCandidateSource,
+} = await import('./lib/site-editor-preload-harness.mjs');
 
 function withEnv(values, callback) {
   const previous = {};
@@ -350,4 +354,59 @@ test('summarizeWordPressBootstrapTimeline groups requests and reports per-event 
   assert.equal(summary[0].uri, '/wp-json/slow');
   assert.equal(summary[0].duration_ms, 75);
   assert.equal(summary[0].events[2].delta_from_previous_ms, 73);
+});
+
+// --- Site Editor preload comparison ---------------------------------------
+
+test('installSiteEditorPreloadCandidateSource injects dynamic preload paths once', () => {
+  const source = `<?php
+$preload_paths = array();
+block_editor_rest_api_preload( $preload_paths, $block_editor_context );
+`;
+  const patched = installSiteEditorPreloadCandidateSource(source);
+  assert.match(patched, /HOMEBOY_SITE_EDITOR_PRELOAD_CANDIDATE/);
+  assert.match(patched, /get_block_templates\( array\(\), 'wp_template_part' \)/);
+  assert.match(patched, /rest_get_route_for_post_type_items\( 'post' \)/);
+  assert.match(patched, /'per_page'\s+=> \$homeboy_per_page/);
+  assert.match(patched, /\/wp\/v2\/taxonomies\?context=view/);
+  assert.equal(installSiteEditorPreloadCandidateSource(patched), patched);
+});
+
+test('installSiteEditorPreloadCandidateSource fails when preload call is missing', () => {
+  assert.throws(
+    () => installSiteEditorPreloadCandidateSource('<?php $preload_paths = array();'),
+    /preload call not found/
+  );
+});
+
+test('buildSiteEditorPreloadComparison summarizes the bot-path delta', () => {
+  const comparison = buildSiteEditorPreloadComparison({
+    baseline: {
+      warmup: { duration_ms: 1600 },
+      measure: {
+        duration_ms: 1450,
+        status: 200,
+        resourceTimings: [
+          { url: '/wp-json/wp/v2/template-parts/theme//header', duration_ms: 480, ttfb_ms: 475 },
+          { url: '/wp-json/wp/v2/posts?per_page=3', duration_ms: 440, ttfb_ms: 438 },
+        ],
+      },
+    },
+    candidate: {
+      warmup: { duration_ms: 1550 },
+      measure: {
+        duration_ms: 950,
+        status: 200,
+        resourceTimings: [],
+      },
+    },
+  });
+
+  assert.equal(comparison.baseline_measure_ms, 1450);
+  assert.equal(comparison.candidate_measure_ms, 950);
+  assert.equal(comparison.delta_ms, -500);
+  assert.equal(comparison.delta_pct, -34.5);
+  assert.equal(comparison.baseline_measure_resource_count, 2);
+  assert.equal(comparison.candidate_measure_resource_count, 0);
+  assert.equal(comparison.baseline_slowest_measure_resources[0].duration_ms, 480);
 });

--- a/Automattic/studio/bench/studio-site-editor-preload-comparison.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-preload-comparison.bench.mjs
@@ -1,0 +1,361 @@
+import { createRequire } from 'node:module';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import {
+  STUDIO_PATH,
+  artifactDir as studioArtifactDir,
+  createStudioSite,
+  metric,
+  parseStudioSiteStatus,
+  safeResult,
+  stopStudioSite,
+  studioSiteStatus,
+  variant,
+} from './lib/studio-bench.mjs';
+import {
+  buildTimingDeltaSummary,
+  flattenPhasedResourceTimings,
+  loadTimingCorrelator,
+  requestProfilerPath,
+} from './lib/site-editor-timing-deltas.mjs';
+import {
+  buildSiteEditorPreloadComparison,
+  installSiteEditorPreloadCandidate,
+} from './lib/site-editor-preload-harness.mjs';
+import {
+  collectWordPressBootstrapTimeline,
+  installWordPressBootstrapTimeline,
+  summarizeWordPressBootstrapTimeline,
+  uninstallWordPressBootstrapTimeline,
+} from './lib/wordpress-bootstrap-timeline.mjs';
+
+const BROWSER_HELPER = process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER;
+
+if (!BROWSER_HELPER) {
+  throw new Error('HOMEBOY_NODEJS_BROWSER_BENCH_HELPER is required');
+}
+
+const { runBrowserBench } = await import(BROWSER_HELPER);
+const require = createRequire(import.meta.url);
+
+function loadRequestProfiler() {
+  const profilerPath = requestProfilerPath();
+  if (!profilerPath || !existsSync(profilerPath)) {
+    return { profilerPath, profiler: null };
+  }
+  return { profilerPath, profiler: require(profilerPath) };
+}
+
+function siteAdminUrl(siteUrl, relativePath = '') {
+  const base = siteUrl.endsWith('/') ? siteUrl : `${siteUrl}/`;
+  return new URL(`wp-admin/${relativePath}`, base).toString();
+}
+
+function scrubUrl(url) {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return String(url || '');
+  }
+}
+
+async function sanitizeArtifact(artifact) {
+  if (!artifact || typeof artifact.path !== 'string') {
+    return;
+  }
+  const raw = await readFile(artifact.path, 'utf8');
+  await writeFile(artifact.path, raw.replace(/([?&](?:token|password|key|nonce)=)[^&#\s]+/gi, '$1[redacted]'));
+}
+
+async function collectResourceTimings(page) {
+  const entries = await page.evaluate(() =>
+    performance
+      .getEntriesByType('resource')
+      .filter((entry) => entry.name.includes('/wp-json/') || entry.name.includes('/wp-admin/site-editor.php'))
+      .map((entry) => ({
+        name: entry.name,
+        initiatorType: entry.initiatorType,
+        startTime: entry.startTime,
+        duration: entry.duration,
+        fetchStart: entry.fetchStart,
+        requestStart: entry.requestStart,
+        responseStart: entry.responseStart,
+        responseEnd: entry.responseEnd,
+        transferSize: entry.transferSize,
+        encodedBodySize: entry.encodedBodySize,
+        decodedBodySize: entry.decodedBodySize,
+      }))
+  );
+  return entries;
+}
+
+function summarizeResourceTimings(entries) {
+  return entries
+    .map((entry) => ({
+      url: scrubUrl(entry.name),
+      start_ms: entry.startTime,
+      duration_ms: entry.duration,
+      request_start_ms: entry.requestStart,
+      response_start_ms: entry.responseStart,
+      response_end_ms: entry.responseEnd,
+      ttfb_ms: entry.responseStart - entry.requestStart,
+      transfer_size: entry.transferSize,
+      encoded_body_size: entry.encodedBodySize,
+      decoded_body_size: entry.decodedBodySize,
+    }))
+    .sort((a, b) => b.duration_ms - a.duration_ms);
+}
+
+async function waitForSiteEditorReady(page) {
+  const timings = {};
+  const marks = [];
+  const started = performance.now();
+  const elapsed = () => performance.now() - started;
+  const mark = (name) => marks.push({ name, t_ms: elapsed() });
+
+  const response = await page.goto(siteAdminUrl(page.__studioSiteUrl, 'site-editor.php'), {
+    waitUntil: 'commit',
+    timeout: 120000,
+  });
+  timings.commit_ms = elapsed();
+  timings.status = response ? response.status() : 0;
+  mark('commit');
+
+  await page.waitForSelector('iframe[name="editor-canvas"]', { state: 'visible', timeout: 120000 });
+  timings.editor_canvas_iframe_visible_ms = elapsed();
+  mark('iframe-visible');
+
+  const frame = page.frame({ name: 'editor-canvas' });
+  if (!frame) {
+    throw new Error('Site Editor canvas frame not found');
+  }
+
+  await frame.waitForLoadState('domcontentloaded', { timeout: 120000 });
+  timings.editor_canvas_domcontentloaded_ms = elapsed();
+  mark('iframe-domcontentloaded');
+
+  await frame.waitForSelector('[data-block]', { timeout: 60000 });
+  timings.first_data_block_ms = elapsed();
+  mark('first-data-block');
+
+  await frame.waitForFunction(
+    () =>
+      document.querySelectorAll('[data-block]').length > 0 &&
+      !document.querySelector('.components-spinner') &&
+      !document.querySelector('.is-loading') &&
+      !document.querySelector('.wp-block-editor__loading'),
+    { timeout: 60000 }
+  );
+  timings.site_editor_ready_ms = elapsed();
+  timings.duration_ms = timings.site_editor_ready_ms;
+  mark('ready');
+  timings.marks = marks;
+  timings.resourceTimings = await collectResourceTimings(page);
+
+  return timings;
+}
+
+async function runBotPath({ label, artifactDir, sitePath, status, profiler, candidate }) {
+  if (candidate) {
+    await installSiteEditorPreloadCandidate(sitePath);
+  }
+  await installWordPressBootstrapTimeline(sitePath, { clearArtifact: true });
+  profiler?.installWordPressRequestProfiler?.(sitePath, { clearArtifact: true });
+
+  let warmup = {};
+  let measure = {};
+  const browserResult = await runBrowserBench({
+    id: `studio-site-editor-preload-${label}`,
+    artifactsDir: path.join(artifactDir, label),
+    trace: true,
+    screenshot: true,
+    action: async ({ page, mark }) => {
+      page.__studioSiteUrl = status.siteUrl;
+      await page.goto(status.autoLoginUrl, { waitUntil: 'domcontentloaded', timeout: 120000 });
+      await page.waitForLoadState('networkidle', { timeout: 120000 });
+      await mark(`${label}_auto_login_networkidle`);
+
+      warmup = await waitForSiteEditorReady(page);
+      await mark(`${label}_warmup_site_editor_ready`);
+
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await page.goto(siteAdminUrl(status.siteUrl), { waitUntil: 'domcontentloaded', timeout: 120000 });
+      await page.waitForLoadState('networkidle', { timeout: 120000 });
+      await mark(`${label}_admin_networkidle_between_runs`);
+
+      measure = await waitForSiteEditorReady(page);
+      await mark(`${label}_measure_site_editor_ready`);
+    },
+  });
+
+  await sanitizeArtifact(browserResult.artifacts?.network);
+
+  const wordpressRequests = profiler?.collectWordPressRequestProfiles?.(sitePath) || [];
+  const bootstrapRows = await collectWordPressBootstrapTimeline(sitePath);
+  const phasedBrowserTimings = flattenPhasedResourceTimings({
+    [`${label}-warmup-site-editor`]: warmup.resourceTimings || [],
+    [`${label}-measure-site-editor`]: measure.resourceTimings || [],
+  });
+  const { module: correlator } = loadTimingCorrelator({ profilerPath: requestProfilerPath() });
+
+  profiler?.uninstallWordPressRequestProfiler?.(sitePath);
+  await uninstallWordPressBootstrapTimeline(sitePath);
+
+  return {
+    sitePath,
+    siteUrl: status.siteUrl,
+    warmup: {
+      ...warmup,
+      resourceTimings: summarizeResourceTimings(warmup.resourceTimings || []),
+    },
+    measure: {
+      ...measure,
+      resourceTimings: summarizeResourceTimings(measure.resourceTimings || []),
+    },
+    timingDeltas: buildTimingDeltaSummary({
+      browserResourceTimings: phasedBrowserTimings,
+      wordpressRequests,
+      correlator,
+    }),
+    bootstrapTimeline: summarizeWordPressBootstrapTimeline(bootstrapRows, { limit: 80 }),
+    browserMetrics: browserResult.metrics,
+    browserArtifacts: browserResult.artifacts,
+  };
+}
+
+async function createAndStatus(sitePath, name) {
+  const create = await createStudioSite(sitePath, { name, timeoutMs: 420000 });
+  const statusResult = await studioSiteStatus(sitePath, { timeoutMs: 90000 });
+  const status = parseStudioSiteStatus(statusResult.stdout);
+  if (!status.siteUrl || !status.autoLoginUrl) {
+    throw new Error('site status missing siteUrl/autoLoginUrl');
+  }
+  return { create, statusResult, status };
+}
+
+export default async function studioSiteEditorPreloadComparisonBench() {
+  const currentVariant = variant();
+  const runId = `${currentVariant}-site-editor-preload-comparison-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const artifactDir = path.join(studioArtifactDir('studio-site-editor-preload-comparison-artifacts'), runId);
+  await mkdir(artifactDir, { recursive: true });
+
+  const totalStarted = Date.now();
+  const { profilerPath, profiler } = loadRequestProfiler();
+  const baselineSitePath = path.join(artifactDir, 'baseline-site');
+  const candidateSitePath = path.join(artifactDir, 'candidate-site');
+  let baselineCreate;
+  let baselineStatusResult;
+  let candidateCreate;
+  let candidateStatusResult;
+  let baseline;
+  let candidate;
+
+  try {
+    const baselineSite = await createAndStatus(
+      baselineSitePath,
+      `Studio Bench ${currentVariant} Site Editor Preload Baseline ${process.pid}`
+    );
+    baselineCreate = baselineSite.create;
+    baselineStatusResult = baselineSite.statusResult;
+    baseline = await runBotPath({
+      label: 'baseline',
+      artifactDir,
+      sitePath: baselineSitePath,
+      status: baselineSite.status,
+      profiler,
+      candidate: false,
+    });
+
+    const candidateSite = await createAndStatus(
+      candidateSitePath,
+      `Studio Bench ${currentVariant} Site Editor Preload Candidate ${process.pid}`
+    );
+    candidateCreate = candidateSite.create;
+    candidateStatusResult = candidateSite.statusResult;
+    candidate = await runBotPath({
+      label: 'candidate',
+      artifactDir,
+      sitePath: candidateSitePath,
+      status: candidateSite.status,
+      profiler,
+      candidate: true,
+    });
+
+    const comparison = buildSiteEditorPreloadComparison({ baseline, candidate });
+    const totalElapsedMs = Date.now() - totalStarted;
+    const artifactFile = path.join(artifactDir, `result-${runId}.json`);
+    await writeFile(
+      artifactFile,
+      JSON.stringify(
+        {
+          variant: currentVariant,
+          studioPath: STUDIO_PATH,
+          profilerPath,
+          profilerAvailable: Boolean(profiler),
+          timings: {
+            baseline_site_create_ms: baselineCreate.elapsedMs,
+            baseline_site_status_ms: baselineStatusResult.elapsedMs,
+            candidate_site_create_ms: candidateCreate.elapsedMs,
+            candidate_site_status_ms: candidateStatusResult.elapsedMs,
+            total_elapsed_ms: totalElapsedMs,
+          },
+          comparison,
+          baseline,
+          candidate,
+          commands: {
+            baselineCreate: safeResult(baselineCreate),
+            baselineStatus: safeResult(baselineStatusResult),
+            candidateCreate: safeResult(candidateCreate),
+            candidateStatus: safeResult(candidateStatusResult),
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    if (comparison.baseline_status < 200 || comparison.baseline_status >= 400) {
+      throw new Error(`Baseline Site Editor returned HTTP status ${comparison.baseline_status}; raw_result=${artifactFile}`);
+    }
+    if (comparison.candidate_status < 200 || comparison.candidate_status >= 400) {
+      throw new Error(`Candidate Site Editor returned HTTP status ${comparison.candidate_status}; raw_result=${artifactFile}`);
+    }
+
+    return {
+      metrics: {
+        success_rate: 1,
+        elapsed_ms: totalElapsedMs,
+        baseline_site_editor_measure_ms: metric(comparison.baseline_measure_ms),
+        candidate_site_editor_measure_ms: metric(comparison.candidate_measure_ms),
+        site_editor_preload_delta_ms: metric(comparison.delta_ms),
+        site_editor_preload_delta_pct: metric(comparison.delta_pct),
+        baseline_measure_resource_count: metric(comparison.baseline_measure_resource_count),
+        candidate_measure_resource_count: metric(comparison.candidate_measure_resource_count),
+        baseline_slowest_measure_resource_ms: metric(comparison.baseline_slowest_measure_resources[0]?.duration_ms),
+        candidate_slowest_measure_resource_ms: metric(comparison.candidate_slowest_measure_resources[0]?.duration_ms),
+        baseline_bootstrap_request_count: metric(baseline.bootstrapTimeline.length),
+        candidate_bootstrap_request_count: metric(candidate.bootstrapTimeline.length),
+        total_elapsed_ms: totalElapsedMs,
+      },
+      artifacts: {
+        raw_result: artifactFile,
+        baseline_site_path: baselineSitePath,
+        candidate_site_path: candidateSitePath,
+        baseline_trace: baseline.browserArtifacts?.trace,
+        candidate_trace: candidate.browserArtifacts?.trace,
+        baseline_screenshot: baseline.browserArtifacts?.screenshot,
+        candidate_screenshot: candidate.browserArtifacts?.screenshot,
+      },
+    };
+  } finally {
+    profiler?.uninstallWordPressRequestProfiler?.(baselineSitePath);
+    profiler?.uninstallWordPressRequestProfiler?.(candidateSitePath);
+    await uninstallWordPressBootstrapTimeline(baselineSitePath);
+    await uninstallWordPressBootstrapTimeline(candidateSitePath);
+    await stopStudioSite(baselineSitePath, { timeoutMs: 90000 });
+    await stopStudioSite(candidateSitePath, { timeoutMs: 90000 });
+  }
+}

--- a/Automattic/studio/rigs/studio-combined/rig.json
+++ b/Automattic/studio/rigs/studio-combined/rig.json
@@ -58,7 +58,8 @@
       "${package.root}/bench/studio-admin-theme-page-browser.bench.mjs",
       "${package.root}/bench/studio-dashboard-browser.bench.mjs",
       "${package.root}/bench/studio-site-editor-browser.bench.mjs",
-      "${package.root}/bench/studio-site-editor-diagnostics.bench.mjs"
+      "${package.root}/bench/studio-site-editor-diagnostics.bench.mjs",
+      "${package.root}/bench/studio-site-editor-preload-comparison.bench.mjs"
     ]
   },
 


### PR DESCRIPTION
## Summary
- Adds a Studio Site Editor preload comparison workload that runs the PR-bot-style warmup/measure path against baseline and local preload-candidate sites.
- Captures browser resource timings, WordPress request/bootstrap timelines, traces, screenshots, and a concise A/B delta artifact.
- Registers the workload in the Studio combined rig and adds focused tests for the local preload patching and comparison summary logic.

## Validation
- `node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- Live smoke against `/Users/chubes/Developer/studio@test-site-editor-baseline` using this worktree's workload file:
  - `baseline_site_editor_measure_ms: 1443`
  - `candidate_site_editor_measure_ms: 943`
  - `site_editor_preload_delta_ms: -500`
  - `site_editor_preload_delta_pct: -34.6`
  - `baseline_measure_resource_count: 5`
  - `candidate_measure_resource_count: 0`
- Raw smoke artifact: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/studio-site-editor-preload-comparison-artifacts/preload-harness-smoke-2-site-editor-preload-comparison-28089-1778196527700-0ve47olmhrcn/result-preload-harness-smoke-2-site-editor-preload-comparison-28089-1778196527700-0ve47olmhrcn.json`

## Notes
- This does not patch Studio itself. The candidate patch is applied only to generated benchmark sites so we can evaluate the WordPress Site Editor preload-list hypothesis locally before proposing any upstream change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Homeboy-rigs workload, helper, tests, and validation commands; Chris remains responsible for review and merge.