### PR TITLE
Share Studio bench artifact sanitization

### DIFF
--- a/Automattic/studio/bench/lib/studio-bench.mjs
+++ b/Automattic/studio/bench/lib/studio-bench.mjs
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
@@ -52,6 +52,13 @@ export function redact(text) {
     .replace(/("adminPassword"\s*:\s*")[^"]+(")/g, '$1[redacted]$2')
     .replace(/(autoLoginUrl"?\s*[:=]\s*"?)[^"\s,}]+/gi, '$1[redacted]')
     .replace(/([?&](?:token|password|key|nonce)=)[^&#\s]+/gi, '$1[redacted]');
+}
+
+export async function sanitizeArtifact(artifact) {
+  if (!artifact || typeof artifact.path !== 'string') {
+    return;
+  }
+  await writeFile(artifact.path, redact(await readFile(artifact.path, 'utf8')));
 }
 
 export function safeResult(result) {

--- a/Automattic/studio/bench/studio-admin-theme-page-browser.bench.mjs
+++ b/Automattic/studio/bench/studio-admin-theme-page-browser.bench.mjs
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import {
   artifactDir as studioArtifactDir,
@@ -7,6 +7,7 @@ import {
   parseStudioSiteStatus,
   redact,
   safeResult,
+  sanitizeArtifact,
   stopStudioSite,
   studioSiteStatus,
   variant,
@@ -39,14 +40,6 @@ function autoLoginUrl(siteUrl, relativePath) {
   const url = new URL('/studio-auto-login', siteUrl);
   url.searchParams.set('redirect_to', new URL(relativePath, siteUrl).pathname);
   return url.toString();
-}
-
-async function sanitizeNetworkArtifact(artifact) {
-  if (!artifact || typeof artifact.path !== 'string') {
-    return;
-  }
-  const raw = await readFile(artifact.path, 'utf8');
-  await writeFile(artifact.path, redact(raw));
 }
 
 async function firstContentfulPaint(page) {
@@ -107,7 +100,7 @@ export default async function studioAdminThemePageBrowserBench() {
       },
     });
 
-    await sanitizeNetworkArtifact(browserResult.artifacts?.network);
+    await sanitizeArtifact(browserResult.artifacts?.network);
     stop = await stopSite(sitePath);
 
     const totalElapsedMs = Date.now() - totalStarted;

--- a/Automattic/studio/bench/studio-dashboard-browser.bench.mjs
+++ b/Automattic/studio/bench/studio-dashboard-browser.bench.mjs
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import {
   artifactDir as studioArtifactDir,
@@ -7,6 +7,7 @@ import {
   parseStudioSiteStatus,
   redact,
   safeResult,
+  sanitizeArtifact,
   stopStudioSite,
   studioSiteStatus,
   variant,
@@ -33,14 +34,6 @@ async function siteStatus(sitePath) {
 
 async function stopSite(sitePath) {
   return stopStudioSite(sitePath, { timeoutMs: 90000 });
-}
-
-async function sanitizeNetworkArtifact(artifact) {
-  if (!artifact || typeof artifact.path !== 'string') {
-    return;
-  }
-  const raw = await readFile(artifact.path, 'utf8');
-  await writeFile(artifact.path, redact(raw));
 }
 
 async function firstContentfulPaint(page) {
@@ -98,7 +91,7 @@ export default async function studioDashboardBrowserBench() {
       },
     });
 
-    await sanitizeNetworkArtifact(browserResult.artifacts?.network);
+    await sanitizeArtifact(browserResult.artifacts?.network);
     stop = await stopSite(sitePath);
 
     const totalElapsedMs = Date.now() - totalStarted;

--- a/Automattic/studio/bench/studio-page-timing-matrix.bench.mjs
+++ b/Automattic/studio/bench/studio-page-timing-matrix.bench.mjs
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import {
@@ -8,6 +8,7 @@ import {
   parseStudioSiteStatus,
   redact,
   safeResult,
+  sanitizeArtifact,
   setting,
   stopStudioSite,
   studioSiteStatus,
@@ -214,14 +215,6 @@ async function collectAdminMenuPaths(page, siteUrl) {
   );
 }
 
-async function sanitizeNetworkArtifact(artifact) {
-  if (!artifact || typeof artifact.path !== 'string') {
-    return;
-  }
-  const raw = await readFile(artifact.path, 'utf8');
-  await writeFile(artifact.path, redact(raw));
-}
-
 function summarizePage(page, siteUrl) {
   const failedRequests = page.requests.filter((request) => request.failed || request.status >= 400);
   const requestDurations = page.requests.map((request) => request.duration_ms).filter((value) => Number.isFinite(value));
@@ -385,7 +378,7 @@ export default async function studioPageTimingMatrixBench() {
       },
     });
 
-    await sanitizeNetworkArtifact(browserResult.artifacts?.network);
+    await sanitizeArtifact(browserResult.artifacts?.network);
     stop = await stopSite(sitePath);
 
     const totalElapsedMs = Date.now() - totalStarted;

--- a/Automattic/studio/bench/studio-rest-latency-diagnostics.bench.mjs
+++ b/Automattic/studio/bench/studio-rest-latency-diagnostics.bench.mjs
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import {
@@ -8,6 +8,7 @@ import {
   parseStudioSiteStatus,
   redact,
   safeResult,
+  sanitizeArtifact,
   setting,
   stopStudioSite,
   studioSiteStatus,
@@ -164,13 +165,6 @@ function summarizeRoutes({ routes, browserResults, wpSummaries, bootstrapSummari
       slowest_priority_bands: wpRows.flatMap((row) => row.priority_bands).sort((a, b) => b.duration_ms - a.duration_ms).slice(0, 5),
     };
   });
-}
-
-async function sanitizeArtifact(artifact) {
-  if (!artifact?.path) {
-    return;
-  }
-  await writeFile(artifact.path, redact(await readFile(artifact.path, 'utf8')));
 }
 
 export default async function studioRestLatencyDiagnosticsBench() {

--- a/Automattic/studio/bench/studio-site-editor-browser.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-browser.bench.mjs
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import {
@@ -8,6 +8,7 @@ import {
   parseStudioSiteStatus,
   redact,
   safeResult,
+  sanitizeArtifact,
   stopStudioSite,
   studioSiteStatus,
   variant,
@@ -39,14 +40,6 @@ async function stopSite(sitePath) {
 function siteAdminUrl(siteUrl, relativePath = '') {
   const base = siteUrl.endsWith('/') ? siteUrl : `${siteUrl}/`;
   return new URL(`wp-admin/${relativePath}`, base).toString();
-}
-
-async function sanitizeNetworkArtifact(artifact) {
-  if (!artifact || typeof artifact.path !== 'string') {
-    return;
-  }
-  const raw = await readFile(artifact.path, 'utf8');
-  await writeFile(artifact.path, redact(raw));
 }
 
 async function waitForSiteEditorReady(page) {
@@ -145,7 +138,7 @@ export default async function studioSiteEditorBrowserBench() {
       },
     });
 
-    await sanitizeNetworkArtifact(browserResult.artifacts?.network);
+    await sanitizeArtifact(browserResult.artifacts?.network);
     stop = await stopSite(sitePath);
 
     const totalElapsedMs = Date.now() - totalStarted;

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
@@ -1,4 +1,4 @@
-import { cp, mkdir, readFile, rename, rm, symlink, writeFile } from 'node:fs/promises';
+import { cp, mkdir, rename, rm, symlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { pathToFileURL } from 'node:url';
@@ -12,6 +12,7 @@ import {
   redact,
   runCli,
   safeResult,
+  sanitizeArtifact,
   startStudioSite,
   stopStudioSite,
   studioSiteStatus,
@@ -161,14 +162,6 @@ function scrubUrl(url) {
   } catch {
     return redact(url);
   }
-}
-
-async function sanitizeNetworkArtifact(artifact) {
-  if (!artifact || typeof artifact.path !== 'string') {
-    return;
-  }
-  const raw = await readFile(artifact.path, 'utf8');
-  await writeFile(artifact.path, redact(raw));
 }
 
 async function loadProfileExtensionModule() {
@@ -351,7 +344,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
       },
     });
 
-    await sanitizeNetworkArtifact(browserResult.artifacts?.network);
+    await sanitizeArtifact(browserResult.artifacts?.network);
     wordpressRequests = profiler?.collectWordPressRequestProfiles?.(sitePath) || [];
     profiler?.uninstallWordPressRequestProfiler?.(sitePath);
     wordpressBootstrapTimeline = await collectWordPressBootstrapTimeline(sitePath);

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -40,6 +40,9 @@ const {
 const {
   normalizeWordPressAdminScaleSweepManifest,
 } = await import('./lib/wordpress-admin-scale-sweep.mjs');
+const {
+  sanitizeArtifact,
+} = await import('./lib/studio-bench.mjs');
 
 function withEnv(values, callback) {
   const previous = {};
@@ -65,6 +68,25 @@ function withEnv(values, callback) {
 }
 
 // --- path resolution -------------------------------------------------------
+
+test('sanitizeArtifact redacts sensitive network artifact values', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'homeboy-rigs-sanitize-'));
+  const artifactPath = path.join(tempDir, 'network.json');
+  await writeFile(
+    artifactPath,
+    JSON.stringify({ url: 'http://example.test/wp-json/?token=abc123&nonce=secret', autoLoginUrl: 'http://example.test/studio-auto-login?token=login' })
+  );
+
+  try {
+    await sanitizeArtifact({ path: artifactPath });
+    const sanitized = await readFile(artifactPath, 'utf8');
+    assert.match(sanitized, /token=\[redacted\]/);
+    assert.match(sanitized, /nonce=\[redacted\]/);
+    assert.doesNotMatch(sanitized, /abc123|secret|login/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
 
 test('timingCorrelatorPath sits next to the request profiler by default', () => {
   withEnv({ HOMEBOY_SETTINGS_JSON: undefined }, () => {

--- a/Automattic/studio/bench/studio-site-editor-preload-comparison.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-preload-comparison.bench.mjs
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import {
@@ -9,6 +9,7 @@ import {
   parseStudioSiteStatus,
   runCli,
   safeResult,
+  sanitizeArtifact,
   stopStudioSite,
   studioSiteStatus,
   variant,
@@ -47,14 +48,6 @@ const { runBrowserBench } = await import(BROWSER_HELPER);
 function siteAdminUrl(siteUrl, relativePath = '') {
   const base = siteUrl.endsWith('/') ? siteUrl : `${siteUrl}/`;
   return new URL(`wp-admin/${relativePath}`, base).toString();
-}
-
-async function sanitizeArtifact(artifact) {
-  if (!artifact || typeof artifact.path !== 'string') {
-    return;
-  }
-  const raw = await readFile(artifact.path, 'utf8');
-  await writeFile(artifact.path, raw.replace(/([?&](?:token|password|key|nonce)=)[^&#\s]+/gi, '$1[redacted]'));
 }
 
 async function runBotPath({ label, artifactDir, sitePath, status, requestProfiler, pageProfiler, candidate }) {

--- a/Automattic/studio/bench/studio-wordpress-admin-scale-sweep.bench.mjs
+++ b/Automattic/studio/bench/studio-wordpress-admin-scale-sweep.bench.mjs
@@ -1,4 +1,4 @@
-import { cp, mkdir, readFile, rename, rm, symlink, writeFile } from 'node:fs/promises';
+import { cp, mkdir, rename, rm, symlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -11,6 +11,7 @@ import {
   redact,
   runCli,
   safeResult,
+  sanitizeArtifact,
   setting,
   startStudioSite,
   stopStudioSite,
@@ -206,14 +207,6 @@ function adaptAdminPageSummary({ pageSpec, pageSummary, profile, artifacts }) {
   };
 }
 
-async function sanitizeNetworkArtifact(artifact) {
-  if (!artifact || typeof artifact.path !== 'string') {
-    return;
-  }
-  const raw = await readFile(artifact.path, 'utf8');
-  await writeFile(artifact.path, redact(raw));
-}
-
 function summarizeWordPressRequests(entries = []) {
   const byRequest = new Map();
   for (const entry of entries) {
@@ -345,7 +338,7 @@ export default async function studioWordPressAdminScaleSweepBench() {
       },
     });
 
-    await sanitizeNetworkArtifact(browserResult.artifacts?.network);
+    await sanitizeArtifact(browserResult.artifacts?.network);
     wordpressRequests = profiler?.collectWordPressRequestProfiles?.(sitePath) || [];
     profiler?.uninstallWordPressRequestProfiler?.(sitePath);
     if (createdSite) {


### PR DESCRIPTION
## Summary
- Add a shared `sanitizeArtifact()` helper beside the existing Studio bench `redact()` utility.
- Replace repeated network-artifact sanitizer implementations across Studio browser, diagnostics, page matrix, REST latency, preload comparison, and admin sweep rigs.
- Add a regression test that proves tokens, nonces, and auto-login URLs are redacted consistently.

## Verification
- `node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `homeboy lint --path /Users/chubes/Developer/homeboy-rigs@refactor-site-editor-profiler-primitives --extension nodejs --changed-since origin/main`
- Smoke benchmark: `studio-site-editor-browser` with `--iterations 1`
  - Run ID: `32740841-5c73-4d72-b3b1-9bd2e2451a90`
  - Result: passed, `success_rate=1`, `site_editor_status=200`, trace/screenshot/network artifacts present.
  - Note: Homeboy reported the machine was warm (`load average 20.5/18 CPUs`), so this smoke validates behavior/artifact flow rather than performance numbers.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified sanitizer duplication, refactored the shared helper, added a regression test, and ran verification. Chris remains responsible for review and merge.