### PR TITLE
Preserve Playground trace event sources

### DIFF
--- a/Automattic/studio/bench/playground-web-startup.trace.mjs
+++ b/Automattic/studio/bench/playground-web-startup.trace.mjs
@@ -17,7 +17,7 @@ const TIMEOUT_MS = Number(process.env.PLAYGROUND_WEB_TRACE_TIMEOUT_MS || 120_000
 const ARTIFACT_DIR = process.env.HOMEBOY_TRACE_ARTIFACT_DIR || path.join(tmpdir(), 'playground-web-trace-artifacts');
 
 const { createTraceRecorder } = await import(pathToFileURL(`${HELPER_DIR}/timeline.mjs`).href);
-const { installConsoleBridge, pollHttp } = await import(pathToFileURL(`${HELPER_DIR}/probes.mjs`).href);
+const { pollHttp } = await import(pathToFileURL(`${HELPER_DIR}/probes.mjs`).href);
 
 const playwright = require(require.resolve('playwright', { paths: [PLAYGROUND_PATH] }));
 const recorder = createTraceRecorder({ scenarioId: 'playground-web-startup' });
@@ -126,11 +126,34 @@ function buildUrl(baseUrl, variant) {
 	const url = new URL(baseUrl);
 	url.searchParams.set('url', '/');
 	url.searchParams.set('trace-run', `${variant}-${Date.now()}`);
+	url.searchParams.set('homeboy-trace', '1');
 	if (variant === 'seeded') {
 		url.searchParams.set('preinstalled-sqlite-template', TEMPLATE_PATH);
 	}
 	url.hash = JSON.stringify({ preferredVersions: { wp: WP_VERSION, php: PHP_VERSION } });
 	return url.toString();
+}
+
+function installHomeboyTraceBridge(page, variant) {
+	page.on('console', async (message) => {
+		const text = typeof message.text === 'function' ? message.text() : String(message);
+		if (!text.startsWith('trace:')) {
+			return;
+		}
+		try {
+			const payload = JSON.parse(text.slice('trace:'.length));
+			if (!payload || typeof payload.source !== 'string' || typeof payload.event !== 'string') {
+				return;
+			}
+			await recorder.recordEvent(`${payload.source}.${variant}`, payload.event, {
+				variant,
+				source: payload.source,
+				...(payload.data || {}),
+			});
+		} catch {
+			await recorder.recordEvent(`browser.${variant}`, 'trace_parse_error', { text });
+		}
+	});
 }
 
 async function collectResources(page, variant) {
@@ -159,7 +182,7 @@ async function measure(browser, baseUrl, variant) {
 	});
 	const context = await browser.newContext();
 	const page = await context.newPage();
-	installConsoleBridge(page, { prefix: 'trace:', source: `browser.${variant}`, onEvent });
+	installHomeboyTraceBridge(page, variant);
 
 	try {
 		await page.goto(buildUrl(baseUrl, variant), { waitUntil: 'commit', timeout: TIMEOUT_MS });


### PR DESCRIPTION
## Summary
- Preserve original Playground `trace:` payload sources when recording Web startup trace events.
- Tag captured events with the measured variant so baseline and seeded spans can be compared directly.
- Enable the local `homeboy-trace=1` query flag in the trace workload URL.

## Evidence
- `npx nx lint playground-wordpress` passed in the local Playground investigation worktree.
- `npx nx lint playground-blueprints` passed in the local Playground investigation worktree.
- `homeboy trace nodejs playground-web-startup --path /Users/chubes/Developer/wordpress-playground@investigate-preinstalled-sqlite-template` passed while validating this trace bridge locally.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the Homeboy-rigs trace bridge update, running local trace/lint checks, and drafting this PR description. Chris reviewed the investigation direction and constrained Playground changes to local-only probes.