### PR TITLE
Migrate Studio create-site trace to Node helpers

### DIFF
--- a/Automattic/studio/bench/studio-app-create-site.trace.mjs
+++ b/Automattic/studio/bench/studio-app-create-site.trace.mjs
@@ -1,4 +1,4 @@
-import { access, copyFile, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, copyFile, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -23,33 +23,32 @@ if (!STUDIO_PATH) {
 if (!RESULTS_FILE) {
   throw new Error('HOMEBOY_TRACE_RESULTS_FILE is required');
 }
+if (!HELPER_DIR) {
+  throw new Error('HOMEBOY_TRACE_HELPER_DIR is required');
+}
+process.env.HOMEBOY_TRACE_ARTIFACT_DIR ||= ARTIFACT_DIR;
 
 const playwright = require(require.resolve('playwright', { paths: [STUDIO_PATH] }));
 const { findLatestBuild, parseElectronApp } = require(
   require.resolve('electron-playwright-helpers', { paths: [STUDIO_PATH] })
 );
-const { pollHttp: helperPollHttp } = HELPER_DIR
-  ? await import(pathToFileURL(`${HELPER_DIR}/probes.mjs`).href)
-  : { pollHttp: null };
+const { createTraceRecorder } = await import(pathToFileURL(path.join(HELPER_DIR, 'timeline.mjs')).href);
+const { captureTraceEventText, pollHttp: helperPollHttp, pollJsonFile } = await import(
+  pathToFileURL(path.join(HELPER_DIR, 'probes.mjs')).href
+);
 
-const timeline = [];
-const assertions = [];
-const artifacts = [];
-const startedAt = performance.now();
+const recorder = createTraceRecorder({
+  componentId: COMPONENT_ID,
+  scenarioId: SCENARIO_ID,
+  resultsFile: RESULTS_FILE,
+});
+recorder.timestampMs = () => Math.round(performance.now() - recorder.start);
 const seenCliMessages = new Set();
 
-function timestampMs() {
-  return Math.round(performance.now() - startedAt);
-}
-
 function event(source, name, data = {}) {
-  const entry = { t_ms: timestampMs(), source, event: name, data };
-  timeline.push(entry);
-  return entry;
+  return recorder.recordEvent(source, name, data);
 }
 
-// Local observation helpers preserve the current trace behavior until the Node.js
-// Homeboy extension ships reusable trace probes.
 function eventNameFromCliMessage(message) {
   return message
     .replace(/\u2026/g, '')
@@ -60,7 +59,7 @@ function eventNameFromCliMessage(message) {
 
 function captureCliEvents(chunk) {
 	for (const line of chunk.toString().split(/\r?\n/)) {
-		captureHarnessEvent(line);
+		void captureHarnessEvent(line);
 		const match = line.match(
 			/^\[CLI - ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\]\s+(.*)$/i
 		);
@@ -69,7 +68,7 @@ function captureCliEvents(chunk) {
     }
 		const [, commandId, message] = match;
 		if (message.startsWith('[HOMEBOY_TRACE] ')) {
-			captureHarnessEvent(message);
+			void captureHarnessEvent(message);
 			continue;
 		}
 		const eventName = eventNameFromCliMessage(message);
@@ -82,20 +81,21 @@ function captureCliEvents(chunk) {
   }
 }
 
-function captureHarnessEvent(text) {
-  const prefix = '[HOMEBOY_TRACE] ';
-  if (!text.startsWith(prefix)) {
-    return;
-  }
-  try {
-    const item = JSON.parse(text.slice(prefix.length));
-    if (!item || typeof item.source !== 'string' || typeof item.event !== 'string') {
-      return;
+async function captureHarnessEvent(text) {
+  await captureTraceEventText(
+    text,
+    (source, name, data) => {
+      if (source === '__ignored_trace_bridge' && name === '__ignored_trace_bridge') {
+        return null;
+      }
+      return event(source, name, data);
+    },
+    {
+      prefix: '[HOMEBOY_TRACE] ',
+      source: '__ignored_trace_bridge',
+      event: '__ignored_trace_bridge',
     }
-    event(item.source, item.event, item.data || {});
-  } catch {
-    // Ignore non-contract console noise.
-  }
+  );
 }
 
 async function installIpcProbe(mainWindow) {
@@ -233,63 +233,32 @@ function extractStudioFailureMessage(log) {
 }
 
 async function pollHttp(port, timeoutMs, getFailureMessage = () => null) {
-  if (helperPollHttp) {
-    const result = await Promise.race([
-      helperPollHttp(`http://${HTTP_PROBE_HOST}:${port}/`, {
-        source: 'probe',
-        intervalMs: 250,
-        readyStatus: 200,
-        requestTimeoutMs: HTTP_REQUEST_TIMEOUT_MS,
-        timeoutMs,
-        onEvent: (source, name, data) => {
-          event(source, name, data);
-          if (source === 'probe' && name === 'http.first_response') {
-            event('probe', 'http_first_response', { port, status: data.status });
-          }
-          if (source === 'probe' && name === 'http.ready') {
-            event('probe', 'http_ready', { port, status: data.status });
-          }
-          if (source === 'probe' && name === 'http.timeout') {
-            event('probe', 'http_timeout', { port });
-          }
-        },
-      }),
-      waitForStudioFailure(getFailureMessage, timeoutMs),
-    ]);
-    if (result.status !== 'ready') {
-      throw new Error(`HTTP did not become ready on port ${port}`);
-    }
-    return result;
+  const result = await Promise.race([
+    helperPollHttp(`http://${HTTP_PROBE_HOST}:${port}/`, {
+      source: 'probe',
+      intervalMs: 250,
+      readyStatus: 200,
+      requestTimeoutMs: HTTP_REQUEST_TIMEOUT_MS,
+      timeoutMs,
+      onEvent: (source, name, data) => {
+        event(source, name, data);
+        if (source === 'probe' && name === 'http.first_response') {
+          event('probe', 'http_first_response', { port, status: data.status });
+        }
+        if (source === 'probe' && name === 'http.ready') {
+          event('probe', 'http_ready', { port, status: data.status });
+        }
+        if (source === 'probe' && name === 'http.timeout') {
+          event('probe', 'http_timeout', { port });
+        }
+      },
+    }),
+    waitForStudioFailure(getFailureMessage, timeoutMs),
+  ]);
+  if (result.status !== 'ready') {
+    throw new Error(`HTTP did not become ready on port ${port}`);
   }
-
-  const deadline = Date.now() + timeoutMs;
-  let sawResponse = false;
-  while (Date.now() < deadline) {
-    const failureMessage = getFailureMessage();
-    if (failureMessage) {
-      event('probe', 'studio_failure_detected', { message: failureMessage });
-      throw new Error(failureMessage);
-    }
-    try {
-      const response = await fetch(`http://${HTTP_PROBE_HOST}:${port}/`, {
-        signal: AbortSignal.timeout(HTTP_REQUEST_TIMEOUT_MS),
-      });
-      if (!sawResponse) {
-        event('probe', 'http_first_response', { port, status: response.status });
-        sawResponse = true;
-      }
-      if (response.status >= 200 && response.status < 400) {
-        event('probe', 'http_ready', { port, status: response.status });
-        return;
-      }
-      await wait(250);
-    } catch {
-      await wait(100);
-    }
-  }
-  event('probe', 'http_timeout', { port });
-  const failureMessage = getFailureMessage();
-  throw new Error(failureMessage || `HTTP did not become ready on port ${port}`);
+  return result;
 }
 
 async function waitForStudioFailure(getFailureMessage, timeoutMs) {
@@ -419,51 +388,49 @@ async function captureSeedDatabase(site) {
 
 async function pollCliConfig(cliConfigPath, siteName, timeoutMs) {
   const configFile = path.join(cliConfigPath, 'cli.json');
-  const deadline = Date.now() + timeoutMs;
-  let seenSite = false;
-  let seenPort;
-
-  while (Date.now() < deadline) {
-    try {
-      const data = JSON.parse(await readFile(configFile, 'utf8'));
+  const result = await pollJsonFile(configFile, {
+    source: 'probe',
+    intervalMs: 50,
+    timeoutMs,
+    select: (data) => {
       const sites = Array.isArray(data.sites) ? data.sites : [];
-      const site = sites.find((candidate) => candidate.name === siteName);
-      if (site && !seenSite) {
-        seenSite = true;
-        event('probe', 'cli_config_site_seen', {
+      return sites.find((candidate) => candidate.name === siteName) || null;
+    },
+    events: [
+      {
+        name: 'cli_config_site_seen',
+        when: (site) => Boolean(site),
+        data: (site) => ({
           id: site.id,
           path: site.path,
           port: site.port,
           running: site.running,
-        });
-      }
-      if (site?.port > 0 && site.port !== seenPort) {
-        seenPort = site.port;
-        event('probe', 'cli_config_port_known', { id: site.id, port: site.port });
-        return site;
-      }
-    } catch {
-      // Config file may not exist yet or may be mid-write.
-    }
-    await wait(50);
+        }),
+      },
+      {
+        name: 'cli_config_port_known',
+        terminal: true,
+        when: (site) => site?.port > 0,
+        data: (site) => ({ id: site.id, port: site.port }),
+      },
+    ],
+    onEvent: (source, name, data) => event(source, name, data),
+  });
+
+  if (result.status !== 'matched') {
+    event('probe', 'cli_config_port_timeout', { site_name: siteName });
+    return null;
   }
 
-  event('probe', 'cli_config_port_timeout', { site_name: siteName });
-  return null;
+  return result.value;
 }
 
 function assertion(id, ok, message) {
-  const item = { id, status: ok ? 'pass' : 'fail', message };
-  assertions.push(item);
-  return item;
-}
-
-function relativeArtifact(filePath) {
-  return path.relative(ARTIFACT_DIR, filePath);
+  return recorder.recordCheck(id, ok, message);
 }
 
 function addArtifact(label, filePath) {
-  artifacts.push({ label, path: relativeArtifact(filePath) });
+  recorder.addArtifact(label, filePath);
 }
 
 async function captureArtifacts(mainWindow, mainProcessLog, suffix = '') {
@@ -493,20 +460,7 @@ async function captureArtifacts(mainWindow, mainProcessLog, suffix = '') {
 }
 
 async function writeResults(status, summary, failure) {
-  const envelope = {
-    component_id: COMPONENT_ID,
-    scenario_id: SCENARIO_ID,
-    status,
-    summary,
-    timeline,
-    assertions,
-    artifacts,
-  };
-  if (failure) {
-    envelope.failure = failure;
-  }
-  await mkdir(path.dirname(RESULTS_FILE), { recursive: true });
-  await writeFile(RESULTS_FILE, JSON.stringify(envelope, null, 2));
+  await recorder.writeTraceResults({ status, summary, failure });
 }
 
 async function waitFor(locator, eventName, timeout = 120_000) {
@@ -598,7 +552,7 @@ async function main() {
     mainWindow = await electronApp.firstWindow({ timeout: 60_000 });
     event('desktop', 'first_window.ready', { title: await mainWindow.title() });
     await mainWindow.context().tracing.start({ screenshots: true, snapshots: true, sources: true });
-    mainWindow.on('console', (message) => captureHarnessEvent(message.text()));
+    mainWindow.on('console', (message) => void captureHarnessEvent(message.text()));
     await installIpcProbe(mainWindow);
     await installRendererStateProbe(mainWindow, siteName);
 


### PR DESCRIPTION
## Summary
- Migrate `studio-app-create-site.trace.mjs` onto the shared Homeboy Extensions Node trace recorder for result envelopes, timeline events, assertions, and artifacts.
- Consume the generic bridge-event parser, HTTP poller, and JSON-file poller while keeping Studio-specific Electron, renderer, IPC, and site readiness probes local.
- Preserve existing Studio phase event names by emitting compatibility events such as `probe.http_ready`, `probe.http_first_response`, and `probe.cli_config_port_known`.

Part of https://github.com/chubes4/homeboy-rigs/issues/138.

## Tests
- `node --check Automattic/studio/bench/studio-app-create-site.trace.mjs`
- `git diff --check origin/main...HEAD`
- Helper-contract smoke against a fresh clone of merged `Extra-Chill/homeboy-extensions` PR #903, exercising `createTraceRecorder`, `recordCheck`, `captureTraceEventText`, and `pollJsonFile`.

## Not run
- Full `homeboy trace --rig studio-combined studio studio-app-create-site`: local Studio checkout does not have a packaged app at `apps/studio/out`, and dependencies such as `playwright` / `electron-playwright-helpers` are not installed in this environment.
- `homeboy trace --path /Users/chubes/Developer/homeboy-rigs@issue-138-studio-node-trace-helpers --rig studio-combined studio list --json-summary` failed because Homeboy trace discovery expects a `package.json` at the selected path; this rig package checkout is not itself a Node project.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Migrated the Studio create-site trace workload to the merged generic Node trace helper APIs, ran targeted validation, and prepared this PR; Chris remains responsible for review and merge.