### PR TITLE
feat(playground): add CLI diagnostic rig

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,14 @@ WooCommerce site-generation benchmarks are tracked as future work until the Stud
 
 `stacks/playground-combined.json` rebuilds `origin/dev/combined-fixes` from `upstream/trunk` plus Chris's active PHP-WASM and worker-pool PRs.
 
+`rigs/playground-cli-diagnostics/rig.json` runs focused Playground CLI repros against the local `~/Developer/wordpress-playground` checkout. The first workload captures whether Blueprint `runPHP` fatal errors surface useful diagnostics or collapse to a blank `Error:` line.
+
+```bash
+homeboy rig install --all ./WordPress/wordpress-playground
+homeboy rig check playground-cli-diagnostics
+homeboy bench --rig playground-cli-diagnostics --scenario playground-cli-runphp-errors --iterations 1 --shared-state /tmp/playground-cli-diagnostics
+```
+
 ## chubes4/isolated-block-editor
 
 `rigs/isolated-block-editor/rig.json` runs the checks used while shaving Isolated Block Editor toward modern Gutenberg APIs.

--- a/WordPress/wordpress-playground/bench/playground-cli-runphp-errors.bench.mjs
+++ b/WordPress/wordpress-playground/bench/playground-cli-runphp-errors.bench.mjs
@@ -1,0 +1,190 @@
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const CONTROL_BLUEPRINT = {
+  steps: [
+    {
+      step: 'runPHP',
+      code: "<?php echo 'PLAYGROUND_RUNPHP_CONTROL_OK';",
+    },
+  ],
+};
+
+const FATAL_BLUEPRINT = {
+  steps: [
+    {
+      step: 'runPHP',
+      code: "<?php require_once '/wordpress/wp-load.php'; playground_cli_missing_probe_function();",
+    },
+  ],
+};
+
+function expandHome(value) {
+  if (!value || value === '~') {
+    return os.homedir();
+  }
+  if (value.startsWith('~/')) {
+    return path.join(os.homedir(), value.slice(2));
+  }
+  return value;
+}
+
+function artifactRoot() {
+  return (
+    process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR ||
+    process.env.HOMEBOY_BENCH_SHARED_STATE ||
+    path.join(os.tmpdir(), 'playground-cli-diagnostics')
+  );
+}
+
+function componentPath() {
+  return expandHome(process.env.HOMEBOY_COMPONENT_PATH || '~/Developer/wordpress-playground');
+}
+
+function cliArgs(blueprintPath) {
+  return [
+    '--experimental-strip-types',
+    '--experimental-transform-types',
+    '--disable-warning=ExperimentalWarning',
+    '--import',
+    './packages/meta/src/node-es-module-loader/register.mts',
+    './packages/playground/cli/src/cli.ts',
+    'run-blueprint',
+    '--blueprint',
+    blueprintPath,
+    '--wp',
+    process.env.PLAYGROUND_CLI_DIAGNOSTIC_WP_VERSION || 'latest',
+    '--php',
+    process.env.PLAYGROUND_CLI_DIAGNOSTIC_PHP_VERSION || '8.3',
+    '--verbosity=debug',
+  ];
+}
+
+async function runCliProbe(playgroundPath, blueprintPath) {
+  const started = Date.now();
+  try {
+    const result = await execFileAsync(process.execPath, cliArgs(blueprintPath), {
+      cwd: playgroundPath,
+      env: {
+        ...process.env,
+        PLAYGROUND_NO_JSPI_RESPAWN: '1',
+        NO_COLOR: '1',
+      },
+      maxBuffer: 20 * 1024 * 1024,
+    });
+    return {
+      exitCode: 0,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      elapsedMs: Date.now() - started,
+    };
+  } catch (error) {
+    return {
+      exitCode: typeof error.code === 'number' ? error.code : 1,
+      stdout: error.stdout || '',
+      stderr: error.stderr || '',
+      message: error.message || '',
+      elapsedMs: Date.now() - started,
+    };
+  }
+}
+
+function combinedOutput(result) {
+  return `${result.stdout || ''}\n${result.stderr || ''}\n${result.message || ''}`;
+}
+
+function analyzeFatalOutput(result) {
+  const output = combinedOutput(result);
+  const normalized = output.replace(/\x1b\[[0-9;]*m/g, '').trim();
+  return {
+    hasBlankError: /(^|\n)Error:\s*($|\n)/.test(normalized),
+    hasPhpFatal: /Fatal error|Uncaught Error|Call to undefined function|playground_cli_missing_probe_function/i.test(
+      normalized
+    ),
+    errorLine: normalized
+      .split('\n')
+      .find((line) => line.startsWith('Error:')) || '',
+  };
+}
+
+export default async function playgroundCliRunphpErrorsBench() {
+  const runId = `playground-cli-runphp-errors-${process.pid}-${Date.now()}`;
+  const artifactsDir = path.join(artifactRoot(), runId);
+  const blueprintsDir = path.join(artifactsDir, 'blueprints');
+  await mkdir(blueprintsDir, { recursive: true });
+
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'playground-cli-runphp-errors-'));
+  const controlBlueprint = path.join(tmpDir, 'control.json');
+  const fatalBlueprint = path.join(tmpDir, 'fatal-runphp.json');
+  await writeFile(controlBlueprint, JSON.stringify(CONTROL_BLUEPRINT, null, 2));
+  await writeFile(fatalBlueprint, JSON.stringify(FATAL_BLUEPRINT, null, 2));
+  await writeFile(path.join(blueprintsDir, 'control.json'), JSON.stringify(CONTROL_BLUEPRINT, null, 2));
+  await writeFile(path.join(blueprintsDir, 'fatal-runphp.json'), JSON.stringify(FATAL_BLUEPRINT, null, 2));
+
+  const playgroundPath = componentPath();
+  const control = await runCliProbe(playgroundPath, controlBlueprint);
+  const fatal = await runCliProbe(playgroundPath, fatalBlueprint);
+  const fatalAnalysis = analyzeFatalOutput(fatal);
+
+  const report = {
+    playgroundPath,
+    node: process.version,
+    control: {
+      exitCode: control.exitCode,
+      elapsedMs: control.elapsedMs,
+      stdout: control.stdout,
+      stderr: control.stderr,
+    },
+    fatal: {
+      exitCode: fatal.exitCode,
+      elapsedMs: fatal.elapsedMs,
+      stdout: fatal.stdout,
+      stderr: fatal.stderr,
+      message: fatal.message,
+      analysis: fatalAnalysis,
+    },
+  };
+
+  const reportPath = path.join(artifactsDir, 'runphp-error-report.json');
+  const controlOutputPath = path.join(artifactsDir, 'control-output.txt');
+  const fatalOutputPath = path.join(artifactsDir, 'fatal-output.txt');
+  await writeFile(reportPath, JSON.stringify(report, null, 2));
+  await writeFile(controlOutputPath, combinedOutput(control));
+  await writeFile(fatalOutputPath, combinedOutput(fatal));
+
+  if (control.exitCode !== 0) {
+    throw new Error(`control Blueprint failed; see ${controlOutputPath}`);
+  }
+  if (fatal.exitCode === 0) {
+    throw new Error(`fatal Blueprint unexpectedly passed; see ${fatalOutputPath}`);
+  }
+
+  return {
+    metrics: {
+      success_rate: 1,
+      control_exit_code: control.exitCode,
+      fatal_exit_code: fatal.exitCode,
+      fatal_blank_error: fatalAnalysis.hasBlankError ? 1 : 0,
+      fatal_has_php_diagnostic: fatalAnalysis.hasPhpFatal ? 1 : 0,
+      control_elapsed_ms: control.elapsedMs,
+      fatal_elapsed_ms: fatal.elapsedMs,
+    },
+    artifacts: {
+      report: reportPath,
+      control_output: controlOutputPath,
+      fatal_output: fatalOutputPath,
+      control_blueprint: path.join(blueprintsDir, 'control.json'),
+      fatal_blueprint: path.join(blueprintsDir, 'fatal-runphp.json'),
+    },
+    metadata: {
+      fatal_error_line: fatalAnalysis.errorLine,
+      wp_version: process.env.PLAYGROUND_CLI_DIAGNOSTIC_WP_VERSION || 'latest',
+      php_version: process.env.PLAYGROUND_CLI_DIAGNOSTIC_PHP_VERSION || '8.3',
+    },
+  };
+}

--- a/WordPress/wordpress-playground/rigs/playground-cli-diagnostics/rig.json
+++ b/WordPress/wordpress-playground/rigs/playground-cli-diagnostics/rig.json
@@ -1,0 +1,49 @@
+{
+  "id": "playground-cli-diagnostics",
+  "description": "WordPress Playground CLI diagnostic rig. Reproduces Blueprint runPHP fatal reporting through the local unbuilt CLI and captures evidence for upstream fixes.",
+  "components": {
+    "wordpress-playground": {
+      "path": "~/Developer/wordpress-playground",
+      "branch": "trunk",
+      "extensions": {
+        "nodejs": {}
+      }
+    }
+  },
+  "bench": {
+    "default_component": "wordpress-playground"
+  },
+  "bench_workloads": {
+    "nodejs": [
+      "${package.root}/bench/playground-cli-runphp-errors.bench.mjs"
+    ]
+  },
+  "pipeline": {
+    "up": [
+      {
+        "kind": "command",
+        "label": "Install Playground dependencies",
+        "cwd": "${components.wordpress-playground.path}",
+        "command": "npm install"
+      }
+    ],
+    "check": [
+      {
+        "kind": "check",
+        "label": "Playground checkout exists",
+        "file": "${components.wordpress-playground.path}/packages/playground/cli/src/cli.ts"
+      },
+      {
+        "kind": "check",
+        "label": "Playground dependencies installed",
+        "file": "${components.wordpress-playground.path}/node_modules/nx/bin/nx.js"
+      },
+      {
+        "kind": "check",
+        "label": "Playground TypeScript module loader exists",
+        "file": "${components.wordpress-playground.path}/packages/meta/src/node-es-module-loader/register.mts"
+      }
+    ],
+    "down": []
+  }
+}


### PR DESCRIPTION
## Summary
- Add a `playground-cli-diagnostics` rig for local WordPress Playground CLI repros.
- Add a Node.js benchmark that runs a control Blueprint and a fatal `runPHP` Blueprint through the unbuilt Playground CLI.
- Capture artifacts and metrics that show whether fatal `runPHP` output is blank or includes PHP diagnostics.

## Evidence
- `homeboy rig check playground-cli-diagnostics`
- `homeboy bench --force-hot --rig playground-cli-diagnostics --scenario playground-cli-runphp-errors --iterations 1 --shared-state /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/playground-cli-diagnostics --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/playground-cli-diagnostics/bench-output.json`
- Baseline Homeboy run: `79d1d8c6-0bb5-4abb-8e18-5467e708cff2`
- Baseline metrics: `control_exit_code=0`, `fatal_exit_code=1`, `fatal_blank_error=1`, `fatal_has_php_diagnostic=0`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Added the diagnostic rig/workload, ran the baseline repro, and summarized the evidence.