### PR TITLE
Add Studio CLI password Node proof rig

### DIFF
--- a/Automattic/studio/bench/studio-cli-password-node.bench.mjs
+++ b/Automattic/studio/bench/studio-cli-password-node.bench.mjs
@@ -1,0 +1,137 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import {
+  STUDIO_PATH,
+  artifactDir as studioArtifactDir,
+  createStudioSite,
+  metric,
+  redact,
+  safeResult,
+  setting,
+  variant,
+} from './lib/studio-bench.mjs';
+
+function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    let stdout = '';
+    let stderr = '';
+    const child = spawn(command, args, {
+      cwd: options.cwd || STUDIO_PATH,
+      env: { ...process.env, ...(options.env || {}) },
+    });
+
+    child.stdout.on('data', (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      const elapsedMs = Date.now() - started;
+      if (code !== 0 && options.allowFailure !== true) {
+        reject(new Error(`${command} ${args.join(' ')} exited ${code}; stderr=${stderr.slice(-1500)}`));
+        return;
+      }
+      resolve({ code, stdout, stderr, elapsedMs });
+    });
+  });
+}
+
+async function prepareGeneratePasswordPackage(artifactDir) {
+  const packageDir = setting('generate_password_package_dir');
+  const packageTgz = setting('generate_password_package_tgz');
+
+  if (!packageDir && !packageTgz) {
+    return { package_source: 'installed', steps: [] };
+  }
+
+  const steps = [];
+  let tgzPath = packageTgz;
+
+  if (packageDir) {
+    const pack = await runCommand('npm', ['pack', packageDir, '--pack-destination', artifactDir], {
+      cwd: artifactDir,
+    });
+    steps.push({ name: 'npm_pack_generate_password', ...safeResult(pack) });
+    const tarball = pack.stdout
+      .trim()
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .pop();
+    tgzPath = path.join(artifactDir, tarball);
+  }
+
+  const install = await runCommand(
+    'npm',
+    ['install', '--package-lock=false', '--no-save', tgzPath],
+    { cwd: STUDIO_PATH }
+  );
+  steps.push({ name: 'npm_install_generate_password', ...safeResult(install) });
+
+  const buildCli = await runCommand('npm', ['run', 'build'], {
+    cwd: path.join(STUDIO_PATH, 'apps/cli'),
+  });
+  steps.push({ name: 'build_studio_cli', ...safeResult(buildCli) });
+
+  return { package_source: tgzPath, steps };
+}
+
+export default async function studioCliPasswordNodeBench() {
+  const currentVariant = variant();
+  const runId = `${currentVariant}-cli-password-node-${process.pid}-${Date.now()}-${Math.random()
+    .toString(36)
+    .slice(2)}`;
+  const artifactDir = studioArtifactDir('studio-cli-password-node-artifacts');
+  const sitesDir = path.join(artifactDir, 'sites');
+  await mkdir(sitesDir, { recursive: true });
+
+  const sitePath = path.join(sitesDir, runId);
+  const resultFile = path.join(artifactDir, `result-${runId}.json`);
+
+  const started = Date.now();
+  const packagePreparation = await prepareGeneratePasswordPackage(artifactDir);
+  const createResult = await createStudioSite(sitePath, {
+    name: `Studio Bench ${currentVariant} Password Node ${process.pid}`,
+    start: false,
+    allowFailure: true,
+    timeoutMs: 240000,
+  });
+  const totalElapsedMs = Date.now() - started;
+
+  const result = {
+    variant: currentVariant,
+    site_path: sitePath,
+    package_preparation: packagePreparation,
+    command: safeResult(createResult),
+    timings: {
+      site_create_no_start_ms: createResult.elapsedMs,
+      total_elapsed_ms: totalElapsedMs,
+    },
+    passed: createResult.code === 0,
+  };
+  await writeFile(resultFile, JSON.stringify(result, null, 2));
+
+  if (createResult.code !== 0) {
+    throw new Error(
+      `studio site create failed after generate-password preparation; stderr=${redact(
+        createResult.stderr
+      ).slice(-1500)}`
+    );
+  }
+
+  return {
+    metrics: {
+      success_rate: 1,
+      site_create_no_start_ms: metric(createResult.elapsedMs),
+      total_elapsed_ms: totalElapsedMs,
+    },
+    artifacts: {
+      raw_result: resultFile,
+      site_path: sitePath,
+      generate_password_package_source: packagePreparation.package_source,
+    },
+  };
+}

--- a/Automattic/studio/rigs/studio-cli-password-node/rig.json
+++ b/Automattic/studio/rigs/studio-cli-password-node/rig.json
@@ -1,0 +1,44 @@
+{
+  "id": "studio-cli-password-node",
+  "description": "Focused Studio CLI site-create proof for Node-safe @automattic/generate-password package candidates. Pass --setting generate_password_package_dir=/path/to/wp-calypso/packages/generate-password to pack, install without saving, rebuild the Studio CLI, and run `studio site create --no-start` through Homeboy.",
+
+  "components": {
+    "studio": {
+      "path": "~/Developer/studio",
+      "branch": "dev/combined-fixes",
+      "extensions": {
+        "nodejs": {
+          "settings": {
+            "studio_bench_variant": "cli-password-node"
+          }
+        }
+      }
+    }
+  },
+
+  "bench": {
+    "default_component": "studio"
+  },
+
+  "bench_workloads": {
+    "nodejs": [
+      "${package.root}/bench/studio-cli-password-node.bench.mjs"
+    ]
+  },
+
+  "pipeline": {
+    "check": [
+      {
+        "kind": "check",
+        "label": "Studio CLI source exists",
+        "file": "${components.studio.path}/apps/cli/package.json"
+      },
+      {
+        "kind": "check",
+        "label": "Studio common package depends on generate-password",
+        "file": "${components.studio.path}/tools/common/package.json",
+        "contains": "@automattic/generate-password"
+      }
+    ]
+  }
+}

--- a/Automattic/studio/rigs/studio-combined/rig.json
+++ b/Automattic/studio/rigs/studio-combined/rig.json
@@ -54,6 +54,7 @@
   "bench_workloads": {
     "nodejs": [
       "${package.root}/bench/studio-site-create.bench.mjs",
+      "${package.root}/bench/studio-cli-password-node.bench.mjs",
       "${package.root}/bench/studio-admin-theme-page.bench.mjs",
       "${package.root}/bench/studio-admin-theme-page-browser.bench.mjs",
       "${package.root}/bench/studio-dashboard-browser.bench.mjs",


### PR DESCRIPTION
## Summary

- Adds a focused `studio-cli-password-node` rig for proving Studio CLI site creation against a candidate `@automattic/generate-password` package.
- Adds a reusable benchmark workload that packs/installs the candidate package without saving Studio lockfile changes, rebuilds `apps/cli`, and runs `studio site create --no-start`.
- Registers the workload in `studio-combined` so the proof can be reused alongside the existing Studio rig suite.

## Evidence

- Calypso issue: https://github.com/Automattic/wp-calypso/issues/110620
- Downstream Studio issue: https://github.com/Automattic/studio/issues/3417
- Baseline package failure Homeboy run: `5cb85066-4f35-4607-a9e0-e339d5e01a44`
- Fixed-package Studio proof Homeboy run: `f38a2595-a359-4eeb-808d-43f42992cf35`
- Raw result artifact: `/Users/chubes/.local/share/homeboy/artifacts/f38a2595-a359-4eeb-808d-43f42992cf35/0535cb55-0578-4e48-9d24-8c3d7ae0078e-result-cli-password-node-cli-password-node-26696-1778362784838-0mjqzmixbbga.json`

The fixed-package proof packed the Calypso `packages/generate-password` candidate, installed it into a clean Studio trunk proof checkout, rebuilt the Studio CLI, and confirmed `studio site create --no-start` completed with `Site created successfully`.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the Homeboy rig/workload and running the proof command; Chris directed the upstream-first workflow and reviewed the evidence requirement.
