### PR TITLE
Migrate simple Studio browser benches to Node helpers

### DIFF
--- a/Automattic/studio/bench/studio-admin-theme-page-browser.bench.mjs
+++ b/Automattic/studio/bench/studio-admin-theme-page-browser.bench.mjs
@@ -1,5 +1,4 @@
-import { mkdir, writeFile } from 'node:fs/promises';
-import path from 'node:path';
+import { mkdir } from 'node:fs/promises';
 import {
   artifactDir as studioArtifactDir,
   createStudioSite,
@@ -7,19 +6,28 @@ import {
   parseStudioSiteStatus,
   redact,
   safeResult,
-  sanitizeArtifact,
   stopStudioSite,
   studioSiteStatus,
   variant,
 } from './lib/studio-bench.mjs';
 
 const BROWSER_HELPER = process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER;
+const ARTIFACT_CONTEXT_HELPER = process.env.HOMEBOY_NODEJS_BENCH_ARTIFACT_CONTEXT;
+const REDACTION_HELPER = process.env.HOMEBOY_NODEJS_BENCH_REDACTION;
 
 if (!BROWSER_HELPER) {
   throw new Error('HOMEBOY_NODEJS_BROWSER_BENCH_HELPER is required');
 }
+if (!ARTIFACT_CONTEXT_HELPER) {
+  throw new Error('HOMEBOY_NODEJS_BENCH_ARTIFACT_CONTEXT is required');
+}
+if (!REDACTION_HELPER) {
+  throw new Error('HOMEBOY_NODEJS_BENCH_REDACTION is required');
+}
 
-const { runBrowserBench } = await import(BROWSER_HELPER);
+const { runBrowserPageScenario } = await import(BROWSER_HELPER);
+const { createBenchArtifactContext } = await import(ARTIFACT_CONTEXT_HELPER);
+const { sanitizeArtifactFile } = await import(REDACTION_HELPER);
 
 async function createSite(sitePath) {
   return createStudioSite(sitePath, {
@@ -51,9 +59,12 @@ async function firstContentfulPaint(page) {
 
 export default async function studioAdminThemePageBrowserBench() {
   const currentVariant = variant();
-  const runId = `${currentVariant}-admin-theme-page-browser-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  const artifactDir = path.join(studioArtifactDir('studio-admin-theme-page-browser-artifacts'), runId);
-  const sitePath = path.join(artifactDir, 'site');
+  const artifactContext = createBenchArtifactContext({
+    id: `${currentVariant}-admin-theme-page-browser`,
+    artifactsDir: studioArtifactDir('studio-admin-theme-page-browser-artifacts'),
+  });
+  const artifactDir = artifactContext.artifactDir;
+  const sitePath = artifactContext.artifactPath('site', { prefix: '', extension: '' });
   await mkdir(artifactDir, { recursive: true });
 
   const totalStarted = Date.now();
@@ -74,7 +85,7 @@ export default async function studioAdminThemePageBrowserBench() {
       throw new Error(`site status missing siteUrl/autoLoginUrl: ${redact(statusResult.stdout).slice(0, 1000)}`);
     }
 
-    browserResult = await runBrowserBench({
+    browserResult = await runBrowserPageScenario({
       id: 'studio-admin-theme-page-browser',
       artifactsDir: artifactDir,
       trace: true,
@@ -98,37 +109,39 @@ export default async function studioAdminThemePageBrowserBench() {
 
         firstContentfulPaintMs = await firstContentfulPaint(page);
       },
+      postSanitizeAssertions: [
+        { type: 'artifact', key: 'trace', kind: 'playwright-trace' },
+        { type: 'artifact', key: 'screenshot', kind: 'screenshot' },
+      ],
+      sanitizeArtifacts: async ({ artifacts }) => {
+        if (artifacts.network?.path) {
+          await sanitizeArtifactFile(artifacts.network.path, { profile: 'web' });
+        }
+        return artifacts;
+      },
     });
 
-    await sanitizeArtifact(browserResult.artifacts?.network);
     stop = await stopSite(sitePath);
 
     const totalElapsedMs = Date.now() - totalStarted;
-    const artifactFile = path.join(artifactDir, `result-${runId}.json`);
-    await writeFile(
-      artifactFile,
-      JSON.stringify(
-        {
-          variant: currentVariant,
-          sitePath,
-          siteUrl: status.siteUrl,
-          timings: {
-            site_create_ms: create.elapsedMs,
-            site_status_ms: statusResult.elapsedMs,
-            total_elapsed_ms: totalElapsedMs,
-          },
-          commands: {
-            create: safeResult(create),
-            status: safeResult(statusResult),
-            stop: safeResult(stop),
-          },
-          browserMetrics: browserResult.metrics,
-          browserArtifacts: browserResult.artifacts,
-        },
-        null,
-        2
-      )
-    );
+    const rawResultArtifact = await artifactContext.writeJson('raw-result', {
+      variant: currentVariant,
+      sitePath,
+      siteUrl: status.siteUrl,
+      timings: {
+        site_create_ms: create.elapsedMs,
+        site_status_ms: statusResult.elapsedMs,
+        total_elapsed_ms: totalElapsedMs,
+      },
+      commands: {
+        create: safeResult(create),
+        status: safeResult(statusResult),
+        stop: safeResult(stop),
+      },
+      browserMetrics: browserResult.metrics,
+      browserArtifacts: browserResult.artifacts,
+    }, { kind: 'browser-page-scenario-result', label: 'Studio Add Themes browser raw result' });
+    const artifactFile = rawResultArtifact.path;
 
     if (finalStatus < 200 || finalStatus >= 400) {
       throw new Error(`Add Themes returned HTTP status ${finalStatus}; raw_result=${artifactFile}`);
@@ -153,7 +166,7 @@ export default async function studioAdminThemePageBrowserBench() {
         ...browserResult.metrics,
       },
       artifacts: {
-        raw_result: artifactFile,
+        raw_result: rawResultArtifact,
         site_path: sitePath,
         ...browserResult.artifacts,
       },

--- a/Automattic/studio/bench/studio-app-create-site.trace.mjs
+++ b/Automattic/studio/bench/studio-app-create-site.trace.mjs
@@ -1,4 +1,4 @@
-import { access, copyFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, copyFile, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -23,33 +23,32 @@ if (!STUDIO_PATH) {
 if (!RESULTS_FILE) {
   throw new Error('HOMEBOY_TRACE_RESULTS_FILE is required');
 }
+if (!HELPER_DIR) {
+  throw new Error('HOMEBOY_TRACE_HELPER_DIR is required');
+}
+process.env.HOMEBOY_TRACE_ARTIFACT_DIR ||= ARTIFACT_DIR;
 
 const playwright = require(require.resolve('playwright', { paths: [STUDIO_PATH] }));
 const { findLatestBuild, parseElectronApp } = require(
   require.resolve('electron-playwright-helpers', { paths: [STUDIO_PATH] })
 );
-const { pollHttp: helperPollHttp } = HELPER_DIR
-  ? await import(pathToFileURL(`${HELPER_DIR}/probes.mjs`).href)
-  : { pollHttp: null };
+const { createTraceRecorder } = await import(pathToFileURL(path.join(HELPER_DIR, 'timeline.mjs')).href);
+const { captureTraceEventText, pollHttp: helperPollHttp, pollJsonFile } = await import(
+  pathToFileURL(path.join(HELPER_DIR, 'probes.mjs')).href
+);
 
-const timeline = [];
-const assertions = [];
-const artifacts = [];
-const startedAt = performance.now();
+const recorder = createTraceRecorder({
+  componentId: COMPONENT_ID,
+  scenarioId: SCENARIO_ID,
+  resultsFile: RESULTS_FILE,
+});
+recorder.timestampMs = () => Math.round(performance.now() - recorder.start);
 const seenCliMessages = new Set();
 
-function timestampMs() {
-  return Math.round(performance.now() - startedAt);
-}
-
 function event(source, name, data = {}) {
-  const entry = { t_ms: timestampMs(), source, event: name, data };
-  timeline.push(entry);
-  return entry;
+  return recorder.recordEvent(source, name, data);
 }
 
-// Local observation helpers preserve the current trace behavior until the Node.js
-// Homeboy extension ships reusable trace probes.
 function eventNameFromCliMessage(message) {
   return message
     .replace(/\u2026/g, '')
@@ -60,7 +59,7 @@ function eventNameFromCliMessage(message) {
 
 function captureCliEvents(chunk) {
 	for (const line of chunk.toString().split(/\r?\n/)) {
-		captureHarnessEvent(line);
+		void captureHarnessEvent(line);
 		const match = line.match(
 			/^\[CLI - ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\]\s+(.*)$/i
 		);
@@ -69,7 +68,7 @@ function captureCliEvents(chunk) {
     }
 		const [, commandId, message] = match;
 		if (message.startsWith('[HOMEBOY_TRACE] ')) {
-			captureHarnessEvent(message);
+			void captureHarnessEvent(message);
 			continue;
 		}
 		const eventName = eventNameFromCliMessage(message);
@@ -82,20 +81,21 @@ function captureCliEvents(chunk) {
   }
 }
 
-function captureHarnessEvent(text) {
-  const prefix = '[HOMEBOY_TRACE] ';
-  if (!text.startsWith(prefix)) {
-    return;
-  }
-  try {
-    const item = JSON.parse(text.slice(prefix.length));
-    if (!item || typeof item.source !== 'string' || typeof item.event !== 'string') {
-      return;
+async function captureHarnessEvent(text) {
+  await captureTraceEventText(
+    text,
+    (source, name, data) => {
+      if (source === '__ignored_trace_bridge' && name === '__ignored_trace_bridge') {
+        return null;
+      }
+      return event(source, name, data);
+    },
+    {
+      prefix: '[HOMEBOY_TRACE] ',
+      source: '__ignored_trace_bridge',
+      event: '__ignored_trace_bridge',
     }
-    event(item.source, item.event, item.data || {});
-  } catch {
-    // Ignore non-contract console noise.
-  }
+  );
 }
 
 async function installIpcProbe(mainWindow) {
@@ -233,63 +233,32 @@ function extractStudioFailureMessage(log) {
 }
 
 async function pollHttp(port, timeoutMs, getFailureMessage = () => null) {
-  if (helperPollHttp) {
-    const result = await Promise.race([
-      helperPollHttp(`http://${HTTP_PROBE_HOST}:${port}/`, {
-        source: 'probe',
-        intervalMs: 250,
-        readyStatus: 200,
-        requestTimeoutMs: HTTP_REQUEST_TIMEOUT_MS,
-        timeoutMs,
-        onEvent: (source, name, data) => {
-          event(source, name, data);
-          if (source === 'probe' && name === 'http.first_response') {
-            event('probe', 'http_first_response', { port, status: data.status });
-          }
-          if (source === 'probe' && name === 'http.ready') {
-            event('probe', 'http_ready', { port, status: data.status });
-          }
-          if (source === 'probe' && name === 'http.timeout') {
-            event('probe', 'http_timeout', { port });
-          }
-        },
-      }),
-      waitForStudioFailure(getFailureMessage, timeoutMs),
-    ]);
-    if (result.status !== 'ready') {
-      throw new Error(`HTTP did not become ready on port ${port}`);
-    }
-    return result;
+  const result = await Promise.race([
+    helperPollHttp(`http://${HTTP_PROBE_HOST}:${port}/`, {
+      source: 'probe',
+      intervalMs: 250,
+      readyStatus: 200,
+      requestTimeoutMs: HTTP_REQUEST_TIMEOUT_MS,
+      timeoutMs,
+      onEvent: (source, name, data) => {
+        event(source, name, data);
+        if (source === 'probe' && name === 'http.first_response') {
+          event('probe', 'http_first_response', { port, status: data.status });
+        }
+        if (source === 'probe' && name === 'http.ready') {
+          event('probe', 'http_ready', { port, status: data.status });
+        }
+        if (source === 'probe' && name === 'http.timeout') {
+          event('probe', 'http_timeout', { port });
+        }
+      },
+    }),
+    waitForStudioFailure(getFailureMessage, timeoutMs),
+  ]);
+  if (result.status !== 'ready') {
+    throw new Error(`HTTP did not become ready on port ${port}`);
   }
-
-  const deadline = Date.now() + timeoutMs;
-  let sawResponse = false;
-  while (Date.now() < deadline) {
-    const failureMessage = getFailureMessage();
-    if (failureMessage) {
-      event('probe', 'studio_failure_detected', { message: failureMessage });
-      throw new Error(failureMessage);
-    }
-    try {
-      const response = await fetch(`http://${HTTP_PROBE_HOST}:${port}/`, {
-        signal: AbortSignal.timeout(HTTP_REQUEST_TIMEOUT_MS),
-      });
-      if (!sawResponse) {
-        event('probe', 'http_first_response', { port, status: response.status });
-        sawResponse = true;
-      }
-      if (response.status >= 200 && response.status < 400) {
-        event('probe', 'http_ready', { port, status: response.status });
-        return;
-      }
-      await wait(250);
-    } catch {
-      await wait(100);
-    }
-  }
-  event('probe', 'http_timeout', { port });
-  const failureMessage = getFailureMessage();
-  throw new Error(failureMessage || `HTTP did not become ready on port ${port}`);
+  return result;
 }
 
 async function waitForStudioFailure(getFailureMessage, timeoutMs) {
@@ -419,51 +388,49 @@ async function captureSeedDatabase(site) {
 
 async function pollCliConfig(cliConfigPath, siteName, timeoutMs) {
   const configFile = path.join(cliConfigPath, 'cli.json');
-  const deadline = Date.now() + timeoutMs;
-  let seenSite = false;
-  let seenPort;
-
-  while (Date.now() < deadline) {
-    try {
-      const data = JSON.parse(await readFile(configFile, 'utf8'));
+  const result = await pollJsonFile(configFile, {
+    source: 'probe',
+    intervalMs: 50,
+    timeoutMs,
+    select: (data) => {
       const sites = Array.isArray(data.sites) ? data.sites : [];
-      const site = sites.find((candidate) => candidate.name === siteName);
-      if (site && !seenSite) {
-        seenSite = true;
-        event('probe', 'cli_config_site_seen', {
+      return sites.find((candidate) => candidate.name === siteName) || null;
+    },
+    events: [
+      {
+        name: 'cli_config_site_seen',
+        when: (site) => Boolean(site),
+        data: (site) => ({
           id: site.id,
           path: site.path,
           port: site.port,
           running: site.running,
-        });
-      }
-      if (site?.port > 0 && site.port !== seenPort) {
-        seenPort = site.port;
-        event('probe', 'cli_config_port_known', { id: site.id, port: site.port });
-        return site;
-      }
-    } catch {
-      // Config file may not exist yet or may be mid-write.
-    }
-    await wait(50);
+        }),
+      },
+      {
+        name: 'cli_config_port_known',
+        terminal: true,
+        when: (site) => site?.port > 0,
+        data: (site) => ({ id: site.id, port: site.port }),
+      },
+    ],
+    onEvent: (source, name, data) => event(source, name, data),
+  });
+
+  if (result.status !== 'matched') {
+    event('probe', 'cli_config_port_timeout', { site_name: siteName });
+    return null;
   }
 
-  event('probe', 'cli_config_port_timeout', { site_name: siteName });
-  return null;
+  return result.value;
 }
 
 function assertion(id, ok, message) {
-  const item = { id, status: ok ? 'pass' : 'fail', message };
-  assertions.push(item);
-  return item;
-}
-
-function relativeArtifact(filePath) {
-  return path.relative(ARTIFACT_DIR, filePath);
+  return recorder.recordCheck(id, ok, message);
 }
 
 function addArtifact(label, filePath) {
-  artifacts.push({ label, path: relativeArtifact(filePath) });
+  recorder.addArtifact(label, filePath);
 }
 
 async function captureArtifacts(mainWindow, mainProcessLog, suffix = '') {
@@ -493,20 +460,7 @@ async function captureArtifacts(mainWindow, mainProcessLog, suffix = '') {
 }
 
 async function writeResults(status, summary, failure) {
-  const envelope = {
-    component_id: COMPONENT_ID,
-    scenario_id: SCENARIO_ID,
-    status,
-    summary,
-    timeline,
-    assertions,
-    artifacts,
-  };
-  if (failure) {
-    envelope.failure = failure;
-  }
-  await mkdir(path.dirname(RESULTS_FILE), { recursive: true });
-  await writeFile(RESULTS_FILE, JSON.stringify(envelope, null, 2));
+  await recorder.writeTraceResults({ status, summary, failure });
 }
 
 async function waitFor(locator, eventName, timeout = 120_000) {
@@ -598,7 +552,7 @@ async function main() {
     mainWindow = await electronApp.firstWindow({ timeout: 60_000 });
     event('desktop', 'first_window.ready', { title: await mainWindow.title() });
     await mainWindow.context().tracing.start({ screenshots: true, snapshots: true, sources: true });
-    mainWindow.on('console', (message) => captureHarnessEvent(message.text()));
+    mainWindow.on('console', (message) => void captureHarnessEvent(message.text()));
     await installIpcProbe(mainWindow);
     await installRendererStateProbe(mainWindow, siteName);
 

--- a/Automattic/studio/bench/studio-app-create-site.trace.mjs
+++ b/Automattic/studio/bench/studio-app-create-site.trace.mjs
@@ -1,4 +1,4 @@
-import { access, copyFile, mkdir, rm, writeFile } from 'node:fs/promises';
+import { access, copyFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -23,32 +23,33 @@ if (!STUDIO_PATH) {
 if (!RESULTS_FILE) {
   throw new Error('HOMEBOY_TRACE_RESULTS_FILE is required');
 }
-if (!HELPER_DIR) {
-  throw new Error('HOMEBOY_TRACE_HELPER_DIR is required');
-}
-process.env.HOMEBOY_TRACE_ARTIFACT_DIR ||= ARTIFACT_DIR;
 
 const playwright = require(require.resolve('playwright', { paths: [STUDIO_PATH] }));
 const { findLatestBuild, parseElectronApp } = require(
   require.resolve('electron-playwright-helpers', { paths: [STUDIO_PATH] })
 );
-const { createTraceRecorder } = await import(pathToFileURL(path.join(HELPER_DIR, 'timeline.mjs')).href);
-const { captureTraceEventText, pollHttp: helperPollHttp, pollJsonFile } = await import(
-  pathToFileURL(path.join(HELPER_DIR, 'probes.mjs')).href
-);
+const { pollHttp: helperPollHttp } = HELPER_DIR
+  ? await import(pathToFileURL(`${HELPER_DIR}/probes.mjs`).href)
+  : { pollHttp: null };
 
-const recorder = createTraceRecorder({
-  componentId: COMPONENT_ID,
-  scenarioId: SCENARIO_ID,
-  resultsFile: RESULTS_FILE,
-});
-recorder.timestampMs = () => Math.round(performance.now() - recorder.start);
+const timeline = [];
+const assertions = [];
+const artifacts = [];
+const startedAt = performance.now();
 const seenCliMessages = new Set();
 
-function event(source, name, data = {}) {
-  return recorder.recordEvent(source, name, data);
+function timestampMs() {
+  return Math.round(performance.now() - startedAt);
 }
 
+function event(source, name, data = {}) {
+  const entry = { t_ms: timestampMs(), source, event: name, data };
+  timeline.push(entry);
+  return entry;
+}
+
+// Local observation helpers preserve the current trace behavior until the Node.js
+// Homeboy extension ships reusable trace probes.
 function eventNameFromCliMessage(message) {
   return message
     .replace(/\u2026/g, '')
@@ -59,7 +60,7 @@ function eventNameFromCliMessage(message) {
 
 function captureCliEvents(chunk) {
 	for (const line of chunk.toString().split(/\r?\n/)) {
-		void captureHarnessEvent(line);
+		captureHarnessEvent(line);
 		const match = line.match(
 			/^\[CLI - ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\]\s+(.*)$/i
 		);
@@ -68,7 +69,7 @@ function captureCliEvents(chunk) {
     }
 		const [, commandId, message] = match;
 		if (message.startsWith('[HOMEBOY_TRACE] ')) {
-			void captureHarnessEvent(message);
+			captureHarnessEvent(message);
 			continue;
 		}
 		const eventName = eventNameFromCliMessage(message);
@@ -81,21 +82,20 @@ function captureCliEvents(chunk) {
   }
 }
 
-async function captureHarnessEvent(text) {
-  await captureTraceEventText(
-    text,
-    (source, name, data) => {
-      if (source === '__ignored_trace_bridge' && name === '__ignored_trace_bridge') {
-        return null;
-      }
-      return event(source, name, data);
-    },
-    {
-      prefix: '[HOMEBOY_TRACE] ',
-      source: '__ignored_trace_bridge',
-      event: '__ignored_trace_bridge',
+function captureHarnessEvent(text) {
+  const prefix = '[HOMEBOY_TRACE] ';
+  if (!text.startsWith(prefix)) {
+    return;
+  }
+  try {
+    const item = JSON.parse(text.slice(prefix.length));
+    if (!item || typeof item.source !== 'string' || typeof item.event !== 'string') {
+      return;
     }
-  );
+    event(item.source, item.event, item.data || {});
+  } catch {
+    // Ignore non-contract console noise.
+  }
 }
 
 async function installIpcProbe(mainWindow) {
@@ -233,32 +233,63 @@ function extractStudioFailureMessage(log) {
 }
 
 async function pollHttp(port, timeoutMs, getFailureMessage = () => null) {
-  const result = await Promise.race([
-    helperPollHttp(`http://${HTTP_PROBE_HOST}:${port}/`, {
-      source: 'probe',
-      intervalMs: 250,
-      readyStatus: 200,
-      requestTimeoutMs: HTTP_REQUEST_TIMEOUT_MS,
-      timeoutMs,
-      onEvent: (source, name, data) => {
-        event(source, name, data);
-        if (source === 'probe' && name === 'http.first_response') {
-          event('probe', 'http_first_response', { port, status: data.status });
-        }
-        if (source === 'probe' && name === 'http.ready') {
-          event('probe', 'http_ready', { port, status: data.status });
-        }
-        if (source === 'probe' && name === 'http.timeout') {
-          event('probe', 'http_timeout', { port });
-        }
-      },
-    }),
-    waitForStudioFailure(getFailureMessage, timeoutMs),
-  ]);
-  if (result.status !== 'ready') {
-    throw new Error(`HTTP did not become ready on port ${port}`);
+  if (helperPollHttp) {
+    const result = await Promise.race([
+      helperPollHttp(`http://${HTTP_PROBE_HOST}:${port}/`, {
+        source: 'probe',
+        intervalMs: 250,
+        readyStatus: 200,
+        requestTimeoutMs: HTTP_REQUEST_TIMEOUT_MS,
+        timeoutMs,
+        onEvent: (source, name, data) => {
+          event(source, name, data);
+          if (source === 'probe' && name === 'http.first_response') {
+            event('probe', 'http_first_response', { port, status: data.status });
+          }
+          if (source === 'probe' && name === 'http.ready') {
+            event('probe', 'http_ready', { port, status: data.status });
+          }
+          if (source === 'probe' && name === 'http.timeout') {
+            event('probe', 'http_timeout', { port });
+          }
+        },
+      }),
+      waitForStudioFailure(getFailureMessage, timeoutMs),
+    ]);
+    if (result.status !== 'ready') {
+      throw new Error(`HTTP did not become ready on port ${port}`);
+    }
+    return result;
   }
-  return result;
+
+  const deadline = Date.now() + timeoutMs;
+  let sawResponse = false;
+  while (Date.now() < deadline) {
+    const failureMessage = getFailureMessage();
+    if (failureMessage) {
+      event('probe', 'studio_failure_detected', { message: failureMessage });
+      throw new Error(failureMessage);
+    }
+    try {
+      const response = await fetch(`http://${HTTP_PROBE_HOST}:${port}/`, {
+        signal: AbortSignal.timeout(HTTP_REQUEST_TIMEOUT_MS),
+      });
+      if (!sawResponse) {
+        event('probe', 'http_first_response', { port, status: response.status });
+        sawResponse = true;
+      }
+      if (response.status >= 200 && response.status < 400) {
+        event('probe', 'http_ready', { port, status: response.status });
+        return;
+      }
+      await wait(250);
+    } catch {
+      await wait(100);
+    }
+  }
+  event('probe', 'http_timeout', { port });
+  const failureMessage = getFailureMessage();
+  throw new Error(failureMessage || `HTTP did not become ready on port ${port}`);
 }
 
 async function waitForStudioFailure(getFailureMessage, timeoutMs) {
@@ -388,49 +419,51 @@ async function captureSeedDatabase(site) {
 
 async function pollCliConfig(cliConfigPath, siteName, timeoutMs) {
   const configFile = path.join(cliConfigPath, 'cli.json');
-  const result = await pollJsonFile(configFile, {
-    source: 'probe',
-    intervalMs: 50,
-    timeoutMs,
-    select: (data) => {
+  const deadline = Date.now() + timeoutMs;
+  let seenSite = false;
+  let seenPort;
+
+  while (Date.now() < deadline) {
+    try {
+      const data = JSON.parse(await readFile(configFile, 'utf8'));
       const sites = Array.isArray(data.sites) ? data.sites : [];
-      return sites.find((candidate) => candidate.name === siteName) || null;
-    },
-    events: [
-      {
-        name: 'cli_config_site_seen',
-        when: (site) => Boolean(site),
-        data: (site) => ({
+      const site = sites.find((candidate) => candidate.name === siteName);
+      if (site && !seenSite) {
+        seenSite = true;
+        event('probe', 'cli_config_site_seen', {
           id: site.id,
           path: site.path,
           port: site.port,
           running: site.running,
-        }),
-      },
-      {
-        name: 'cli_config_port_known',
-        terminal: true,
-        when: (site) => site?.port > 0,
-        data: (site) => ({ id: site.id, port: site.port }),
-      },
-    ],
-    onEvent: (source, name, data) => event(source, name, data),
-  });
-
-  if (result.status !== 'matched') {
-    event('probe', 'cli_config_port_timeout', { site_name: siteName });
-    return null;
+        });
+      }
+      if (site?.port > 0 && site.port !== seenPort) {
+        seenPort = site.port;
+        event('probe', 'cli_config_port_known', { id: site.id, port: site.port });
+        return site;
+      }
+    } catch {
+      // Config file may not exist yet or may be mid-write.
+    }
+    await wait(50);
   }
 
-  return result.value;
+  event('probe', 'cli_config_port_timeout', { site_name: siteName });
+  return null;
 }
 
 function assertion(id, ok, message) {
-  return recorder.recordCheck(id, ok, message);
+  const item = { id, status: ok ? 'pass' : 'fail', message };
+  assertions.push(item);
+  return item;
+}
+
+function relativeArtifact(filePath) {
+  return path.relative(ARTIFACT_DIR, filePath);
 }
 
 function addArtifact(label, filePath) {
-  recorder.addArtifact(label, filePath);
+  artifacts.push({ label, path: relativeArtifact(filePath) });
 }
 
 async function captureArtifacts(mainWindow, mainProcessLog, suffix = '') {
@@ -460,7 +493,20 @@ async function captureArtifacts(mainWindow, mainProcessLog, suffix = '') {
 }
 
 async function writeResults(status, summary, failure) {
-  await recorder.writeTraceResults({ status, summary, failure });
+  const envelope = {
+    component_id: COMPONENT_ID,
+    scenario_id: SCENARIO_ID,
+    status,
+    summary,
+    timeline,
+    assertions,
+    artifacts,
+  };
+  if (failure) {
+    envelope.failure = failure;
+  }
+  await mkdir(path.dirname(RESULTS_FILE), { recursive: true });
+  await writeFile(RESULTS_FILE, JSON.stringify(envelope, null, 2));
 }
 
 async function waitFor(locator, eventName, timeout = 120_000) {
@@ -552,7 +598,7 @@ async function main() {
     mainWindow = await electronApp.firstWindow({ timeout: 60_000 });
     event('desktop', 'first_window.ready', { title: await mainWindow.title() });
     await mainWindow.context().tracing.start({ screenshots: true, snapshots: true, sources: true });
-    mainWindow.on('console', (message) => void captureHarnessEvent(message.text()));
+    mainWindow.on('console', (message) => captureHarnessEvent(message.text()));
     await installIpcProbe(mainWindow);
     await installRendererStateProbe(mainWindow, siteName);
 

--- a/Automattic/studio/bench/studio-dashboard-browser.bench.mjs
+++ b/Automattic/studio/bench/studio-dashboard-browser.bench.mjs
@@ -1,5 +1,4 @@
-import { mkdir, writeFile } from 'node:fs/promises';
-import path from 'node:path';
+import { mkdir } from 'node:fs/promises';
 import {
   artifactDir as studioArtifactDir,
   createStudioSite,
@@ -7,19 +6,28 @@ import {
   parseStudioSiteStatus,
   redact,
   safeResult,
-  sanitizeArtifact,
   stopStudioSite,
   studioSiteStatus,
   variant,
 } from './lib/studio-bench.mjs';
 
 const BROWSER_HELPER = process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER;
+const ARTIFACT_CONTEXT_HELPER = process.env.HOMEBOY_NODEJS_BENCH_ARTIFACT_CONTEXT;
+const REDACTION_HELPER = process.env.HOMEBOY_NODEJS_BENCH_REDACTION;
 
 if (!BROWSER_HELPER) {
   throw new Error('HOMEBOY_NODEJS_BROWSER_BENCH_HELPER is required');
 }
+if (!ARTIFACT_CONTEXT_HELPER) {
+  throw new Error('HOMEBOY_NODEJS_BENCH_ARTIFACT_CONTEXT is required');
+}
+if (!REDACTION_HELPER) {
+  throw new Error('HOMEBOY_NODEJS_BENCH_REDACTION is required');
+}
 
-const { runBrowserBench } = await import(BROWSER_HELPER);
+const { runBrowserPageScenario } = await import(BROWSER_HELPER);
+const { createBenchArtifactContext } = await import(ARTIFACT_CONTEXT_HELPER);
+const { sanitizeArtifactFile } = await import(REDACTION_HELPER);
 
 async function createSite(sitePath) {
   return createStudioSite(sitePath, {
@@ -45,9 +53,12 @@ async function firstContentfulPaint(page) {
 
 export default async function studioDashboardBrowserBench() {
   const currentVariant = variant();
-  const runId = `${currentVariant}-dashboard-browser-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  const artifactDir = path.join(studioArtifactDir('studio-dashboard-browser-artifacts'), runId);
-  const sitePath = path.join(artifactDir, 'site');
+  const artifactContext = createBenchArtifactContext({
+    id: `${currentVariant}-dashboard-browser`,
+    artifactsDir: studioArtifactDir('studio-dashboard-browser-artifacts'),
+  });
+  const artifactDir = artifactContext.artifactDir;
+  const sitePath = artifactContext.artifactPath('site', { prefix: '', extension: '' });
   await mkdir(artifactDir, { recursive: true });
 
   const totalStarted = Date.now();
@@ -68,7 +79,7 @@ export default async function studioDashboardBrowserBench() {
       throw new Error(`site status missing siteUrl/autoLoginUrl: ${redact(statusResult.stdout).slice(0, 1000)}`);
     }
 
-    browserResult = await runBrowserBench({
+    browserResult = await runBrowserPageScenario({
       id: 'studio-dashboard-browser',
       artifactsDir: artifactDir,
       trace: true,
@@ -89,37 +100,39 @@ export default async function studioDashboardBrowserBench() {
 
         firstContentfulPaintMs = await firstContentfulPaint(page);
       },
+      postSanitizeAssertions: [
+        { type: 'artifact', key: 'trace', kind: 'playwright-trace' },
+        { type: 'artifact', key: 'screenshot', kind: 'screenshot' },
+      ],
+      sanitizeArtifacts: async ({ artifacts }) => {
+        if (artifacts.network?.path) {
+          await sanitizeArtifactFile(artifacts.network.path, { profile: 'web' });
+        }
+        return artifacts;
+      },
     });
 
-    await sanitizeArtifact(browserResult.artifacts?.network);
     stop = await stopSite(sitePath);
 
     const totalElapsedMs = Date.now() - totalStarted;
-    const artifactFile = path.join(artifactDir, `result-${runId}.json`);
-    await writeFile(
-      artifactFile,
-      JSON.stringify(
-        {
-          variant: currentVariant,
-          sitePath,
-          siteUrl: status.siteUrl,
-          timings: {
-            site_create_ms: create.elapsedMs,
-            site_status_ms: statusResult.elapsedMs,
-            total_elapsed_ms: totalElapsedMs,
-          },
-          commands: {
-            create: safeResult(create),
-            status: safeResult(statusResult),
-            stop: safeResult(stop),
-          },
-          browserMetrics: browserResult.metrics,
-          browserArtifacts: browserResult.artifacts,
-        },
-        null,
-        2
-      )
-    );
+    const rawResultArtifact = await artifactContext.writeJson('raw-result', {
+      variant: currentVariant,
+      sitePath,
+      siteUrl: status.siteUrl,
+      timings: {
+        site_create_ms: create.elapsedMs,
+        site_status_ms: statusResult.elapsedMs,
+        total_elapsed_ms: totalElapsedMs,
+      },
+      commands: {
+        create: safeResult(create),
+        status: safeResult(statusResult),
+        stop: safeResult(stop),
+      },
+      browserMetrics: browserResult.metrics,
+      browserArtifacts: browserResult.artifacts,
+    }, { kind: 'browser-page-scenario-result', label: 'Studio Dashboard browser raw result' });
+    const artifactFile = rawResultArtifact.path;
 
     if (finalStatus < 200 || finalStatus >= 400) {
       throw new Error(`Dashboard returned HTTP status ${finalStatus}; raw_result=${artifactFile}`);
@@ -144,7 +157,7 @@ export default async function studioDashboardBrowserBench() {
         ...browserResult.metrics,
       },
       artifacts: {
-        raw_result: artifactFile,
+        raw_result: rawResultArtifact,
         site_path: sitePath,
         ...browserResult.artifacts,
       },

--- a/Automattic/studio/bench/studio-site-editor-browser.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-browser.bench.mjs
@@ -1,5 +1,4 @@
-import { mkdir, writeFile } from 'node:fs/promises';
-import path from 'node:path';
+import { mkdir } from 'node:fs/promises';
 import {
   artifactDir as studioArtifactDir,
   createStudioSite,
@@ -7,7 +6,6 @@ import {
   parseStudioSiteStatus,
   redact,
   safeResult,
-  sanitizeArtifact,
   stopStudioSite,
   studioSiteStatus,
   variant,
@@ -20,12 +18,22 @@ import {
 } from './lib/wordpress-page-profiler.mjs';
 
 const BROWSER_HELPER = process.env.HOMEBOY_NODEJS_BROWSER_BENCH_HELPER;
+const ARTIFACT_CONTEXT_HELPER = process.env.HOMEBOY_NODEJS_BENCH_ARTIFACT_CONTEXT;
+const REDACTION_HELPER = process.env.HOMEBOY_NODEJS_BENCH_REDACTION;
 
 if (!BROWSER_HELPER) {
   throw new Error('HOMEBOY_NODEJS_BROWSER_BENCH_HELPER is required');
 }
+if (!ARTIFACT_CONTEXT_HELPER) {
+  throw new Error('HOMEBOY_NODEJS_BENCH_ARTIFACT_CONTEXT is required');
+}
+if (!REDACTION_HELPER) {
+  throw new Error('HOMEBOY_NODEJS_BENCH_REDACTION is required');
+}
 
-const { runBrowserBench } = await import(BROWSER_HELPER);
+const { runBrowserPageScenario } = await import(BROWSER_HELPER);
+const { createBenchArtifactContext } = await import(ARTIFACT_CONTEXT_HELPER);
+const { sanitizeArtifactFile } = await import(REDACTION_HELPER);
 
 async function createSite(sitePath) {
   return createStudioSite(sitePath, {
@@ -60,9 +68,12 @@ function siteEditorTimingsFromProfile(profile) {
 
 export default async function studioSiteEditorBrowserBench() {
   const currentVariant = variant();
-  const runId = `${currentVariant}-site-editor-browser-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  const artifactDir = path.join(studioArtifactDir('studio-site-editor-browser-artifacts'), runId);
-  const sitePath = path.join(artifactDir, 'site');
+  const artifactContext = createBenchArtifactContext({
+    id: `${currentVariant}-site-editor-browser`,
+    artifactsDir: studioArtifactDir('studio-site-editor-browser-artifacts'),
+  });
+  const artifactDir = artifactContext.artifactDir;
+  const sitePath = artifactContext.artifactPath('site', { prefix: '', extension: '' });
   await mkdir(artifactDir, { recursive: true });
 
   const totalStarted = Date.now();
@@ -93,7 +104,7 @@ export default async function studioSiteEditorBrowserBench() {
     const pageProfiler = pageProfilerResult.module;
     pageProfilerAvailable = Boolean(pageProfiler);
 
-    browserResult = await runBrowserBench({
+    browserResult = await runBrowserPageScenario({
       id: 'studio-site-editor-browser',
       artifactsDir: artifactDir,
       trace: true,
@@ -131,47 +142,49 @@ export default async function studioSiteEditorBrowserBench() {
         measureTimings = siteEditorTimingsFromProfile(measureProfile);
         await mark('measure_site_editor_ready');
       },
+      postSanitizeAssertions: [
+        { type: 'artifact', key: 'trace', kind: 'playwright-trace' },
+        { type: 'artifact', key: 'screenshot', kind: 'screenshot' },
+      ],
+      sanitizeArtifacts: async ({ artifacts }) => {
+        if (artifacts.network?.path) {
+          await sanitizeArtifactFile(artifacts.network.path, { profile: 'web' });
+        }
+        return artifacts;
+      },
     });
 
-    await sanitizeArtifact(browserResult.artifacts?.network);
     stop = await stopSite(sitePath);
 
     const totalElapsedMs = Date.now() - totalStarted;
-    const artifactFile = path.join(artifactDir, `result-${runId}.json`);
-    await writeFile(
-      artifactFile,
-      JSON.stringify(
-        {
-          variant: currentVariant,
-          sitePath,
-          siteUrl: status.siteUrl,
-          pageProfilerPath,
-          pageProfilerAvailable,
-          timings: {
-            site_create_ms: create.elapsedMs,
-            site_status_ms: statusResult.elapsedMs,
-            total_elapsed_ms: totalElapsedMs,
-          },
-          siteEditorTimings: {
-            warmup: warmupTimings,
-            measure: measureTimings,
-          },
-          pageProfiles: {
-            warmup: warmupProfile,
-            measure: measureProfile,
-          },
-          commands: {
-            create: safeResult(create),
-            status: safeResult(statusResult),
-            stop: safeResult(stop),
-          },
-          browserMetrics: browserResult.metrics,
-          browserArtifacts: browserResult.artifacts,
-        },
-        null,
-        2
-      )
-    );
+    const rawResultArtifact = await artifactContext.writeJson('raw-result', {
+      variant: currentVariant,
+      sitePath,
+      siteUrl: status.siteUrl,
+      pageProfilerPath,
+      pageProfilerAvailable,
+      timings: {
+        site_create_ms: create.elapsedMs,
+        site_status_ms: statusResult.elapsedMs,
+        total_elapsed_ms: totalElapsedMs,
+      },
+      siteEditorTimings: {
+        warmup: warmupTimings,
+        measure: measureTimings,
+      },
+      pageProfiles: {
+        warmup: warmupProfile,
+        measure: measureProfile,
+      },
+      commands: {
+        create: safeResult(create),
+        status: safeResult(statusResult),
+        stop: safeResult(stop),
+      },
+      browserMetrics: browserResult.metrics,
+      browserArtifacts: browserResult.artifacts,
+    }, { kind: 'browser-page-scenario-result', label: 'Studio Site Editor browser raw result' });
+    const artifactFile = rawResultArtifact.path;
 
     if (measureTimings.status < 200 || measureTimings.status >= 400) {
       throw new Error(`Site Editor returned HTTP status ${measureTimings.status}; raw_result=${artifactFile}`);
@@ -201,7 +214,7 @@ export default async function studioSiteEditorBrowserBench() {
         total_elapsed_ms: totalElapsedMs,
       },
       artifacts: {
-        raw_result: artifactFile,
+        raw_result: rawResultArtifact,
         site_path: sitePath,
         ...browserResult.artifacts,
       },


### PR DESCRIPTION
## Summary
- Migrates the Studio Dashboard, Add Themes, and Site Editor browser benches from direct `runBrowserBench()` usage to the merged `runBrowserPageScenario()` helper.
- Uses the merged Node artifact context helper for per-run artifact directories and raw-result artifact descriptors.
- Uses the merged web redaction helper for browser network artifacts while preserving existing metric names and benchmark checks.

Closes https://github.com/chubes4/homeboy-rigs/issues/138

## Tests
- `node --check Automattic/studio/bench/studio-dashboard-browser.bench.mjs && node --check Automattic/studio/bench/studio-admin-theme-page-browser.bench.mjs && node --check Automattic/studio/bench/studio-site-editor-browser.bench.mjs`
- `node --input-type=module -e '<imports changed benchmark modules with helper stubs>'`
- `git diff --check`

## Notes
- `homeboy bench list --path /Users/chubes/Developer/studio --extension nodejs --rig studio-combined --scenario studio-dashboard-browser --scenario studio-admin-theme-page-browser --scenario studio-site-editor-browser` was attempted, but Homeboy refused because the `studio-combined` rig check is currently unhealthy.
- This slice intentionally leaves diagnostics/preload comparison workloads unmigrated.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the browser benchmark migration, running local syntax/import verification, committing, pushing, and drafting this PR.