### PR TITLE
Relax profile plugin activation timeout

### DIFF
--- a/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
@@ -117,10 +117,11 @@ async function installProfilePlugins(sitePath) {
   }
 
   const activate = installed.filter((plugin) => plugin.activate !== false);
-  if (activate.length > 0) {
+  const activateTimeoutMs = Number(process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGIN_ACTIVATE_TIMEOUT_MS || 420000);
+  for (const plugin of activate) {
     await runCli(
-      ['wp', 'plugin', 'activate', ...activate.map((plugin) => plugin.plugin || plugin.slug)],
-      { cwd: sitePath, timeoutMs: 120000 }
+      ['wp', 'plugin', 'activate', plugin.plugin || plugin.slug],
+      { cwd: sitePath, timeoutMs: activateTimeoutMs }
     );
   }
 


### PR DESCRIPTION
## Summary
- Activate WordPress page profile plugins one at a time so slow setup is easier to attribute.
- Raise the default activation timeout to 420s and allow overriding it with `HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGIN_ACTIVATE_TIMEOUT_MS`.

## Testing
- `node --test /Users/chubes/Developer/homeboy-rigs@datamachine-pipelines-page-profile/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the Data Machine profiling setup timeout and drafted the focused rig change; Chris reviewed the direction.