### PR TITLE
Start existing profile sites before diagnostics

### DIFF
--- a/Automattic/studio/bench/lib/studio-bench.mjs
+++ b/Automattic/studio/bench/lib/studio-bench.mjs
@@ -155,6 +155,10 @@ export async function stopStudioSite(sitePath, options = {}) {
   return runCli(['site', 'stop', '--path', sitePath], { allowFailure: true, ...options });
 }
 
+export async function startStudioSite(sitePath, options = {}) {
+  return runCli(['site', 'start', '--path', sitePath, '--skip-browser'], options);
+}
+
 export async function studioSiteStatus(sitePath, options = {}) {
   return runCli(['site', 'status', '--path', sitePath, '--format', 'json'], options);
 }

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
@@ -11,6 +11,7 @@ import {
   redact,
   runCli,
   safeResult,
+  startStudioSite,
   stopStudioSite,
   studioSiteStatus,
   variant,
@@ -224,6 +225,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
   const { path: pageProfilerPath, module: pageProfiler } = loadWordPressPageProfiler({ profilerPath });
   const { path: correlatorPath, module: correlator } = loadTimingCorrelator({ profilerPath });
   let create;
+  let start;
   let statusResult;
   let stop;
   let status;
@@ -242,6 +244,8 @@ export default async function studioSiteEditorDiagnosticsBench() {
   try {
     if (createdSite) {
       create = await createSite(sitePath);
+    } else {
+      start = await startStudioSite(sitePath, { timeoutMs: 240000 });
     }
     installedPlugins = await installProfilePlugins(sitePath);
     statusResult = await siteStatus(sitePath);
@@ -319,7 +323,9 @@ export default async function studioSiteEditorDiagnosticsBench() {
     profiler?.uninstallWordPressRequestProfiler?.(sitePath);
     wordpressBootstrapTimeline = await collectWordPressBootstrapTimeline(sitePath);
     await uninstallWordPressBootstrapTimeline(sitePath);
-    stop = await stopSite(sitePath);
+    if (createdSite) {
+      stop = await stopSite(sitePath);
+    }
 
     const totalElapsedMs = Date.now() - totalStarted;
     const measureResourceTimingSummary = measureProfile.resources?.slowest || [];
@@ -390,6 +396,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
           timingDeltas,
           commands: {
             create: safeResult(create),
+            start: safeResult(start),
             status: safeResult(statusResult),
             stop: safeResult(stop),
           },


### PR DESCRIPTION
## Summary
- Start `HOMEBOY_WORDPRESS_PAGE_PROFILE_SITE_PATH` sites before reading Studio status so existing-site profiling gets a fresh `autoLoginUrl`.
- Preserve existing sites after diagnostics by only stopping sites created by the workload.
- Record the start command result in the raw diagnostics artifact.

## Testing
- `node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- Existing-site Data Machine pipelines profile passed: Homeboy run `bcdca196-64dd-4be2-9550-5741e64cf1c4`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the existing-site profiling status/login failure, drafted the harness fix, and validated it against a Data Machine pipelines page profile.