### PR TITLE
Refactor Studio admin sweep around profiler primitives

### DIFF
--- a/Automattic/studio/bench/lib/wordpress-admin-scale-sweep.mjs
+++ b/Automattic/studio/bench/lib/wordpress-admin-scale-sweep.mjs
@@ -1,9 +1,8 @@
 import { readFile } from 'node:fs/promises';
 
-import { metric } from './studio-bench.mjs';
+import { wordpressResourceInclude } from './wordpress-page-profiler.mjs';
 
 const DEFAULT_ADMIN_READY = { selector: '#wpbody-content, body.wp-admin', timeout: 120000 };
-const DEFAULT_RESOURCE_INCLUDE = ['/wp-json/', '?rest_route=', '/wp-admin/', '/wp-content/', '/wp-includes/'];
 
 function pageIdFromPath(pagePath) {
   return String(pagePath || '')
@@ -20,13 +19,15 @@ function metricId(id) {
     .replace(/^_+|_+$/g, '') || 'page';
 }
 
-export function normalizeWordPressAdminScaleSweepManifest(manifest) {
+export function normalizeWordPressAdminScaleSweepManifest(manifest, options = {}) {
   if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
     throw new Error('WordPress admin scale sweep manifest must be an object');
   }
   if (!Array.isArray(manifest.pages) || manifest.pages.length === 0) {
     throw new Error('WordPress admin scale sweep manifest requires a non-empty pages array');
   }
+
+  const resourceInclude = options.resourceInclude || wordpressResourceInclude(options);
 
   return {
     ...manifest,
@@ -47,7 +48,7 @@ export function normalizeWordPressAdminScaleSweepManifest(manifest) {
         label: page.label || id,
         ready,
         resources: {
-          includeResourceSubstrings: DEFAULT_RESOURCE_INCLUDE,
+          includeResourceSubstrings: resourceInclude,
           ...(page.resources || {}),
         },
         timeout: Number(page.timeout || ready.timeout || 120000),
@@ -61,10 +62,10 @@ export async function loadWordPressAdminScaleSweepManifest(options = {}) {
   const rawJson = options.json || process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_MANIFEST_JSON;
   const manifestPath = options.path || process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_MANIFEST;
   if (rawJson) {
-    return normalizeWordPressAdminScaleSweepManifest(JSON.parse(rawJson));
+    return normalizeWordPressAdminScaleSweepManifest(JSON.parse(rawJson), options);
   }
   if (manifestPath) {
-    return normalizeWordPressAdminScaleSweepManifest(JSON.parse(await readFile(manifestPath, 'utf8')));
+    return normalizeWordPressAdminScaleSweepManifest(JSON.parse(await readFile(manifestPath, 'utf8')), options);
   }
 
   return normalizeWordPressAdminScaleSweepManifest({
@@ -75,158 +76,5 @@ export async function loadWordPressAdminScaleSweepManifest(options = {}) {
       { id: 'posts', path: '/wp-admin/edit.php' },
       { id: 'add-post', path: '/wp-admin/post-new.php', ready: { selector: '.edit-post-layout, #editor, body.wp-admin', timeout: 120000 } },
     ],
-  });
-}
-
-function numberValue(...values) {
-  for (const value of values) {
-    const number = Number(value);
-    if (Number.isFinite(number)) {
-      return number;
-    }
-  }
-  return 0;
-}
-
-function resourceUrl(resource) {
-  return resource?.url || resource?.name || resource?.href || '';
-}
-
-function resourceDuration(resource) {
-  return numberValue(resource?.durationMs, resource?.duration_ms, resource?.duration);
-}
-
-function resourceBytes(resource) {
-  return numberValue(resource?.transferSize, resource?.transfer_size, resource?.encodedBodySize, resource?.encoded_body_size, resource?.decodedBodySize, resource?.decoded_body_size);
-}
-
-function isRestResource(resource) {
-  const url = resourceUrl(resource);
-  return url.includes('/wp-json/') || url.includes('?rest_route=');
-}
-
-function summarizeResources(resources = []) {
-  const all = Array.isArray(resources) ? resources : [];
-  const rest = all.filter(isRestResource);
-  return {
-    count: all.length,
-    rest_count: rest.length,
-    rest_bytes: rest.reduce((total, resource) => total + resourceBytes(resource), 0),
-    slowest: all
-      .slice()
-      .sort((a, b) => resourceDuration(b) - resourceDuration(a))
-      .slice(0, 20)
-      .map((resource) => ({
-        url: resourceUrl(resource),
-        duration_ms: resourceDuration(resource),
-        ttfb_ms: numberValue(resource?.ttfbMs, resource?.ttfb_ms),
-        transfer_size: numberValue(resource?.transferSize, resource?.transfer_size),
-        encoded_body_size: numberValue(resource?.encodedBodySize, resource?.encoded_body_size),
-        resource_type: resource?.resourceType || resource?.initiatorType || resource?.kind || '',
-      })),
-  };
-}
-
-export function summarizeWordPressAdminScaleSweepPage({ pageSpec, profile, networkRequests = [], interactionResult, artifacts }) {
-  const resources = summarizeResources(profile?.resources?.resources || profile?.resources || []);
-  const failedRequests = networkRequests.filter((request) => request.failed || Number(request.status || 0) >= 400);
-  const slowestNetwork = networkRequests
-    .slice()
-    .sort((a, b) => numberValue(b.duration_ms) - numberValue(a.duration_ms))
-    .slice(0, 20);
-  const interaction = profile?.interactions ?? interactionResult ?? null;
-  const failures = [
-    ...failedRequests.map((request) => ({
-      type: 'request',
-      url: request.url,
-      status: request.status || 0,
-      error: request.failure || '',
-    })),
-    ...(profile?.failure ? [{ type: 'profile', error: profile.failure }] : []),
-    ...(interaction?.failed || interaction?.failure ? [{ type: 'interaction', error: interaction.failure || 'interaction failed' }] : []),
-  ];
-
-  return {
-    id: pageSpec.id,
-    metric_id: pageSpec.metricId || metricId(pageSpec.id),
-    label: pageSpec.label || pageSpec.id,
-    path: pageSpec.path,
-    status: metric(profile?.status),
-    ready_ms: metric(profile?.readyMs),
-    resource_count: metric(profile?.resources?.count ?? resources.count),
-    rest_count: metric(profile?.resources?.restCount ?? resources.rest_count),
-    rest_bytes: metric(profile?.resources?.restBytes ?? resources.rest_bytes),
-    failed_request_count: failedRequests.length,
-    failure_count: failures.length,
-    slowest_resource_ms: metric(resources.slowest[0]?.duration_ms),
-    slowest_resources: resources.slowest,
-    slowest_requests: slowestNetwork,
-    failures,
-    interaction,
-    artifacts: artifacts || {},
-    rawProfile: profile,
-  };
-}
-
-export function buildWordPressAdminScaleSweepSummary(pages) {
-  const rows = pages
-    .map((page) => ({
-      id: page.id,
-      label: page.label,
-      path: page.path,
-      status: page.status,
-      ready_ms: page.ready_ms,
-      rest_count: page.rest_count,
-      rest_bytes: page.rest_bytes,
-      failed_request_count: page.failed_request_count,
-      failure_count: page.failure_count,
-      slowest_resource_ms: page.slowest_resource_ms,
-    }))
-    .sort((a, b) => {
-      if (a.failure_count !== b.failure_count) {
-        return b.failure_count - a.failure_count;
-      }
-      if (a.ready_ms !== b.ready_ms) {
-        return b.ready_ms - a.ready_ms;
-      }
-      return b.slowest_resource_ms - a.slowest_resource_ms;
-    });
-
-  const requests = pages
-    .flatMap((page) =>
-      (page.slowest_requests || []).map((request) => ({
-        page_id: page.id,
-        url: request.url,
-        method: request.method,
-        status: request.status || 0,
-        failed: Boolean(request.failed),
-        duration_ms: metric(request.duration_ms),
-        resource_type: request.resource_type || request.resourceType || '',
-      }))
-    )
-    .sort((a, b) => {
-      if (a.failed !== b.failed) {
-        return a.failed ? -1 : 1;
-      }
-      return b.duration_ms - a.duration_ms;
-    })
-    .slice(0, 40);
-
-  const pageTable = [
-    '| Page | Status | Ready ms | REST | REST bytes | Failed requests | Slowest resource ms |',
-    '|---|---:|---:|---:|---:|---:|---:|',
-    ...rows.map((row) => `| ${row.id} | ${row.status} | ${Math.round(row.ready_ms)} | ${row.rest_count} | ${row.rest_bytes} | ${row.failed_request_count} | ${Math.round(row.slowest_resource_ms)} |`),
-  ].join('\n');
-
-  const requestTable = [
-    '| Page | Status | Duration ms | URL |',
-    '|---|---:|---:|---|',
-    ...requests.slice(0, 15).map((request) => `| ${request.page_id} | ${request.status} | ${Math.round(request.duration_ms)} | ${String(request.url || '').replace(/\|/g, '%7C')} |`),
-  ].join('\n');
-
-  return {
-    pages: rows,
-    worst_requests: requests,
-    markdown: `${pageTable}\n\n${requestTable}`,
-  };
+  }, options);
 }

--- a/Automattic/studio/bench/lib/wordpress-page-profiler.mjs
+++ b/Automattic/studio/bench/lib/wordpress-page-profiler.mjs
@@ -23,7 +23,15 @@ export const SITE_EDITOR_PAGE_SPEC = {
   timeout: 120000,
 };
 
-export function wordpressPageProfilerSpec() {
+export function wordpressResourceInclude(options = {}) {
+  const pageProfiler = options.pageProfiler || loadWordPressPageProfiler(options).module;
+  if (!Array.isArray(pageProfiler?.DEFAULT_RESOURCE_INCLUDE)) {
+    throw new Error('Homeboy WordPress page profiler must export DEFAULT_RESOURCE_INCLUDE. Update homeboy-extensions.');
+  }
+  return pageProfiler.DEFAULT_RESOURCE_INCLUDE;
+}
+
+export function wordpressPageProfilerSpec(options = {}) {
   const rawSpec = process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_SPEC_JSON;
   if (rawSpec) {
     return JSON.parse(rawSpec);
@@ -51,7 +59,7 @@ export function wordpressPageProfilerSpec() {
     resources: {
       includeResourceSubstrings: process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_RESOURCE_INCLUDE
         ? process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_RESOURCE_INCLUDE.split(',').map((value) => value.trim()).filter(Boolean)
-        : ['/wp-json/', '?rest_route=', '/wp-admin/', '/wp-content/', '/wp-includes/'],
+        : wordpressResourceInclude(options),
     },
     timeout,
   };

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -6,6 +6,15 @@ import test from 'node:test';
 
 process.env.HOMEBOY_COMPONENT_PATH ||= '/tmp/homeboy-rigs-test-component';
 
+const DEFAULT_RESOURCE_INCLUDE = Object.freeze([
+  '/wp-json/',
+  '?rest_route=',
+  '/wp-admin/',
+  '/wp-content/',
+  '/wp-includes/',
+]);
+const pageProfilerApi = { DEFAULT_RESOURCE_INCLUDE };
+
 const {
   annotatePhase,
   buildTimingDeltaSummary,
@@ -29,9 +38,7 @@ const {
   wordpressPageProfilerSpec,
 } = await import('./lib/wordpress-page-profiler.mjs');
 const {
-  buildWordPressAdminScaleSweepSummary,
   normalizeWordPressAdminScaleSweepManifest,
-  summarizeWordPressAdminScaleSweepPage,
 } = await import('./lib/wordpress-admin-scale-sweep.mjs');
 
 function withEnv(values, callback) {
@@ -110,7 +117,7 @@ test('wordpressPageProfilerSpec defaults to Site Editor', () => {
       HOMEBOY_WORDPRESS_PAGE_PROFILE_PATH: undefined,
     },
     () => {
-      const spec = wordpressPageProfilerSpec();
+      const spec = wordpressPageProfilerSpec({ pageProfiler: pageProfilerApi });
       assert.equal(spec.id, 'site-editor');
       assert.equal(spec.path, '/wp-admin/site-editor.php');
     }
@@ -127,17 +134,13 @@ test('wordpressPageProfilerSpec builds a generic WordPress page spec from env', 
       HOMEBOY_WORDPRESS_PAGE_PROFILE_READY_SELECTOR: undefined,
     },
     () => {
-      const spec = wordpressPageProfilerSpec();
+      const spec = wordpressPageProfilerSpec({ pageProfiler: pageProfilerApi });
       assert.equal(spec.id, 'front-page');
       assert.equal(spec.label, 'Front page');
       assert.equal(spec.path, '/');
       assert.equal(spec.ready.state, 'domcontentloaded');
       assert.deepEqual(spec.resources.includeResourceSubstrings, [
-        '/wp-json/',
-        '?rest_route=',
-        '/wp-admin/',
-        '/wp-content/',
-        '/wp-includes/',
+        ...DEFAULT_RESOURCE_INCLUDE,
       ]);
     }
   );
@@ -429,7 +432,7 @@ test('normalizeWordPressAdminScaleSweepManifest accepts page manifests and adds 
         interactions: [{ type: 'click', selector: '.jobs-row:first-child button' }],
       },
     ],
-  });
+  }, { pageProfiler: pageProfilerApi });
 
   assert.equal(manifest.pages.length, 2);
   assert.equal(manifest.pages[0].metricId, 'pipelines');
@@ -437,83 +440,6 @@ test('normalizeWordPressAdminScaleSweepManifest accepts page manifests and adds 
   assert.equal(manifest.pages[1].id, 'wp-admin-admin.php-page-datamachine-jobs');
   assert.equal(manifest.pages[1].ready.selector, '#wpbody-content, body.wp-admin');
   assert.equal(manifest.pages[1].interactions.length, 1);
-});
-
-test('summarizeWordPressAdminScaleSweepPage records readiness, REST bytes, failures, and slow resources', () => {
-  const page = summarizeWordPressAdminScaleSweepPage({
-    pageSpec: { id: 'jobs', path: '/wp-admin/admin.php?page=datamachine-jobs' },
-    profile: {
-      status: 200,
-      readyMs: 1234,
-      interactions: {
-        actions: [{ name: 'open_jobs_modal', status: 'passed', durationMs: 77 }],
-        durationMs: 77,
-        failed: false,
-      },
-      resources: {
-        resources: [
-          { url: '/wp-json/datamachine/v1/jobs', durationMs: 250, transferSize: 1000, kind: 'fetch' },
-          { url: '/wp-content/plugins/data-machine/app.js', durationMs: 400, transferSize: 2000, kind: 'script' },
-        ],
-      },
-    },
-    networkRequests: [
-      { url: '/wp-json/datamachine/v1/jobs', method: 'GET', status: 200, duration_ms: 250 },
-      { url: '/wp-json/datamachine/v1/fail', method: 'GET', status: 500, duration_ms: 100 },
-    ],
-    interactionResult: {
-      skipped: true,
-      reason: 'fallback runner unavailable',
-      interaction_count: 1,
-    },
-    artifacts: { trace: '/tmp/trace.zip', screenshot: '/tmp/page.png' },
-  });
-
-  assert.equal(page.status, 200);
-  assert.equal(page.ready_ms, 1234);
-  assert.equal(page.rest_count, 1);
-  assert.equal(page.rest_bytes, 1000);
-  assert.equal(page.failed_request_count, 1);
-  assert.equal(page.failure_count, 1);
-  assert.equal(page.interaction.actions[0].name, 'open_jobs_modal');
-  assert.equal(page.interaction.skipped, undefined);
-  assert.equal(page.slowest_resources[0].url, '/wp-content/plugins/data-machine/app.js');
-  assert.equal(page.artifacts.trace, '/tmp/trace.zip');
-});
-
-test('buildWordPressAdminScaleSweepSummary sorts worst pages and requests first', () => {
-  const summary = buildWordPressAdminScaleSweepSummary([
-    {
-      id: 'fast',
-      label: 'Fast',
-      path: '/wp-admin/admin.php?page=fast',
-      status: 200,
-      ready_ms: 100,
-      rest_count: 1,
-      rest_bytes: 10,
-      failed_request_count: 0,
-      failure_count: 0,
-      slowest_resource_ms: 50,
-      slowest_requests: [{ url: '/fast', status: 200, duration_ms: 50 }],
-    },
-    {
-      id: 'slow',
-      label: 'Slow',
-      path: '/wp-admin/admin.php?page=slow',
-      status: 200,
-      ready_ms: 900,
-      rest_count: 4,
-      rest_bytes: 100,
-      failed_request_count: 1,
-      failure_count: 1,
-      slowest_resource_ms: 800,
-      slowest_requests: [{ url: '/slow', status: 500, failed: true, duration_ms: 800 }],
-    },
-  ]);
-
-  assert.equal(summary.pages[0].id, 'slow');
-  assert.equal(summary.worst_requests[0].url, '/slow');
-  assert.match(summary.markdown, /\| slow \| 200 \| 900 \| 4 \| 100 \| 1 \| 800 \|/);
 });
 
 // --- WordPress bootstrap timeline -----------------------------------------

--- a/Automattic/studio/bench/studio-wordpress-admin-scale-sweep.bench.mjs
+++ b/Automattic/studio/bench/studio-wordpress-admin-scale-sweep.bench.mjs
@@ -1,6 +1,5 @@
 import { cp, mkdir, readFile, rename, rm, symlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { performance } from 'node:perf_hooks';
 import { pathToFileURL } from 'node:url';
 
 import {
@@ -19,14 +18,11 @@ import {
   variant,
 } from './lib/studio-bench.mjs';
 import {
-  buildWordPressAdminScaleSweepSummary,
   loadWordPressAdminScaleSweepManifest,
-  summarizeWordPressAdminScaleSweepPage,
 } from './lib/wordpress-admin-scale-sweep.mjs';
 import {
   loadWordPressPageProfiler,
   loadWordPressRequestProfiler,
-  profileWordPressPage,
 } from './lib/wordpress-page-profiler.mjs';
 
 const BROWSER_HELPER = process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER;
@@ -152,21 +148,62 @@ async function loadProfileExtensionModule() {
   return import(pathToFileURL(modulePath).href);
 }
 
-function scrubUrl(url, siteUrl) {
-  try {
-    const parsed = new URL(url);
-    const base = new URL(siteUrl);
-    if (parsed.origin === base.origin) {
-      return `${parsed.pathname}${parsed.search}`;
-    }
-  } catch {
-    // Fall through to normal redaction.
-  }
-  return redact(url);
+function manifestHasInteractions(manifest) {
+  return (manifest.pages || []).some((page) => Array.isArray(page.interactions) && page.interactions.length > 0);
 }
 
-function scrubNetworkRequests(requests, siteUrl) {
-  return requests.map((request) => ({ ...request, url: scrubUrl(request.url, siteUrl) }));
+function assertInteractionSupport({ manifest, pageProfiler, profileExtension }) {
+  if (!manifestHasInteractions(manifest)) {
+    return;
+  }
+  if (pageProfiler?.runBrowserActions || profileExtension?.runBrowserActions || profileExtension?.profileWordPressAdminScaleSweepPages) {
+    return;
+  }
+  throw new Error('WordPress admin scale sweep manifest includes interactions, but the installed Homeboy WordPress page profiler does not expose runBrowserActions(). Update homeboy-extensions.');
+}
+
+function assertAdminSweepSummarySupport({ pageProfiler, profileExtension }) {
+  const profiler = profileExtension || pageProfiler;
+  if (
+    profiler?.summarizeWordPressAdminPageProfile &&
+    profiler?.buildWordPressAdminPageSweepSummary &&
+    profiler?.formatWordPressAdminPageSweepMarkdownReport
+  ) {
+    return;
+  }
+  throw new Error('WordPress admin scale sweep requires admin page summary helpers. Update homeboy-extensions to include summarizeWordPressAdminPageProfile().');
+}
+
+function pageMetricId(pageSpec, pageSummary) {
+  return pageSpec?.metricId || String(pageSummary.id || 'page')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '') || 'page';
+}
+
+function adaptAdminPageSummary({ pageSpec, pageSummary, profile, artifacts }) {
+  return {
+    ...pageSummary,
+    metric_id: pageMetricId(pageSpec, pageSummary),
+    status: metric(pageSummary.status),
+    ready_ms: metric(pageSummary.readyMs),
+    resource_count: metric(pageSummary.resourceCount),
+    rest_count: metric(pageSummary.restCount),
+    rest_bytes: metric(pageSummary.restBytes),
+    failed_request_count: metric(pageSummary.failedRequestCount),
+    failure_count: metric(pageSummary.failureCount),
+    slowest_resource_ms: metric(pageSummary.slowestResources?.[0]?.durationMs),
+    slowest_resources: pageSummary.slowestResources || [],
+    slowest_requests: pageSummary.slowestRestRows || [],
+    failures: [
+      ...(pageSummary.failedRestRows || []).map((row) => ({ type: 'rest', url: row.url, status: row.status || 0, error: row.error || '' })),
+      ...(pageSummary.findings || []).map((finding) => ({ type: 'budget', code: finding.code, error: finding.message })),
+    ],
+    interaction: profile?.interactions || null,
+    artifacts: artifacts || {},
+    rawProfile: profile,
+    profileSummary: pageSummary,
+  };
 }
 
 async function sanitizeNetworkArtifact(artifact) {
@@ -175,53 +212,6 @@ async function sanitizeNetworkArtifact(artifact) {
   }
   const raw = await readFile(artifact.path, 'utf8');
   await writeFile(artifact.path, redact(raw));
-}
-
-async function runOptionalInteractions({ profileExtension, pageProfiler, page, pageSpec, siteUrl, mark, profile }) {
-  if (profile?.interactions !== undefined) {
-    return profile.interactions;
-  }
-  if (!pageSpec.interactions.length) {
-    return null;
-  }
-
-  if (profileExtension?.runWordPressAdminScaleSweepInteractions) {
-    return profileExtension.runWordPressAdminScaleSweepInteractions({
-      page,
-      baseUrl: siteUrl,
-      spec: pageSpec,
-      interactions: pageSpec.interactions,
-      mark,
-    });
-  }
-
-  if (pageProfiler?.runBrowserActions) {
-    return pageProfiler.runBrowserActions(page, pageSpec.interactions, {
-      mark,
-      timeout: pageSpec.interactionTimeout,
-      failureScreenshotPath: pageSpec.failureScreenshotPath,
-      tracePath: pageSpec.tracePath,
-    });
-  }
-
-  return {
-    skipped: true,
-    reason: 'No declarative WordPress page interaction runner is available in the installed extensions.',
-    interaction_count: pageSpec.interactions.length,
-  };
-}
-
-function shouldMarkInteractionFallback(profile, interaction) {
-  if (!interaction) {
-    return false;
-  }
-  if (profile?.interactions !== undefined) {
-    return false;
-  }
-  if (interaction.skipped) {
-    return false;
-  }
-  return true;
 }
 
 function summarizeWordPressRequests(entries = []) {
@@ -250,9 +240,12 @@ function summarizeWordPressRequests(entries = []) {
 
 export default async function studioWordPressAdminScaleSweepBench() {
   const currentVariant = variant();
+  const { path: profilerPath, module: profiler } = loadWordPressRequestProfiler();
+  const { path: pageProfilerPath, module: pageProfiler } = loadWordPressPageProfiler({ profilerPath });
   const manifest = await loadWordPressAdminScaleSweepManifest({
     json: setting('wordpress_admin_scale_sweep_manifest_json'),
     path: expandHome(setting('wordpress_admin_scale_sweep_manifest')),
+    pageProfiler,
   });
   const runId = `${currentVariant}-wordpress-admin-scale-sweep-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   const artifactDir = path.join(studioArtifactDir('studio-wordpress-admin-scale-sweep-artifacts'), runId);
@@ -267,8 +260,6 @@ export default async function studioWordPressAdminScaleSweepBench() {
   await mkdir(artifactDir, { recursive: true });
 
   const totalStarted = Date.now();
-  const { path: profilerPath, module: profiler } = loadWordPressRequestProfiler();
-  const { path: pageProfilerPath, module: pageProfiler } = loadWordPressPageProfiler({ profilerPath });
   let create;
   let start;
   let initialStatusResult;
@@ -283,9 +274,6 @@ export default async function studioWordPressAdminScaleSweepBench() {
   let wordpressRequests = [];
   const pageResults = [];
   const metrics = {};
-  const network = [];
-  const startedRequests = new Map();
-  let phase = 'setup';
 
   try {
     if (createdSite) {
@@ -296,6 +284,8 @@ export default async function studioWordPressAdminScaleSweepBench() {
     initialStatusResult = await siteStatus(sitePath);
     installedPlugins = await installProfilePlugins(sitePath);
     profileExtension = await loadProfileExtensionModule();
+    assertInteractionSupport({ manifest, pageProfiler, profileExtension });
+    assertAdminSweepSummarySupport({ pageProfiler, profileExtension });
     if (profileExtension?.setupWordPressAdminScaleSweep || profileExtension?.setupWordPressPageProfile) {
       const startedSetup = Date.now();
       const setup = profileExtension.setupWordPressAdminScaleSweep || profileExtension.setupWordPressPageProfile;
@@ -318,60 +308,40 @@ export default async function studioWordPressAdminScaleSweepBench() {
       screenshot: true,
       waitForNetworkIdle: false,
       action: async ({ page, mark }) => {
-        page.on('request', (request) => startedRequests.set(request, { started: performance.now(), phase }));
-        page.on('requestfinished', async (request) => {
-          const response = await request.response().catch(() => null);
-          const started = startedRequests.get(request) || { started: performance.now(), phase: 'unknown' };
-          network.push({
-            phase: started.phase,
-            url: request.url(),
-            method: request.method(),
-            status: response?.status() ?? 0,
-            duration_ms: performance.now() - started.started,
-            resource_type: request.resourceType(),
-          });
-        });
-        page.on('requestfailed', (request) => {
-          const started = startedRequests.get(request) || { started: performance.now(), phase: 'unknown' };
-          network.push({
-            phase: started.phase,
-            url: request.url(),
-            method: request.method(),
-            status: 0,
-            failed: true,
-            failure: request.failure()?.errorText || 'request failed',
-            duration_ms: performance.now() - started.started,
-            resource_type: request.resourceType(),
-          });
-        });
-
-        phase = 'login';
         await page.goto(status.autoLoginUrl, { waitUntil: 'domcontentloaded', timeout: 120000 });
         await page.waitForLoadState('networkidle', { timeout: 120000 }).catch(() => {});
         await mark('auto_login_ready');
         loginFormSeen = await page.locator('#loginform').count().catch(() => 0);
 
-        const runPageProfile = profileExtension?.profileWordPressAdminScaleSweepPage || profileExtension?.profileWordPressPage || profileWordPressPage;
-        for (const pageSpec of manifest.pages) {
-          phase = `page:${pageSpec.id}`;
-          const startedNetworkIndex = network.length;
-          const profile = await runPageProfile({ page, siteUrl: status.siteUrl, pageProfiler, pageSpec, mark });
-          await mark(`page_${pageSpec.metricId}_ready`);
-          const interaction = await runOptionalInteractions({ profileExtension, pageProfiler, page, pageSpec, siteUrl: status.siteUrl, mark, profile });
-          if (shouldMarkInteractionFallback(profile, interaction)) {
-            await mark(`page_${pageSpec.metricId}_interactions_done`);
-          }
-          const pageNetwork = scrubNetworkRequests(network.slice(startedNetworkIndex), status.siteUrl);
+        const runPagesProfile = profileExtension?.profileWordPressAdminScaleSweepPages || profileExtension?.profileWordPressPages || pageProfiler?.profileWordPressPages;
+        const adminPageProfiler = profileExtension?.summarizeWordPressAdminPageProfile ? profileExtension : pageProfiler;
+        if (!runPagesProfile) {
+          throw new Error('WordPress admin scale sweep requires pageProfiler.profileWordPressPages(). Update homeboy-extensions.');
+        }
+
+        const sweepProfile = await runPagesProfile({
+          page,
+          baseUrl: status.siteUrl,
+          siteUrl: status.siteUrl,
+          pageProfiler,
+          manifest,
+          mark,
+        });
+
+        const pageSummaries = [];
+        for (const profile of sweepProfile.pages || []) {
+          const pageSpec = manifest.pages.find((candidate) => candidate.id === profile.id) || { id: profile.id, label: profile.label, path: profile.path };
+          const pageSummary = adminPageProfiler.summarizeWordPressAdminPageProfile({ profile, spec: pageSpec });
+          pageSummaries.push(pageSummary);
           pageResults.push(
-            summarizeWordPressAdminScaleSweepPage({
+            adaptAdminPageSummary({
               pageSpec,
+              pageSummary,
               profile,
-              networkRequests: pageNetwork,
-              interactionResult: interaction,
             })
           );
         }
-        phase = 'done';
+        pageResults.profileSummaries = pageSummaries;
       },
     });
 
@@ -399,8 +369,10 @@ export default async function studioWordPressAdminScaleSweepBench() {
       metrics[`page_${pageMetricId}_slowest_resource_ms`] = metric(page.slowest_resource_ms);
     }
 
-    const summary = buildWordPressAdminScaleSweepSummary(pageResults);
-    const failingPageCount = pageResults.filter((page) => page.status >= 500 || page.status === 0 || page.failure_count > 0).length;
+    const adminPageProfiler = profileExtension?.buildWordPressAdminPageSweepSummary ? profileExtension : pageProfiler;
+    const summary = adminPageProfiler.buildWordPressAdminPageSweepSummary(pageResults.profileSummaries || pageResults.map((page) => page.profileSummary));
+    summary.markdown = adminPageProfiler.formatWordPressAdminPageSweepMarkdownReport(summary, { title: 'WordPress admin scale sweep' });
+    const failingPageCount = summary.totals.failedPageCount;
     const slowestPageMs = Math.max(0, ...pageResults.map((page) => metric(page.ready_ms)));
     const artifactFile = path.join(artifactDir, `result-${runId}.json`);
     await writeFile(


### PR DESCRIPTION
## Summary
- Delegate Studio admin scale sweep page profiling, interactions, resource defaults, and summary formatting to Homeboy Extensions WordPress page-profiler primitives.
- Keep Homeboy Rigs focused on Studio lifecycle, plugin/profile setup, artifact wiring, and metric adaptation.
- Fail clearly when the installed Homeboy Extensions profiler is too old to provide admin sweep primitives.

## Verification
- `node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `homeboy lint --path /Users/chubes/Developer/homeboy-rigs@refactor-admin-sweep-primitives --extension nodejs --changed-since origin/main`
- Smoke benchmark against existing scaled Studio site:
  - Run ID: `c36f7967-a460-4bdb-a644-a57802a1827e`
  - Command used latest Homeboy Extensions profiler primitives via `HOMEBOY_WORDPRESS_REQUEST_PROFILER_PATH` and `HOMEBOY_WORDPRESS_PAGE_PROFILER_PATH`.
  - Scenario: `studio-wordpress-admin-scale-sweep`
  - Result: passed, `failing_page_count=0`, dashboard `ready_ms=851.3`, dashboard `rest_count=1`, dashboard `rest_bytes=2851`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Refactored the rig to consume upstream profiler primitives, updated tests, and ran verification. Chris remains responsible for review and merge.