### PR TITLE
Document Studio slow-path benchmark matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,30 @@ homeboy rig up studio-combined
 homeboy rig down studio-combined
 ```
 
-`rigs/studio-combined/rig.json` also declares the `studio-site-create` bench workload for timing fresh Studio site provisioning through the combined-fixes dev copy.
+`rigs/studio-combined/rig.json` also declares Studio slow-path bench workloads for timing fresh provisioning, SQLite drop-in startup behavior, wp-admin page loads, and Site Editor readiness through the combined-fixes dev copy.
 
 ```bash
 homeboy bench --rig studio-combined --scenario studio-site-create --iterations 1 --shared-state /tmp/studio-site-create-bench
 ```
 
 The workload creates one `--no-start` site and one normally-started site per iteration, then reports create, started-site status, stop, and total timings. Artifacts are written below the shared-state directory for inspection.
+
+Use this focused matrix when investigating user reports that Studio feels slow, hangs during local site startup, or returns intermittent 502 responses:
+
+```bash
+# CLI-only provisioning and startup boundaries.
+homeboy bench --rig studio-combined --scenario studio-site-create --iterations 1 --shared-state /tmp/studio-slow-path-bench
+homeboy bench --rig studio-combined --scenario studio-db-dropin-startup --iterations 1 --shared-state /tmp/studio-slow-path-bench
+
+# Browser-visible wp-admin paths.
+homeboy bench --rig studio-combined --scenario studio-dashboard-browser --iterations 1 --shared-state /tmp/studio-slow-path-bench
+homeboy bench --rig studio-combined --scenario studio-admin-theme-page-browser --iterations 1 --shared-state /tmp/studio-slow-path-bench
+
+# Site Editor readiness and REST/bootstrap diagnostics.
+homeboy bench --rig studio-combined --scenario studio-site-editor-diagnostics --iterations 1 --shared-state /tmp/studio-slow-path-bench
+```
+
+Run the CLI-only scenarios first to separate Studio provisioning and Playground startup cost from browser-visible WordPress admin cost. Use the browser scenarios next when the slow path reproduces after the site is running. Use `studio-site-editor-diagnostics` when the signal points at Site Editor, REST request waterfalls, WordPress bootstrap time, or browser-vs-WordPress transport overhead.
 
 The Studio trace workload exercises the packaged app at `apps/studio/out` and records create-site readiness boundaries across the desktop shell, CLI log output, `cli.json`, HTTP readiness, `getSiteDetails()`, and the visible running-state UI.
 


### PR DESCRIPTION
## Summary
- Document the Studio slow-path benchmark matrix for provisioning, DB drop-in startup, wp-admin browser paths, and Site Editor diagnostics.
- Add `studio-page-timing-matrix`, a configurable browser benchmark that records per-page status, elapsed time, DOMContentLoaded, load, TTFB, FCP, request counts, failed requests, slowest requests, login regressions, and timeout markers.
- Support `studio_page_timing_paths=admin-menu` so the benchmark can crawl every wp-admin URL exposed in the current site's admin menu, including plugin-added admin screens.

## Verification
- `node --check Automattic/studio/bench/studio-page-timing-matrix.bench.mjs` passed.
- `homeboy bench --rig studio-combined --scenario studio-site-create --iterations 1 --shared-state /tmp/studio-slow-path-bench --ignore-baseline` passed. Run ID: `6eb3470f-b559-426c-8e7f-c106a303a946`.
- `homeboy bench --rig studio-combined --scenario studio-db-dropin-startup --iterations 1 --shared-state /tmp/studio-slow-path-bench --ignore-baseline` passed. Run ID: `87f21a3d-919f-4456-8d1a-b3855ff5ff5f`.
- Direct workload smoke with `STUDIO_PAGE_TIMING_PATHS='/,/wp-admin/index.php'` passed: 2 pages, 0 failing pages, no login regression.
- Direct default matrix smoke passed: 9 pages, 0 failing pages; `post-new.php` and `site-editor.php` hit the 30s network-idle cap, which is useful diagnostic signal.
- Direct `admin-menu` matrix smoke passed: 33 wp-admin screens, 0 failing pages; captured slow editor/network-idle behavior and per-page request counts.

## Note
- A local `homeboy rig install --id studio-combined ./Automattic/studio` attempt failed before scenario execution because this machine has stale Homeboy stack-source metadata pointing at deleted worktrees. The workload itself was verified directly with the same env Homeboy provides.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the README update and benchmark workload, ran smoke checks, and summarized observed benchmark evidence; Chris remains responsible for review and merge.