### PR TITLE
Add Data Machine pipelines scale profile workload

### DIFF
--- a/Automattic/studio/bench/lib/datamachine-pipelines-scale-profile.mjs
+++ b/Automattic/studio/bench/lib/datamachine-pipelines-scale-profile.mjs
@@ -1,0 +1,390 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const REST_ENDPOINTS = [
+  { key: 'pipelines', needle: '/datamachine/v1/pipelines' },
+  { key: 'flows', needle: '/datamachine/v1/flows' },
+  { key: 'handlers', needle: '/datamachine/v1/handlers' },
+  { key: 'agents', needle: '/datamachine/v1/agents' },
+];
+
+function intEnv(name, fallback) {
+  const value = Number(process.env[name] || fallback);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative number`);
+  }
+  return Math.floor(value);
+}
+
+function metric(value) {
+  const number = Number(value ?? 0);
+  return Number.isFinite(number) ? Math.round(number) : 0;
+}
+
+function pageUrl(siteUrl, pagePath) {
+  const base = siteUrl.endsWith('/') ? siteUrl : `${siteUrl}/`;
+  return new URL(pagePath.replace(/^\/+/, ''), base).toString();
+}
+
+async function collectResources(page) {
+  return page.evaluate(() =>
+    performance.getEntriesByType('resource').map((entry) => ({
+      name: entry.name,
+      url: entry.name,
+      initiatorType: entry.initiatorType,
+      startTime: entry.startTime,
+      responseStart: entry.responseStart,
+      responseEnd: entry.responseEnd,
+      requestStart: entry.requestStart,
+      duration: entry.duration,
+      transferSize: entry.transferSize,
+      encodedBodySize: entry.encodedBodySize,
+      decodedBodySize: entry.decodedBodySize,
+    }))
+  );
+}
+
+function normalizeUrl(url) {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return String(url || '');
+  }
+}
+
+function summarizeResources(resources) {
+  const mapped = resources.map((entry) => ({
+    url: normalizeUrl(entry.url || entry.name),
+    kind: String(entry.url || entry.name).includes('/wp-json/') ? 'rest' : 'other',
+    initiatorType: entry.initiatorType,
+    startMs: metric(entry.startTime),
+    responseEndMs: metric(entry.responseEnd),
+    durationMs: metric(entry.duration),
+    ttfbMs: metric(entry.responseStart - entry.requestStart),
+    transferSize: metric(entry.transferSize),
+    encodedBodySize: metric(entry.encodedBodySize),
+    decodedBodySize: metric(entry.decodedBodySize),
+  }));
+
+  return {
+    count: mapped.length,
+    restCount: mapped.filter((entry) => entry.kind === 'rest').length,
+    slowest: mapped.slice().sort((a, b) => b.durationMs - a.durationMs).slice(0, 20),
+    resources: mapped,
+  };
+}
+
+function summarizeRestEndpoints(resources) {
+  const summary = {};
+  for (const endpoint of REST_ENDPOINTS) {
+    const matches = resources
+      .filter((entry) => String(entry.url || entry.name).includes(endpoint.needle))
+      .map((entry) => ({
+        url: normalizeUrl(entry.url || entry.name),
+        startMs: metric(entry.startTime),
+        responseEndMs: metric(entry.responseEnd),
+        durationMs: metric(entry.duration),
+        ttfbMs: metric(entry.responseStart - entry.requestStart),
+        transferSize: metric(entry.transferSize),
+        decodedBodySize: metric(entry.decodedBodySize),
+      }))
+      .sort((a, b) => b.durationMs - a.durationMs);
+
+    summary[endpoint.key] = {
+      count: matches.length,
+      totalDurationMs: matches.reduce((sum, entry) => sum + entry.durationMs, 0),
+      slowestDurationMs: matches[0]?.durationMs || 0,
+      requests: matches,
+    };
+  }
+  return summary;
+}
+
+function endpointKey(url) {
+  for (const endpoint of REST_ENDPOINTS) {
+    if (String(url || '').includes(endpoint.needle)) {
+      return endpoint.key;
+    }
+  }
+  return '';
+}
+
+async function markPhase(mark, name, started) {
+  if (typeof mark === 'function') {
+    await mark(`datamachine_pipelines_${name}`);
+  }
+  return Date.now() - started;
+}
+
+async function waitForProfileSelector(page, selector, options = {}) {
+  try {
+    await page.waitForSelector(selector, { timeout: options.timeout });
+  } catch (error) {
+    const url = typeof page.url === 'function' ? page.url() : '';
+    const bodyText = await page.locator('body').innerText({ timeout: 1000 }).catch(() => '');
+    const debug = await page.evaluate(() => ({
+      dataMachineConfig: Boolean(window.dataMachineConfig),
+      root: document.querySelector('#datamachine-react-root')?.outerHTML || '',
+      dataMachineScripts: [...document.scripts].map((script) => script.src).filter((src) => src.includes('data-machine')),
+      moduleScripts: [...document.scripts].filter((script) => script.type === 'module').map((script) => script.src).slice(-10),
+    })).catch(() => ({}));
+    const messages = (options.browserMessages || []).slice(-20);
+    throw new Error(`${error.message}; current_url=${url}; body=${bodyText.slice(0, 500)}; messages=${JSON.stringify(messages).slice(0, 1000)}; debug=${JSON.stringify(debug).slice(0, 1000)}`);
+  }
+}
+
+export async function setupWordPressPageProfile({ sitePath, artifactDir }) {
+  const pipelineCount = intEnv('HOMEBOY_DATAMACHINE_PIPELINE_COUNT', 12);
+  const flowsPerPipeline = intEnv('HOMEBOY_DATAMACHINE_FLOWS_PER_PIPELINE', 8);
+  const stepsPerFlow = intEnv('HOMEBOY_DATAMACHINE_STEPS_PER_FLOW', 6);
+  const configPayloadSize = intEnv('HOMEBOY_DATAMACHINE_CONFIG_PAYLOAD_SIZE', 1024);
+  const seedSlug = process.env.HOMEBOY_DATAMACHINE_SCALE_SEED_SLUG || `homeboy-scale-${process.pid}`;
+  const loaderPath = path.join(sitePath, 'wp-content', 'mu-plugins', 'homeboy-datamachine-scale-profile.php');
+  const artifactPath = path.join(artifactDir, 'datamachine-scale-seed.json');
+  const signature = JSON.stringify({ pipelineCount, flowsPerPipeline, stepsPerFlow, configPayloadSize, seedSlug });
+  const php = `<?php
+/**
+ * Temporary Homeboy Data Machine scale profile loader.
+ * Generated by homeboy-rigs and removed after the workload completes.
+ */
+
+add_action('muplugins_loaded', function () {
+    $plugins = array(
+        WP_PLUGIN_DIR . '/agents-api/agents-api.php',
+        WP_PLUGIN_DIR . '/data-machine/data-machine.php',
+    );
+    foreach ($plugins as $plugin_file) {
+        if (is_readable($plugin_file)) {
+            require_once $plugin_file;
+        }
+    }
+}, 1);
+
+add_action('admin_init', function () {
+    if (function_exists('datamachine_register_capabilities')) {
+        datamachine_register_capabilities();
+    }
+    if (function_exists('datamachine_activate_defaults_for_site')) {
+        datamachine_activate_defaults_for_site();
+    }
+
+    if (!current_user_can('manage_options')) {
+        return;
+    }
+
+    $signature = ${JSON.stringify(signature)};
+    if (get_option('homeboy_datamachine_scale_signature') === $signature) {
+        return;
+    }
+
+    $pipeline_count = ${pipelineCount};
+    $flows_per_pipeline = ${flowsPerPipeline};
+    $steps_per_flow = ${stepsPerFlow};
+    $config_payload_size = ${configPayloadSize};
+    $seed_slug = sanitize_title(${JSON.stringify(seedSlug)});
+    $payload = str_repeat('x', max(0, $config_payload_size));
+
+    $pipelines = new \\DataMachine\\Core\\Database\\Pipelines\\Pipelines();
+    $flows = new \\DataMachine\\Core\\Database\\Flows\\Flows();
+    $pipelines->create_table();
+    $pipelines->migrate_columns();
+    $flows->create_table();
+    $flows->migrate_columns();
+
+    global $wpdb;
+    $pipelines_table = $wpdb->prefix . 'datamachine_pipelines';
+    $flows_table = $wpdb->prefix . 'datamachine_flows';
+    $existing_ids = $wpdb->get_col(
+      $wpdb->prepare("SELECT pipeline_id FROM \{$pipelines_table} WHERE portable_slug LIKE %s", $seed_slug . '-%')
+    );
+    if ($existing_ids) {
+      $placeholders = implode(',', array_fill(0, count($existing_ids), '%d'));
+      $wpdb->query($wpdb->prepare("DELETE FROM \{$flows_table} WHERE pipeline_id IN ($placeholders)", array_map('intval', $existing_ids)));
+      $wpdb->query($wpdb->prepare("DELETE FROM \{$pipelines_table} WHERE pipeline_id IN ($placeholders)", array_map('intval', $existing_ids)));
+    }
+
+    $created_pipeline_ids = array();
+    for ($pipeline_index = 1; $pipeline_index <= $pipeline_count; $pipeline_index++) {
+      $pipeline_config = array();
+      for ($step_index = 1; $step_index <= $steps_per_flow; $step_index++) {
+        $step_id = sprintf('scale_pipeline_%03d_step_%03d', $pipeline_index, $step_index);
+        $pipeline_config[$step_id] = array(
+          'pipeline_step_id' => $step_id,
+          'step_type' => $step_index % 2 === 0 ? 'ai' : 'system_task',
+          'execution_order' => $step_index,
+          'handler_config' => array(
+            'task' => 'profile_scale_fixture',
+            'payload' => $payload,
+            'pipeline_index' => $pipeline_index,
+            'step_index' => $step_index,
+          ),
+          'system_prompt' => 'Scale fixture prompt ' . $pipeline_index . '.' . $step_index . ' ' . $payload,
+        );
+      }
+
+      $pipeline_id = $pipelines->create_pipeline(array(
+        'pipeline_name' => sprintf('Homeboy Scale Pipeline %03d', $pipeline_index),
+        'pipeline_config' => $pipeline_config,
+        'user_id' => 1,
+        'portable_slug' => sprintf('%s-pipeline-%03d', $seed_slug, $pipeline_index),
+      ));
+      if (!$pipeline_id) {
+        throw new RuntimeException('Failed to create scale pipeline ' . $pipeline_index);
+      }
+      $created_pipeline_ids[] = $pipeline_id;
+
+      for ($flow_index = 1; $flow_index <= $flows_per_pipeline; $flow_index++) {
+        $flow_config = array();
+        foreach ($pipeline_config as $step_id => $step_config) {
+          $flow_config[$step_id] = array(
+            'pipeline_step_id' => $step_id,
+            'flow_step_id' => sprintf('scale_flow_%03d_%03d_%s', $pipeline_index, $flow_index, $step_id),
+            'step_type' => $step_config['step_type'],
+            'handler_config' => array_merge($step_config['handler_config'], array(
+              'flow_index' => $flow_index,
+              'payload' => $payload,
+            )),
+          );
+        }
+
+        $flow_id = $flows->create_flow(array(
+          'pipeline_id' => $pipeline_id,
+          'flow_name' => sprintf('Homeboy Scale Flow %03d.%03d', $pipeline_index, $flow_index),
+          'flow_config' => $flow_config,
+          'scheduling_config' => array('type' => 'manual'),
+          'user_id' => 1,
+          'portable_slug' => sprintf('%s-flow-%03d-%03d', $seed_slug, $pipeline_index, $flow_index),
+        ));
+        if (!$flow_id) {
+          throw new RuntimeException('Failed to create scale flow ' . $pipeline_index . '.' . $flow_index);
+        }
+      }
+    }
+
+    update_option('homeboy_datamachine_scale_signature', $signature, false);
+  });
+`;
+
+  await mkdir(path.dirname(loaderPath), { recursive: true });
+  await writeFile(loaderPath, php);
+  await writeFile(
+    artifactPath,
+    JSON.stringify({ pipelineCount, flowsPerPipeline, stepsPerFlow, configPayloadSize, seedSlug, loaderPath }, null, 2)
+  );
+  return { pipelineCount, flowsPerPipeline, stepsPerFlow, configPayloadSize, seedSlug, loaderPath, artifactPath };
+}
+
+export async function cleanupWordPressPageProfile({ setupProfile }) {
+  if (setupProfile?.loaderPath) {
+    await rm(setupProfile.loaderPath, { force: true });
+  }
+}
+
+export async function profileWordPressPage({ page, siteUrl, pageSpec, mark }) {
+  const spec = pageSpec || {};
+  const url = pageUrl(siteUrl, spec.path || '/wp-admin/admin.php?page=datamachine-pipelines');
+  const started = Date.now();
+  const phaseTimings = {};
+  const browserMessages = [];
+  const restSeen = new Map();
+  const restWaiters = new Map();
+
+  function noteRestResponse(response) {
+    const responseUrl = response.url();
+    const key = endpointKey(responseUrl);
+    if (!key) {
+      return;
+    }
+    const record = { status: response.status(), url: normalizeUrl(responseUrl), elapsedMs: Date.now() - started };
+    restSeen.set(key, record);
+    browserMessages.push(`rest: ${record.status} ${record.url}`);
+    const waiters = restWaiters.get(key) || [];
+    restWaiters.delete(key);
+    for (const resolve of waiters) {
+      resolve(record);
+    }
+  }
+
+  function waitForRest(key, timeout = spec.timeout || 120000) {
+    if (restSeen.has(key)) {
+      return Promise.resolve(restSeen.get(key));
+    }
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`Timed out waiting for Data Machine REST ${key}`)), timeout);
+      const waiters = restWaiters.get(key) || [];
+      waiters.push((record) => {
+        clearTimeout(timer);
+        resolve(record);
+      });
+      restWaiters.set(key, waiters);
+    });
+  }
+
+  page.on('console', (message) => {
+    if (message.type() === 'error' || message.type() === 'warning') {
+      browserMessages.push(`${message.type()}: ${message.text()}`);
+    }
+  });
+  page.on('pageerror', (error) => {
+    browserMessages.push(`pageerror: ${error.message}`);
+  });
+  page.on('response', (response) => {
+    noteRestResponse(response);
+  });
+
+  const response = await page.goto(url, {
+    waitUntil: 'commit',
+    timeout: spec.timeout || 120000,
+  });
+  if (typeof mark === 'function') {
+    await mark('datamachine_pipelines_commit');
+  }
+
+  const waitOptions = { timeout: spec.timeout || 120000, browserMessages };
+
+  await waitForProfileSelector(page, 'body.wp-admin, #wpbody-content', waitOptions);
+  phaseTimings.adminShellReadyMs = await markPhase(mark, 'admin_shell_ready', started);
+
+  await waitForProfileSelector(page, '.datamachine-pipelines-layout', waitOptions);
+  phaseTimings.pipelineShellReadyMs = await markPhase(mark, 'pipeline_shell_ready', started);
+
+  await waitForRest('pipelines');
+  await waitForRest('handlers');
+  phaseTimings.pipelineStepsReadyMs = await markPhase(mark, 'pipeline_steps_ready', started);
+
+  await waitForRest('flows');
+  phaseTimings.flowsSectionReadyMs = await markPhase(mark, 'flows_section_ready', started);
+
+  await page.waitForLoadState('networkidle', { timeout: spec.timeout || 120000 });
+  phaseTimings.networkIdleMs = await markPhase(mark, 'network_idle', started);
+
+  const resources = await collectResources(page);
+  const resourceSummary = summarizeResources(resources);
+  const restEndpointTimings = summarizeRestEndpoints(resources);
+  const readyMs = phaseTimings.flowsSectionReadyMs;
+
+  return {
+    id: spec.id || 'datamachine-pipelines-scale',
+    label: spec.label || 'Data Machine Pipelines Scale Profile',
+    url,
+    path: new URL(url).pathname + new URL(url).search,
+    status: response && typeof response.status === 'function' ? response.status() : 0,
+    readyMs,
+    phaseTimings,
+    resources: resourceSummary,
+    restEndpointTimings,
+    restWaterfall: restEndpointTimings,
+    metrics: {
+      datamachine_pipelines_admin_shell_ready_ms: metric(phaseTimings.adminShellReadyMs),
+      datamachine_pipelines_pipeline_shell_ready_ms: metric(phaseTimings.pipelineShellReadyMs),
+      datamachine_pipelines_pipeline_steps_ready_ms: metric(phaseTimings.pipelineStepsReadyMs),
+      datamachine_pipelines_flows_section_ready_ms: metric(phaseTimings.flowsSectionReadyMs),
+      datamachine_pipelines_network_idle_ms: metric(phaseTimings.networkIdleMs),
+      datamachine_pipelines_rest_pipelines_ms: metric(restEndpointTimings.pipelines?.slowestDurationMs),
+      datamachine_pipelines_rest_flows_ms: metric(restEndpointTimings.flows?.slowestDurationMs),
+      datamachine_pipelines_rest_handlers_ms: metric(restEndpointTimings.handlers?.slowestDurationMs),
+      datamachine_pipelines_rest_agents_ms: metric(restEndpointTimings.agents?.slowestDurationMs),
+    },
+  };
+}

--- a/Automattic/studio/bench/studio-datamachine-pipelines-scale-profile.bench.mjs
+++ b/Automattic/studio/bench/studio-datamachine-pipelines-scale-profile.bench.mjs
@@ -1,0 +1,56 @@
+import path from 'node:path';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function defaultPluginPath(envName, repoName) {
+  if (process.env[envName]) {
+    return process.env[envName];
+  }
+  const studioPluginPath = path.join('/Users/chubes/Studio/intelligence-chubes4/wp-content/plugins', repoName);
+  if (existsSync(studioPluginPath)) {
+    return studioPluginPath;
+  }
+  return path.join('/Users/chubes/Developer', repoName);
+}
+
+process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_ID ||= 'datamachine-pipelines-scale';
+process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_LABEL ||= 'Data Machine Pipelines Scale Profile';
+process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_PATH ||= '/wp-admin/admin.php?page=datamachine-pipelines';
+process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_TIMEOUT ||= '180000';
+process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_RESOURCE_INCLUDE ||= '/wp-json/datamachine/v1,/wp-admin/admin.php?page=datamachine-pipelines,/wp-content/plugins/data-machine';
+process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_EXTENSION_MODULE ||= path.join(
+  __dirname,
+  'lib/datamachine-pipelines-scale-profile.mjs'
+);
+
+process.env.HOMEBOY_DATAMACHINE_PIPELINE_COUNT ||= '12';
+process.env.HOMEBOY_DATAMACHINE_FLOWS_PER_PIPELINE ||= '8';
+process.env.HOMEBOY_DATAMACHINE_STEPS_PER_FLOW ||= '6';
+process.env.HOMEBOY_DATAMACHINE_CONFIG_PAYLOAD_SIZE ||= '1024';
+
+if (!process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGINS_JSON) {
+  process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGINS_JSON = JSON.stringify([
+    {
+      slug: 'agents-api',
+      plugin: 'agents-api',
+      path: defaultPluginPath('HOMEBOY_AGENTS_API_PLUGIN_PATH', 'agents-api'),
+      activate: false,
+      copy: true,
+    },
+    {
+      slug: 'data-machine',
+      plugin: 'data-machine',
+      path: defaultPluginPath('HOMEBOY_DATAMACHINE_PLUGIN_PATH', 'data-machine'),
+      activate: false,
+      copy: true,
+    },
+  ]);
+}
+
+const { default: runWordPressPageDiagnostics } = await import('./studio-site-editor-diagnostics.bench.mjs');
+
+export default async function studioDatamachinePipelinesScaleProfileBench() {
+  return runWordPressPageDiagnostics();
+}

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
@@ -1,6 +1,7 @@
-import { mkdir, readFile, rename, rm, symlink, writeFile } from 'node:fs/promises';
+import { cp, mkdir, readFile, rename, rm, symlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
+import { pathToFileURL } from 'node:url';
 import {
   STUDIO_PATH,
   artifactDir as studioArtifactDir,
@@ -113,7 +114,11 @@ async function installProfilePlugins(sitePath) {
     }
 
     await rm(linkPath, { recursive: true, force: true });
-    await symlink(plugin.path, linkPath, 'dir');
+    if (plugin.copy === true) {
+      await cp(plugin.path, linkPath, { recursive: true, force: true });
+    } else {
+      await symlink(plugin.path, linkPath, 'dir');
+    }
     installed.push({ ...plugin, slug, linkPath, backupPath, hadExistingPath });
   }
 
@@ -164,6 +169,14 @@ async function sanitizeNetworkArtifact(artifact) {
   }
   const raw = await readFile(artifact.path, 'utf8');
   await writeFile(artifact.path, redact(raw));
+}
+
+async function loadProfileExtensionModule() {
+  const modulePath = expandHome(process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_EXTENSION_MODULE || '');
+  if (!modulePath) {
+    return null;
+  }
+  return import(pathToFileURL(modulePath).href);
 }
 
 function summarizeNetwork(network, phase) {
@@ -226,6 +239,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
   const { path: correlatorPath, module: correlator } = loadTimingCorrelator({ profilerPath });
   let create;
   let start;
+  let initialStatusResult;
   let statusResult;
   let stop;
   let status;
@@ -233,6 +247,8 @@ export default async function studioSiteEditorDiagnosticsBench() {
   let warmupProfile = {};
   let measureProfile = {};
   let installedPlugins = [];
+  let profileExtension = null;
+  let setupProfile = null;
   let loginFormSeen = 0;
   let wordpressRequests = [];
   let wordpressBootstrapTimeline = [];
@@ -247,7 +263,22 @@ export default async function studioSiteEditorDiagnosticsBench() {
     } else {
       start = await startStudioSite(sitePath, { timeoutMs: 240000 });
     }
+    initialStatusResult = await siteStatus(sitePath);
     installedPlugins = await installProfilePlugins(sitePath);
+    profileExtension = await loadProfileExtensionModule();
+    if (profileExtension?.setupWordPressPageProfile) {
+      const startedSetup = Date.now();
+      setupProfile = await profileExtension.setupWordPressPageProfile({
+        sitePath,
+        artifactDir,
+        pageSpec,
+        runCli,
+      });
+      setupProfile = {
+        elapsedMs: Date.now() - startedSetup,
+        ...setupProfile,
+      };
+    }
     statusResult = await siteStatus(sitePath);
     status = parseStudioSiteStatus(statusResult.stdout);
     if (!status.siteUrl || !status.autoLoginUrl) {
@@ -302,8 +333,10 @@ export default async function studioSiteEditorDiagnosticsBench() {
 
         loginFormSeen = await page.locator('#loginform').count();
 
+        const runPageProfile = profileExtension?.profileWordPressPage || profileWordPressPage;
+
         phase = 'warmup-page';
-        warmupProfile = await profileWordPressPage({ page, siteUrl: status.siteUrl, pageProfiler, pageSpec, mark });
+        warmupProfile = await runPageProfile({ page, siteUrl: status.siteUrl, pageProfiler, pageSpec, mark });
         await mark('warmup_wordpress_page_ready');
 
         phase = 'dashboard-between-runs';
@@ -312,7 +345,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
         await mark('browser_admin_networkidle_between_runs');
 
         phase = 'measure-page';
-        measureProfile = await profileWordPressPage({ page, siteUrl: status.siteUrl, pageProfiler, pageSpec, mark });
+        measureProfile = await runPageProfile({ page, siteUrl: status.siteUrl, pageProfiler, pageSpec, mark });
         await mark('measure_wordpress_page_ready');
         phase = 'done';
       },
@@ -375,8 +408,11 @@ export default async function studioSiteEditorDiagnosticsBench() {
           sitePath,
           siteUrl: status.siteUrl,
           installedPlugins,
+          setupProfile,
           timings: {
             site_create_ms: create?.elapsedMs || 0,
+            site_initial_status_ms: initialStatusResult.elapsedMs,
+            setup_profile_ms: setupProfile?.elapsedMs || 0,
             site_status_ms: statusResult.elapsedMs,
             total_elapsed_ms: totalElapsedMs,
           },
@@ -397,6 +433,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
           commands: {
             create: safeResult(create),
             start: safeResult(start),
+            initialStatus: safeResult(initialStatusResult),
             status: safeResult(statusResult),
             stop: safeResult(stop),
           },
@@ -433,6 +470,8 @@ export default async function studioSiteEditorDiagnosticsBench() {
         success_rate: 1,
         elapsed_ms: totalElapsedMs,
         site_create_ms: metric(create?.elapsedMs),
+        site_initial_status_ms: metric(initialStatusResult.elapsedMs),
+        setup_profile_ms: metric(setupProfile?.elapsedMs),
         site_status_ms: metric(statusResult.elapsedMs),
         login_form_seen: metric(loginFormSeen),
         wordpress_page_status: metric(measureProfile.status),
@@ -471,6 +510,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
         site_editor_bootstrap_timeline_request_count: metric(bootstrapTimelineSummary.length),
         site_editor_slowest_bootstrap_request_ms: metric(slowestBootstrapRequest.duration_ms),
         site_editor_slowest_bootstrap_slice_ms: metric(slowestBootstrapSlice.delta_from_previous_ms),
+        ...(measureProfile.metrics || {}),
         total_elapsed_ms: totalElapsedMs,
         ...browserResult.metrics,
       },
@@ -482,6 +522,9 @@ export default async function studioSiteEditorDiagnosticsBench() {
       },
     };
   } finally {
+    if (profileExtension?.cleanupWordPressPageProfile) {
+      await profileExtension.cleanupWordPressPageProfile({ sitePath, setupProfile });
+    }
     if (profiler) {
       profiler.uninstallWordPressRequestProfiler?.(sitePath);
     }


### PR DESCRIPTION
## Summary
- Add a Studio/Data Machine pipelines scale profiling workload for `/wp-admin/admin.php?page=datamachine-pipelines`.
- Seed configurable fixture dimensions through env vars: pipeline count, flows per pipeline, steps per flow, and config payload size.
- Capture Data Machine-specific phase metrics plus REST timings for `/pipelines`, `/flows`, `/handlers`, and `/agents` while reusing the generic WordPress page diagnostics artifacts.

## Testing
- `node --check Automattic/studio/bench/studio-datamachine-pipelines-scale-profile.bench.mjs`
- `node --check Automattic/studio/bench/lib/datamachine-pipelines-scale-profile.mjs`
- `node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- Small fixture workload passed with `HOMEBOY_DATAMACHINE_PIPELINE_COUNT=2`, `HOMEBOY_DATAMACHINE_FLOWS_PER_PIPELINE=2`, `HOMEBOY_DATAMACHINE_STEPS_PER_FLOW=2`, `HOMEBOY_DATAMACHINE_CONFIG_PAYLOAD_SIZE=128`: Homeboy run `6c40c2d8-8862-4f0b-a81c-a75f45068d57`

## Artifacts
- Raw result: `/Users/chubes/Developer/_bench-evidence/homeboy-artifacts/6c40c2d8-8862-4f0b-a81c-a75f45068d57/d47c8332-6b47-4e86-afb7-5929cde809e2-result-studio-datamachine-pipelines-scale-diagnostics-20281-1778542119804-4l5yz3hzbct.json`
- Screenshot: `/Users/chubes/Developer/_bench-evidence/homeboy-artifacts/6c40c2d8-8862-4f0b-a81c-a75f45068d57/72c95a8e-b37f-4f83-ada9-fb43feee2cfd-studio-wordpress-page-diagnostics-datamachine-pipelines-scale-screenshot.png`
- Trace: `/Users/chubes/Developer/_bench-evidence/homeboy-artifacts/6c40c2d8-8862-4f0b-a81c-a75f45068d57/5f1d29cd-b65c-4a32-baf8-4d9dec56d051-studio-wordpress-page-diagnostics-datamachine-pipelines-scale-trace.zip`
- Network log: `/Users/chubes/Developer/_bench-evidence/homeboy-artifacts/6c40c2d8-8862-4f0b-a81c-a75f45068d57/8a0e699d-c74a-49aa-a517-c27cbb25dbae-studio-wordpress-page-diagnostics-datamachine-pipelines-scale-network.json`
- Console log: `/Users/chubes/Developer/_bench-evidence/homeboy-artifacts/6c40c2d8-8862-4f0b-a81c-a75f45068d57/87948440-7fa2-4414-80a9-03c5006ea1d7-studio-wordpress-page-diagnostics-datamachine-pipelines-scale-console.json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the Homeboy rig workload and diagnostics harness extension points, debugged Studio/Data Machine fixture setup, and ran the validation workload; Chris remains responsible for review and merge.