### PR TITLE
Use WordPress page profiler for Site Editor rigs

### DIFF
--- a/Automattic/studio/bench/lib/site-editor-preload-harness.mjs
+++ b/Automattic/studio/bench/lib/site-editor-preload-harness.mjs
@@ -169,14 +169,14 @@ function round(value) {
 function slowResourceFingerprint(resource) {
   return {
     url: resource.url,
-    duration_ms: round(resource.duration_ms),
-    ttfb_ms: round(resource.ttfb_ms),
+    duration_ms: round(resource.durationMs),
+    ttfb_ms: round(resource.ttfbMs),
   };
 }
 
 export function buildSiteEditorPreloadComparison({ baseline, candidate }) {
-  const baselineMeasure = baseline?.measure?.duration_ms || 0;
-  const candidateMeasure = candidate?.measure?.duration_ms || 0;
+  const baselineMeasure = baseline?.measure?.readyMs || 0;
+  const candidateMeasure = candidate?.measure?.readyMs || 0;
   const delta = candidateMeasure - baselineMeasure;
   const deltaPct = baselineMeasure > 0 ? (delta / baselineMeasure) * 100 : 0;
 
@@ -185,16 +185,12 @@ export function buildSiteEditorPreloadComparison({ baseline, candidate }) {
     candidate_measure_ms: round(candidateMeasure),
     delta_ms: round(delta),
     delta_pct: Math.round(deltaPct * 10) / 10,
-    baseline_warmup_ms: round(baseline?.warmup?.duration_ms),
-    candidate_warmup_ms: round(candidate?.warmup?.duration_ms),
-    baseline_measure_resource_count: baseline?.measure?.resourceTimings?.length || 0,
-    candidate_measure_resource_count: candidate?.measure?.resourceTimings?.length || 0,
-    baseline_slowest_measure_resources: (baseline?.measure?.resourceTimings || [])
-      .slice(0, 10)
-      .map(slowResourceFingerprint),
-    candidate_slowest_measure_resources: (candidate?.measure?.resourceTimings || [])
-      .slice(0, 10)
-      .map(slowResourceFingerprint),
+    baseline_warmup_ms: round(baseline?.warmup?.readyMs),
+    candidate_warmup_ms: round(candidate?.warmup?.readyMs),
+    baseline_measure_resource_count: baseline?.measure?.resources?.count || 0,
+    candidate_measure_resource_count: candidate?.measure?.resources?.count || 0,
+    baseline_slowest_measure_resources: (baseline?.measure?.resources?.slowest || []).map(slowResourceFingerprint),
+    candidate_slowest_measure_resources: (candidate?.measure?.resources?.slowest || []).map(slowResourceFingerprint),
     baseline_status: baseline?.measure?.status || 0,
     candidate_status: candidate?.measure?.status || 0,
   };

--- a/Automattic/studio/bench/lib/wordpress-page-profiler.mjs
+++ b/Automattic/studio/bench/lib/wordpress-page-profiler.mjs
@@ -23,10 +23,6 @@ export const SITE_EDITOR_PAGE_SPEC = {
   timeout: 120000,
 };
 
-function round(value) {
-  return typeof value === 'number' && Number.isFinite(value) ? Math.round(value) : 0;
-}
-
 export function pageProfilerPath(options = {}) {
   const explicit = options.override || process.env.HOMEBOY_WORDPRESS_PAGE_PROFILER_PATH;
   if (explicit) {
@@ -56,60 +52,16 @@ export function loadWordPressRequestProfiler(options = {}) {
   return { path: profilerPath, module: require(profilerPath) };
 }
 
-export function legacyResourceTimings(profileResult) {
-  return (profileResult?.resources?.resources || [])
-    .map((resource) => ({
-      name: resource.url,
-      url: resource.url,
-      initiatorType: resource.initiatorType,
-      kind: resource.kind,
-      startMs: resource.startMs,
-      startTime: resource.startMs,
-      durationMs: resource.durationMs,
-      duration: resource.durationMs,
-      ttfbMs: resource.ttfbMs,
-      transferSize: resource.transferSize,
-      encodedBodySize: resource.encodedBodySize,
-      decodedBodySize: resource.decodedBodySize,
-    }))
-    .sort((a, b) => b.durationMs - a.durationMs);
-}
-
-export function summarizeProfileResourceTimings(entries) {
-  return (entries || [])
-    .map((entry) => ({
-      url: entry.url || entry.name,
-      kind: entry.kind,
-      initiatorType: entry.initiatorType,
-      start_ms: round(entry.startMs ?? entry.startTime),
-      duration_ms: round(entry.durationMs ?? entry.duration),
-      ttfb_ms: round(entry.ttfbMs ?? entry.ttfb_ms),
-      transfer_size: entry.transferSize || 0,
-      encoded_body_size: entry.encodedBodySize || 0,
-      decoded_body_size: entry.decodedBodySize || 0,
-    }))
-    .sort((a, b) => b.duration_ms - a.duration_ms);
-}
-
-export async function profileSiteEditorReady({ page, siteUrl, pageProfiler, wordpressProfilerRows = [], mark }) {
+export async function profileSiteEditorPage({ page, siteUrl, pageProfiler, wordpressProfilerRows = [], mark }) {
   if (!pageProfiler?.profileWordPressPage) {
     throw new Error('Homeboy WordPress page profiler is unavailable. Update homeboy-extensions or set HOMEBOY_WORDPRESS_PAGE_PROFILER_PATH.');
   }
 
-  const profile = await pageProfiler.profileWordPressPage({
+  return pageProfiler.profileWordPressPage({
     page,
     baseUrl: siteUrl,
     spec: SITE_EDITOR_PAGE_SPEC,
     wordpressProfilerRows,
     mark,
   });
-
-  return {
-    status: profile.status,
-    site_editor_ready_ms: profile.readyMs,
-    duration_ms: profile.readyMs,
-    marks: [],
-    resourceTimings: legacyResourceTimings(profile),
-    pageProfile: profile,
-  };
 }

--- a/Automattic/studio/bench/lib/wordpress-page-profiler.mjs
+++ b/Automattic/studio/bench/lib/wordpress-page-profiler.mjs
@@ -23,6 +23,40 @@ export const SITE_EDITOR_PAGE_SPEC = {
   timeout: 120000,
 };
 
+export function wordpressPageProfilerSpec() {
+  const rawSpec = process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_SPEC_JSON;
+  if (rawSpec) {
+    return JSON.parse(rawSpec);
+  }
+
+  const pathValue = process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_PATH;
+  if (!pathValue) {
+    return SITE_EDITOR_PAGE_SPEC;
+  }
+
+  const id = process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_ID ||
+    pathValue.replace(/^\/+/, '').replace(/[^A-Za-z0-9_.:-]+/g, '-').replace(/^-|-$/g, '') ||
+    'wordpress-page';
+  const selector = process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_READY_SELECTOR;
+  const timeout = Number(process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_TIMEOUT || 120000);
+  const ready = selector
+    ? { selector, timeout }
+    : { state: process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_READY_STATE || 'domcontentloaded' };
+
+  return {
+    id,
+    label: process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_LABEL || id,
+    path: pathValue,
+    ready,
+    resources: {
+      includeResourceSubstrings: process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_RESOURCE_INCLUDE
+        ? process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_RESOURCE_INCLUDE.split(',').map((value) => value.trim()).filter(Boolean)
+        : ['/wp-json/', '?rest_route=', '/wp-admin/', '/wp-content/', '/wp-includes/'],
+    },
+    timeout,
+  };
+}
+
 export function pageProfilerPath(options = {}) {
   const explicit = options.override || process.env.HOMEBOY_WORDPRESS_PAGE_PROFILER_PATH;
   if (explicit) {
@@ -52,7 +86,7 @@ export function loadWordPressRequestProfiler(options = {}) {
   return { path: profilerPath, module: require(profilerPath) };
 }
 
-export async function profileSiteEditorPage({ page, siteUrl, pageProfiler, wordpressProfilerRows = [], mark }) {
+export async function profileWordPressPage({ page, siteUrl, pageProfiler, pageSpec, wordpressProfilerRows = [], mark }) {
   if (!pageProfiler?.profileWordPressPage) {
     throw new Error('Homeboy WordPress page profiler is unavailable. Update homeboy-extensions or set HOMEBOY_WORDPRESS_PAGE_PROFILER_PATH.');
   }
@@ -60,7 +94,7 @@ export async function profileSiteEditorPage({ page, siteUrl, pageProfiler, wordp
   return pageProfiler.profileWordPressPage({
     page,
     baseUrl: siteUrl,
-    spec: SITE_EDITOR_PAGE_SPEC,
+    spec: pageSpec || wordpressPageProfilerSpec(),
     wordpressProfilerRows,
     mark,
   });

--- a/Automattic/studio/bench/lib/wordpress-page-profiler.mjs
+++ b/Automattic/studio/bench/lib/wordpress-page-profiler.mjs
@@ -1,0 +1,115 @@
+import { createRequire } from 'node:module';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import { requestProfilerPath } from './site-editor-timing-deltas.mjs';
+
+const require = createRequire(import.meta.url);
+const PAGE_PROFILER_FILENAME = 'page-profiler.js';
+
+export const SITE_EDITOR_PAGE_SPEC = {
+  id: 'site-editor',
+  path: '/wp-admin/site-editor.php',
+  ready: {
+    selector: 'iframe[name="editor-canvas"]',
+    frameName: 'editor-canvas',
+    frameState: 'domcontentloaded',
+    frameSelector: '[data-block]',
+    timeout: 120000,
+  },
+  resources: {
+    includeResourceSubstrings: ['/wp-json/', '/wp-admin/site-editor.php'],
+  },
+  timeout: 120000,
+};
+
+function round(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.round(value) : 0;
+}
+
+export function pageProfilerPath(options = {}) {
+  const explicit = options.override || process.env.HOMEBOY_WORDPRESS_PAGE_PROFILER_PATH;
+  if (explicit) {
+    return explicit;
+  }
+
+  const profiler = options.profilerPath || requestProfilerPath();
+  if (!profiler) {
+    return '';
+  }
+  return path.join(path.dirname(profiler), PAGE_PROFILER_FILENAME);
+}
+
+export function loadWordPressPageProfiler(options = {}) {
+  const profilerPath = pageProfilerPath(options);
+  if (!profilerPath || !existsSync(profilerPath)) {
+    return { path: profilerPath, module: null };
+  }
+  return { path: profilerPath, module: require(profilerPath) };
+}
+
+export function loadWordPressRequestProfiler(options = {}) {
+  const profilerPath = options.override || requestProfilerPath();
+  if (!profilerPath || !existsSync(profilerPath)) {
+    return { path: profilerPath, module: null };
+  }
+  return { path: profilerPath, module: require(profilerPath) };
+}
+
+export function legacyResourceTimings(profileResult) {
+  return (profileResult?.resources?.resources || [])
+    .map((resource) => ({
+      name: resource.url,
+      url: resource.url,
+      initiatorType: resource.initiatorType,
+      kind: resource.kind,
+      startMs: resource.startMs,
+      startTime: resource.startMs,
+      durationMs: resource.durationMs,
+      duration: resource.durationMs,
+      ttfbMs: resource.ttfbMs,
+      transferSize: resource.transferSize,
+      encodedBodySize: resource.encodedBodySize,
+      decodedBodySize: resource.decodedBodySize,
+    }))
+    .sort((a, b) => b.durationMs - a.durationMs);
+}
+
+export function summarizeProfileResourceTimings(entries) {
+  return (entries || [])
+    .map((entry) => ({
+      url: entry.url || entry.name,
+      kind: entry.kind,
+      initiatorType: entry.initiatorType,
+      start_ms: round(entry.startMs ?? entry.startTime),
+      duration_ms: round(entry.durationMs ?? entry.duration),
+      ttfb_ms: round(entry.ttfbMs ?? entry.ttfb_ms),
+      transfer_size: entry.transferSize || 0,
+      encoded_body_size: entry.encodedBodySize || 0,
+      decoded_body_size: entry.decodedBodySize || 0,
+    }))
+    .sort((a, b) => b.duration_ms - a.duration_ms);
+}
+
+export async function profileSiteEditorReady({ page, siteUrl, pageProfiler, wordpressProfilerRows = [], mark }) {
+  if (!pageProfiler?.profileWordPressPage) {
+    throw new Error('Homeboy WordPress page profiler is unavailable. Update homeboy-extensions or set HOMEBOY_WORDPRESS_PAGE_PROFILER_PATH.');
+  }
+
+  const profile = await pageProfiler.profileWordPressPage({
+    page,
+    baseUrl: siteUrl,
+    spec: SITE_EDITOR_PAGE_SPEC,
+    wordpressProfilerRows,
+    mark,
+  });
+
+  return {
+    status: profile.status,
+    site_editor_ready_ms: profile.readyMs,
+    duration_ms: profile.readyMs,
+    marks: [],
+    resourceTimings: legacyResourceTimings(profile),
+    pageProfile: profile,
+  };
+}

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
@@ -27,8 +27,7 @@ import {
 import {
   loadWordPressPageProfiler,
   loadWordPressRequestProfiler,
-  profileSiteEditorReady,
-  summarizeProfileResourceTimings,
+  profileSiteEditorPage,
 } from './lib/wordpress-page-profiler.mjs';
 
 const BROWSER_HELPER = process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER;
@@ -203,7 +202,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
         loginFormSeen = await page.locator('#loginform').count();
 
         phase = 'warmup-site-editor';
-        warmupTimings = await profileSiteEditorReady({ page, siteUrl: status.siteUrl, pageProfiler, mark });
+        warmupTimings = await profileSiteEditorPage({ page, siteUrl: status.siteUrl, pageProfiler, mark });
         await mark('warmup_site_editor_ready');
 
         phase = 'dashboard-between-runs';
@@ -212,7 +211,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
         await mark('browser_admin_networkidle_between_runs');
 
         phase = 'measure-site-editor';
-        measureTimings = await profileSiteEditorReady({ page, siteUrl: status.siteUrl, pageProfiler, mark });
+        measureTimings = await profileSiteEditorPage({ page, siteUrl: status.siteUrl, pageProfiler, mark });
         await mark('measure_site_editor_ready');
         phase = 'done';
       },
@@ -226,7 +225,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
     stop = await stopSite(sitePath);
 
     const totalElapsedMs = Date.now() - totalStarted;
-    const measureResourceTimingSummary = summarizeProfileResourceTimings(measureTimings.resourceTimings || []);
+    const measureResourceTimingSummary = measureTimings.resources?.slowest || [];
 
     // Studio-specific browser-vs-WordPress timing delta summary. Consumes
     // the generic homeboy-extensions correlator (PR #452) and tags each
@@ -234,8 +233,8 @@ export default async function studioSiteEditorDiagnosticsBench() {
     // resulting summary highlights where in the Site Editor flow the
     // largest transport overhead lives.
     const phasedBrowserTimings = flattenPhasedResourceTimings({
-      'warmup-site-editor': warmupTimings.resourceTimings || [],
-      'measure-site-editor': measureTimings.resourceTimings || [],
+      'warmup-site-editor': warmupTimings.resources?.resources || [],
+      'measure-site-editor': measureTimings.resources?.resources || [],
     });
     const timingDeltas = buildTimingDeltaSummary({
       browserResourceTimings: phasedBrowserTimings,
@@ -271,14 +270,8 @@ export default async function studioSiteEditorDiagnosticsBench() {
             total_elapsed_ms: totalElapsedMs,
           },
           siteEditorTimings: {
-            warmup: {
-              ...warmupTimings,
-              resourceTimings: summarizeProfileResourceTimings(warmupTimings.resourceTimings || []),
-            },
-            measure: {
-              ...measureTimings,
-              resourceTimings: measureResourceTimingSummary,
-            },
+            warmup: warmupTimings,
+            measure: measureTimings,
           },
           network: {
             login: summarizeNetwork(network, 'login'),
@@ -329,14 +322,12 @@ export default async function studioSiteEditorDiagnosticsBench() {
         site_status_ms: metric(statusResult.elapsedMs),
         login_form_seen: metric(loginFormSeen),
         site_editor_status: metric(measureTimings.status),
-        site_editor_commit_ms: metric(measureTimings.commit_ms),
-        site_editor_iframe_visible_ms: metric(measureTimings.editor_canvas_iframe_visible_ms),
-        site_editor_iframe_domcontentloaded_ms: metric(measureTimings.editor_canvas_domcontentloaded_ms),
-        site_editor_first_data_block_ms: metric(measureTimings.first_data_block_ms),
-        site_editor_ready_ms: metric(measureTimings.site_editor_ready_ms),
-        site_editor_warmup_ready_ms: metric(warmupTimings.site_editor_ready_ms),
-        site_editor_slowest_resource_ms: metric(slowestResource.duration_ms),
-        site_editor_slowest_resource_ttfb_ms: metric(slowestResource.ttfb_ms),
+        site_editor_ready_ms: metric(measureTimings.readyMs),
+        site_editor_warmup_ready_ms: metric(warmupTimings.readyMs),
+        site_editor_resource_count: metric(measureTimings.resources?.count),
+        site_editor_rest_resource_count: metric(measureTimings.resources?.restCount),
+        site_editor_slowest_resource_ms: metric(slowestResource.durationMs),
+        site_editor_slowest_resource_ttfb_ms: metric(slowestResource.ttfbMs),
         // Browser-vs-WordPress timing deltas. Transport delta = browser
         // TTFB - WordPress app duration; it is the canonical signal for
         // Playground request/bootstrap/transport overhead under Studio.

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
@@ -1,5 +1,3 @@
-import { createRequire } from 'node:module';
-import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
@@ -19,7 +17,6 @@ import {
   buildTimingDeltaSummary,
   flattenPhasedResourceTimings,
   loadTimingCorrelator,
-  requestProfilerPath,
 } from './lib/site-editor-timing-deltas.mjs';
 import {
   collectWordPressBootstrapTimeline,
@@ -27,6 +24,12 @@ import {
   summarizeWordPressBootstrapTimeline,
   uninstallWordPressBootstrapTimeline,
 } from './lib/wordpress-bootstrap-timeline.mjs';
+import {
+  loadWordPressPageProfiler,
+  loadWordPressRequestProfiler,
+  profileSiteEditorReady,
+  summarizeProfileResourceTimings,
+} from './lib/wordpress-page-profiler.mjs';
 
 const BROWSER_HELPER = process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER;
 
@@ -35,15 +38,6 @@ if (!BROWSER_HELPER) {
 }
 
 const { runBrowserBench } = await import(BROWSER_HELPER);
-const require = createRequire(import.meta.url);
-
-function loadRequestProfiler() {
-  const profilerPath = requestProfilerPath();
-  if (!profilerPath || !existsSync(profilerPath)) {
-    return { profilerPath, profiler: null };
-  }
-  return { profilerPath, profiler: require(profilerPath) };
-}
 
 async function createSite(sitePath) {
   return createStudioSite(sitePath, {
@@ -82,27 +76,6 @@ async function sanitizeNetworkArtifact(artifact) {
   await writeFile(artifact.path, redact(raw));
 }
 
-function collectResourceTimings(page) {
-  return page.evaluate(() =>
-    performance
-      .getEntriesByType('resource')
-      .filter((entry) => entry.name.includes('/wp-json/') || entry.name.includes('/wp-admin/site-editor.php'))
-      .map((entry) => ({
-        name: entry.name,
-        initiatorType: entry.initiatorType,
-        startTime: entry.startTime,
-        duration: entry.duration,
-        fetchStart: entry.fetchStart,
-        requestStart: entry.requestStart,
-        responseStart: entry.responseStart,
-        responseEnd: entry.responseEnd,
-        transferSize: entry.transferSize,
-        encodedBodySize: entry.encodedBodySize,
-        decodedBodySize: entry.decodedBodySize,
-      }))
-  );
-}
-
 function summarizeNetwork(network, phase) {
   return network
     .filter((request) => request.phase === phase)
@@ -113,24 +86,6 @@ function summarizeNetwork(network, phase) {
       ...request,
       url: scrubUrl(request.url),
     }));
-}
-
-function summarizeResourceTimings(resourceTimings) {
-  return resourceTimings
-    .map((entry) => ({
-      url: scrubUrl(entry.name),
-      initiatorType: entry.initiatorType,
-      start_ms: entry.startTime,
-      duration_ms: entry.duration,
-      request_start_ms: entry.requestStart,
-      response_start_ms: entry.responseStart,
-      response_end_ms: entry.responseEnd,
-      ttfb_ms: entry.responseStart - entry.requestStart,
-      transfer_size: entry.transferSize,
-      encoded_body_size: entry.encodedBodySize,
-      decoded_body_size: entry.decodedBodySize,
-    }))
-    .sort((a, b) => b.duration_ms - a.duration_ms);
 }
 
 function summarizeWordPressRequests(entries) {
@@ -165,60 +120,6 @@ function summarizeWordPressRequests(entries) {
     .slice(0, 80);
 }
 
-async function waitForSiteEditorReady(page) {
-  const timings = {};
-  const marks = [];
-  const started = performance.now();
-  const elapsed = () => performance.now() - started;
-  const mark = (name) => marks.push({ name, t_ms: elapsed() });
-
-  const response = await page.goto(siteAdminUrl(page.__studioSiteUrl, 'site-editor.php'), {
-    waitUntil: 'commit',
-    timeout: 120000,
-  });
-  timings.commit_ms = elapsed();
-  timings.status = response ? response.status() : 0;
-  mark('commit');
-
-  await page.waitForSelector('iframe[name="editor-canvas"]', {
-    state: 'visible',
-    timeout: 120000,
-  });
-  timings.editor_canvas_iframe_visible_ms = elapsed();
-  mark('iframe-visible');
-
-  const frame = page.frame({ name: 'editor-canvas' });
-  if (!frame) {
-    throw new Error('Site Editor canvas frame not found');
-  }
-
-  await frame.waitForLoadState('domcontentloaded', { timeout: 120000 });
-  timings.editor_canvas_domcontentloaded_ms = elapsed();
-  mark('iframe-domcontentloaded');
-
-  await frame.waitForSelector('[data-block]', { timeout: 60000 });
-  timings.first_data_block_ms = elapsed();
-  mark('first-data-block');
-
-  await frame.waitForFunction(
-    () => {
-      return (
-        document.querySelectorAll('[data-block]').length > 0 &&
-        !document.querySelector('.components-spinner') &&
-        !document.querySelector('.is-loading') &&
-        !document.querySelector('.wp-block-editor__loading')
-      );
-    },
-    { timeout: 60000 }
-  );
-  timings.site_editor_ready_ms = elapsed();
-  mark('ready');
-  timings.marks = marks;
-  timings.resourceTimings = await collectResourceTimings(page);
-
-  return timings;
-}
-
 export default async function studioSiteEditorDiagnosticsBench() {
   const currentVariant = variant();
   const runId = `${currentVariant}-site-editor-diagnostics-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
@@ -227,7 +128,8 @@ export default async function studioSiteEditorDiagnosticsBench() {
   await mkdir(artifactDir, { recursive: true });
 
   const totalStarted = Date.now();
-  const { profilerPath, profiler } = loadRequestProfiler();
+  const { path: profilerPath, module: profiler } = loadWordPressRequestProfiler();
+  const { path: pageProfilerPath, module: pageProfiler } = loadWordPressPageProfiler({ profilerPath });
   const { path: correlatorPath, module: correlator } = loadTimingCorrelator({ profilerPath });
   let create;
   let statusResult;
@@ -301,7 +203,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
         loginFormSeen = await page.locator('#loginform').count();
 
         phase = 'warmup-site-editor';
-        warmupTimings = await waitForSiteEditorReady(page);
+        warmupTimings = await profileSiteEditorReady({ page, siteUrl: status.siteUrl, pageProfiler, mark });
         await mark('warmup_site_editor_ready');
 
         phase = 'dashboard-between-runs';
@@ -310,7 +212,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
         await mark('browser_admin_networkidle_between_runs');
 
         phase = 'measure-site-editor';
-        measureTimings = await waitForSiteEditorReady(page);
+        measureTimings = await profileSiteEditorReady({ page, siteUrl: status.siteUrl, pageProfiler, mark });
         await mark('measure_site_editor_ready');
         phase = 'done';
       },
@@ -324,7 +226,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
     stop = await stopSite(sitePath);
 
     const totalElapsedMs = Date.now() - totalStarted;
-    const measureResourceTimingSummary = summarizeResourceTimings(measureTimings.resourceTimings || []);
+    const measureResourceTimingSummary = summarizeProfileResourceTimings(measureTimings.resourceTimings || []);
 
     // Studio-specific browser-vs-WordPress timing delta summary. Consumes
     // the generic homeboy-extensions correlator (PR #452) and tags each
@@ -349,6 +251,8 @@ export default async function studioSiteEditorDiagnosticsBench() {
           variant: currentVariant,
           profilerPath,
           profilerAvailable: Boolean(profiler),
+          pageProfilerPath,
+          pageProfilerAvailable: Boolean(pageProfiler),
           correlatorPath,
           correlatorAvailable: Boolean(correlator),
           bootstrapTimelineArtifactPath,
@@ -369,7 +273,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
           siteEditorTimings: {
             warmup: {
               ...warmupTimings,
-              resourceTimings: summarizeResourceTimings(warmupTimings.resourceTimings || []),
+              resourceTimings: summarizeProfileResourceTimings(warmupTimings.resourceTimings || []),
             },
             measure: {
               ...measureTimings,

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
@@ -243,6 +243,12 @@ export default async function studioSiteEditorDiagnosticsBench() {
       wordpressRequests,
       correlator,
     });
+    const pageDiagnosis = pageProfiler?.diagnoseWordPressPageProfile
+      ? pageProfiler.diagnoseWordPressPageProfile(measureProfile, {
+          browserMetrics: browserResult.metrics,
+          networkRequests: network,
+        })
+      : measureProfile.diagnosis;
 
     const artifactFile = path.join(artifactDir, `result-${runId}.json`);
     await writeFile(
@@ -284,6 +290,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
           },
           wordpressRequests: summarizeWordPressRequests(wordpressRequests),
           wordpressBootstrapTimeline: summarizeWordPressBootstrapTimeline(wordpressBootstrapTimeline),
+          pageDiagnosis,
           timingDeltas,
           commands: {
             create: safeResult(create),
@@ -317,6 +324,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
       .sort((a, b) => (b.delta_from_previous_ms || 0) - (a.delta_from_previous_ms || 0))[0] || {};
     const overallDelta = timingDeltas?.overall || {};
     const largestTransport = overallDelta.largest_transport_delta || {};
+    const diagnosisSummary = pageDiagnosis?.summary || {};
     return {
       metrics: {
         success_rate: 1,
@@ -331,6 +339,11 @@ export default async function studioSiteEditorDiagnosticsBench() {
         wordpress_page_rest_resource_count: metric(measureProfile.resources?.restCount),
         wordpress_page_slowest_resource_ms: metric(slowestResource.durationMs),
         wordpress_page_slowest_resource_ttfb_ms: metric(slowestResource.ttfbMs),
+        wordpress_page_network_idle_after_ready_ms: metric(diagnosisSummary.networkIdleAfterReadyMs),
+        wordpress_page_late_request_count: metric(diagnosisSummary.lateRequestCount),
+        wordpress_page_rest_after_ready_count: metric(diagnosisSummary.restAfterReadyCount),
+        wordpress_page_failed_request_count: metric(diagnosisSummary.failedRequestCount),
+        wordpress_page_diagnosis_finding_count: metric(pageDiagnosis?.findings?.length),
         site_editor_status: metric(measureProfile.status),
         site_editor_ready_ms: metric(measureProfile.readyMs),
         site_editor_warmup_ready_ms: metric(warmupProfile.readyMs),

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
@@ -27,7 +27,8 @@ import {
 import {
   loadWordPressPageProfiler,
   loadWordPressRequestProfiler,
-  profileSiteEditorPage,
+  profileWordPressPage,
+  wordpressPageProfilerSpec,
 } from './lib/wordpress-page-profiler.mjs';
 
 const BROWSER_HELPER = process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER;
@@ -121,8 +122,9 @@ function summarizeWordPressRequests(entries) {
 
 export default async function studioSiteEditorDiagnosticsBench() {
   const currentVariant = variant();
-  const runId = `${currentVariant}-site-editor-diagnostics-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  const artifactDir = path.join(studioArtifactDir('studio-site-editor-diagnostics-artifacts'), runId);
+  const pageSpec = wordpressPageProfilerSpec();
+  const runId = `${currentVariant}-${pageSpec.id}-diagnostics-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const artifactDir = path.join(studioArtifactDir('studio-wordpress-page-diagnostics-artifacts'), runId);
   const sitePath = path.join(artifactDir, 'site');
   await mkdir(artifactDir, { recursive: true });
 
@@ -135,8 +137,8 @@ export default async function studioSiteEditorDiagnosticsBench() {
   let stop;
   let status;
   let browserResult;
-  let warmupTimings = {};
-  let measureTimings = {};
+  let warmupProfile = {};
+  let measureProfile = {};
   let loginFormSeen = 0;
   let wordpressRequests = [];
   let wordpressBootstrapTimeline = [];
@@ -158,7 +160,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
     profiler?.installWordPressRequestProfiler?.(sitePath);
 
     browserResult = await runBrowserBench({
-      id: 'studio-site-editor-diagnostics',
+      id: `studio-wordpress-page-diagnostics-${pageSpec.id}`,
       artifactsDir: artifactDir,
       trace: true,
       screenshot: true,
@@ -201,18 +203,18 @@ export default async function studioSiteEditorDiagnosticsBench() {
 
         loginFormSeen = await page.locator('#loginform').count();
 
-        phase = 'warmup-site-editor';
-        warmupTimings = await profileSiteEditorPage({ page, siteUrl: status.siteUrl, pageProfiler, mark });
-        await mark('warmup_site_editor_ready');
+        phase = 'warmup-page';
+        warmupProfile = await profileWordPressPage({ page, siteUrl: status.siteUrl, pageProfiler, pageSpec, mark });
+        await mark('warmup_wordpress_page_ready');
 
         phase = 'dashboard-between-runs';
         await page.goto(siteAdminUrl(status.siteUrl), { waitUntil: 'domcontentloaded', timeout: 120000 });
         await page.waitForLoadState('networkidle', { timeout: 120000 });
         await mark('browser_admin_networkidle_between_runs');
 
-        phase = 'measure-site-editor';
-        measureTimings = await profileSiteEditorPage({ page, siteUrl: status.siteUrl, pageProfiler, mark });
-        await mark('measure_site_editor_ready');
+        phase = 'measure-page';
+        measureProfile = await profileWordPressPage({ page, siteUrl: status.siteUrl, pageProfiler, pageSpec, mark });
+        await mark('measure_wordpress_page_ready');
         phase = 'done';
       },
     });
@@ -225,7 +227,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
     stop = await stopSite(sitePath);
 
     const totalElapsedMs = Date.now() - totalStarted;
-    const measureResourceTimingSummary = measureTimings.resources?.slowest || [];
+    const measureResourceTimingSummary = measureProfile.resources?.slowest || [];
 
     // Studio-specific browser-vs-WordPress timing delta summary. Consumes
     // the generic homeboy-extensions correlator (PR #452) and tags each
@@ -233,8 +235,8 @@ export default async function studioSiteEditorDiagnosticsBench() {
     // resulting summary highlights where in the Site Editor flow the
     // largest transport overhead lives.
     const phasedBrowserTimings = flattenPhasedResourceTimings({
-      'warmup-site-editor': warmupTimings.resources?.resources || [],
-      'measure-site-editor': measureTimings.resources?.resources || [],
+      'warmup-page': warmupProfile.resources?.resources || [],
+      'measure-page': measureProfile.resources?.resources || [],
     });
     const timingDeltas = buildTimingDeltaSummary({
       browserResourceTimings: phasedBrowserTimings,
@@ -248,6 +250,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
       JSON.stringify(
         {
           variant: currentVariant,
+          pageSpec,
           profilerPath,
           profilerAvailable: Boolean(profiler),
           pageProfilerPath,
@@ -269,15 +272,15 @@ export default async function studioSiteEditorDiagnosticsBench() {
             site_status_ms: statusResult.elapsedMs,
             total_elapsed_ms: totalElapsedMs,
           },
-          siteEditorTimings: {
-            warmup: warmupTimings,
-            measure: measureTimings,
+          pageProfiles: {
+            warmup: warmupProfile,
+            measure: measureProfile,
           },
           network: {
             login: summarizeNetwork(network, 'login'),
-            warmupSiteEditor: summarizeNetwork(network, 'warmup-site-editor'),
+            warmupPage: summarizeNetwork(network, 'warmup-page'),
             dashboardBetweenRuns: summarizeNetwork(network, 'dashboard-between-runs'),
-            measureSiteEditor: summarizeNetwork(network, 'measure-site-editor'),
+            measurePage: summarizeNetwork(network, 'measure-page'),
           },
           wordpressRequests: summarizeWordPressRequests(wordpressRequests),
           wordpressBootstrapTimeline: summarizeWordPressBootstrapTimeline(wordpressBootstrapTimeline),
@@ -295,8 +298,8 @@ export default async function studioSiteEditorDiagnosticsBench() {
       )
     );
 
-    if (measureTimings.status < 200 || measureTimings.status >= 400) {
-      throw new Error(`Site Editor returned HTTP status ${measureTimings.status}; raw_result=${artifactFile}`);
+    if (measureProfile.status < 200 || measureProfile.status >= 400) {
+      throw new Error(`${pageSpec.label || pageSpec.id} returned HTTP status ${measureProfile.status}; raw_result=${artifactFile}`);
     }
     if (loginFormSeen > 0) {
       throw new Error(`Login form remained visible after auto-login; raw_result=${artifactFile}`);
@@ -321,11 +324,18 @@ export default async function studioSiteEditorDiagnosticsBench() {
         site_create_ms: metric(create.elapsedMs),
         site_status_ms: metric(statusResult.elapsedMs),
         login_form_seen: metric(loginFormSeen),
-        site_editor_status: metric(measureTimings.status),
-        site_editor_ready_ms: metric(measureTimings.readyMs),
-        site_editor_warmup_ready_ms: metric(warmupTimings.readyMs),
-        site_editor_resource_count: metric(measureTimings.resources?.count),
-        site_editor_rest_resource_count: metric(measureTimings.resources?.restCount),
+        wordpress_page_status: metric(measureProfile.status),
+        wordpress_page_ready_ms: metric(measureProfile.readyMs),
+        wordpress_page_warmup_ready_ms: metric(warmupProfile.readyMs),
+        wordpress_page_resource_count: metric(measureProfile.resources?.count),
+        wordpress_page_rest_resource_count: metric(measureProfile.resources?.restCount),
+        wordpress_page_slowest_resource_ms: metric(slowestResource.durationMs),
+        wordpress_page_slowest_resource_ttfb_ms: metric(slowestResource.ttfbMs),
+        site_editor_status: metric(measureProfile.status),
+        site_editor_ready_ms: metric(measureProfile.readyMs),
+        site_editor_warmup_ready_ms: metric(warmupProfile.readyMs),
+        site_editor_resource_count: metric(measureProfile.resources?.count),
+        site_editor_rest_resource_count: metric(measureProfile.resources?.restCount),
         site_editor_slowest_resource_ms: metric(slowestResource.durationMs),
         site_editor_slowest_resource_ttfb_ms: metric(slowestResource.ttfbMs),
         // Browser-vs-WordPress timing deltas. Transport delta = browser

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -24,10 +24,8 @@ const {
   installSiteEditorPreloadCandidateSource,
 } = await import('./lib/site-editor-preload-harness.mjs');
 const {
-  legacyResourceTimings,
   pageProfilerPath,
-  profileSiteEditorReady,
-  summarizeProfileResourceTimings,
+  profileSiteEditorPage,
 } = await import('./lib/wordpress-page-profiler.mjs');
 
 function withEnv(values, callback) {
@@ -319,61 +317,25 @@ test('buildTimingDeltaSummary forwards unmatched buckets into preview slices', (
 
 // --- WordPress page profiler adapter ---------------------------------------
 
-test('legacyResourceTimings adapts page-profiler resource summaries for timing correlation', () => {
-  const timings = legacyResourceTimings({
+test('profileSiteEditorPage delegates page readiness to the Homeboy Extensions page profiler', async () => {
+  const calls = [];
+  const profile = {
+    status: 200,
+    readyMs: 345,
     resources: {
       resources: [
-        {
-          url: '/wp-json/wp/v2/posts',
-          kind: 'rest',
-          initiatorType: 'fetch',
-          startMs: 12,
-          durationMs: 90,
-          ttfbMs: 80,
-          transferSize: 120,
-          encodedBodySize: 100,
-          decodedBodySize: 200,
-        },
+        { url: '/wp-json/wp/v2/types', kind: 'rest', startMs: 3, durationMs: 44, ttfbMs: 40 },
       ],
     },
-  });
-
-  assert.equal(timings.length, 1);
-  assert.equal(timings[0].name, '/wp-json/wp/v2/posts');
-  assert.equal(timings[0].durationMs, 90);
-  assert.equal(timings[0].ttfbMs, 80);
-});
-
-test('summarizeProfileResourceTimings preserves the existing artifact shape', () => {
-  const summary = summarizeProfileResourceTimings([
-    { url: '/slow', kind: 'rest', startMs: 1, durationMs: 120, ttfbMs: 100, transferSize: 9 },
-    { url: '/fast', kind: 'admin', startMs: 2, durationMs: 20, ttfbMs: 10, transferSize: 4 },
-  ]);
-
-  assert.deepEqual(summary.map((row) => row.url), ['/slow', '/fast']);
-  assert.equal(summary[0].duration_ms, 120);
-  assert.equal(summary[0].ttfb_ms, 100);
-  assert.equal(summary[0].transfer_size, 9);
-});
-
-test('profileSiteEditorReady delegates page readiness to the Homeboy Extensions page profiler', async () => {
-  const calls = [];
+  };
   const pageProfiler = {
     async profileWordPressPage(input) {
       calls.push(input);
-      return {
-        status: 200,
-        readyMs: 345,
-        resources: {
-          resources: [
-            { url: '/wp-json/wp/v2/types', kind: 'rest', startMs: 3, durationMs: 44, ttfbMs: 40 },
-          ],
-        },
-      };
+      return profile;
     },
   };
 
-  const result = await profileSiteEditorReady({
+  const result = await profileSiteEditorPage({
     page: { id: 'fake-page' },
     siteUrl: 'http://example.test',
     pageProfiler,
@@ -384,9 +346,7 @@ test('profileSiteEditorReady delegates page readiness to the Homeboy Extensions 
   assert.equal(calls.length, 1);
   assert.equal(calls[0].baseUrl, 'http://example.test');
   assert.equal(calls[0].spec.path, '/wp-admin/site-editor.php');
-  assert.equal(result.status, 200);
-  assert.equal(result.site_editor_ready_ms, 345);
-  assert.equal(result.resourceTimings[0].url, '/wp-json/wp/v2/types');
+  assert.equal(result, profile);
 });
 
 // --- WordPress bootstrap timeline -----------------------------------------
@@ -468,22 +428,25 @@ test('installSiteEditorPreloadCandidateSource fails when preload call is missing
 test('buildSiteEditorPreloadComparison summarizes the bot-path delta', () => {
   const comparison = buildSiteEditorPreloadComparison({
     baseline: {
-      warmup: { duration_ms: 1600 },
+      warmup: { readyMs: 1600 },
       measure: {
-        duration_ms: 1450,
+        readyMs: 1450,
         status: 200,
-        resourceTimings: [
-          { url: '/wp-json/wp/v2/template-parts/theme//header', duration_ms: 480, ttfb_ms: 475 },
-          { url: '/wp-json/wp/v2/posts?per_page=3', duration_ms: 440, ttfb_ms: 438 },
-        ],
+        resources: {
+          count: 2,
+          slowest: [
+            { url: '/wp-json/wp/v2/template-parts/theme//header', durationMs: 480, ttfbMs: 475 },
+            { url: '/wp-json/wp/v2/posts?per_page=3', durationMs: 440, ttfbMs: 438 },
+          ],
+        },
       },
     },
     candidate: {
-      warmup: { duration_ms: 1550 },
+      warmup: { readyMs: 1550 },
       measure: {
-        duration_ms: 950,
+        readyMs: 950,
         status: 200,
-        resourceTimings: [],
+        resources: { count: 0, slowest: [] },
       },
     },
   });

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -23,6 +23,12 @@ const {
   buildSiteEditorPreloadComparison,
   installSiteEditorPreloadCandidateSource,
 } = await import('./lib/site-editor-preload-harness.mjs');
+const {
+  legacyResourceTimings,
+  pageProfilerPath,
+  profileSiteEditorReady,
+  summarizeProfileResourceTimings,
+} = await import('./lib/wordpress-page-profiler.mjs');
 
 function withEnv(values, callback) {
   const previous = {};
@@ -82,6 +88,14 @@ test('requestProfilerPath honors the wordpress_request_profiler_path setting', (
     () => {
       assert.equal(requestProfilerPath(), '/another/profiler.js');
     }
+  );
+});
+
+test('pageProfilerPath sits next to the request profiler by default', () => {
+  const profilerPath = '/tmp/he/wordpress/lib/request-profiler.js';
+  assert.equal(
+    pageProfilerPath({ profilerPath }),
+    '/tmp/he/wordpress/lib/page-profiler.js'
   );
 });
 
@@ -301,6 +315,78 @@ test('buildTimingDeltaSummary forwards unmatched buckets into preview slices', (
   assert.equal(summary.unmatched_browser_preview[0].url, '/missing-from-wp');
   assert.equal(summary.unmatched_wordpress_preview[0].uri, '/wp-cron.php');
   assert.equal(summary.unmatched_wordpress_preview[0].request_id, 'wp-only');
+});
+
+// --- WordPress page profiler adapter ---------------------------------------
+
+test('legacyResourceTimings adapts page-profiler resource summaries for timing correlation', () => {
+  const timings = legacyResourceTimings({
+    resources: {
+      resources: [
+        {
+          url: '/wp-json/wp/v2/posts',
+          kind: 'rest',
+          initiatorType: 'fetch',
+          startMs: 12,
+          durationMs: 90,
+          ttfbMs: 80,
+          transferSize: 120,
+          encodedBodySize: 100,
+          decodedBodySize: 200,
+        },
+      ],
+    },
+  });
+
+  assert.equal(timings.length, 1);
+  assert.equal(timings[0].name, '/wp-json/wp/v2/posts');
+  assert.equal(timings[0].durationMs, 90);
+  assert.equal(timings[0].ttfbMs, 80);
+});
+
+test('summarizeProfileResourceTimings preserves the existing artifact shape', () => {
+  const summary = summarizeProfileResourceTimings([
+    { url: '/slow', kind: 'rest', startMs: 1, durationMs: 120, ttfbMs: 100, transferSize: 9 },
+    { url: '/fast', kind: 'admin', startMs: 2, durationMs: 20, ttfbMs: 10, transferSize: 4 },
+  ]);
+
+  assert.deepEqual(summary.map((row) => row.url), ['/slow', '/fast']);
+  assert.equal(summary[0].duration_ms, 120);
+  assert.equal(summary[0].ttfb_ms, 100);
+  assert.equal(summary[0].transfer_size, 9);
+});
+
+test('profileSiteEditorReady delegates page readiness to the Homeboy Extensions page profiler', async () => {
+  const calls = [];
+  const pageProfiler = {
+    async profileWordPressPage(input) {
+      calls.push(input);
+      return {
+        status: 200,
+        readyMs: 345,
+        resources: {
+          resources: [
+            { url: '/wp-json/wp/v2/types', kind: 'rest', startMs: 3, durationMs: 44, ttfbMs: 40 },
+          ],
+        },
+      };
+    },
+  };
+
+  const result = await profileSiteEditorReady({
+    page: { id: 'fake-page' },
+    siteUrl: 'http://example.test',
+    pageProfiler,
+    wordpressProfilerRows: [{ request_id: 'r1' }],
+    mark: () => {},
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].baseUrl, 'http://example.test');
+  assert.equal(calls[0].spec.path, '/wp-admin/site-editor.php');
+  assert.equal(result.status, 200);
+  assert.equal(result.site_editor_ready_ms, 345);
+  assert.equal(result.resourceTimings[0].url, '/wp-json/wp/v2/types');
 });
 
 // --- WordPress bootstrap timeline -----------------------------------------

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -25,7 +25,8 @@ const {
 } = await import('./lib/site-editor-preload-harness.mjs');
 const {
   pageProfilerPath,
-  profileSiteEditorPage,
+  profileWordPressPage,
+  wordpressPageProfilerSpec,
 } = await import('./lib/wordpress-page-profiler.mjs');
 
 function withEnv(values, callback) {
@@ -94,6 +95,64 @@ test('pageProfilerPath sits next to the request profiler by default', () => {
   assert.equal(
     pageProfilerPath({ profilerPath }),
     '/tmp/he/wordpress/lib/page-profiler.js'
+  );
+});
+
+test('wordpressPageProfilerSpec defaults to Site Editor', () => {
+  withEnv(
+    {
+      HOMEBOY_WORDPRESS_PAGE_PROFILE_SPEC_JSON: undefined,
+      HOMEBOY_WORDPRESS_PAGE_PROFILE_PATH: undefined,
+    },
+    () => {
+      const spec = wordpressPageProfilerSpec();
+      assert.equal(spec.id, 'site-editor');
+      assert.equal(spec.path, '/wp-admin/site-editor.php');
+    }
+  );
+});
+
+test('wordpressPageProfilerSpec builds a generic WordPress page spec from env', () => {
+  withEnv(
+    {
+      HOMEBOY_WORDPRESS_PAGE_PROFILE_SPEC_JSON: undefined,
+      HOMEBOY_WORDPRESS_PAGE_PROFILE_PATH: '/',
+      HOMEBOY_WORDPRESS_PAGE_PROFILE_ID: 'front-page',
+      HOMEBOY_WORDPRESS_PAGE_PROFILE_LABEL: 'Front page',
+      HOMEBOY_WORDPRESS_PAGE_PROFILE_READY_SELECTOR: undefined,
+    },
+    () => {
+      const spec = wordpressPageProfilerSpec();
+      assert.equal(spec.id, 'front-page');
+      assert.equal(spec.label, 'Front page');
+      assert.equal(spec.path, '/');
+      assert.equal(spec.ready.state, 'domcontentloaded');
+      assert.deepEqual(spec.resources.includeResourceSubstrings, [
+        '/wp-json/',
+        '?rest_route=',
+        '/wp-admin/',
+        '/wp-content/',
+        '/wp-includes/',
+      ]);
+    }
+  );
+});
+
+test('wordpressPageProfilerSpec supports selector readiness and resource include overrides', () => {
+  withEnv(
+    {
+      HOMEBOY_WORDPRESS_PAGE_PROFILE_SPEC_JSON: undefined,
+      HOMEBOY_WORDPRESS_PAGE_PROFILE_PATH: '/wp-admin/themes.php',
+      HOMEBOY_WORDPRESS_PAGE_PROFILE_ID: 'themes',
+      HOMEBOY_WORDPRESS_PAGE_PROFILE_READY_SELECTOR: '.theme-browser',
+      HOMEBOY_WORDPRESS_PAGE_PROFILE_RESOURCE_INCLUDE: '/wp-json/,/custom-cache/',
+    },
+    () => {
+      const spec = wordpressPageProfilerSpec();
+      assert.equal(spec.path, '/wp-admin/themes.php');
+      assert.equal(spec.ready.selector, '.theme-browser');
+      assert.deepEqual(spec.resources.includeResourceSubstrings, ['/wp-json/', '/custom-cache/']);
+    }
   );
 });
 
@@ -317,7 +376,7 @@ test('buildTimingDeltaSummary forwards unmatched buckets into preview slices', (
 
 // --- WordPress page profiler adapter ---------------------------------------
 
-test('profileSiteEditorPage delegates page readiness to the Homeboy Extensions page profiler', async () => {
+test('profileWordPressPage delegates page readiness to the Homeboy Extensions page profiler', async () => {
   const calls = [];
   const profile = {
     status: 200,
@@ -335,17 +394,18 @@ test('profileSiteEditorPage delegates page readiness to the Homeboy Extensions p
     },
   };
 
-  const result = await profileSiteEditorPage({
+  const result = await profileWordPressPage({
     page: { id: 'fake-page' },
     siteUrl: 'http://example.test',
     pageProfiler,
+    pageSpec: { id: 'themes', path: '/wp-admin/themes.php', ready: '#wpbody-content' },
     wordpressProfilerRows: [{ request_id: 'r1' }],
     mark: () => {},
   });
 
   assert.equal(calls.length, 1);
   assert.equal(calls[0].baseUrl, 'http://example.test');
-  assert.equal(calls[0].spec.path, '/wp-admin/site-editor.php');
+  assert.equal(calls[0].spec.path, '/wp-admin/themes.php');
   assert.equal(result, profile);
 });
 

--- a/Automattic/studio/bench/studio-site-editor-preload-comparison.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-preload-comparison.bench.mjs
@@ -29,9 +29,10 @@ import {
   uninstallWordPressBootstrapTimeline,
 } from './lib/wordpress-bootstrap-timeline.mjs';
 import {
+  SITE_EDITOR_PAGE_SPEC,
   loadWordPressPageProfiler,
   loadWordPressRequestProfiler,
-  profileSiteEditorPage,
+  profileWordPressPage,
 } from './lib/wordpress-page-profiler.mjs';
 
 const BROWSER_HELPER = process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER;
@@ -75,7 +76,13 @@ async function runBotPath({ label, artifactDir, sitePath, status, requestProfile
       await page.waitForLoadState('networkidle', { timeout: 120000 });
       await mark(`${label}_auto_login_networkidle`);
 
-      warmup = await profileSiteEditorPage({ page, siteUrl: status.siteUrl, pageProfiler, mark });
+      warmup = await profileWordPressPage({
+        page,
+        siteUrl: status.siteUrl,
+        pageProfiler,
+        pageSpec: SITE_EDITOR_PAGE_SPEC,
+        mark,
+      });
       await mark(`${label}_warmup_site_editor_ready`);
 
       await new Promise((resolve) => setTimeout(resolve, 2000));
@@ -83,7 +90,13 @@ async function runBotPath({ label, artifactDir, sitePath, status, requestProfile
       await page.waitForLoadState('networkidle', { timeout: 120000 });
       await mark(`${label}_admin_networkidle_between_runs`);
 
-      measure = await profileSiteEditorPage({ page, siteUrl: status.siteUrl, pageProfiler, mark });
+      measure = await profileWordPressPage({
+        page,
+        siteUrl: status.siteUrl,
+        pageProfiler,
+        pageSpec: SITE_EDITOR_PAGE_SPEC,
+        mark,
+      });
       await mark(`${label}_measure_site_editor_ready`);
     },
   });

--- a/Automattic/studio/bench/studio-site-editor-preload-comparison.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-preload-comparison.bench.mjs
@@ -31,8 +31,7 @@ import {
 import {
   loadWordPressPageProfiler,
   loadWordPressRequestProfiler,
-  profileSiteEditorReady,
-  summarizeProfileResourceTimings,
+  profileSiteEditorPage,
 } from './lib/wordpress-page-profiler.mjs';
 
 const BROWSER_HELPER = process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER;
@@ -76,7 +75,7 @@ async function runBotPath({ label, artifactDir, sitePath, status, requestProfile
       await page.waitForLoadState('networkidle', { timeout: 120000 });
       await mark(`${label}_auto_login_networkidle`);
 
-      warmup = await profileSiteEditorReady({ page, siteUrl: status.siteUrl, pageProfiler, mark });
+      warmup = await profileSiteEditorPage({ page, siteUrl: status.siteUrl, pageProfiler, mark });
       await mark(`${label}_warmup_site_editor_ready`);
 
       await new Promise((resolve) => setTimeout(resolve, 2000));
@@ -84,7 +83,7 @@ async function runBotPath({ label, artifactDir, sitePath, status, requestProfile
       await page.waitForLoadState('networkidle', { timeout: 120000 });
       await mark(`${label}_admin_networkidle_between_runs`);
 
-      measure = await profileSiteEditorReady({ page, siteUrl: status.siteUrl, pageProfiler, mark });
+      measure = await profileSiteEditorPage({ page, siteUrl: status.siteUrl, pageProfiler, mark });
       await mark(`${label}_measure_site_editor_ready`);
     },
   });
@@ -94,8 +93,8 @@ async function runBotPath({ label, artifactDir, sitePath, status, requestProfile
   const wordpressRequests = requestProfiler?.collectWordPressRequestProfiles?.(sitePath) || [];
   const bootstrapRows = await collectWordPressBootstrapTimeline(sitePath);
   const phasedBrowserTimings = flattenPhasedResourceTimings({
-    [`${label}-warmup-site-editor`]: warmup.resourceTimings || [],
-    [`${label}-measure-site-editor`]: measure.resourceTimings || [],
+    [`${label}-warmup-site-editor`]: warmup.resources?.resources || [],
+    [`${label}-measure-site-editor`]: measure.resources?.resources || [],
   });
   const { module: correlator } = loadTimingCorrelator({ profilerPath: requestProfilerPath() });
 
@@ -105,14 +104,8 @@ async function runBotPath({ label, artifactDir, sitePath, status, requestProfile
   return {
     sitePath,
     siteUrl: status.siteUrl,
-    warmup: {
-      ...warmup,
-      resourceTimings: summarizeProfileResourceTimings(warmup.resourceTimings || []),
-    },
-    measure: {
-      ...measure,
-      resourceTimings: summarizeProfileResourceTimings(measure.resourceTimings || []),
-    },
+    warmup,
+    measure,
     timingDeltas: buildTimingDeltaSummary({
       browserResourceTimings: phasedBrowserTimings,
       wordpressRequests,

--- a/Automattic/studio/bench/studio-site-editor-preload-comparison.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-preload-comparison.bench.mjs
@@ -1,8 +1,5 @@
-import { createRequire } from 'node:module';
-import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { performance } from 'node:perf_hooks';
 import {
   STUDIO_PATH,
   artifactDir as studioArtifactDir,
@@ -31,6 +28,12 @@ import {
   summarizeWordPressBootstrapTimeline,
   uninstallWordPressBootstrapTimeline,
 } from './lib/wordpress-bootstrap-timeline.mjs';
+import {
+  loadWordPressPageProfiler,
+  loadWordPressRequestProfiler,
+  profileSiteEditorReady,
+  summarizeProfileResourceTimings,
+} from './lib/wordpress-page-profiler.mjs';
 
 const BROWSER_HELPER = process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER;
 
@@ -39,28 +42,10 @@ if (!BROWSER_HELPER) {
 }
 
 const { runBrowserBench } = await import(BROWSER_HELPER);
-const require = createRequire(import.meta.url);
-
-function loadRequestProfiler() {
-  const profilerPath = requestProfilerPath();
-  if (!profilerPath || !existsSync(profilerPath)) {
-    return { profilerPath, profiler: null };
-  }
-  return { profilerPath, profiler: require(profilerPath) };
-}
 
 function siteAdminUrl(siteUrl, relativePath = '') {
   const base = siteUrl.endsWith('/') ? siteUrl : `${siteUrl}/`;
   return new URL(`wp-admin/${relativePath}`, base).toString();
-}
-
-function scrubUrl(url) {
-  try {
-    const parsed = new URL(url);
-    return `${parsed.pathname}${parsed.search}`;
-  } catch {
-    return String(url || '');
-  }
 }
 
 async function sanitizeArtifact(artifact) {
@@ -71,100 +56,12 @@ async function sanitizeArtifact(artifact) {
   await writeFile(artifact.path, raw.replace(/([?&](?:token|password|key|nonce)=)[^&#\s]+/gi, '$1[redacted]'));
 }
 
-async function collectResourceTimings(page) {
-  const entries = await page.evaluate(() =>
-    performance
-      .getEntriesByType('resource')
-      .filter((entry) => entry.name.includes('/wp-json/') || entry.name.includes('/wp-admin/site-editor.php'))
-      .map((entry) => ({
-        name: entry.name,
-        initiatorType: entry.initiatorType,
-        startTime: entry.startTime,
-        duration: entry.duration,
-        fetchStart: entry.fetchStart,
-        requestStart: entry.requestStart,
-        responseStart: entry.responseStart,
-        responseEnd: entry.responseEnd,
-        transferSize: entry.transferSize,
-        encodedBodySize: entry.encodedBodySize,
-        decodedBodySize: entry.decodedBodySize,
-      }))
-  );
-  return entries;
-}
-
-function summarizeResourceTimings(entries) {
-  return entries
-    .map((entry) => ({
-      url: scrubUrl(entry.name),
-      start_ms: entry.startTime,
-      duration_ms: entry.duration,
-      request_start_ms: entry.requestStart,
-      response_start_ms: entry.responseStart,
-      response_end_ms: entry.responseEnd,
-      ttfb_ms: entry.responseStart - entry.requestStart,
-      transfer_size: entry.transferSize,
-      encoded_body_size: entry.encodedBodySize,
-      decoded_body_size: entry.decodedBodySize,
-    }))
-    .sort((a, b) => b.duration_ms - a.duration_ms);
-}
-
-async function waitForSiteEditorReady(page) {
-  const timings = {};
-  const marks = [];
-  const started = performance.now();
-  const elapsed = () => performance.now() - started;
-  const mark = (name) => marks.push({ name, t_ms: elapsed() });
-
-  const response = await page.goto(siteAdminUrl(page.__studioSiteUrl, 'site-editor.php'), {
-    waitUntil: 'commit',
-    timeout: 120000,
-  });
-  timings.commit_ms = elapsed();
-  timings.status = response ? response.status() : 0;
-  mark('commit');
-
-  await page.waitForSelector('iframe[name="editor-canvas"]', { state: 'visible', timeout: 120000 });
-  timings.editor_canvas_iframe_visible_ms = elapsed();
-  mark('iframe-visible');
-
-  const frame = page.frame({ name: 'editor-canvas' });
-  if (!frame) {
-    throw new Error('Site Editor canvas frame not found');
-  }
-
-  await frame.waitForLoadState('domcontentloaded', { timeout: 120000 });
-  timings.editor_canvas_domcontentloaded_ms = elapsed();
-  mark('iframe-domcontentloaded');
-
-  await frame.waitForSelector('[data-block]', { timeout: 60000 });
-  timings.first_data_block_ms = elapsed();
-  mark('first-data-block');
-
-  await frame.waitForFunction(
-    () =>
-      document.querySelectorAll('[data-block]').length > 0 &&
-      !document.querySelector('.components-spinner') &&
-      !document.querySelector('.is-loading') &&
-      !document.querySelector('.wp-block-editor__loading'),
-    { timeout: 60000 }
-  );
-  timings.site_editor_ready_ms = elapsed();
-  timings.duration_ms = timings.site_editor_ready_ms;
-  mark('ready');
-  timings.marks = marks;
-  timings.resourceTimings = await collectResourceTimings(page);
-
-  return timings;
-}
-
-async function runBotPath({ label, artifactDir, sitePath, status, profiler, candidate }) {
+async function runBotPath({ label, artifactDir, sitePath, status, requestProfiler, pageProfiler, candidate }) {
   if (candidate) {
     await installSiteEditorPreloadCandidate(sitePath);
   }
   await installWordPressBootstrapTimeline(sitePath, { clearArtifact: true });
-  profiler?.installWordPressRequestProfiler?.(sitePath, { clearArtifact: true });
+  requestProfiler?.installWordPressRequestProfiler?.(sitePath, { clearArtifact: true });
 
   let warmup = {};
   let measure = {};
@@ -179,7 +76,7 @@ async function runBotPath({ label, artifactDir, sitePath, status, profiler, cand
       await page.waitForLoadState('networkidle', { timeout: 120000 });
       await mark(`${label}_auto_login_networkidle`);
 
-      warmup = await waitForSiteEditorReady(page);
+      warmup = await profileSiteEditorReady({ page, siteUrl: status.siteUrl, pageProfiler, mark });
       await mark(`${label}_warmup_site_editor_ready`);
 
       await new Promise((resolve) => setTimeout(resolve, 2000));
@@ -187,14 +84,14 @@ async function runBotPath({ label, artifactDir, sitePath, status, profiler, cand
       await page.waitForLoadState('networkidle', { timeout: 120000 });
       await mark(`${label}_admin_networkidle_between_runs`);
 
-      measure = await waitForSiteEditorReady(page);
+      measure = await profileSiteEditorReady({ page, siteUrl: status.siteUrl, pageProfiler, mark });
       await mark(`${label}_measure_site_editor_ready`);
     },
   });
 
   await sanitizeArtifact(browserResult.artifacts?.network);
 
-  const wordpressRequests = profiler?.collectWordPressRequestProfiles?.(sitePath) || [];
+  const wordpressRequests = requestProfiler?.collectWordPressRequestProfiles?.(sitePath) || [];
   const bootstrapRows = await collectWordPressBootstrapTimeline(sitePath);
   const phasedBrowserTimings = flattenPhasedResourceTimings({
     [`${label}-warmup-site-editor`]: warmup.resourceTimings || [],
@@ -202,7 +99,7 @@ async function runBotPath({ label, artifactDir, sitePath, status, profiler, cand
   });
   const { module: correlator } = loadTimingCorrelator({ profilerPath: requestProfilerPath() });
 
-  profiler?.uninstallWordPressRequestProfiler?.(sitePath);
+  requestProfiler?.uninstallWordPressRequestProfiler?.(sitePath);
   await uninstallWordPressBootstrapTimeline(sitePath);
 
   return {
@@ -210,11 +107,11 @@ async function runBotPath({ label, artifactDir, sitePath, status, profiler, cand
     siteUrl: status.siteUrl,
     warmup: {
       ...warmup,
-      resourceTimings: summarizeResourceTimings(warmup.resourceTimings || []),
+      resourceTimings: summarizeProfileResourceTimings(warmup.resourceTimings || []),
     },
     measure: {
       ...measure,
-      resourceTimings: summarizeResourceTimings(measure.resourceTimings || []),
+      resourceTimings: summarizeProfileResourceTimings(measure.resourceTimings || []),
     },
     timingDeltas: buildTimingDeltaSummary({
       browserResourceTimings: phasedBrowserTimings,
@@ -301,7 +198,8 @@ export default async function studioSiteEditorPreloadComparisonBench() {
   await mkdir(artifactDir, { recursive: true });
 
   const totalStarted = Date.now();
-  const { profilerPath, profiler } = loadRequestProfiler();
+  const { path: profilerPath, module: requestProfiler } = loadWordPressRequestProfiler();
+  const { path: pageProfilerPath, module: pageProfiler } = loadWordPressPageProfiler({ profilerPath });
   const baselineSitePath = path.join(artifactDir, 'baseline-site');
   const candidateSitePath = path.join(artifactDir, 'candidate-site');
   let baselineCreate;
@@ -323,7 +221,8 @@ export default async function studioSiteEditorPreloadComparisonBench() {
       artifactDir,
       sitePath: baselineSitePath,
       status: baselineSite.status,
-      profiler,
+      requestProfiler,
+      pageProfiler,
       candidate: false,
     });
 
@@ -338,7 +237,8 @@ export default async function studioSiteEditorPreloadComparisonBench() {
       artifactDir,
       sitePath: candidateSitePath,
       status: candidateSite.status,
-      profiler,
+      requestProfiler,
+      pageProfiler,
       candidate: true,
     });
 
@@ -352,7 +252,9 @@ export default async function studioSiteEditorPreloadComparisonBench() {
           variant: currentVariant,
           studioPath: STUDIO_PATH,
           profilerPath,
-          profilerAvailable: Boolean(profiler),
+          profilerAvailable: Boolean(requestProfiler),
+          pageProfilerPath,
+          pageProfilerAvailable: Boolean(pageProfiler),
           timings: {
             baseline_site_create_ms: baselineCreate.elapsedMs,
             baseline_site_status_ms: baselineStatusResult.elapsedMs,
@@ -409,8 +311,8 @@ export default async function studioSiteEditorPreloadComparisonBench() {
       },
     };
   } finally {
-    profiler?.uninstallWordPressRequestProfiler?.(baselineSitePath);
-    profiler?.uninstallWordPressRequestProfiler?.(candidateSitePath);
+    requestProfiler?.uninstallWordPressRequestProfiler?.(baselineSitePath);
+    requestProfiler?.uninstallWordPressRequestProfiler?.(candidateSitePath);
     await uninstallWordPressBootstrapTimeline(baselineSitePath);
     await uninstallWordPressBootstrapTimeline(candidateSitePath);
     await stopStudioSite(baselineSitePath, { timeoutMs: 90000 });


### PR DESCRIPTION
## Summary
- Add a Studio bench adapter for the Homeboy Extensions WordPress page profiler.
- Refactor the Site Editor diagnostics and preload comparison rigs to reuse the page profiler for navigation, readiness, and resource summaries.
- Add unit coverage for the adapter path while preserving the existing raw artifact shape.
- Add existing-site profiling support for WordPress page diagnostics, including temporary local plugin path swaps with automatic restore.

## Verification
- `node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `node --check Automattic/studio/bench/lib/wordpress-page-profiler.mjs`
- `node --check Automattic/studio/bench/studio-site-editor-preload-comparison.bench.mjs`
- `node --check Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs`
- `node --check Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `node --check Automattic/studio/bench/lib/studio-bench.mjs`
- `git diff --check`
- Existing-site profile run against `intelligence-chubes4` using a Data Machine worktree plugin swap; original plugin path restored afterward.

## Notes
- `homeboy lint --path /Users/chubes/Developer/homeboy-rigs@use-wordpress-page-profiler` could not run because this worktree has no configured extension provider.
- Retrying with `--extension nodejs` also could not run because there is no `package.json` at or above the worktree root.
- `homeboy bench --rig studio-combined` currently refuses to run because rig check catches a separate proc_open/glue regression in the materialized Studio install; direct workload execution was used for the existing-site evidence after `homeboy rig up studio-combined` succeeded.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the refactor, tests, existing-site profiling hook, and validation runs; Chris remains responsible for review and merge.