### PR TITLE
Support method-aware Site Editor preload experiments

### DIFF
--- a/Automattic/studio/bench/lib/site-editor-preload-harness.mjs
+++ b/Automattic/studio/bench/lib/site-editor-preload-harness.mjs
@@ -3,6 +3,59 @@ import path from 'node:path';
 
 const PRELOAD_MARKER = 'HOMEBOY_SITE_EDITOR_PRELOAD_CANDIDATE';
 
+function quotePhpString(value) {
+  return `'${String(value || '').replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+function preloadExpression(spec) {
+  if (typeof spec === 'string') {
+    return quotePhpString(spec);
+  }
+  if (!spec || typeof spec !== 'object' || typeof spec.path !== 'string') {
+    throw new Error('preload path specs must be strings or objects with a path');
+  }
+  if (!spec.method || String(spec.method).toUpperCase() === 'GET') {
+    return quotePhpString(spec.path);
+  }
+  return `array( ${quotePhpString(spec.path)}, ${quotePhpString(String(spec.method).toUpperCase())} )`;
+}
+
+function preloadLinesFromJsonEnv(name) {
+  const raw = process.env[name];
+  if (!raw) {
+    return [];
+  }
+
+  const specs = JSON.parse(raw);
+  if (!Array.isArray(specs)) {
+    throw new Error(`${name} must be an array`);
+  }
+  return specs.map((spec) => `$preload_paths[] = ${preloadExpression(spec)};`);
+}
+
+function dynamicPreloadLines() {
+  const raw = process.env.HOMEBOY_SITE_EDITOR_DYNAMIC_PRELOADS_JSON;
+  if (!raw) {
+    return [];
+  }
+  const specs = JSON.parse(raw);
+  if (!Array.isArray(specs)) {
+    throw new Error('HOMEBOY_SITE_EDITOR_DYNAMIC_PRELOADS_JSON must be an array');
+  }
+
+  const lines = [];
+  if (specs.includes('navigation-fallback')) {
+    lines.push(`
+$homeboy_navigation_fallback = class_exists( 'WP_Navigation_Fallback' ) ? WP_Navigation_Fallback::get_fallback() : null;
+if ( $homeboy_navigation_fallback instanceof WP_Post ) {
+	$preload_paths[] = '/wp-block-editor/v1/navigation-fallback?_embed=true';
+	$preload_paths[] = '/wp/v2/navigation/' . $homeboy_navigation_fallback->ID . '?context=edit';
+}
+`);
+  }
+  return lines;
+}
+
 export function installSiteEditorPreloadCandidateSource(source) {
 	if (source.includes(PRELOAD_MARKER)) {
 		return source;
@@ -152,6 +205,18 @@ $preload_paths[] = '/wp/v2/taxonomies?context=view';
 	if (!source.includes(needle)) {
 		throw new Error('site-editor.php preload call not found');
 	}
+
+  const extraLines = [
+    ...preloadLinesFromJsonEnv('HOMEBOY_SITE_EDITOR_EXTRA_PRELOAD_PATHS_JSON'),
+    ...dynamicPreloadLines(),
+  ];
+  if (extraLines.length > 0) {
+    patch += `
+// ${PRELOAD_MARKER}_EXTRA: begin
+${extraLines.join('\n')}
+// ${PRELOAD_MARKER}_EXTRA: end
+`;
+  }
 
   return source.replace(needle, `${patch}\n${needle}`);
 }

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -536,6 +536,30 @@ block_editor_rest_api_preload( $preload_paths, $block_editor_context );
   assert.equal(installSiteEditorPreloadCandidateSource(patched), patched);
 });
 
+test('installSiteEditorPreloadCandidateSource injects extra method and dynamic preload controls', () => {
+  withEnv(
+    {
+      HOMEBOY_SITE_EDITOR_EXTRA_PRELOAD_PATHS_JSON: JSON.stringify([
+        '/wp/v2/types/post?context=edit',
+        { path: '/wp/v2/settings', method: 'OPTIONS' },
+      ]),
+      HOMEBOY_SITE_EDITOR_DYNAMIC_PRELOADS_JSON: JSON.stringify(['navigation-fallback']),
+    },
+    () => {
+      const source = `<?php
+$preload_paths = array();
+block_editor_rest_api_preload( $preload_paths, $block_editor_context );
+`;
+      const patched = installSiteEditorPreloadCandidateSource(source);
+      assert.match(patched, /'\/wp\/v2\/types\/post\?context=edit'/);
+      assert.match(patched, /array\( '\/wp\/v2\/settings', 'OPTIONS' \)/);
+      assert.match(patched, /WP_Navigation_Fallback::get_fallback\(\)/);
+      assert.match(patched, /'\/wp-block-editor\/v1\/navigation-fallback\?_embed=true'/);
+      assert.match(patched, /'\/wp\/v2\/navigation\/' \.[\s\S]*\?context=edit/);
+    }
+  );
+});
+
 test('installSiteEditorPreloadCandidateSource fails when preload call is missing', () => {
   assert.throws(
     () => installSiteEditorPreloadCandidateSource('<?php $preload_paths = array();'),

--- a/Automattic/studio/bench/studio-site-editor-preload-comparison.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-preload-comparison.bench.mjs
@@ -319,6 +319,16 @@ export default async function studioSiteEditorPreloadComparisonBench() {
           profilerAvailable: Boolean(requestProfiler),
           pageProfilerPath,
           pageProfilerAvailable: Boolean(pageProfiler),
+          preloadExperiment: {
+            scenario: process.env.HOMEBOY_SITE_EDITOR_SCENARIO || 'default',
+            mode: process.env.HOMEBOY_SITE_EDITOR_PRELOAD_MODE || 'broad',
+            extraPreloadPaths: process.env.HOMEBOY_SITE_EDITOR_EXTRA_PRELOAD_PATHS_JSON
+              ? JSON.parse(process.env.HOMEBOY_SITE_EDITOR_EXTRA_PRELOAD_PATHS_JSON)
+              : [],
+            dynamicPreloads: process.env.HOMEBOY_SITE_EDITOR_DYNAMIC_PRELOADS_JSON
+              ? JSON.parse(process.env.HOMEBOY_SITE_EDITOR_DYNAMIC_PRELOADS_JSON)
+              : [],
+          },
           timings: {
             baseline_site_create_ms: baselineCreate.elapsedMs,
             baseline_site_status_ms: baselineStatusResult.elapsedMs,

--- a/Automattic/studio/bench/studio-site-editor-preload-diagnostics.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-preload-diagnostics.bench.mjs
@@ -51,18 +51,48 @@ $preload_paths[] = array( $navigation_rest_route . '?_locale=user', 'OPTIONS' );
 
 function extraPreloadPatch() {
   const raw = process.env.HOMEBOY_SITE_EDITOR_PRELOAD_DIAGNOSTICS_EXTRA_PATHS_JSON;
-  if (!raw) {
+  const dynamicRaw = process.env.HOMEBOY_SITE_EDITOR_PRELOAD_DIAGNOSTICS_DYNAMIC_PRELOADS_JSON;
+  const lines = [];
+
+  if (raw) {
+    const paths = JSON.parse(raw);
+    if (!Array.isArray(paths)) {
+      throw new Error('HOMEBOY_SITE_EDITOR_PRELOAD_DIAGNOSTICS_EXTRA_PATHS_JSON must be an array');
+    }
+    lines.push(...paths.map((pathValue) => {
+      if (typeof pathValue === 'string') {
+        return `$preload_paths[] = ${JSON.stringify(pathValue)};`;
+      }
+      if (!pathValue || typeof pathValue !== 'object' || typeof pathValue.path !== 'string') {
+        throw new Error('extra preload paths must be strings or objects with a path');
+      }
+      if (!pathValue.method || String(pathValue.method).toUpperCase() === 'GET') {
+        return `$preload_paths[] = ${JSON.stringify(pathValue.path)};`;
+      }
+      return `$preload_paths[] = array( ${JSON.stringify(pathValue.path)}, ${JSON.stringify(String(pathValue.method).toUpperCase())} );`;
+    }));
+  }
+
+  if (dynamicRaw) {
+    const dynamicSpecs = JSON.parse(dynamicRaw);
+    if (!Array.isArray(dynamicSpecs)) {
+      throw new Error('HOMEBOY_SITE_EDITOR_PRELOAD_DIAGNOSTICS_DYNAMIC_PRELOADS_JSON must be an array');
+    }
+    if (dynamicSpecs.includes('navigation-fallback')) {
+      lines.push(`$homeboy_navigation_fallback = class_exists( 'WP_Navigation_Fallback' ) ? WP_Navigation_Fallback::get_fallback() : null;
+if ( $homeboy_navigation_fallback instanceof WP_Post ) {
+	$preload_paths[] = '/wp-block-editor/v1/navigation-fallback?_embed=true';
+	$preload_paths[] = '/wp/v2/navigation/' . $homeboy_navigation_fallback->ID . '?context=edit';
+}`);
+    }
+  }
+
+  if (lines.length === 0) {
     return '';
   }
-
-  const paths = JSON.parse(raw);
-  if (!Array.isArray(paths)) {
-    throw new Error('HOMEBOY_SITE_EDITOR_PRELOAD_DIAGNOSTICS_EXTRA_PATHS_JSON must be an array');
-  }
-
   return [
     '// HOMEBOY_SITE_EDITOR_PRELOAD_DIAGNOSTICS_EXTRA: begin',
-    ...paths.map((pathValue) => `$preload_paths[] = ${JSON.stringify(pathValue)};`),
+    ...lines,
     '// HOMEBOY_SITE_EDITOR_PRELOAD_DIAGNOSTICS_EXTRA: end',
   ].join('\n');
 }


### PR DESCRIPTION
## Summary
- Let Site Editor preload experiments inject both string preload paths and method tuple specs such as `{ "path": "/wp/v2/settings", "method": "OPTIONS" }`.
- Add dynamic `navigation-fallback` preload derivation so rigs can test fallback navigation and item routes without hardcoded IDs.
- Record preload experiment metadata in comparison artifacts and cover the new injection controls in unit tests.

## Verification
- `node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `node --check Automattic/studio/bench/studio-site-editor-preload-diagnostics.bench.mjs`
- `node --check Automattic/studio/bench/lib/site-editor-preload-harness.mjs`
- `node --check Automattic/studio/bench/studio-site-editor-preload-comparison.bench.mjs`
- `homeboy lint --path /Users/chubes/Developer/homeboy-rigs@site-editor-preload-diagnostics --extension nodejs --changed-since origin/main`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the method-aware experiment controls, dynamic navigation fallback support, artifact metadata, and verification workflow for Chris to review and test.