### PR TITLE
Add Gutenberg RTC stress rig

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,17 @@ WooCommerce site-generation benchmarks are tracked as future work until the Stud
 
 `stacks/playground-combined.json` rebuilds `origin/dev/combined-fixes` from `upstream/trunk` plus Chris's active PHP-WASM and worker-pool PRs.
 
+## WordPress/gutenberg
+
+`rigs/gutenberg-rtc/rig.json` is the planned Gutenberg real-time collaboration stress rig. It is structured around small/medium Playwright editor scenarios plus high-cardinality synthetic Yjs/REST load against the real WordPress sync endpoint.
+
+```bash
+homeboy rig install ./WordPress/gutenberg
+homeboy rig up gutenberg-rtc
+homeboy rig check gutenberg-rtc
+homeboy bench --rig gutenberg-rtc --profile smoke --iterations 1 --setting rtc_clients=10
+```
+
 ## chubes4/isolated-block-editor
 
 `rigs/isolated-block-editor/rig.json` runs the checks used while shaving Isolated Block Editor toward modern Gutenberg APIs.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ WooCommerce site-generation benchmarks are tracked as future work until the Stud
 
 ```bash
 homeboy rig install ./WordPress/gutenberg
-homeboy rig up gutenberg-rtc
 homeboy rig check gutenberg-rtc
 homeboy bench --rig gutenberg-rtc --profile smoke --iterations 1 --setting rtc_clients=10
 ```

--- a/WordPress/gutenberg/README.md
+++ b/WordPress/gutenberg/README.md
@@ -17,12 +17,16 @@ in the post editor.
 
 ```bash
 homeboy rig install /Users/chubes/Developer/homeboy-rigs@<branch>/WordPress/gutenberg
-homeboy rig up gutenberg-rtc
 homeboy rig check gutenberg-rtc
 homeboy bench --rig gutenberg-rtc --scenario gutenberg-rtc-browser-basic --iterations 1
 homeboy bench --rig gutenberg-rtc --scenario gutenberg-rtc-protocol-load --iterations 1 --setting rtc_clients=100
 homeboy bench --rig gutenberg-rtc --profile hot --iterations 1 --setting rtc_clients=1000 --force-hot
 ```
+
+`homeboy bench --rig gutenberg-rtc` runs the rig's `bench_prepare` pipeline before
+the timed workload. That pipeline installs Gutenberg npm dependencies when
+`node_modules/.bin/wp-env` is missing, then Homeboy runs the normal rig health
+check before benchmark timing starts.
 
 ## Layers
 

--- a/WordPress/gutenberg/README.md
+++ b/WordPress/gutenberg/README.md
@@ -1,0 +1,44 @@
+# Gutenberg RTC Homeboy Rig
+
+Durable Homeboy rig package for stress testing Gutenberg real-time collaboration
+in the post editor.
+
+## Goals
+
+- Exercise real editor behavior with Playwright for small and medium scenarios.
+- Exercise the real `/wp-sync/v1/updates` WordPress endpoint with synthetic Yjs
+  clients for high-cardinality load.
+- Capture benchmark metrics, traces, final document snapshots, seeds, and
+  reproduction commands as Homeboy artifacts.
+- Keep repeatable failures tied to Gutenberg issues or PRs before using rig
+  results as maintainer-facing evidence.
+
+## Initial Commands
+
+```bash
+homeboy rig install /Users/chubes/Developer/homeboy-rigs@<branch>/WordPress/gutenberg
+homeboy rig up gutenberg-rtc
+homeboy rig check gutenberg-rtc
+homeboy bench --rig gutenberg-rtc --scenario gutenberg-rtc-browser-basic --iterations 1
+homeboy bench --rig gutenberg-rtc --scenario gutenberg-rtc-protocol-load --iterations 1 --setting rtc_clients=100
+homeboy bench --rig gutenberg-rtc --profile hot --iterations 1 --setting rtc_clients=1000 --force-hot
+```
+
+## Layers
+
+```text
+Playwright editor sessions        2-25 clients, real UI correctness
+Synthetic Yjs/REST clients        10-1000 clients, real WP sync endpoint load
+Seeded conflict fuzzer            deterministic operation streams
+Settings matrix                   roles, post states, metaboxes, autosave, doc size
+```
+
+See `docs/rtc-rig-plan.md` for the implementation plan.
+
+## Current Workloads
+
+- `gutenberg-rtc-browser-basic` runs core two-user collaboration Playwright specs.
+- `gutenberg-rtc-browser-tabs` runs reload, self-presence, and cursor-awareness specs.
+- `gutenberg-rtc-protocol-load` starts `wp-env-test`, creates a draft post, enables RTC, then drives `/wp-sync/v1/updates` with configurable synthetic clients. It uses Yjs when Gutenberg dependencies expose `yjs`, and falls back to opaque sync payloads so endpoint/storage load still runs on lean installs.
+- `gutenberg-rtc-conflict-fuzzer` runs the existing stress, undo/redo, and block-gauntlet specs as the first correctness gauntlet.
+- `gutenberg-rtc-settings-matrix` runs metabox, document-size, sync-error, and autodraft specs.

--- a/WordPress/gutenberg/bench/gutenberg-rtc-browser-basic.bench.mjs
+++ b/WordPress/gutenberg/bench/gutenberg-rtc-browser-basic.bench.mjs
@@ -1,0 +1,19 @@
+import { runPlaywrightSpecSuite, setting } from './lib/gutenberg-rtc-bench.mjs';
+
+const DEFAULT_SPECS = [
+  'collaboration-sync.spec.ts',
+  'collaboration-presence.spec.ts',
+  'collaboration-selection.spec.ts',
+];
+
+export default async function gutenbergRtcBrowserBasic() {
+  const specs = setting('rtc_browser_basic_specs')
+    .split(',')
+    .map((spec) => spec.trim())
+    .filter(Boolean);
+
+  return runPlaywrightSpecSuite({
+    id: 'gutenberg-rtc-browser-basic',
+    specs: specs.length > 0 ? specs : DEFAULT_SPECS,
+  });
+}

--- a/WordPress/gutenberg/bench/gutenberg-rtc-browser-tabs.bench.mjs
+++ b/WordPress/gutenberg/bench/gutenberg-rtc-browser-tabs.bench.mjs
@@ -1,0 +1,19 @@
+import { runPlaywrightSpecSuite, setting } from './lib/gutenberg-rtc-bench.mjs';
+
+const DEFAULT_SPECS = [
+  'collaboration-refresh.spec.ts',
+  'collaboration-self-presence.spec.ts',
+  'collaboration-awareness-cursor-position.spec.ts',
+];
+
+export default async function gutenbergRtcBrowserTabs() {
+  const specs = setting('rtc_browser_tabs_specs')
+    .split(',')
+    .map((spec) => spec.trim())
+    .filter(Boolean);
+
+  return runPlaywrightSpecSuite({
+    id: 'gutenberg-rtc-browser-tabs',
+    specs: specs.length > 0 ? specs : DEFAULT_SPECS,
+  });
+}

--- a/WordPress/gutenberg/bench/gutenberg-rtc-conflict-fuzzer.bench.mjs
+++ b/WordPress/gutenberg/bench/gutenberg-rtc-conflict-fuzzer.bench.mjs
@@ -1,0 +1,20 @@
+import { runPlaywrightSpecSuite, setting } from './lib/gutenberg-rtc-bench.mjs';
+
+const DEFAULT_SPECS = [
+  'collaboration-stress.spec.ts',
+  'collaboration-undo-redo.spec.ts',
+  'collaboration-block-gauntlet.spec.ts',
+];
+
+export default async function gutenbergRtcConflictFuzzer() {
+  const specs = setting('rtc_conflict_specs')
+    .split(',')
+    .map((spec) => spec.trim())
+    .filter(Boolean);
+
+  return runPlaywrightSpecSuite({
+    id: 'gutenberg-rtc-conflict-fuzzer',
+    specs: specs.length > 0 ? specs : DEFAULT_SPECS,
+    timeoutMs: 1500000,
+  });
+}

--- a/WordPress/gutenberg/bench/gutenberg-rtc-protocol-load.bench.mjs
+++ b/WordPress/gutenberg/bench/gutenberg-rtc-protocol-load.bench.mjs
@@ -1,0 +1,393 @@
+import crypto from 'node:crypto';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import {
+  GUTENBERG_PATH,
+  artifactDir,
+  metric,
+  percentile,
+  redact,
+  runId,
+  runWpEnvTest,
+  setting,
+  writeJson,
+  writeText,
+} from './lib/gutenberg-rtc-bench.mjs';
+
+const requireFromGutenberg = createRequire(path.join(GUTENBERG_PATH, 'package.json'));
+
+const DEFAULT_BASE_URL = 'http://localhost:8889';
+
+function intSetting(key, fallback, { min = 1, max = Number.MAX_SAFE_INTEGER } = {}) {
+  const value = Number.parseInt(setting(key, String(fallback)), 10);
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(min, Math.min(max, value));
+}
+
+function base64FromUint8Array(value) {
+  return Buffer.from(value).toString('base64');
+}
+
+function uint8ArrayFromBase64(value) {
+  return new Uint8Array(Buffer.from(value, 'base64'));
+}
+
+function loadYjs() {
+  try {
+    return requireFromGutenberg('yjs');
+  } catch {
+    return null;
+  }
+}
+
+function hash(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+async function wpCli(args, options = {}) {
+  return runWpEnvTest(['run', 'cli', 'wp', ...args], {
+    timeoutMs: 180000,
+    ...options,
+  });
+}
+
+async function fetchJson(url, { authHeader, body }) {
+  const started = performance.now();
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: authHeader,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  const elapsedMs = performance.now() - started;
+  const text = await response.text();
+  let json = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    // Preserve text in the caller's artifact.
+  }
+  return {
+    elapsedMs,
+    json,
+    ok: response.ok,
+    status: response.status,
+    text,
+  };
+}
+
+async function prepareWordPress({ baseUrl, runName }) {
+  const start = await runWpEnvTest(['start'], { timeoutMs: 300000, allowFailure: true });
+  if (start.code !== 0) {
+    throw new Error(`wp-env-test start failed; stderr=${redact(start.stderr).slice(0, 1600)}`);
+  }
+
+  await wpCli(['option', 'update', 'wp_collaboration_enabled', '1']);
+
+  const appPassword = await wpCli([
+    'user',
+    'application-password',
+    'create',
+    'admin',
+    `Homeboy RTC ${runName}`,
+    '--porcelain',
+  ]);
+  const password = appPassword.stdout.trim().replace(/\s+/g, '');
+  const authHeader = `Basic ${Buffer.from(`admin:${password}`).toString('base64')}`;
+
+  const post = await wpCli([
+    'post',
+    'create',
+    '--post_type=post',
+    '--post_status=draft',
+    `--post_title=Homeboy RTC Protocol Load ${runName}`,
+    '--porcelain',
+  ]);
+  const postId = Number.parseInt(post.stdout.trim(), 10);
+  if (!Number.isFinite(postId) || postId <= 0) {
+    throw new Error(`wp post create did not return a valid post id: ${post.stdout}`);
+  }
+
+  return {
+    authHeader,
+    postId,
+    room: `postType/post:${postId}`,
+    syncUrl: `${baseUrl.replace(/\/$/, '')}/index.php?rest_route=/wp-sync/v1/updates`,
+  };
+}
+
+function createClient(index, Y) {
+  const doc = Y ? new Y.Doc() : null;
+  const text = doc ? doc.getText('content') : null;
+  return {
+    clientId: index + 1,
+    cursor: 0,
+    doc,
+    seenUpdateHashes: new Set(),
+    text,
+  };
+}
+
+function createUpdate(client, round, operationProfile, Y) {
+  if (!Y) {
+    const data = Buffer.from(`client:${client.clientId}:round:${round}:profile:${operationProfile}`).toString('base64');
+    client.seenUpdateHashes.add(hash(data));
+    return {
+      data,
+      type: 'update',
+    };
+  }
+
+  client.doc.transact(() => {
+    if (operationProfile === 'churn' && round % 3 === 2 && client.text.length > 0) {
+      client.text.delete(0, Math.min(3, client.text.length));
+    }
+    client.text.insert(0, `[c${client.clientId}:r${round}]`);
+  });
+  const data = base64FromUint8Array(Y.encodeStateAsUpdateV2(client.doc));
+  client.seenUpdateHashes.add(hash(data));
+  return {
+    data,
+    type: 'update',
+  };
+}
+
+function createCompactionUpdate(client, Y) {
+  return {
+    data: Y ? base64FromUint8Array(Y.encodeStateAsUpdateV2(client.doc)) : Buffer.from(`compact:${client.clientId}:${client.cursor}`).toString('base64'),
+    type: 'compaction',
+  };
+}
+
+function applyServerUpdates(client, updates, Y) {
+  let applied = 0;
+  for (const update of updates || []) {
+    if (update?.data && (update.type === 'update' || update.type === 'compaction')) {
+      if (Y) {
+        Y.applyUpdateV2(client.doc, uint8ArrayFromBase64(update.data));
+      }
+      client.seenUpdateHashes.add(hash(update.data));
+      applied++;
+    }
+  }
+  return applied;
+}
+
+export default async function gutenbergRtcProtocolLoad() {
+  const clientCount = intSetting('rtc_clients', 10, { min: 1, max: 5000 });
+  const rounds = intSetting('rtc_rounds', 3, { min: 1, max: 100 });
+  const batchSize = intSetting('rtc_batch_size', 25, { min: 1, max: 50 });
+  const operationProfile = setting('rtc_operation_profile', 'smoke');
+  const baseUrl = setting('wp_base_url', process.env.WP_BASE_URL || DEFAULT_BASE_URL);
+  const currentRunId = runId('gutenberg-rtc-protocol-load');
+  const outDir = path.join(artifactDir('gutenberg-rtc-protocol-load'), currentRunId);
+  const rawResultFile = path.join(outDir, 'result.json');
+  const responseLogFile = path.join(outDir, 'responses.jsonl');
+  const responseRows = [];
+  const Y = loadYjs();
+
+  const wordpress = await prepareWordPress({ baseUrl, runName: currentRunId });
+  const clients = Array.from({ length: clientCount }, (_, index) => createClient(index, Y));
+  const latencies = [];
+  const statuses = new Map();
+  let requestsTotal = 0;
+  let updatesSent = 0;
+  let updatesApplied = 0;
+  let compactionRequests = 0;
+  let http4xx = 0;
+  let http5xx = 0;
+
+  const started = performance.now();
+  for (let round = 0; round < rounds; round++) {
+    for (let offset = 0; offset < clients.length; offset += batchSize) {
+      const batch = clients.slice(offset, offset + batchSize);
+      const rooms = batch.map((client) => {
+        const updates = [createUpdate(client, round, operationProfile, Y)];
+        updatesSent += updates.length;
+        return {
+          after: client.cursor,
+          awareness: {
+            user: { name: `RTC ${client.clientId}` },
+            cursor: { round, offset: client.clientId },
+          },
+          client_id: client.clientId,
+          room: wordpress.room,
+          updates,
+        };
+      });
+
+      const response = await fetchJson(wordpress.syncUrl, {
+        authHeader: wordpress.authHeader,
+        body: { rooms },
+      });
+      requestsTotal++;
+      latencies.push(response.elapsedMs);
+      statuses.set(response.status, (statuses.get(response.status) || 0) + 1);
+      if (response.status >= 400 && response.status < 500) {
+        http4xx++;
+      }
+      if (response.status >= 500) {
+        http5xx++;
+      }
+
+      responseRows.push({
+        round,
+        offset,
+        status: response.status,
+        elapsed_ms: response.elapsedMs,
+        room_count: rooms.length,
+        body_preview: response.ok ? undefined : redact(response.text).slice(0, 1000),
+      });
+
+      if (!response.ok || !response.json?.rooms) {
+        throw new Error(`sync request failed with HTTP ${response.status}; raw_result=${rawResultFile}`);
+      }
+
+      for (const [index, roomResponse] of response.json.rooms.entries()) {
+        const client = batch[index];
+        client.cursor = roomResponse.end_cursor ?? client.cursor;
+        updatesApplied += applyServerUpdates(client, roomResponse.updates, Y);
+        if (roomResponse.should_compact) {
+          compactionRequests++;
+          const compactResponse = await fetchJson(wordpress.syncUrl, {
+            authHeader: wordpress.authHeader,
+            body: {
+              rooms: [
+                {
+                  after: client.cursor,
+                  awareness: null,
+                  client_id: client.clientId,
+                  room: wordpress.room,
+                  updates: [createCompactionUpdate(client, Y)],
+                },
+              ],
+            },
+          });
+          requestsTotal++;
+          latencies.push(compactResponse.elapsedMs);
+          statuses.set(compactResponse.status, (statuses.get(compactResponse.status) || 0) + 1);
+        }
+      }
+    }
+  }
+
+  // One catch-up pass with no new updates lets late clients apply the final room state.
+  for (let offset = 0; offset < clients.length; offset += batchSize) {
+    const batch = clients.slice(offset, offset + batchSize);
+    const response = await fetchJson(wordpress.syncUrl, {
+      authHeader: wordpress.authHeader,
+      body: {
+        rooms: batch.map((client) => ({
+          after: client.cursor,
+          awareness: null,
+          client_id: client.clientId,
+          room: wordpress.room,
+          updates: [],
+        })),
+      },
+    });
+    requestsTotal++;
+    latencies.push(response.elapsedMs);
+    statuses.set(response.status, (statuses.get(response.status) || 0) + 1);
+    if (!response.ok || !response.json?.rooms) {
+      throw new Error(`catch-up request failed with HTTP ${response.status}; raw_result=${rawResultFile}`);
+    }
+    for (const [index, roomResponse] of response.json.rooms.entries()) {
+      const client = batch[index];
+      client.cursor = roomResponse.end_cursor ?? client.cursor;
+      updatesApplied += applyServerUpdates(client, roomResponse.updates, Y);
+    }
+  }
+
+  const elapsedMs = performance.now() - started;
+  const expectedUpdateHashes = new Set();
+  for (const client of clients) {
+    for (const updateHash of client.seenUpdateHashes) {
+      expectedUpdateHashes.add(updateHash);
+    }
+  }
+  const texts = Y ? clients.map((client) => client.text.toString()) : clients.map((client) => [...client.seenUpdateHashes].sort().join(','));
+  const finalTextHash = hash(texts[0] || '');
+  const divergentClients = texts.filter((text) => hash(text) !== finalTextHash).length;
+  const finalStateHashes = Y
+    ? clients.map((client) => hash(Buffer.from(Y.encodeStateAsUpdateV2(client.doc))))
+    : clients.map((client) => hash([...client.seenUpdateHashes].sort().join(',')));
+  const uniqueFinalStateHashes = new Set(finalStateHashes).size;
+
+  const result = {
+    id: 'gutenberg-rtc-protocol-load',
+    base_url: baseUrl,
+    post_id: wordpress.postId,
+    room: wordpress.room,
+    client_count: clientCount,
+    rounds,
+    batch_size: batchSize,
+    operation_profile: operationProfile,
+    payload_mode: Y ? 'yjs' : 'opaque',
+    elapsed_ms: elapsedMs,
+    requests_total: requestsTotal,
+    updates_sent: updatesSent,
+    updates_applied: updatesApplied,
+    compaction_requests: compactionRequests,
+    statuses: Object.fromEntries(statuses.entries()),
+    latency_ms: {
+      p50: percentile(latencies, 50),
+      p95: percentile(latencies, 95),
+      p99: percentile(latencies, 99),
+      max: Math.max(...latencies),
+    },
+    convergence: {
+      final_text_hash: finalTextHash,
+      divergent_clients: divergentClients,
+      unique_final_state_hashes: uniqueFinalStateHashes,
+      sample_text: texts[0]?.slice(0, 1000) || '',
+      expected_update_hashes: expectedUpdateHashes.size,
+    },
+  };
+
+  await writeJson(rawResultFile, result);
+  await writeText(responseLogFile, responseRows.map((row) => JSON.stringify(row)).join('\n'));
+
+  if (divergentClients > 0) {
+    throw new Error(`synthetic clients did not converge; divergent_clients=${divergentClients}; raw_result=${rawResultFile}`);
+  }
+
+  return {
+    metrics: {
+      success_rate: 1,
+      client_count: clientCount,
+      rounds,
+      batch_size: batchSize,
+      requests_total: requestsTotal,
+      requests_per_second: metric(requestsTotal / (elapsedMs / 1000)),
+      updates_sent: updatesSent,
+      updates_applied: updatesApplied,
+      compaction_count: compactionRequests,
+      sync_p50_ms: metric(result.latency_ms.p50),
+      sync_p95_ms: metric(result.latency_ms.p95),
+      sync_p99_ms: metric(result.latency_ms.p99),
+      sync_max_ms: metric(result.latency_ms.max),
+      http_4xx_count: http4xx,
+      http_5xx_count: http5xx,
+      divergent_clients: divergentClients,
+      unique_final_state_hashes: uniqueFinalStateHashes,
+      payload_mode_yjs: Y ? 1 : 0,
+      total_elapsed_ms: metric(elapsedMs),
+    },
+    artifacts: {
+      raw_result: rawResultFile,
+      response_log: responseLogFile,
+    },
+    metadata: {
+      operation_profile: operationProfile,
+      payload_mode: Y ? 'yjs' : 'opaque',
+      room: wordpress.room,
+      post_id: wordpress.postId,
+    },
+  };
+}

--- a/WordPress/gutenberg/bench/gutenberg-rtc-settings-matrix.bench.mjs
+++ b/WordPress/gutenberg/bench/gutenberg-rtc-settings-matrix.bench.mjs
@@ -1,0 +1,22 @@
+import { runPlaywrightSpecSuite, setting } from './lib/gutenberg-rtc-bench.mjs';
+
+const DEFAULT_SPECS = [
+  'collaboration-metabox-lock.spec.ts',
+  'collaboration-document-size-lock.spec.ts',
+  'collaboration-sync-error-filter.spec.ts',
+  'collaboration-autodraft-autosave-loss.spec.ts',
+  'collaboration-autodraft-collaborator-autosave-loss.spec.ts',
+];
+
+export default async function gutenbergRtcSettingsMatrix() {
+  const specs = setting('rtc_settings_specs')
+    .split(',')
+    .map((spec) => spec.trim())
+    .filter(Boolean);
+
+  return runPlaywrightSpecSuite({
+    id: 'gutenberg-rtc-settings-matrix',
+    specs: specs.length > 0 ? specs : DEFAULT_SPECS,
+    timeoutMs: 1500000,
+  });
+}

--- a/WordPress/gutenberg/bench/lib/gutenberg-rtc-bench.mjs
+++ b/WordPress/gutenberg/bench/lib/gutenberg-rtc-bench.mjs
@@ -1,0 +1,194 @@
+import { spawn } from 'node:child_process';
+import { mkdir, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+
+export const GUTENBERG_PATH = process.env.HOMEBOY_COMPONENT_PATH;
+export const SHARED_STATE = process.env.HOMEBOY_BENCH_SHARED_STATE || os.tmpdir();
+
+if (!GUTENBERG_PATH) {
+  throw new Error('HOMEBOY_COMPONENT_PATH is required');
+}
+
+export function setting(key, fallback = '') {
+  try {
+    const settings = JSON.parse(process.env.HOMEBOY_SETTINGS_JSON || '{}');
+    if (settings && settings[key] !== undefined) {
+      return String(settings[key]);
+    }
+  } catch {
+    // Ignore malformed settings and use direct env/defaults.
+  }
+
+  return process.env[`HOMEBOY_SETTINGS_${key.toUpperCase()}`] || fallback;
+}
+
+export function metric(value) {
+  const number = Number(value ?? 0);
+  return Number.isFinite(number) ? number : 0;
+}
+
+export function artifactDir(name) {
+  return path.join(SHARED_STATE, name);
+}
+
+export function runId(name) {
+  const namespace = setting('gutenberg_rtc_namespace', path.basename(GUTENBERG_PATH));
+  return `${namespace}-${name}-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function redact(text) {
+  return String(text || '')
+    .replace(/(Authorization:\s*Basic\s+)[A-Za-z0-9+/=._:-]+/gi, '$1[redacted]')
+    .replace(/("password"\s*:\s*")[^"]+(")/gi, '$1[redacted]$2')
+    .replace(/([?&](?:_wpnonce|token|password|key)=)[^&#\s]+/gi, '$1[redacted]');
+}
+
+export function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const started = performance.now();
+    let settled = false;
+    let stdout = '';
+    let stderr = '';
+    const child = spawn(command, args, {
+      cwd: options.cwd || GUTENBERG_PATH,
+      env: { ...process.env, ...(options.env || {}) },
+      shell: false,
+    });
+
+    const timer = options.timeoutMs
+      ? setTimeout(() => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          child.kill('SIGKILL');
+          reject(
+            new Error(
+              `${command} ${args.join(' ')} timed out after ${options.timeoutMs}ms; stdout=${redact(stdout).slice(-1200)}; stderr=${redact(stderr).slice(-1200)}`
+            )
+          );
+        }, options.timeoutMs)
+      : undefined;
+
+    child.stdout.on('data', (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on('error', (error) => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      reject(error);
+    });
+    child.on('close', (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      const elapsedMs = performance.now() - started;
+      const result = { code, stdout, stderr, elapsedMs };
+      if (code !== 0 && options.allowFailure !== true) {
+        reject(new Error(`${command} ${args.join(' ')} exited ${code}; stderr=${redact(stderr).slice(0, 2000)}`));
+        return;
+      }
+      resolve(result);
+    });
+  });
+}
+
+export async function runNpmScript(script, args = [], options = {}) {
+  return runCommand('npm', ['run', script, '--', ...args], options);
+}
+
+export async function runWpEnvTest(args, options = {}) {
+  return runNpmScript('wp-env-test', args, options);
+}
+
+export async function writeJson(file, data) {
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(file, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+export async function writeText(file, data) {
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(file, redact(data));
+}
+
+export function percentile(values, pct) {
+  const sorted = values.filter((value) => Number.isFinite(value)).sort((a, b) => a - b);
+  if (sorted.length === 0) {
+    return 0;
+  }
+  if (sorted.length === 1) {
+    return sorted[0];
+  }
+  const rank = (pct / 100) * (sorted.length - 1);
+  const lower = Math.floor(rank);
+  const upper = Math.ceil(rank);
+  if (lower === upper) {
+    return sorted[lower];
+  }
+  const weight = rank - lower;
+  return sorted[lower] * (1 - weight) + sorted[upper] * weight;
+}
+
+export async function runPlaywrightSpecSuite({ id, specs, timeoutMs = 900000 }) {
+  const idForRun = runId(id);
+  const outDir = path.join(artifactDir('gutenberg-rtc-playwright'), idForRun);
+  await mkdir(outDir, { recursive: true });
+
+  const args = [
+    '--project=chromium',
+    ...specs.map((spec) => `test/e2e/specs/editor/collaboration/${spec}`),
+  ];
+  const result = await runNpmScript('test:e2e', args, {
+    allowFailure: true,
+    timeoutMs,
+    env: {
+      PLAYWRIGHT_HTML_REPORT: path.join(outDir, 'html-report'),
+      PLAYWRIGHT_BLOB_OUTPUT_DIR: path.join(outDir, 'blob-report'),
+    },
+  });
+
+  const stdoutFile = path.join(outDir, 'stdout.txt');
+  const stderrFile = path.join(outDir, 'stderr.txt');
+  const resultFile = path.join(outDir, 'result.json');
+  await writeText(stdoutFile, result.stdout);
+  await writeText(stderrFile, result.stderr);
+  await writeJson(resultFile, {
+    id,
+    specs,
+    command: `npm run test:e2e -- ${args.join(' ')}`,
+    exit_code: result.code,
+    elapsed_ms: result.elapsedMs,
+  });
+
+  if (result.code !== 0) {
+    throw new Error(`${id} failed; raw_result=${resultFile}; stderr=${redact(result.stderr).slice(0, 1200)}`);
+  }
+
+  return {
+    metrics: {
+      success_rate: 1,
+      spec_count: specs.length,
+      elapsed_ms: metric(result.elapsedMs),
+      exit_code: result.code,
+    },
+    artifacts: {
+      raw_result: resultFile,
+      stdout: stdoutFile,
+      stderr: stderrFile,
+    },
+    metadata: {
+      specs,
+      command: `npm run test:e2e -- ${args.join(' ')}`,
+    },
+  };
+}

--- a/WordPress/gutenberg/docs/rtc-rig-plan.md
+++ b/WordPress/gutenberg/docs/rtc-rig-plan.md
@@ -1,0 +1,163 @@
+# Gutenberg RTC Rig Plan
+
+## 1. Rig Contract
+
+Create a package installable with `homeboy rig install ./WordPress/gutenberg`.
+The rig points at the local Gutenberg checkout and runs Homeboy Node benchmark
+workloads from this package.
+
+```text
+WordPress/gutenberg/
+  rigs/gutenberg-rtc/rig.json
+  bench/gutenberg-rtc-browser-basic.bench.mjs
+  bench/gutenberg-rtc-browser-tabs.bench.mjs
+  bench/gutenberg-rtc-protocol-load.bench.mjs
+  bench/gutenberg-rtc-conflict-fuzzer.bench.mjs
+  bench/gutenberg-rtc-settings-matrix.bench.mjs
+```
+
+## 2. Benchmark Pyramid
+
+### Browser Basic
+
+Purpose: catch visible editor bugs and small-team correctness regressions.
+
+Scenarios:
+
+- 2 users editing the same paragraph.
+- 2 users editing different blocks.
+- 3 users at the default client limit.
+- 4 users over the default client limit, expecting graceful rejection.
+- Reload, close, reconnect, and stale awareness cleanup.
+
+Metrics:
+
+- `mutual_discovery_ms`
+- `first_sync_ms`
+- `convergence_ms`
+- `rest_error_count`
+- `final_state_equal`
+
+Artifacts:
+
+- Playwright trace.
+- Screenshot on failure.
+- Final block JSON for each client.
+- Sync request log.
+
+### Browser Tabs
+
+Purpose: model real user tab explosion without pretending Chromium process count
+is a scalable load generator.
+
+Scenarios:
+
+- 1 user with 5 tabs on the same post.
+- 10 users with 5 tabs each.
+- Mixed foreground/background tabs to exercise the 25s background polling path.
+- Session expiry and manual retry flows.
+
+Metrics:
+
+- `tabs_opened`
+- `background_poll_count`
+- `foreground_poll_count`
+- `disconnect_dialog_count`
+- `reconnect_success_rate`
+
+### Protocol Load
+
+Purpose: stress the real WordPress REST sync endpoint at high cardinality.
+
+Scenarios:
+
+- 10 synthetic clients smoke.
+- 100 synthetic clients normal load.
+- 1000 synthetic clients hot load.
+- Burst joins, staggered joins, churn, and offline catch-up.
+- Compaction threshold pressure and request-size boundary pressure.
+
+Metrics:
+
+- `client_count`
+- `requests_total`
+- `requests_per_second`
+- `sync_p50_ms`
+- `sync_p95_ms`
+- `sync_p99_ms`
+- `http_4xx_count`
+- `http_5xx_count`
+- `stored_update_count`
+- `compaction_count`
+- `final_crdt_equal`
+
+Artifacts:
+
+- Seed and scenario config.
+- Per-client final CRDT state vector hash.
+- HTTP response histogram.
+- Storage room summary.
+
+### Conflict Fuzzer
+
+Purpose: find correctness bugs in concurrent operations, not just perf cliffs.
+
+Operation set:
+
+- Insert text.
+- Delete text.
+- Replace text.
+- Split paragraph.
+- Merge paragraph.
+- Insert block.
+- Move block.
+- Update block attributes.
+- Undo/redo.
+- Save/autosave/reload.
+
+Invariant checks:
+
+- Every active client converges to the same block tree.
+- Persisted post content parses as valid block markup.
+- `_crdt_document` remains readable after reload.
+- No client gets stuck disconnected after retries unless the scenario expects it.
+
+### Settings Matrix
+
+Purpose: prove bugs are not hidden behind one idealized site shape.
+
+Axes:
+
+- Collaboration enabled/disabled.
+- Roles: admin, editor, author, contributor, mixed permissions.
+- Post status: auto-draft, draft, scheduled, published.
+- Document size: tiny, normal, large, huge.
+- Metabox compatibility on/off.
+- Autosave/revisions pressure.
+- Permalink settings.
+- Classic editor-adjacent screens where RTC must stay disabled.
+
+## 3. Implementation Sequence
+
+1. Make `homeboy bench list --rig gutenberg-rtc` discover all scenario IDs.
+2. Implement `browser-basic` by reusing Gutenberg's existing collaboration e2e
+   helpers where possible.
+3. Implement `protocol-load` with synthetic Yjs clients that authenticate once,
+   create one post, and hit `/wp-sync/v1/updates` directly.
+4. Add artifact capture and deterministic seeds.
+5. Run local smoke: 2 browser users, 10 synthetic clients.
+6. Add hot profiles: 100 synthetic clients and 1000 synthetic clients, intended
+   for `homeboy bench --runner <lab-runner>` or `--force-hot`.
+7. Promote recurring failures into Gutenberg issues/PRs with artifact links.
+
+## 4. Guardrails
+
+- Do not use 1000 browser tabs as the primary hot path; that mostly measures
+  Chromium and host process limits.
+- Use synthetic clients for 100/1000-client load while preserving the real
+  WordPress REST server, auth, permission, storage, compaction, and payload
+  limits.
+- Keep scenario failures reproducible with `seed`, `client_count`, `operation`
+  profile, and created post ID in the artifact.
+- Do not publish local-only artifact paths as maintainer-facing evidence; mirror
+  evidence into PR comments, issue comments, or persisted Homeboy artifacts.

--- a/WordPress/gutenberg/docs/rtc-rig-plan.md
+++ b/WordPress/gutenberg/docs/rtc-rig-plan.md
@@ -145,10 +145,12 @@ Axes:
 3. Implement `protocol-load` with synthetic Yjs clients that authenticate once,
    create one post, and hit `/wp-sync/v1/updates` directly.
 4. Add artifact capture and deterministic seeds.
-5. Run local smoke: 2 browser users, 10 synthetic clients.
-6. Add hot profiles: 100 synthetic clients and 1000 synthetic clients, intended
+5. Use the rig `bench_prepare` pipeline to bootstrap Gutenberg dependencies
+   before timed workload execution when `wp-env` is missing.
+6. Run local smoke: 2 browser users, 10 synthetic clients.
+7. Add hot profiles: 100 synthetic clients and 1000 synthetic clients, intended
    for `homeboy bench --runner <lab-runner>` or `--force-hot`.
-7. Promote recurring failures into Gutenberg issues/PRs with artifact links.
+8. Promote recurring failures into Gutenberg issues/PRs with artifact links.
 
 ## 4. Guardrails
 

--- a/WordPress/gutenberg/rigs/gutenberg-rtc/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-rtc/rig.json
@@ -1,0 +1,86 @@
+{
+  "id": "gutenberg-rtc",
+  "description": "Gutenberg real-time collaboration stress rig. Uses Playwright for small/medium editor correctness scenarios and synthetic Yjs/REST clients for high-cardinality sync endpoint load.",
+  "components": {
+    "gutenberg": {
+      "path": "~/Developer/gutenberg",
+      "branch": "trunk",
+      "extensions": {
+        "nodejs": {
+          "gutenberg_rtc_component_path": "~/Developer/gutenberg"
+        }
+      }
+    }
+  },
+  "resources": {
+    "exclusive": [
+      "gutenberg-rtc:${env.HOMEBOY_SETTINGS_GUTENBERG_RTC_NAMESPACE}"
+    ],
+    "paths": [
+      "${components.gutenberg.path}"
+    ]
+  },
+  "bench": {
+    "default_component": "gutenberg",
+    "warmup_iterations": 0
+  },
+  "bench_workloads": {
+    "nodejs": [
+      { "path": "${package.root}/bench/gutenberg-rtc-browser-basic.bench.mjs" },
+      { "path": "${package.root}/bench/gutenberg-rtc-browser-tabs.bench.mjs" },
+      { "path": "${package.root}/bench/gutenberg-rtc-protocol-load.bench.mjs" },
+      { "path": "${package.root}/bench/gutenberg-rtc-conflict-fuzzer.bench.mjs" },
+      { "path": "${package.root}/bench/gutenberg-rtc-settings-matrix.bench.mjs" }
+    ]
+  },
+  "bench_profiles": {
+    "smoke": [
+      "gutenberg-rtc-browser-basic",
+      "gutenberg-rtc-protocol-load"
+    ],
+    "hot": [
+      "gutenberg-rtc-protocol-load",
+      "gutenberg-rtc-conflict-fuzzer"
+    ]
+  },
+  "pipeline": {
+    "check": [
+      {
+        "kind": "check",
+        "label": "Gutenberg checkout exists",
+        "file": "${components.gutenberg.path}/package.json",
+        "contains": "\"name\": \"gutenberg\""
+      },
+      {
+        "kind": "check",
+        "label": "Gutenberg RTC e2e fixtures exist",
+        "file": "${components.gutenberg.path}/test/e2e/specs/editor/collaboration/fixtures/collaboration-utils.ts"
+      },
+      {
+        "kind": "check",
+        "label": "Gutenberg HTTP polling provider exists",
+        "file": "${components.gutenberg.path}/packages/sync/src/providers/http-polling/polling-manager.ts"
+      },
+      {
+        "kind": "check",
+        "label": "Gutenberg sync server exists",
+        "file": "${components.gutenberg.path}/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php"
+      }
+    ],
+    "up": [
+      {
+        "kind": "check",
+        "label": "Gutenberg checkout exists",
+        "file": "${components.gutenberg.path}/package.json",
+        "contains": "\"name\": \"gutenberg\""
+      },
+      {
+        "kind": "command",
+        "label": "Install Gutenberg npm dependencies when missing",
+        "cwd": "${components.gutenberg.path}",
+        "command": "if [ ! -x node_modules/.bin/wp-env ]; then npm install; fi"
+      }
+    ],
+    "down": []
+  }
+}

--- a/WordPress/gutenberg/rigs/gutenberg-rtc/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-rtc/rig.json
@@ -67,7 +67,7 @@
         "file": "${components.gutenberg.path}/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php"
       }
     ],
-    "up": [
+    "bench_prepare": [
       {
         "kind": "check",
         "label": "Gutenberg checkout exists",
@@ -81,6 +81,7 @@
         "command": "if [ ! -x node_modules/.bin/wp-env ]; then npm install; fi"
       }
     ],
+    "up": [],
     "down": []
   }
 }


### PR DESCRIPTION
## Summary
- Add a `WordPress/gutenberg` Homeboy rig package for Gutenberg real-time collaboration stress testing.
- Add five benchmark workloads covering browser RTC specs, tab/presence flows, protocol load, conflict gauntlets, and settings/autodraft coverage.
- Add a protocol-load workload that starts `wp-env-test`, creates an RTC-enabled draft post, and drives `/wp-sync/v1/updates` with configurable synthetic clients.

## Validation
- `jq empty WordPress/gutenberg/rigs/gutenberg-rtc/rig.json`
- `node --check` for all Gutenberg RTC bench files
- Temp `homeboy rig install ./WordPress/gutenberg`
- Temp `homeboy rig check gutenberg-rtc`
- Temp `homeboy bench list --rig gutenberg-rtc`

## Notes
- The local Gutenberg checkout used for prep does not currently have `node_modules/.bin/wp-env`, so live benchmark execution needs `homeboy rig up gutenberg-rtc` or an already-bootstrapped Gutenberg checkout first.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the rig package, benchmark workload wrappers, protocol-load harness, docs, and validation commands for Chris to review and run.