### PR TITLE
Add WordPress admin scale sweep benchmark

### DIFF
--- a/Automattic/studio/bench/lib/wordpress-admin-scale-sweep.mjs
+++ b/Automattic/studio/bench/lib/wordpress-admin-scale-sweep.mjs
@@ -1,0 +1,231 @@
+import { readFile } from 'node:fs/promises';
+
+import { metric } from './studio-bench.mjs';
+
+const DEFAULT_ADMIN_READY = { selector: '#wpbody-content, body.wp-admin', timeout: 120000 };
+const DEFAULT_RESOURCE_INCLUDE = ['/wp-json/', '?rest_route=', '/wp-admin/', '/wp-content/', '/wp-includes/'];
+
+function pageIdFromPath(pagePath) {
+  return String(pagePath || '')
+    .replace(/^https?:\/\/[^/]+/i, '')
+    .replace(/^\/+/, '')
+    .replace(/[^A-Za-z0-9_.:-]+/g, '-')
+    .replace(/^-|-$/g, '') || 'wordpress-admin-page';
+}
+
+function metricId(id) {
+  return String(id || 'page')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '') || 'page';
+}
+
+export function normalizeWordPressAdminScaleSweepManifest(manifest) {
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    throw new Error('WordPress admin scale sweep manifest must be an object');
+  }
+  if (!Array.isArray(manifest.pages) || manifest.pages.length === 0) {
+    throw new Error('WordPress admin scale sweep manifest requires a non-empty pages array');
+  }
+
+  return {
+    ...manifest,
+    pages: manifest.pages.map((page, index) => {
+      if (!page || typeof page !== 'object' || Array.isArray(page)) {
+        throw new Error(`WordPress admin scale sweep page ${index + 1} must be an object`);
+      }
+      if (!page.path || typeof page.path !== 'string') {
+        throw new Error(`WordPress admin scale sweep page ${index + 1} requires a path`);
+      }
+
+      const id = page.id || pageIdFromPath(page.path);
+      const ready = page.ready || DEFAULT_ADMIN_READY;
+      return {
+        ...page,
+        id,
+        metricId: metricId(id),
+        label: page.label || id,
+        ready,
+        resources: {
+          includeResourceSubstrings: DEFAULT_RESOURCE_INCLUDE,
+          ...(page.resources || {}),
+        },
+        timeout: Number(page.timeout || ready.timeout || 120000),
+        interactions: Array.isArray(page.interactions) ? page.interactions : [],
+      };
+    }),
+  };
+}
+
+export async function loadWordPressAdminScaleSweepManifest(options = {}) {
+  const rawJson = options.json || process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_MANIFEST_JSON;
+  const manifestPath = options.path || process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_MANIFEST;
+  if (rawJson) {
+    return normalizeWordPressAdminScaleSweepManifest(JSON.parse(rawJson));
+  }
+  if (manifestPath) {
+    return normalizeWordPressAdminScaleSweepManifest(JSON.parse(await readFile(manifestPath, 'utf8')));
+  }
+
+  return normalizeWordPressAdminScaleSweepManifest({
+    pages: [
+      { id: 'dashboard', path: '/wp-admin/index.php' },
+      { id: 'plugins', path: '/wp-admin/plugins.php' },
+      { id: 'themes', path: '/wp-admin/themes.php', ready: { selector: '.theme-browser, #wpbody-content', timeout: 120000 } },
+      { id: 'posts', path: '/wp-admin/edit.php' },
+      { id: 'add-post', path: '/wp-admin/post-new.php', ready: { selector: '.edit-post-layout, #editor, body.wp-admin', timeout: 120000 } },
+    ],
+  });
+}
+
+function numberValue(...values) {
+  for (const value of values) {
+    const number = Number(value);
+    if (Number.isFinite(number)) {
+      return number;
+    }
+  }
+  return 0;
+}
+
+function resourceUrl(resource) {
+  return resource?.url || resource?.name || resource?.href || '';
+}
+
+function resourceDuration(resource) {
+  return numberValue(resource?.durationMs, resource?.duration_ms, resource?.duration);
+}
+
+function resourceBytes(resource) {
+  return numberValue(resource?.transferSize, resource?.transfer_size, resource?.encodedBodySize, resource?.encoded_body_size, resource?.decodedBodySize, resource?.decoded_body_size);
+}
+
+function isRestResource(resource) {
+  const url = resourceUrl(resource);
+  return url.includes('/wp-json/') || url.includes('?rest_route=');
+}
+
+function summarizeResources(resources = []) {
+  const all = Array.isArray(resources) ? resources : [];
+  const rest = all.filter(isRestResource);
+  return {
+    count: all.length,
+    rest_count: rest.length,
+    rest_bytes: rest.reduce((total, resource) => total + resourceBytes(resource), 0),
+    slowest: all
+      .slice()
+      .sort((a, b) => resourceDuration(b) - resourceDuration(a))
+      .slice(0, 20)
+      .map((resource) => ({
+        url: resourceUrl(resource),
+        duration_ms: resourceDuration(resource),
+        ttfb_ms: numberValue(resource?.ttfbMs, resource?.ttfb_ms),
+        transfer_size: numberValue(resource?.transferSize, resource?.transfer_size),
+        encoded_body_size: numberValue(resource?.encodedBodySize, resource?.encoded_body_size),
+        resource_type: resource?.resourceType || resource?.initiatorType || resource?.kind || '',
+      })),
+  };
+}
+
+export function summarizeWordPressAdminScaleSweepPage({ pageSpec, profile, networkRequests = [], interactionResult, artifacts }) {
+  const resources = summarizeResources(profile?.resources?.resources || profile?.resources || []);
+  const failedRequests = networkRequests.filter((request) => request.failed || Number(request.status || 0) >= 400);
+  const slowestNetwork = networkRequests
+    .slice()
+    .sort((a, b) => numberValue(b.duration_ms) - numberValue(a.duration_ms))
+    .slice(0, 20);
+  const failures = [
+    ...failedRequests.map((request) => ({
+      type: 'request',
+      url: request.url,
+      status: request.status || 0,
+      error: request.failure || '',
+    })),
+    ...(profile?.failure ? [{ type: 'profile', error: profile.failure }] : []),
+    ...(interactionResult?.failure ? [{ type: 'interaction', error: interactionResult.failure }] : []),
+  ];
+
+  return {
+    id: pageSpec.id,
+    metric_id: pageSpec.metricId || metricId(pageSpec.id),
+    label: pageSpec.label || pageSpec.id,
+    path: pageSpec.path,
+    status: metric(profile?.status),
+    ready_ms: metric(profile?.readyMs),
+    resource_count: metric(profile?.resources?.count ?? resources.count),
+    rest_count: metric(profile?.resources?.restCount ?? resources.rest_count),
+    rest_bytes: metric(profile?.resources?.restBytes ?? resources.rest_bytes),
+    failed_request_count: failedRequests.length,
+    failure_count: failures.length,
+    slowest_resource_ms: metric(resources.slowest[0]?.duration_ms),
+    slowest_resources: resources.slowest,
+    slowest_requests: slowestNetwork,
+    failures,
+    interaction: interactionResult || null,
+    artifacts: artifacts || {},
+    rawProfile: profile,
+  };
+}
+
+export function buildWordPressAdminScaleSweepSummary(pages) {
+  const rows = pages
+    .map((page) => ({
+      id: page.id,
+      label: page.label,
+      path: page.path,
+      status: page.status,
+      ready_ms: page.ready_ms,
+      rest_count: page.rest_count,
+      rest_bytes: page.rest_bytes,
+      failed_request_count: page.failed_request_count,
+      failure_count: page.failure_count,
+      slowest_resource_ms: page.slowest_resource_ms,
+    }))
+    .sort((a, b) => {
+      if (a.failure_count !== b.failure_count) {
+        return b.failure_count - a.failure_count;
+      }
+      if (a.ready_ms !== b.ready_ms) {
+        return b.ready_ms - a.ready_ms;
+      }
+      return b.slowest_resource_ms - a.slowest_resource_ms;
+    });
+
+  const requests = pages
+    .flatMap((page) =>
+      (page.slowest_requests || []).map((request) => ({
+        page_id: page.id,
+        url: request.url,
+        method: request.method,
+        status: request.status || 0,
+        failed: Boolean(request.failed),
+        duration_ms: metric(request.duration_ms),
+        resource_type: request.resource_type || request.resourceType || '',
+      }))
+    )
+    .sort((a, b) => {
+      if (a.failed !== b.failed) {
+        return a.failed ? -1 : 1;
+      }
+      return b.duration_ms - a.duration_ms;
+    })
+    .slice(0, 40);
+
+  const pageTable = [
+    '| Page | Status | Ready ms | REST | REST bytes | Failed requests | Slowest resource ms |',
+    '|---|---:|---:|---:|---:|---:|---:|',
+    ...rows.map((row) => `| ${row.id} | ${row.status} | ${Math.round(row.ready_ms)} | ${row.rest_count} | ${row.rest_bytes} | ${row.failed_request_count} | ${Math.round(row.slowest_resource_ms)} |`),
+  ].join('\n');
+
+  const requestTable = [
+    '| Page | Status | Duration ms | URL |',
+    '|---|---:|---:|---|',
+    ...requests.slice(0, 15).map((request) => `| ${request.page_id} | ${request.status} | ${Math.round(request.duration_ms)} | ${String(request.url || '').replace(/\|/g, '%7C')} |`),
+  ].join('\n');
+
+  return {
+    pages: rows,
+    worst_requests: requests,
+    markdown: `${pageTable}\n\n${requestTable}`,
+  };
+}

--- a/Automattic/studio/bench/lib/wordpress-admin-scale-sweep.mjs
+++ b/Automattic/studio/bench/lib/wordpress-admin-scale-sweep.mjs
@@ -134,6 +134,7 @@ export function summarizeWordPressAdminScaleSweepPage({ pageSpec, profile, netwo
     .slice()
     .sort((a, b) => numberValue(b.duration_ms) - numberValue(a.duration_ms))
     .slice(0, 20);
+  const interaction = profile?.interactions ?? interactionResult ?? null;
   const failures = [
     ...failedRequests.map((request) => ({
       type: 'request',
@@ -142,7 +143,7 @@ export function summarizeWordPressAdminScaleSweepPage({ pageSpec, profile, netwo
       error: request.failure || '',
     })),
     ...(profile?.failure ? [{ type: 'profile', error: profile.failure }] : []),
-    ...(interactionResult?.failure ? [{ type: 'interaction', error: interactionResult.failure }] : []),
+    ...(interaction?.failed || interaction?.failure ? [{ type: 'interaction', error: interaction.failure || 'interaction failed' }] : []),
   ];
 
   return {
@@ -161,7 +162,7 @@ export function summarizeWordPressAdminScaleSweepPage({ pageSpec, profile, netwo
     slowest_resources: resources.slowest,
     slowest_requests: slowestNetwork,
     failures,
-    interaction: interactionResult || null,
+    interaction,
     artifacts: artifacts || {},
     rawProfile: profile,
   };

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -28,6 +28,11 @@ const {
   profileWordPressPage,
   wordpressPageProfilerSpec,
 } = await import('./lib/wordpress-page-profiler.mjs');
+const {
+  buildWordPressAdminScaleSweepSummary,
+  normalizeWordPressAdminScaleSweepManifest,
+  summarizeWordPressAdminScaleSweepPage,
+} = await import('./lib/wordpress-admin-scale-sweep.mjs');
 
 function withEnv(values, callback) {
   const previous = {};
@@ -407,6 +412,96 @@ test('profileWordPressPage delegates page readiness to the Homeboy Extensions pa
   assert.equal(calls[0].baseUrl, 'http://example.test');
   assert.equal(calls[0].spec.path, '/wp-admin/themes.php');
   assert.equal(result, profile);
+});
+
+// --- WordPress admin scale sweep ------------------------------------------
+
+test('normalizeWordPressAdminScaleSweepManifest accepts page manifests and adds defaults', () => {
+  const manifest = normalizeWordPressAdminScaleSweepManifest({
+    pages: [
+      {
+        id: 'pipelines',
+        path: '/wp-admin/admin.php?page=datamachine-pipelines',
+        ready: { selector: '.datamachine-pipelines-app' },
+      },
+      {
+        path: '/wp-admin/admin.php?page=datamachine-jobs',
+        interactions: [{ type: 'click', selector: '.jobs-row:first-child button' }],
+      },
+    ],
+  });
+
+  assert.equal(manifest.pages.length, 2);
+  assert.equal(manifest.pages[0].metricId, 'pipelines');
+  assert.equal(manifest.pages[0].resources.includeResourceSubstrings.includes('/wp-json/'), true);
+  assert.equal(manifest.pages[1].id, 'wp-admin-admin.php-page-datamachine-jobs');
+  assert.equal(manifest.pages[1].ready.selector, '#wpbody-content, body.wp-admin');
+  assert.equal(manifest.pages[1].interactions.length, 1);
+});
+
+test('summarizeWordPressAdminScaleSweepPage records readiness, REST bytes, failures, and slow resources', () => {
+  const page = summarizeWordPressAdminScaleSweepPage({
+    pageSpec: { id: 'jobs', path: '/wp-admin/admin.php?page=datamachine-jobs' },
+    profile: {
+      status: 200,
+      readyMs: 1234,
+      resources: {
+        resources: [
+          { url: '/wp-json/datamachine/v1/jobs', durationMs: 250, transferSize: 1000, kind: 'fetch' },
+          { url: '/wp-content/plugins/data-machine/app.js', durationMs: 400, transferSize: 2000, kind: 'script' },
+        ],
+      },
+    },
+    networkRequests: [
+      { url: '/wp-json/datamachine/v1/jobs', method: 'GET', status: 200, duration_ms: 250 },
+      { url: '/wp-json/datamachine/v1/fail', method: 'GET', status: 500, duration_ms: 100 },
+    ],
+    artifacts: { trace: '/tmp/trace.zip', screenshot: '/tmp/page.png' },
+  });
+
+  assert.equal(page.status, 200);
+  assert.equal(page.ready_ms, 1234);
+  assert.equal(page.rest_count, 1);
+  assert.equal(page.rest_bytes, 1000);
+  assert.equal(page.failed_request_count, 1);
+  assert.equal(page.failure_count, 1);
+  assert.equal(page.slowest_resources[0].url, '/wp-content/plugins/data-machine/app.js');
+  assert.equal(page.artifacts.trace, '/tmp/trace.zip');
+});
+
+test('buildWordPressAdminScaleSweepSummary sorts worst pages and requests first', () => {
+  const summary = buildWordPressAdminScaleSweepSummary([
+    {
+      id: 'fast',
+      label: 'Fast',
+      path: '/wp-admin/admin.php?page=fast',
+      status: 200,
+      ready_ms: 100,
+      rest_count: 1,
+      rest_bytes: 10,
+      failed_request_count: 0,
+      failure_count: 0,
+      slowest_resource_ms: 50,
+      slowest_requests: [{ url: '/fast', status: 200, duration_ms: 50 }],
+    },
+    {
+      id: 'slow',
+      label: 'Slow',
+      path: '/wp-admin/admin.php?page=slow',
+      status: 200,
+      ready_ms: 900,
+      rest_count: 4,
+      rest_bytes: 100,
+      failed_request_count: 1,
+      failure_count: 1,
+      slowest_resource_ms: 800,
+      slowest_requests: [{ url: '/slow', status: 500, failed: true, duration_ms: 800 }],
+    },
+  ]);
+
+  assert.equal(summary.pages[0].id, 'slow');
+  assert.equal(summary.worst_requests[0].url, '/slow');
+  assert.match(summary.markdown, /\| slow \| 200 \| 900 \| 4 \| 100 \| 1 \| 800 \|/);
 });
 
 // --- WordPress bootstrap timeline -----------------------------------------

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -445,6 +445,11 @@ test('summarizeWordPressAdminScaleSweepPage records readiness, REST bytes, failu
     profile: {
       status: 200,
       readyMs: 1234,
+      interactions: {
+        actions: [{ name: 'open_jobs_modal', status: 'passed', durationMs: 77 }],
+        durationMs: 77,
+        failed: false,
+      },
       resources: {
         resources: [
           { url: '/wp-json/datamachine/v1/jobs', durationMs: 250, transferSize: 1000, kind: 'fetch' },
@@ -456,6 +461,11 @@ test('summarizeWordPressAdminScaleSweepPage records readiness, REST bytes, failu
       { url: '/wp-json/datamachine/v1/jobs', method: 'GET', status: 200, duration_ms: 250 },
       { url: '/wp-json/datamachine/v1/fail', method: 'GET', status: 500, duration_ms: 100 },
     ],
+    interactionResult: {
+      skipped: true,
+      reason: 'fallback runner unavailable',
+      interaction_count: 1,
+    },
     artifacts: { trace: '/tmp/trace.zip', screenshot: '/tmp/page.png' },
   });
 
@@ -465,6 +475,8 @@ test('summarizeWordPressAdminScaleSweepPage records readiness, REST bytes, failu
   assert.equal(page.rest_bytes, 1000);
   assert.equal(page.failed_request_count, 1);
   assert.equal(page.failure_count, 1);
+  assert.equal(page.interaction.actions[0].name, 'open_jobs_modal');
+  assert.equal(page.interaction.skipped, undefined);
   assert.equal(page.slowest_resources[0].url, '/wp-content/plugins/data-machine/app.js');
   assert.equal(page.artifacts.trace, '/tmp/trace.zip');
 });

--- a/Automattic/studio/bench/studio-wordpress-admin-scale-sweep.bench.mjs
+++ b/Automattic/studio/bench/studio-wordpress-admin-scale-sweep.bench.mjs
@@ -177,21 +177,51 @@ async function sanitizeNetworkArtifact(artifact) {
   await writeFile(artifact.path, redact(raw));
 }
 
-async function runOptionalInteractions({ profileExtension, pageProfiler, page, pageSpec, siteUrl, mark }) {
+async function runOptionalInteractions({ profileExtension, pageProfiler, page, pageSpec, siteUrl, mark, profile }) {
+  if (profile?.interactions !== undefined) {
+    return profile.interactions;
+  }
   if (!pageSpec.interactions.length) {
     return null;
   }
 
-  const runner = profileExtension?.runWordPressAdminScaleSweepInteractions || pageProfiler?.runWordPressPageInteractions;
-  if (!runner) {
-    return {
-      skipped: true,
-      reason: 'No declarative WordPress page interaction runner is available in the installed extensions.',
-      interaction_count: pageSpec.interactions.length,
-    };
+  if (profileExtension?.runWordPressAdminScaleSweepInteractions) {
+    return profileExtension.runWordPressAdminScaleSweepInteractions({
+      page,
+      baseUrl: siteUrl,
+      spec: pageSpec,
+      interactions: pageSpec.interactions,
+      mark,
+    });
   }
 
-  return runner({ page, baseUrl: siteUrl, spec: pageSpec, interactions: pageSpec.interactions, mark });
+  if (pageProfiler?.runBrowserActions) {
+    return pageProfiler.runBrowserActions(page, pageSpec.interactions, {
+      mark,
+      timeout: pageSpec.interactionTimeout,
+      failureScreenshotPath: pageSpec.failureScreenshotPath,
+      tracePath: pageSpec.tracePath,
+    });
+  }
+
+  return {
+    skipped: true,
+    reason: 'No declarative WordPress page interaction runner is available in the installed extensions.',
+    interaction_count: pageSpec.interactions.length,
+  };
+}
+
+function shouldMarkInteractionFallback(profile, interaction) {
+  if (!interaction) {
+    return false;
+  }
+  if (profile?.interactions !== undefined) {
+    return false;
+  }
+  if (interaction.skipped) {
+    return false;
+  }
+  return true;
 }
 
 function summarizeWordPressRequests(entries = []) {
@@ -327,8 +357,8 @@ export default async function studioWordPressAdminScaleSweepBench() {
           const startedNetworkIndex = network.length;
           const profile = await runPageProfile({ page, siteUrl: status.siteUrl, pageProfiler, pageSpec, mark });
           await mark(`page_${pageSpec.metricId}_ready`);
-          const interaction = await runOptionalInteractions({ profileExtension, pageProfiler, page, pageSpec, siteUrl: status.siteUrl, mark });
-          if (interaction) {
+          const interaction = await runOptionalInteractions({ profileExtension, pageProfiler, page, pageSpec, siteUrl: status.siteUrl, mark, profile });
+          if (shouldMarkInteractionFallback(profile, interaction)) {
             await mark(`page_${pageSpec.metricId}_interactions_done`);
           }
           const pageNetwork = scrubNetworkRequests(network.slice(startedNetworkIndex), status.siteUrl);

--- a/Automattic/studio/bench/studio-wordpress-admin-scale-sweep.bench.mjs
+++ b/Automattic/studio/bench/studio-wordpress-admin-scale-sweep.bench.mjs
@@ -1,0 +1,460 @@
+import { cp, mkdir, readFile, rename, rm, symlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { pathToFileURL } from 'node:url';
+
+import {
+  artifactDir as studioArtifactDir,
+  createStudioSite,
+  expandHome,
+  metric,
+  parseStudioSiteStatus,
+  redact,
+  runCli,
+  safeResult,
+  setting,
+  startStudioSite,
+  stopStudioSite,
+  studioSiteStatus,
+  variant,
+} from './lib/studio-bench.mjs';
+import {
+  buildWordPressAdminScaleSweepSummary,
+  loadWordPressAdminScaleSweepManifest,
+  summarizeWordPressAdminScaleSweepPage,
+} from './lib/wordpress-admin-scale-sweep.mjs';
+import {
+  loadWordPressPageProfiler,
+  loadWordPressRequestProfiler,
+  profileWordPressPage,
+} from './lib/wordpress-page-profiler.mjs';
+
+const BROWSER_HELPER = process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER;
+
+if (!BROWSER_HELPER) {
+  throw new Error('HOMEBOY_NODEJS_BROWSER_BENCH_HELPER is required');
+}
+
+const { runBrowserBench } = await import(BROWSER_HELPER);
+
+async function createSite(sitePath) {
+  return createStudioSite(sitePath, {
+    name: `Studio Bench ${variant()} WordPress Admin Scale Sweep ${process.pid}`,
+    wp: process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_WP_VERSION || process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_WP_VERSION,
+    php: process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_PHP_VERSION || process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_PHP_VERSION,
+    timeoutMs: 420000,
+  });
+}
+
+async function siteStatus(sitePath) {
+  return studioSiteStatus(sitePath, { timeoutMs: 90000 });
+}
+
+async function stopSite(sitePath) {
+  return stopStudioSite(sitePath, { timeoutMs: 90000 });
+}
+
+function profilePlugins() {
+  const json = process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_PLUGINS_JSON || process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGINS_JSON;
+  if (json) {
+    const parsed = JSON.parse(json);
+    if (!Array.isArray(parsed)) {
+      throw new Error('HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_PLUGINS_JSON must be an array');
+    }
+    return parsed.map((plugin) => {
+      if (typeof plugin === 'string') {
+        return { path: expandHome(plugin) };
+      }
+      return { ...plugin, path: expandHome(plugin.path) };
+    });
+  }
+
+  const paths = process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_PLUGIN_PATHS || process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGIN_PATHS;
+  if (!paths) {
+    return [];
+  }
+  return paths
+    .split(',')
+    .map((pluginPath) => ({ path: expandHome(pluginPath.trim()) }))
+    .filter((plugin) => plugin.path);
+}
+
+async function installProfilePlugins(sitePath) {
+  const plugins = profilePlugins();
+  if (plugins.length === 0) {
+    return [];
+  }
+
+  const pluginDir = path.join(sitePath, 'wp-content', 'plugins');
+  await mkdir(pluginDir, { recursive: true });
+
+  const installed = [];
+  for (const plugin of plugins) {
+    if (!plugin.path) {
+      throw new Error('Profile plugin entry requires a path');
+    }
+    const slug = plugin.slug || path.basename(plugin.path);
+    const linkPath = path.join(pluginDir, slug);
+    const backupPath = `${linkPath}.homeboy-profile-backup-${process.pid}-${Date.now()}`;
+    let hadExistingPath = false;
+
+    try {
+      await rename(linkPath, backupPath);
+      hadExistingPath = true;
+    } catch (error) {
+      if (error?.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+
+    await rm(linkPath, { recursive: true, force: true });
+    if (plugin.copy === true) {
+      await cp(plugin.path, linkPath, { recursive: true, force: true });
+    } else {
+      await symlink(plugin.path, linkPath, 'dir');
+    }
+    installed.push({ ...plugin, slug, linkPath, backupPath, hadExistingPath });
+  }
+
+  const activate = installed.filter((plugin) => plugin.activate !== false);
+  const activateTimeoutMs = Number(process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_PLUGIN_ACTIVATE_TIMEOUT_MS || process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGIN_ACTIVATE_TIMEOUT_MS || 420000);
+  for (const plugin of activate) {
+    await runCli(['wp', 'plugin', 'activate', plugin.plugin || plugin.slug], { cwd: sitePath, timeoutMs: activateTimeoutMs });
+  }
+
+  return installed.map((plugin) => ({
+    slug: plugin.slug,
+    path: plugin.path,
+    linkPath: plugin.linkPath,
+    backupPath: plugin.backupPath,
+    hadExistingPath: plugin.hadExistingPath,
+  }));
+}
+
+async function restoreProfilePlugins(installedPlugins) {
+  for (const plugin of [...installedPlugins].reverse()) {
+    await rm(plugin.linkPath, { recursive: true, force: true });
+    if (plugin.hadExistingPath) {
+      await rename(plugin.backupPath, plugin.linkPath);
+    }
+  }
+}
+
+async function loadProfileExtensionModule() {
+  const modulePath = expandHome(
+    process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_EXTENSION_MODULE ||
+      process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_EXTENSION_MODULE ||
+      ''
+  );
+  if (!modulePath) {
+    return null;
+  }
+  return import(pathToFileURL(modulePath).href);
+}
+
+function scrubUrl(url, siteUrl) {
+  try {
+    const parsed = new URL(url);
+    const base = new URL(siteUrl);
+    if (parsed.origin === base.origin) {
+      return `${parsed.pathname}${parsed.search}`;
+    }
+  } catch {
+    // Fall through to normal redaction.
+  }
+  return redact(url);
+}
+
+function scrubNetworkRequests(requests, siteUrl) {
+  return requests.map((request) => ({ ...request, url: scrubUrl(request.url, siteUrl) }));
+}
+
+async function sanitizeNetworkArtifact(artifact) {
+  if (!artifact || typeof artifact.path !== 'string') {
+    return;
+  }
+  const raw = await readFile(artifact.path, 'utf8');
+  await writeFile(artifact.path, redact(raw));
+}
+
+async function runOptionalInteractions({ profileExtension, pageProfiler, page, pageSpec, siteUrl, mark }) {
+  if (!pageSpec.interactions.length) {
+    return null;
+  }
+
+  const runner = profileExtension?.runWordPressAdminScaleSweepInteractions || pageProfiler?.runWordPressPageInteractions;
+  if (!runner) {
+    return {
+      skipped: true,
+      reason: 'No declarative WordPress page interaction runner is available in the installed extensions.',
+      interaction_count: pageSpec.interactions.length,
+    };
+  }
+
+  return runner({ page, baseUrl: siteUrl, spec: pageSpec, interactions: pageSpec.interactions, mark });
+}
+
+function summarizeWordPressRequests(entries = []) {
+  const byRequest = new Map();
+  for (const entry of entries) {
+    const id = entry.request_id || 'unknown';
+    if (!byRequest.has(id)) {
+      byRequest.set(id, []);
+    }
+    byRequest.get(id).push(entry);
+  }
+
+  return [...byRequest.values()]
+    .map((events) => {
+      events.sort((a, b) => (a.t_ms || 0) - (b.t_ms || 0));
+      const last = events[events.length - 1];
+      return {
+        uri: redact(last?.uri || ''),
+        method: last?.method,
+        duration_ms: last?.t_ms || 0,
+      };
+    })
+    .sort((a, b) => b.duration_ms - a.duration_ms)
+    .slice(0, 120);
+}
+
+export default async function studioWordPressAdminScaleSweepBench() {
+  const currentVariant = variant();
+  const manifest = await loadWordPressAdminScaleSweepManifest({
+    json: setting('wordpress_admin_scale_sweep_manifest_json'),
+    path: expandHome(setting('wordpress_admin_scale_sweep_manifest')),
+  });
+  const runId = `${currentVariant}-wordpress-admin-scale-sweep-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const artifactDir = path.join(studioArtifactDir('studio-wordpress-admin-scale-sweep-artifacts'), runId);
+  const existingSitePath = expandHome(
+    setting('wordpress_admin_scale_sweep_site_path') ||
+    process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_SITE_PATH ||
+      process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_SITE_PATH ||
+      ''
+  );
+  const sitePath = existingSitePath || path.join(artifactDir, 'site');
+  const createdSite = !existingSitePath;
+  await mkdir(artifactDir, { recursive: true });
+
+  const totalStarted = Date.now();
+  const { path: profilerPath, module: profiler } = loadWordPressRequestProfiler();
+  const { path: pageProfilerPath, module: pageProfiler } = loadWordPressPageProfiler({ profilerPath });
+  let create;
+  let start;
+  let initialStatusResult;
+  let statusResult;
+  let stop;
+  let status;
+  let browserResult;
+  let setupProfile = null;
+  let profileExtension = null;
+  let installedPlugins = [];
+  let loginFormSeen = 0;
+  let wordpressRequests = [];
+  const pageResults = [];
+  const metrics = {};
+  const network = [];
+  const startedRequests = new Map();
+  let phase = 'setup';
+
+  try {
+    if (createdSite) {
+      create = await createSite(sitePath);
+    } else {
+      start = await startStudioSite(sitePath, { timeoutMs: 240000 });
+    }
+    initialStatusResult = await siteStatus(sitePath);
+    installedPlugins = await installProfilePlugins(sitePath);
+    profileExtension = await loadProfileExtensionModule();
+    if (profileExtension?.setupWordPressAdminScaleSweep || profileExtension?.setupWordPressPageProfile) {
+      const startedSetup = Date.now();
+      const setup = profileExtension.setupWordPressAdminScaleSweep || profileExtension.setupWordPressPageProfile;
+      setupProfile = await setup({ sitePath, artifactDir, manifest, pageSpecs: manifest.pages, pageSpec: manifest.pages[0], runCli });
+      setupProfile = { elapsedMs: Date.now() - startedSetup, ...setupProfile };
+    }
+
+    statusResult = await siteStatus(sitePath);
+    status = parseStudioSiteStatus(statusResult.stdout);
+    if (!status.siteUrl || !status.autoLoginUrl) {
+      throw new Error(`site status missing siteUrl/autoLoginUrl: ${redact(statusResult.stdout).slice(0, 1000)}`);
+    }
+
+    profiler?.installWordPressRequestProfiler?.(sitePath);
+
+    browserResult = await runBrowserBench({
+      id: 'studio-wordpress-admin-scale-sweep',
+      artifactsDir: artifactDir,
+      trace: true,
+      screenshot: true,
+      waitForNetworkIdle: false,
+      action: async ({ page, mark }) => {
+        page.on('request', (request) => startedRequests.set(request, { started: performance.now(), phase }));
+        page.on('requestfinished', async (request) => {
+          const response = await request.response().catch(() => null);
+          const started = startedRequests.get(request) || { started: performance.now(), phase: 'unknown' };
+          network.push({
+            phase: started.phase,
+            url: request.url(),
+            method: request.method(),
+            status: response?.status() ?? 0,
+            duration_ms: performance.now() - started.started,
+            resource_type: request.resourceType(),
+          });
+        });
+        page.on('requestfailed', (request) => {
+          const started = startedRequests.get(request) || { started: performance.now(), phase: 'unknown' };
+          network.push({
+            phase: started.phase,
+            url: request.url(),
+            method: request.method(),
+            status: 0,
+            failed: true,
+            failure: request.failure()?.errorText || 'request failed',
+            duration_ms: performance.now() - started.started,
+            resource_type: request.resourceType(),
+          });
+        });
+
+        phase = 'login';
+        await page.goto(status.autoLoginUrl, { waitUntil: 'domcontentloaded', timeout: 120000 });
+        await page.waitForLoadState('networkidle', { timeout: 120000 }).catch(() => {});
+        await mark('auto_login_ready');
+        loginFormSeen = await page.locator('#loginform').count().catch(() => 0);
+
+        const runPageProfile = profileExtension?.profileWordPressAdminScaleSweepPage || profileExtension?.profileWordPressPage || profileWordPressPage;
+        for (const pageSpec of manifest.pages) {
+          phase = `page:${pageSpec.id}`;
+          const startedNetworkIndex = network.length;
+          const profile = await runPageProfile({ page, siteUrl: status.siteUrl, pageProfiler, pageSpec, mark });
+          await mark(`page_${pageSpec.metricId}_ready`);
+          const interaction = await runOptionalInteractions({ profileExtension, pageProfiler, page, pageSpec, siteUrl: status.siteUrl, mark });
+          if (interaction) {
+            await mark(`page_${pageSpec.metricId}_interactions_done`);
+          }
+          const pageNetwork = scrubNetworkRequests(network.slice(startedNetworkIndex), status.siteUrl);
+          pageResults.push(
+            summarizeWordPressAdminScaleSweepPage({
+              pageSpec,
+              profile,
+              networkRequests: pageNetwork,
+              interactionResult: interaction,
+            })
+          );
+        }
+        phase = 'done';
+      },
+    });
+
+    await sanitizeNetworkArtifact(browserResult.artifacts?.network);
+    wordpressRequests = profiler?.collectWordPressRequestProfiles?.(sitePath) || [];
+    profiler?.uninstallWordPressRequestProfiler?.(sitePath);
+    if (createdSite) {
+      stop = await stopSite(sitePath);
+    }
+
+    const totalElapsedMs = Date.now() - totalStarted;
+    for (const page of pageResults) {
+      const pageMetricId = page.metric_id || page.id;
+      page.artifacts = {
+        trace: browserResult.artifacts?.trace,
+        screenshot: browserResult.artifacts?.screenshot,
+        network: browserResult.artifacts?.network,
+      };
+      metrics[`page_${pageMetricId}_status`] = metric(page.status);
+      metrics[`page_${pageMetricId}_ready_ms`] = metric(page.ready_ms);
+      metrics[`page_${pageMetricId}_rest_count`] = metric(page.rest_count);
+      metrics[`page_${pageMetricId}_rest_bytes`] = metric(page.rest_bytes);
+      metrics[`page_${pageMetricId}_failed_request_count`] = metric(page.failed_request_count);
+      metrics[`page_${pageMetricId}_failure_count`] = metric(page.failure_count);
+      metrics[`page_${pageMetricId}_slowest_resource_ms`] = metric(page.slowest_resource_ms);
+    }
+
+    const summary = buildWordPressAdminScaleSweepSummary(pageResults);
+    const failingPageCount = pageResults.filter((page) => page.status >= 500 || page.status === 0 || page.failure_count > 0).length;
+    const slowestPageMs = Math.max(0, ...pageResults.map((page) => metric(page.ready_ms)));
+    const artifactFile = path.join(artifactDir, `result-${runId}.json`);
+    await writeFile(
+      artifactFile,
+      JSON.stringify(
+        {
+          variant: currentVariant,
+          manifest,
+          profilerPath,
+          profilerAvailable: Boolean(profiler),
+          pageProfilerPath,
+          pageProfilerAvailable: Boolean(pageProfiler),
+          sitePath,
+          siteUrl: status.siteUrl,
+          installedPlugins,
+          setupProfile,
+          timings: {
+            site_create_ms: create?.elapsedMs || 0,
+            site_initial_status_ms: initialStatusResult.elapsedMs,
+            setup_profile_ms: setupProfile?.elapsedMs || 0,
+            site_status_ms: statusResult.elapsedMs,
+            total_elapsed_ms: totalElapsedMs,
+          },
+          pages: pageResults,
+          combinedSummary: summary,
+          wordpressRequests: summarizeWordPressRequests(wordpressRequests),
+          commands: {
+            create: safeResult(create),
+            start: safeResult(start),
+            initialStatus: safeResult(initialStatusResult),
+            status: safeResult(statusResult),
+            stop: safeResult(stop),
+          },
+          browserMetrics: browserResult.metrics,
+          browserArtifacts: browserResult.artifacts,
+        },
+        null,
+        2
+      )
+    );
+
+    if (loginFormSeen > 0) {
+      throw new Error(`Login form remained visible after auto-login; raw_result=${artifactFile}`);
+    }
+    if (failingPageCount > 0) {
+      throw new Error(`WordPress admin scale sweep found ${failingPageCount} failing page(s); raw_result=${artifactFile}`);
+    }
+    if (!browserResult.artifacts?.trace || !browserResult.artifacts?.screenshot) {
+      throw new Error(`Browser trace/screenshot artifacts missing; raw_result=${artifactFile}`);
+    }
+
+    return {
+      metrics: {
+        success_rate: 1,
+        elapsed_ms: totalElapsedMs,
+        page_count: pageResults.length,
+        failing_page_count: failingPageCount,
+        slowest_page_ms: slowestPageMs,
+        site_create_ms: metric(create?.elapsedMs),
+        site_initial_status_ms: metric(initialStatusResult.elapsedMs),
+        setup_profile_ms: metric(setupProfile?.elapsedMs),
+        site_status_ms: metric(statusResult.elapsedMs),
+        login_form_seen: metric(loginFormSeen),
+        total_elapsed_ms: totalElapsedMs,
+        ...metrics,
+        ...browserResult.metrics,
+      },
+      artifacts: {
+        raw_result: artifactFile,
+        site_path: sitePath,
+        ...browserResult.artifacts,
+      },
+    };
+  } finally {
+    if (profileExtension?.cleanupWordPressAdminScaleSweep || profileExtension?.cleanupWordPressPageProfile) {
+      const cleanup = profileExtension.cleanupWordPressAdminScaleSweep || profileExtension.cleanupWordPressPageProfile;
+      await cleanup({ sitePath, setupProfile, manifest, pageSpecs: manifest.pages, pageSpec: manifest.pages[0] });
+    }
+    if (profiler) {
+      profiler.uninstallWordPressRequestProfiler?.(sitePath);
+    }
+    await restoreProfilePlugins(installedPlugins);
+    if (createdSite && !stop) {
+      stop = await stopSite(sitePath);
+    }
+  }
+}

--- a/Automattic/studio/rigs/studio-combined/rig.json
+++ b/Automattic/studio/rigs/studio-combined/rig.json
@@ -59,6 +59,7 @@
       "${package.root}/bench/studio-admin-theme-page-browser.bench.mjs",
       "${package.root}/bench/studio-dashboard-browser.bench.mjs",
       "${package.root}/bench/studio-page-timing-matrix.bench.mjs",
+      "${package.root}/bench/studio-wordpress-admin-scale-sweep.bench.mjs",
       "${package.root}/bench/studio-rest-latency-diagnostics.bench.mjs",
       "${package.root}/bench/studio-site-editor-browser.bench.mjs",
       "${package.root}/bench/studio-site-editor-diagnostics.bench.mjs",

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ homeboy bench --rig studio-combined --scenario studio-db-dropin-startup --iterat
 
 # Browser-visible wp-admin paths.
 homeboy bench --rig studio-combined --scenario studio-page-timing-matrix --iterations 1 --shared-state /tmp/studio-slow-path-bench
+homeboy bench --rig studio-combined --scenario studio-wordpress-admin-scale-sweep --iterations 1 --shared-state /tmp/studio-slow-path-bench
 homeboy bench --rig studio-combined --scenario studio-dashboard-browser --iterations 1 --shared-state /tmp/studio-slow-path-bench
 homeboy bench --rig studio-combined --scenario studio-admin-theme-page-browser --iterations 1 --shared-state /tmp/studio-slow-path-bench
 
@@ -75,7 +76,7 @@ homeboy bench --rig studio-combined --scenario studio-site-editor-diagnostics --
 homeboy bench --rig studio-combined --scenario studio-rest-latency-diagnostics --iterations 1 --shared-state /tmp/studio-slow-path-bench
 ```
 
-Run the CLI-only scenarios first to separate Studio provisioning and Playground startup cost from browser-visible WordPress admin cost. Use `studio-page-timing-matrix` next to sweep multiple wp-admin and frontend URLs in one logged-in browser session. Use the focused browser scenarios when a matrix page needs a dedicated trace, use `studio-site-editor-diagnostics` when the signal points at Site Editor readiness, and use `studio-rest-latency-diagnostics` when the signal points at per-request REST latency, WordPress bootstrap time, or browser-vs-WordPress transport overhead.
+Run the CLI-only scenarios first to separate Studio provisioning and Playground startup cost from browser-visible WordPress admin cost. Use `studio-page-timing-matrix` next to sweep multiple wp-admin and frontend URLs in one logged-in browser session. Use `studio-wordpress-admin-scale-sweep` when plugin admin screens need page-profiler diagnostics across one prepared site. Use the focused browser scenarios when a matrix page needs a dedicated trace, use `studio-site-editor-diagnostics` when the signal points at Site Editor readiness, and use `studio-rest-latency-diagnostics` when the signal points at per-request REST latency, WordPress bootstrap time, or browser-vs-WordPress transport overhead.
 
 `studio-rest-latency-diagnostics` logs into a fresh Studio site, extracts a real REST nonce from the post editor, and fetches a static asset, the front page, representative authenticated REST endpoints, and `admin-ajax.php` several times in one browser session. By default it installs WordPress bootstrap and request profilers so route summaries can compare browser timing, WordPress entry-to-shutdown timing, MU-plugin-to-shutdown timing, and likely outer transport/proxy overhead. Use `studio_rest_latency_iterations`, `studio_rest_latency_routes`, and `studio_rest_latency_profile_wordpress=0` to adjust the matrix or run an uninstrumented control:
 
@@ -96,6 +97,18 @@ homeboy bench --rig studio-combined \
   --iterations 1 \
   --shared-state /tmp/studio-page-timing
 ```
+
+`studio-wordpress-admin-scale-sweep` is the reusable plugin-admin stress rig. It logs into one prepared Studio site, profiles every page in a manifest with the Homeboy WordPress page profiler, and writes one combined artifact with per-page ready time, REST count, REST bytes, slowest resources, failures, trace/screenshot references, and a summary table sorted by the worst pages and requests. It can create a fresh Studio site or target an existing site with `HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_SITE_PATH`. Provide pages with `HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_MANIFEST_JSON` or `HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_MANIFEST`:
+
+```bash
+HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_MANIFEST_JSON='{"pages":[{"id":"pipelines","path":"/wp-admin/admin.php?page=datamachine-pipelines","ready":{"selector":".datamachine-pipelines-app"}},{"id":"jobs","path":"/wp-admin/admin.php?page=datamachine-jobs","ready":{"selector":".datamachine-jobs-app"}}]}' \
+homeboy bench --rig studio-combined \
+  --scenario studio-wordpress-admin-scale-sweep \
+  --iterations 1 \
+  --shared-state /tmp/studio-admin-scale-sweep
+```
+
+Manifest pages may include an `interactions` array. The rig records those declarations now and runs them only when the installed Homeboy Extensions page profiler exposes a compatible declarative interaction hook, so the workload stays usable with current released extension APIs.
 
 The Studio trace workload exercises the packaged app at `apps/studio/out` and records create-site readiness boundaries across the desktop shell, CLI log output, `cli.json`, HTTP readiness, `getSiteDetails()`, and the visible running-state UI.
 


### PR DESCRIPTION
## Summary
- Adds a reusable `studio-wordpress-admin-scale-sweep` workload that profiles multiple WordPress admin page specs against one prepared Studio site.
- Adds manifest normalization and combined summary helpers for per-page ready timing, REST counts/bytes, slow resources, failures, and worst-request reporting.
- Registers the workload in the Studio combined rig and documents Data Machine-style plugin admin sweep usage.

Closes #123.

## Verification
- `node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `HOMEBOY_COMPONENT_PATH=/tmp HOMEBOY_NODEJS_BROWSER_BENCH_HELPER='data:text/javascript,export async function runBrowserBench(){return {metrics:{},artifacts:{}}}' node --input-type=module -e "await import('./Automattic/studio/bench/studio-wordpress-admin-scale-sweep.bench.mjs'); console.log('loaded')"`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the benchmark workload, helper functions, tests, documentation, and PR description; Chris remains responsible for review and merge.