### PR TITLE
feat(studio): use WordPress admin scenario profiler

### DIFF
--- a/Automattic/studio/bench/lib/wordpress-page-profiler.mjs
+++ b/Automattic/studio/bench/lib/wordpress-page-profiler.mjs
@@ -6,6 +6,7 @@ import { requestProfilerPath } from './site-editor-timing-deltas.mjs';
 
 const require = createRequire(import.meta.url);
 const PAGE_PROFILER_FILENAME = 'page-profiler.js';
+const ADMIN_PAGE_SCENARIOS_FILENAME = 'admin-page-scenarios.js';
 
 export const SITE_EDITOR_PAGE_SPEC = {
   id: 'site-editor',
@@ -83,12 +84,33 @@ export function pageProfilerPath(options = {}) {
   return path.join(path.dirname(profiler), PAGE_PROFILER_FILENAME);
 }
 
+export function adminPageScenariosPath(options = {}) {
+  const explicit = options.override || process.env.HOMEBOY_WORDPRESS_ADMIN_PAGE_SCENARIOS_PATH;
+  if (explicit) {
+    return explicit;
+  }
+
+  const profiler = options.pageProfilerPath || pageProfilerPath(options);
+  if (!profiler) {
+    return '';
+  }
+  return path.join(path.dirname(profiler), ADMIN_PAGE_SCENARIOS_FILENAME);
+}
+
 export function loadWordPressPageProfiler(options = {}) {
   const profilerPath = pageProfilerPath(options);
   if (!profilerPath || !existsSync(profilerPath)) {
     return { path: profilerPath, module: null };
   }
   return { path: profilerPath, module: require(profilerPath) };
+}
+
+export function loadWordPressAdminPageScenarios(options = {}) {
+  const scenariosPath = adminPageScenariosPath(options);
+  if (!scenariosPath || !existsSync(scenariosPath)) {
+    return { path: scenariosPath, module: null };
+  }
+  return { path: scenariosPath, module: require(scenariosPath) };
 }
 
 export function loadWordPressRequestProfiler(options = {}) {
@@ -108,6 +130,36 @@ export async function profileWordPressPage({ page, siteUrl, pageProfiler, pageSp
     page,
     baseUrl: siteUrl,
     spec: pageSpec || wordpressPageProfilerSpec(),
+    wordpressProfilerRows,
+    mark,
+  });
+}
+
+export function wordpressAdminPageScenario({ adminPageScenarios, pageSpec } = {}) {
+  if (!adminPageScenarios?.normalizeWordPressAdminPageScenarioInput) {
+    throw new Error('Homeboy WordPress admin page scenarios are unavailable. Update homeboy-extensions or set HOMEBOY_WORDPRESS_ADMIN_PAGE_SCENARIOS_PATH.');
+  }
+
+  return adminPageScenarios.normalizeWordPressAdminPageScenarioInput(pageSpec || wordpressPageProfilerSpec());
+}
+
+export async function profileWordPressAdminPageScenario({
+  page,
+  siteUrl,
+  adminPageScenarios,
+  pageSpec,
+  wordpressProfilerRows = [],
+  mark,
+}) {
+  if (!adminPageScenarios?.profileWordPressAdminPageScenario) {
+    throw new Error('Homeboy WordPress admin page scenario profiler is unavailable. Update homeboy-extensions or set HOMEBOY_WORDPRESS_ADMIN_PAGE_SCENARIOS_PATH.');
+  }
+
+  return adminPageScenarios.profileWordPressAdminPageScenario({
+    page,
+    baseUrl: siteUrl,
+    siteUrl,
+    scenario: wordpressAdminPageScenario({ adminPageScenarios, pageSpec }),
     wordpressProfilerRows,
     mark,
   });

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
@@ -31,8 +31,9 @@ import {
 } from './lib/wordpress-bootstrap-timeline.mjs';
 import {
   loadWordPressPageProfiler,
+  loadWordPressAdminPageScenarios,
   loadWordPressRequestProfiler,
-  profileWordPressPage,
+  profileWordPressAdminPageScenario,
   wordpressPageProfilerSpec,
 } from './lib/wordpress-page-profiler.mjs';
 
@@ -229,6 +230,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
   const totalStarted = Date.now();
   const { path: profilerPath, module: profiler } = loadWordPressRequestProfiler();
   const { path: pageProfilerPath, module: pageProfiler } = loadWordPressPageProfiler({ profilerPath });
+  const { path: adminPageScenariosPath, module: adminPageScenarios } = loadWordPressAdminPageScenarios({ profilerPath, pageProfilerPath });
   const { path: correlatorPath, module: correlator } = loadTimingCorrelator({ profilerPath });
   let create;
   let start;
@@ -326,10 +328,10 @@ export default async function studioSiteEditorDiagnosticsBench() {
 
         loginFormSeen = await page.locator('#loginform').count();
 
-        const runPageProfile = profileExtension?.profileWordPressPage || profileWordPressPage;
+        const runPageProfile = profileExtension?.profileWordPressAdminPageScenario || profileWordPressAdminPageScenario;
 
         phase = 'warmup-page';
-        warmupProfile = await runPageProfile({ page, siteUrl: status.siteUrl, pageProfiler, pageSpec, mark });
+        warmupProfile = await runPageProfile({ page, siteUrl: status.siteUrl, pageProfiler, adminPageScenarios, pageSpec, mark });
         await mark('warmup_wordpress_page_ready');
 
         phase = 'dashboard-between-runs';
@@ -338,7 +340,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
         await mark('browser_admin_networkidle_between_runs');
 
         phase = 'measure-page';
-        measureProfile = await runPageProfile({ page, siteUrl: status.siteUrl, pageProfiler, pageSpec, mark });
+        measureProfile = await runPageProfile({ page, siteUrl: status.siteUrl, pageProfiler, adminPageScenarios, pageSpec, mark });
         await mark('measure_wordpress_page_ready');
         phase = 'done';
       },
@@ -388,6 +390,8 @@ export default async function studioSiteEditorDiagnosticsBench() {
           profilerAvailable: Boolean(profiler),
           pageProfilerPath,
           pageProfilerAvailable: Boolean(pageProfiler),
+          adminPageScenariosPath,
+          adminPageScenariosAvailable: Boolean(adminPageScenarios),
           correlatorPath,
           correlatorAvailable: Boolean(correlator),
           bootstrapTimelineArtifactPath,

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -14,6 +14,11 @@ const DEFAULT_RESOURCE_INCLUDE = Object.freeze([
   '/wp-includes/',
 ]);
 const pageProfilerApi = { DEFAULT_RESOURCE_INCLUDE };
+const SITE_EDITOR_PAGE_SPEC_FOR_TEST = {
+  id: 'site-editor',
+  path: '/wp-admin/site-editor.php',
+  ready: { selector: 'iframe[name="editor-canvas"]' },
+};
 
 const {
   annotatePhase,
@@ -34,7 +39,11 @@ const {
 } = await import('./lib/site-editor-preload-harness.mjs');
 const {
   pageProfilerPath,
+  adminPageScenariosPath,
+  loadWordPressAdminPageScenarios,
+  profileWordPressAdminPageScenario,
   profileWordPressPage,
+  wordpressAdminPageScenario,
   wordpressPageProfilerSpec,
 } = await import('./lib/wordpress-page-profiler.mjs');
 const {
@@ -132,6 +141,14 @@ test('pageProfilerPath sits next to the request profiler by default', () => {
   );
 });
 
+test('adminPageScenariosPath sits next to the page profiler by default', () => {
+  const profilerPath = '/tmp/he/wordpress/lib/request-profiler.js';
+  assert.equal(
+    adminPageScenariosPath({ profilerPath }),
+    '/tmp/he/wordpress/lib/admin-page-scenarios.js'
+  );
+});
+
 test('wordpressPageProfilerSpec defaults to Site Editor', () => {
   withEnv(
     {
@@ -211,6 +228,62 @@ test('loadTimingCorrelator loads a real correlator module from disk', async () =
   } finally {
     await rm(tmp, { recursive: true, force: true });
   }
+});
+
+test('loadWordPressAdminPageScenarios loads a real scenario module from disk', async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), 'admin-page-scenarios-'));
+  try {
+    const file = path.join(tmp, 'admin-page-scenarios.js');
+    await writeFile(
+      file,
+      "module.exports = { normalizeWordPressAdminPageScenarioInput: (spec) => ({ ...spec, normalized: true }), profileWordPressAdminPageScenario: async (input) => ({ id: input.scenario.id, status: 200, readyMs: 42 }) };\n"
+    );
+    const { module: loaded, path: resolvedPath } = loadWordPressAdminPageScenarios({ override: file });
+    assert.equal(resolvedPath, file);
+    assert.equal(typeof loaded.normalizeWordPressAdminPageScenarioInput, 'function');
+    assert.equal(typeof loaded.profileWordPressAdminPageScenario, 'function');
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('wordpressAdminPageScenario normalizes the selected page spec through Homeboy scenarios', () => {
+  const scenario = wordpressAdminPageScenario({
+    adminPageScenarios: {
+      normalizeWordPressAdminPageScenarioInput: (spec) => ({
+        ...spec,
+        resources: { includeResourceSubstrings: ['/wp-json/'] },
+      }),
+    },
+    pageSpec: SITE_EDITOR_PAGE_SPEC_FOR_TEST,
+  });
+
+  assert.equal(scenario.id, 'site-editor');
+  assert.equal(scenario.path, '/wp-admin/site-editor.php');
+  assert.deepEqual(scenario.resources.includeResourceSubstrings, ['/wp-json/']);
+});
+
+test('profileWordPressAdminPageScenario delegates profiling to Homeboy scenario API', async () => {
+  const calls = [];
+  const profile = await profileWordPressAdminPageScenario({
+    page: { goto: async () => ({ status: () => 200 }) },
+    siteUrl: 'http://example.test',
+    adminPageScenarios: {
+      normalizeWordPressAdminPageScenarioInput: (spec) => ({ ...spec, normalized: true }),
+      profileWordPressAdminPageScenario: async (input) => {
+        calls.push(input);
+        return { id: input.scenario.id, status: 200, readyMs: 123 };
+      },
+    },
+    pageSpec: SITE_EDITOR_PAGE_SPEC_FOR_TEST,
+    mark: async () => {},
+  });
+
+  assert.equal(profile.id, 'site-editor');
+  assert.equal(profile.readyMs, 123);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].baseUrl, 'http://example.test');
+  assert.equal(calls[0].scenario.normalized, true);
 });
 
 // --- phase annotation ------------------------------------------------------

--- a/Automattic/studio/bench/studio-site-editor-preload-comparison.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-preload-comparison.bench.mjs
@@ -32,9 +32,10 @@ import {
 } from './lib/wordpress-bootstrap-timeline.mjs';
 import {
   SITE_EDITOR_PAGE_SPEC,
+  loadWordPressAdminPageScenarios,
   loadWordPressPageProfiler,
   loadWordPressRequestProfiler,
-  profileWordPressPage,
+  profileWordPressAdminPageScenario,
 } from './lib/wordpress-page-profiler.mjs';
 
 const BROWSER_HELPER = process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER;
@@ -50,7 +51,7 @@ function siteAdminUrl(siteUrl, relativePath = '') {
   return new URL(`wp-admin/${relativePath}`, base).toString();
 }
 
-async function runBotPath({ label, artifactDir, sitePath, status, requestProfiler, pageProfiler, candidate }) {
+async function runBotPath({ label, artifactDir, sitePath, status, requestProfiler, pageProfiler, adminPageScenarios, candidate }) {
   if (candidate) {
     await installSiteEditorPreloadCandidate(sitePath);
   }
@@ -110,10 +111,10 @@ async function runBotPath({ label, artifactDir, sitePath, status, requestProfile
       await mark(`${label}_auto_login_networkidle`);
 
       setPhase('warmup-site-editor');
-      warmup = await profileWordPressPage({
+      warmup = await profileWordPressAdminPageScenario({
         page,
         siteUrl: status.siteUrl,
-        pageProfiler,
+        adminPageScenarios,
         pageSpec: SITE_EDITOR_PAGE_SPEC,
         mark,
       });
@@ -126,10 +127,10 @@ async function runBotPath({ label, artifactDir, sitePath, status, requestProfile
       await mark(`${label}_admin_networkidle_between_runs`);
 
       setPhase('measure-site-editor');
-      measure = await profileWordPressPage({
+      measure = await profileWordPressAdminPageScenario({
         page,
         siteUrl: status.siteUrl,
-        pageProfiler,
+        adminPageScenarios,
         pageSpec: SITE_EDITOR_PAGE_SPEC,
         mark,
       });
@@ -262,6 +263,7 @@ export default async function studioSiteEditorPreloadComparisonBench() {
   const totalStarted = Date.now();
   const { path: profilerPath, module: requestProfiler } = loadWordPressRequestProfiler();
   const { path: pageProfilerPath, module: pageProfiler } = loadWordPressPageProfiler({ profilerPath });
+  const { path: adminPageScenariosPath, module: adminPageScenarios } = loadWordPressAdminPageScenarios({ profilerPath, pageProfilerPath });
   const baselineSitePath = path.join(artifactDir, 'baseline-site');
   const candidateSitePath = path.join(artifactDir, 'candidate-site');
   let baselineCreate;
@@ -285,6 +287,7 @@ export default async function studioSiteEditorPreloadComparisonBench() {
       status: baselineSite.status,
       requestProfiler,
       pageProfiler,
+      adminPageScenarios,
       candidate: false,
     });
 
@@ -301,6 +304,7 @@ export default async function studioSiteEditorPreloadComparisonBench() {
       status: candidateSite.status,
       requestProfiler,
       pageProfiler,
+      adminPageScenarios,
       candidate: true,
     });
 
@@ -323,6 +327,8 @@ export default async function studioSiteEditorPreloadComparisonBench() {
           profilerAvailable: Boolean(requestProfiler),
           pageProfilerPath,
           pageProfilerAvailable: Boolean(pageProfiler),
+          adminPageScenariosPath,
+          adminPageScenariosAvailable: Boolean(adminPageScenarios),
           preloadExperiment: {
             scenario: process.env.HOMEBOY_SITE_EDITOR_SCENARIO || 'default',
             mode: process.env.HOMEBOY_SITE_EDITOR_PRELOAD_MODE || 'broad',


### PR DESCRIPTION
## Summary
- Load the merged Homeboy Extensions WordPress admin page scenario module next to the existing page profiler.
- Route Studio Site Editor diagnostics and preload comparison profiling through `profileWordPressAdminPageScenario()` while keeping existing Site Editor spec IDs, metric names, and raw artifact structure.
- Add targeted coverage for scenario module resolution and delegation.

## Verification
- `node --check Automattic/studio/bench/lib/wordpress-page-profiler.mjs && node --check Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs && node --check Automattic/studio/bench/studio-site-editor-preload-comparison.bench.mjs && node --check Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `git diff --check`

Refs #138

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Migrated the Studio Site Editor profiling consumers to the merged Homeboy Extensions WordPress admin scenario profiler APIs and ran targeted verification; Chris remains responsible for review and merge.