### PR TITLE
Add Site Editor preload evidence scenarios

### DIFF
--- a/Automattic/studio/bench/lib/site-editor-preload-harness.mjs
+++ b/Automattic/studio/bench/lib/site-editor-preload-harness.mjs
@@ -4,17 +4,129 @@ import path from 'node:path';
 const PRELOAD_MARKER = 'HOMEBOY_SITE_EDITOR_PRELOAD_CANDIDATE';
 
 export function installSiteEditorPreloadCandidateSource(source) {
-  if (source.includes(PRELOAD_MARKER)) {
-    return source;
-  }
+	if (source.includes(PRELOAD_MARKER)) {
+		return source;
+	}
 
-  const needle = 'block_editor_rest_api_preload( $preload_paths, $block_editor_context );';
-  const patch = `
+	const needle = 'block_editor_rest_api_preload( $preload_paths, $block_editor_context );';
+	const mode = process.env.HOMEBOY_SITE_EDITOR_PRELOAD_MODE || 'broad';
+	let patch;
+
+	if (mode === 'taxonomies') {
+		patch = `
+// ${PRELOAD_MARKER}: begin
+	$preload_paths[] = '/wp/v2/taxonomies?context=view';
+// ${PRELOAD_MARKER}: end
+`;
+	} else if (mode === 'template-aware') {
+		patch = `
+// ${PRELOAD_MARKER}: begin
+$homeboy_template_slugs = array();
+$homeboy_front_page     = null;
+if ( ! empty( $block_editor_context->post ) && 'page' === $block_editor_context->post->post_type ) {
+	$homeboy_template_slugs[] = empty( $block_editor_context->post->post_name ) ? 'page' : 'page-' . $block_editor_context->post->post_name;
+	$homeboy_template_slugs[] = 'page';
+} else {
+	$homeboy_template_slugs[] = 'front-page';
+
+	if ( 'page' === get_option( 'show_on_front' ) ) {
+		$homeboy_front_page = get_post( (int) get_option( 'page_on_front' ) );
+		if ( $homeboy_front_page instanceof WP_Post ) {
+			$homeboy_template_slugs[] = empty( $homeboy_front_page->post_name ) ? 'page' : 'page-' . $homeboy_front_page->post_name;
+			$homeboy_template_slugs[] = 'page';
+		}
+	} else {
+		$homeboy_template_slugs[] = 'home';
+	}
+
+	$homeboy_template_slugs[] = 'index';
+}
+
+$homeboy_template_slugs = array_values( array_unique( $homeboy_template_slugs ) );
+$homeboy_templates      = get_block_templates(
+	array(
+		'slug__in' => $homeboy_template_slugs,
+	),
+	'wp_template'
+);
+$homeboy_priorities     = array_flip( $homeboy_template_slugs );
+
+usort(
+	$homeboy_templates,
+	static function ( $homeboy_template_a, $homeboy_template_b ) use ( $homeboy_priorities ) {
+		return ( $homeboy_priorities[ $homeboy_template_a->slug ] ?? 999 ) - ( $homeboy_priorities[ $homeboy_template_b->slug ] ?? 999 );
+	}
+);
+
+$homeboy_template_part_ids = array();
+$homeboy_has_query         = false;
+$homeboy_walk_blocks       = static function ( $homeboy_blocks ) use ( &$homeboy_walk_blocks, &$homeboy_template_part_ids, &$homeboy_has_query ) {
+	foreach ( $homeboy_blocks as $homeboy_block ) {
+		if ( 'core/template-part' === ( $homeboy_block['blockName'] ?? '' ) && ! empty( $homeboy_block['attrs']['slug'] ) ) {
+			$homeboy_theme             = ! empty( $homeboy_block['attrs']['theme'] ) ? $homeboy_block['attrs']['theme'] : get_stylesheet();
+			$homeboy_template_part_ids[] = $homeboy_theme . '//' . $homeboy_block['attrs']['slug'];
+		}
+
+		if ( 'core/query' === ( $homeboy_block['blockName'] ?? '' ) ) {
+			$homeboy_has_query = true;
+		}
+
+		if ( ! empty( $homeboy_block['innerBlocks'] ) ) {
+			$homeboy_walk_blocks( $homeboy_block['innerBlocks'] );
+		}
+	}
+};
+
+if ( ! empty( $homeboy_templates ) && ! empty( $homeboy_templates[0]->content ) ) {
+	$homeboy_blocks = parse_blocks( $homeboy_templates[0]->content );
+	if ( function_exists( 'resolve_pattern_blocks' ) ) {
+		$homeboy_blocks = resolve_pattern_blocks( $homeboy_blocks );
+	}
+	$homeboy_walk_blocks( $homeboy_blocks );
+}
+
+foreach ( array_unique( $homeboy_template_part_ids ) as $homeboy_template_part_id ) {
+	$preload_paths[] = '/wp/v2/template-parts/' . $homeboy_template_part_id . '?context=edit';
+}
+
+if ( $homeboy_front_page instanceof WP_Post ) {
+	$homeboy_route_for_front_page = rest_get_route_for_post( $homeboy_front_page );
+	if ( $homeboy_route_for_front_page ) {
+		$preload_paths[] = add_query_arg( 'context', 'edit', $homeboy_route_for_front_page );
+	}
+	$preload_paths[] = add_query_arg(
+		'slug',
+		empty( $homeboy_front_page->post_name ) ? 'page' : 'page-' . $homeboy_front_page->post_name,
+		'/wp/v2/templates/lookup'
+	);
+	$preload_paths[] = '/wp/v2/types/page?context=edit';
+}
+
+if ( $homeboy_has_query ) {
+	$homeboy_post_rest_route = rest_get_route_for_post_type_items( 'post' );
+	foreach ( array( 10, 3 ) as $homeboy_per_page ) {
+		$preload_paths[] = add_query_arg(
+			array(
+				'context'       => 'edit',
+				'offset'        => 0,
+				'order'         => 'desc',
+				'orderby'       => 'date',
+				'per_page'      => $homeboy_per_page,
+				'ignore_sticky' => 'false',
+			),
+			$homeboy_post_rest_route
+		);
+	}
+}
+
+$preload_paths[] = '/wp/v2/taxonomies?context=view';
+// ${PRELOAD_MARKER}: end
+`;
+	} else {
+		patch = `
 // ${PRELOAD_MARKER}: begin
 foreach ( get_block_templates( array(), 'wp_template_part' ) as $homeboy_template_part ) {
-	if ( ! empty( $homeboy_template_part->id ) ) {
-		$preload_paths[] = '/wp/v2/template-parts/' . $homeboy_template_part->id . '?context=edit';
-	}
+	$preload_paths[] = '/wp/v2/template-parts/' . $homeboy_template_part->id . '?context=edit';
 }
 
 $homeboy_post_rest_route = rest_get_route_for_post_type_items( 'post' );
@@ -35,10 +147,11 @@ foreach ( array( 10, 3 ) as $homeboy_per_page ) {
 $preload_paths[] = '/wp/v2/taxonomies?context=view';
 // ${PRELOAD_MARKER}: end
 `;
+	}
 
-  if (!source.includes(needle)) {
-    throw new Error('site-editor.php preload call not found');
-  }
+	if (!source.includes(needle)) {
+		throw new Error('site-editor.php preload call not found');
+	}
 
   return source.replace(needle, `${patch}\n${needle}`);
 }

--- a/Automattic/studio/bench/studio-site-editor-preload-comparison.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-preload-comparison.bench.mjs
@@ -9,6 +9,7 @@ import {
   createStudioSite,
   metric,
   parseStudioSiteStatus,
+  runCli,
   safeResult,
   stopStudioSite,
   studioSiteStatus,
@@ -228,12 +229,69 @@ async function runBotPath({ label, artifactDir, sitePath, status, profiler, cand
 
 async function createAndStatus(sitePath, name) {
   const create = await createStudioSite(sitePath, { name, timeoutMs: 420000 });
+  await configureSiteEditorScenario(sitePath);
   const statusResult = await studioSiteStatus(sitePath, { timeoutMs: 90000 });
   const status = parseStudioSiteStatus(statusResult.stdout);
   if (!status.siteUrl || !status.autoLoginUrl) {
     throw new Error('site status missing siteUrl/autoLoginUrl');
   }
   return { create, statusResult, status };
+}
+
+async function configureSiteEditorScenario(sitePath) {
+  const scenario = process.env.HOMEBOY_SITE_EDITOR_SCENARIO || 'default';
+  if (scenario !== 'static-home') {
+    if (scenario === 'front-no-query') {
+      await installFrontPageTemplate(sitePath, '<!-- wp:template-part {"slug":"header","theme":"twentytwentyfive"} /--><!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} --><main class="wp-block-group"><!-- wp:paragraph --><p>Custom front page without posts.</p><!-- /wp:paragraph --></main><!-- /wp:group --><!-- wp:template-part {"slug":"footer","theme":"twentytwentyfive"} /-->');
+    }
+    if (scenario === 'front-query') {
+      await installFrontPageTemplate(sitePath, '<!-- wp:template-part {"slug":"header","theme":"twentytwentyfive"} /--><!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} --><main class="wp-block-group"><!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} --><div class="wp-block-query"><!-- wp:post-template --><!-- wp:post-title /--><!-- /wp:post-template --></div><!-- /wp:query --></main><!-- /wp:group --><!-- wp:template-part {"slug":"footer","theme":"twentytwentyfive"} /-->');
+    }
+    return;
+  }
+
+  const code = `
+$page_id = wp_insert_post(
+	array(
+		'post_title'   => 'About Me',
+		'post_name'    => 'about-me',
+		'post_status'  => 'publish',
+		'post_type'    => 'page',
+		'post_content' => '<!-- wp:paragraph --><p>Static homepage content.</p><!-- /wp:paragraph -->',
+	)
+);
+if ( is_wp_error( $page_id ) ) {
+	fwrite( STDERR, $page_id->get_error_message() );
+	exit( 1 );
+}
+update_option( 'show_on_front', 'page' );
+update_option( 'page_on_front', $page_id );
+echo wp_json_encode( array( 'page_id' => $page_id ) );
+`;
+
+  await runCli(['wp', '--path', sitePath, '--php-version', '8.3', 'eval', code], { timeoutMs: 90000 });
+}
+
+async function installFrontPageTemplate(sitePath, content) {
+  const code = `
+$template_id = wp_insert_post(
+	array(
+		'post_title'   => 'Front Page',
+		'post_name'    => 'front-page',
+		'post_status'  => 'publish',
+		'post_type'    => 'wp_template',
+		'post_content' => ${JSON.stringify(content)},
+	)
+);
+if ( is_wp_error( $template_id ) ) {
+	fwrite( STDERR, $template_id->get_error_message() );
+	exit( 1 );
+}
+wp_set_post_terms( $template_id, get_stylesheet(), 'wp_theme' );
+echo wp_json_encode( array( 'template_id' => $template_id ) );
+`;
+
+  await runCli(['wp', '--path', sitePath, '--php-version', '8.3', 'eval', code], { timeoutMs: 90000 });
 }
 
 export default async function studioSiteEditorPreloadComparisonBench() {


### PR DESCRIPTION
## Summary
- Add benchmark scenarios for default, static-front-page, no-query front-page, and query front-page Site Editor preload behavior.
- Add candidate preload modes so the harness can compare broad, taxonomies-only, and template-aware strategies.
- Provides concrete evidence for the Gutenberg/Core Site Editor preload discussion.

## Testing
- `node --check Automattic/studio/bench/lib/site-editor-preload-harness.mjs`
- Ran the template-aware matrix locally against Studio temp sites:
  - default TT5 home: `1223ms -> 988ms` (`-19.2%`), REST waterfall `5 -> 0`
  - static front page: `1876ms -> 874ms` (`-53.4%`), REST waterfall `4 -> 0`
  - custom front page without Query Loop: `1219ms -> 904ms` (`-25.8%`), REST waterfall `3 -> 0`
  - custom front page with Query Loop: `1277ms -> 897ms` (`-29.8%`), REST waterfall `4 -> 0`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the harness scenario changes and ran local validation/benchmark commands; Chris reviewed the direction and evidence.