### PR TITLE
fix(studio): suppress bootstrap timeline lock warnings

### DIFF
--- a/Automattic/studio/bench/lib/wordpress-bootstrap-timeline.mjs
+++ b/Automattic/studio/bench/lib/wordpress-bootstrap-timeline.mjs
@@ -93,9 +93,7 @@ if ( ! function_exists( 'homeboy_bootstrap_timeline_record' ) ) {
 		if ( ! $start || ! $file ) {
 			return;
 		}
-		file_put_contents(
-			$file,
-			json_encode(
+		$line = json_encode(
 				array(
 					'event'      => $event,
 					'request_id' => $GLOBALS['homeboy_bootstrap_timeline_id'] ?? '',
@@ -104,9 +102,8 @@ if ( ! function_exists( 'homeboy_bootstrap_timeline_record' ) ) {
 					't_ms'       => ( microtime( true ) - $start ) * 1000,
 					'time'       => microtime( true ),
 				)
-			) . "\\n",
-			FILE_APPEND | LOCK_EX
-		);
+			) . "\\n";
+		@file_put_contents( $file, $line, FILE_APPEND | LOCK_EX );
 	}
 }
 homeboy_bootstrap_timeline_record( 'entry.start' );


### PR DESCRIPTION
## Summary
- Suppress unsupported `LOCK_EX` warnings from the Studio bootstrap timeline instrumentation so PHP warnings cannot contaminate REST JSON responses.
- Keep locked appends for environments that support them, preserving atomic timeline writes without emitting warnings into page output.

## Verification
- `node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `homeboy bench --path /Users/chubes/Developer/studio --extension nodejs --scenario studio-site-editor-diagnostics --force-hot` with Data Machine Pipelines scale profile
- Verified run `2b41ab4e-7210-4d17-86b4-f656d203f3fa` had no `invalid_json`, `file_put_contents()`, or `Exclusive locks` contamination in console/response samples.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed the REST response contamination, implemented the focused instrumentation fix, and ran targeted verification. Chris reviewed the direction and requested the PR.