### PR TITLE
Allow extra Site Editor preload diagnostic paths

### DIFF
--- a/Automattic/studio/bench/studio-site-editor-preload-diagnostics.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-preload-diagnostics.bench.mjs
@@ -49,6 +49,24 @@ $preload_paths[] = array( $navigation_rest_route . '?_locale=user', 'OPTIONS' );
 // HOMEBOY_SITE_EDITOR_PRELOAD_DIAGNOSTICS_EXACT_VISIBLE: end
 `;
 
+function extraPreloadPatch() {
+  const raw = process.env.HOMEBOY_SITE_EDITOR_PRELOAD_DIAGNOSTICS_EXTRA_PATHS_JSON;
+  if (!raw) {
+    return '';
+  }
+
+  const paths = JSON.parse(raw);
+  if (!Array.isArray(paths)) {
+    throw new Error('HOMEBOY_SITE_EDITOR_PRELOAD_DIAGNOSTICS_EXTRA_PATHS_JSON must be an array');
+  }
+
+  return [
+    '// HOMEBOY_SITE_EDITOR_PRELOAD_DIAGNOSTICS_EXTRA: begin',
+    ...paths.map((pathValue) => `$preload_paths[] = ${JSON.stringify(pathValue)};`),
+    '// HOMEBOY_SITE_EDITOR_PRELOAD_DIAGNOSTICS_EXTRA: end',
+  ].join('\n');
+}
+
 const WATCH_TARGETS = [
   { label: 'settings OPTIONS', method: 'OPTIONS', pattern: /^\/wp\/v2\/settings(?:\?|$)/ },
   { label: 'pattern categories', method: 'GET', pattern: /^\/wp\/v2\/wp_pattern_category(?:\?|$)/ },
@@ -77,7 +95,12 @@ async function injectPreloadPatch(sitePath) {
   }
 
   const exactVisible = process.env.HOMEBOY_SITE_EDITOR_PRELOAD_DIAGNOSTICS_EXACT_VISIBLE === '1';
-  const patch = exactVisible ? `${WESTON_PRELOAD_PATCH}\n${EXACT_VISIBLE_PRELOAD_PATCH}` : WESTON_PRELOAD_PATCH;
+  const extraPatch = extraPreloadPatch();
+  const patch = [
+    WESTON_PRELOAD_PATCH,
+    exactVisible ? EXACT_VISIBLE_PRELOAD_PATCH : '',
+    extraPatch,
+  ].filter(Boolean).join('\n');
 
   await writeFile(file, source.replace(needle, `${patch}\n${needle}`));
   return patch;


### PR DESCRIPTION
## Summary
- Add `HOMEBOY_SITE_EDITOR_PRELOAD_DIAGNOSTICS_EXTRA_PATHS_JSON` to the Site Editor preload diagnostics workload.
- Let the probe test arbitrary additional preload keys without editing the workload.
- Keep the existing default and exact-visible preload modes intact.

## Verification
- `node --check Automattic/studio/bench/studio-site-editor-preload-diagnostics.bench.mjs`
- `homeboy lint --path /Users/chubes/Developer/homeboy-rigs@site-editor-preload-diagnostics --extension nodejs --changed-since origin/main`
- `HOMEBOY_SITE_EDITOR_PRELOAD_DIAGNOSTICS_EXACT_VISIBLE=1 HOMEBOY_SITE_EDITOR_PRELOAD_DIAGNOSTICS_EXTRA_PATHS_JSON='["/wp/v2/taxonomies?context=view"]' HOMEBOY_BENCH_EXTRA_WORKLOADS="/Users/chubes/Developer/homeboy-rigs@site-editor-preload-diagnostics/Automattic/studio/bench/studio-site-editor-preload-diagnostics.bench.mjs" HOMEBOY_WORDPRESS_PAGE_PROFILER_PATH="/Users/chubes/Developer/homeboy-extensions@expose-preload-checks/wordpress/lib/page-profiler.js" homeboy bench --path /Users/chubes/Developer/studio --extension nodejs --scenario studio-site-editor-preload-diagnostics --iterations 1 --force-hot`

## Evidence
- Homeboy run: `b5b4cfc4-02ff-45cb-9993-bb27405733e3`
- Raw result: `/Users/chubes/Developer/_bench-evidence/homeboy-artifacts/b5b4cfc4-02ff-45cb-9993-bb27405733e3/8977a16f-3fe2-413d-8a8a-1f5a464e2595-result-studio-site-editor-preload-diagnostics-60093-1778702151847-8wo4oeq2cyx.json`
- Observed metrics: `watched_network_request_count=0`, `watched_network_target_count=0`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the diagnostics workload option, verification command, and evidence summary for Chris to review and test.