### PR TITLE
Migrate Studio site-build bench to invocation runtime helper

### DIFF
--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -74,6 +74,7 @@ export {
 } from './lib/site-build-gates.mjs';
 
 const DEFAULT_STUDIO_PORT = 8881;
+const INVOCATION_NAMESPACE = 'studio-agent-site-build';
 const PROMPT_VARIANT_SETTING = 'studio_site_build_prompt_variant';
 const PROMPT_FILE_SETTING = 'studio_site_build_prompt_file';
 const MODEL_SETTING = 'studio_agent_model';
@@ -90,40 +91,41 @@ function envPath(key) {
   return typeof process.env[key] === 'string' && process.env[key] ? process.env[key] : '';
 }
 
-function optionalPort(key) {
-  const value = Number(process.env[key] || 0);
-  if (!value) {
-    return null;
+export async function createStudioBenchRuntime(sharedState = SHARED_STATE) {
+  const helperPath = envPath('HOMEBOY_NODEJS_INVOCATION_RUNTIME_HELPER');
+  if (!helperPath) {
+    const artifactDir = path.join(sharedState, 'studio-agent-site-build-artifacts');
+    return {
+      invocationId: '',
+      artifactDir,
+      siteRoot: path.join(artifactDir, 'sites'),
+      stateDir: '',
+      cliConfigDir: '',
+      appDataDir: '',
+      processManagerHome: '',
+      tmpDir: '',
+      portBase: null,
+      portMax: null,
+      env: {},
+      async prepareDirs() {},
+      assertPort() {},
+    };
   }
-  if (!Number.isInteger(value) || value < 1 || value > 65535) {
-    throw new Error(`${key} must be a TCP port number, got ${process.env[key]}`);
-  }
-  return value;
-}
 
-export function resolveBenchRuntime(sharedState = SHARED_STATE) {
-  const invocationId = envPath('HOMEBOY_INVOCATION_ID');
-  const invocationStateDir = envPath('HOMEBOY_INVOCATION_STATE_DIR');
-  const invocationArtifactDir = envPath('HOMEBOY_INVOCATION_ARTIFACT_DIR');
-  const invocationTmpDir = envPath('HOMEBOY_INVOCATION_TMP_DIR');
-  const portBase = optionalPort('HOMEBOY_INVOCATION_PORT_BASE');
-  const portMax = optionalPort('HOMEBOY_INVOCATION_PORT_MAX');
-  const stateDir = invocationStateDir ? path.join(invocationStateDir, 'studio-agent-site-build') : '';
-  const artifactDir = invocationArtifactDir || path.join(sharedState, 'studio-agent-site-build-artifacts');
-  const tmpDir = invocationTmpDir || (stateDir ? path.join(stateDir, 'tmp') : '');
+  const { resolveHomeboyInvocationRuntime } = await import(helperPath);
+  const invocationRuntime = resolveHomeboyInvocationRuntime({ namespace: INVOCATION_NAMESPACE });
+  const stateDir = invocationRuntime.dirs.state || '';
+  const artifactDir =
+    invocationRuntime.baseDirs.artifact || path.join(sharedState, 'studio-agent-site-build-artifacts');
+  const tmpDir = invocationRuntime.dirs.tmp || (stateDir ? path.join(stateDir, 'tmp') : '');
   const cliConfigDir = stateDir ? path.join(stateDir, 'cli-config') : '';
   const appDataDir = stateDir ? path.join(stateDir, 'appdata') : '';
   const processManagerHome = stateDir ? path.join(stateDir, 'daemon') : '';
-
-  if ((portBase === null) !== (portMax === null)) {
-    throw new Error('HOMEBOY_INVOCATION_PORT_BASE and HOMEBOY_INVOCATION_PORT_MAX must be set together.');
-  }
-  if (portBase !== null && portMax !== null && portMax < portBase) {
-    throw new Error(`HOMEBOY invocation port range is invalid: ${portBase}-${portMax}.`);
-  }
+  const portBase = invocationRuntime.portRange?.base ?? null;
+  const portMax = invocationRuntime.portRange?.max ?? null;
 
   return {
-    invocationId,
+    invocationId: invocationRuntime.invocationId || '',
     artifactDir,
     siteRoot: stateDir ? path.join(stateDir, 'sites') : path.join(artifactDir, 'sites'),
     stateDir,
@@ -133,21 +135,23 @@ export function resolveBenchRuntime(sharedState = SHARED_STATE) {
     tmpDir,
     portBase,
     portMax,
-    env: stateDir
-      ? {
+    env: invocationRuntime.isolated
+      ? invocationRuntime.childEnv({
           E2E: '1',
           E2E_CLI_CONFIG_PATH: cliConfigDir,
           E2E_APP_DATA_PATH: appDataDir,
           STUDIO_PROCESS_MANAGER_HOME: processManagerHome,
           ...(tmpDir ? { TMPDIR: tmpDir } : {}),
-        }
+        })
       : {},
+    prepareDirs: () => invocationRuntime.prepareDirs(),
+    assertPort: invocationRuntime.assertPort,
   };
 }
 
-function cliEnv(extra = {}) {
+async function cliEnv(extra = {}) {
   const staticSiteImporterPath = expandHome(setting('studio_static_site_importer_plugin_path') || '');
-  const runtime = resolveBenchRuntime();
+  const runtime = await createStudioBenchRuntime();
   return {
     ...process.env,
     ...(staticSiteImporterPath
@@ -163,6 +167,7 @@ async function prepareStudioRuntime(runtime) {
     return;
   }
 
+  await runtime.prepareDirs();
   await mkdir(runtime.cliConfigDir, { recursive: true });
   await mkdir(runtime.appDataDir, { recursive: true });
   await mkdir(runtime.processManagerHome, { recursive: true });
@@ -190,11 +195,7 @@ async function prepareStudioRuntime(runtime) {
   await writeFile(configPath, JSON.stringify({ version: 1, sites: reservedSites, snapshots: [] }, null, 2) + '\n');
 }
 
-function assertInvocationPort(status, runtime) {
-  if (runtime.portBase === null || runtime.portMax === null) {
-    return;
-  }
-
+function statusPort(status) {
   const siteUrl = String(status?.siteUrl || status?.url || '');
   let urlPort = 0;
   try {
@@ -202,20 +203,15 @@ function assertInvocationPort(status, runtime) {
   } catch {
     urlPort = 0;
   }
-  const port = Number(status?.port || urlPort || 0);
-  if (!Number.isInteger(port) || port < runtime.portBase || port > runtime.portMax) {
-    throw new Error(
-      `Homeboy invocation "${runtime.invocationId || 'unknown'}" expected Studio to use a port in ${runtime.portBase}-${runtime.portMax}, but site status reported ${port || 'none'}. Isolated ports cannot be guaranteed.`
-    );
-  }
+  return Number(status?.port || urlPort || 0);
 }
 
 async function runCli(args, options = {}) {
-  return sharedRunCli(args, { ...options, env: cliEnv(options.env) });
+  return sharedRunCli(args, { ...options, env: await cliEnv(options.env) });
 }
 
 async function runEval(prompt, vars) {
-  return sharedRunEval(prompt, vars, { env: cliEnv() });
+  return sharedRunEval(prompt, vars, { env: await cliEnv() });
 }
 
 function promptVariant() {
@@ -663,7 +659,7 @@ function optionalArtifactPath(name, value) {
 
 
 export default async function studioAgentSiteBuildBench() {
-  const runtime = resolveBenchRuntime();
+  const runtime = await createStudioBenchRuntime();
   const currentVariant = variant();
   const runId = `${currentVariant}-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   const artifactDir = runtime.artifactDir;
@@ -692,7 +688,7 @@ export default async function studioAgentSiteBuildBench() {
   const quality = await probeQuality(sitePath, { runCli });
   const qualityProbeMs = Date.now() - qualityProbeStarted;
   const status = await siteStatus(sitePath);
-  assertInvocationPort(status, runtime);
+  runtime.assertPort(statusPort(status));
   const importReport = await collectLatestImportReport(sitePath);
   const importerTimings = importerTimingMetrics(importReport);
   await mkdir(artifactDir, { recursive: true });

--- a/Automattic/studio/bench/studio-agent-site-build.test.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.test.mjs
@@ -9,12 +9,12 @@ process.env.HOMEBOY_COMPONENT_PATH ||= '/tmp/homeboy-rigs-test-component';
 const {
   agentSuccessGate,
   availablePromptVariants,
+  createStudioBenchRuntime,
   hiddenEditorContentDiagnostics,
   importerBlockQualityFailureDetails,
   importerBlockQualityMetrics,
   importerTimingMetrics,
   promptVariantCatalog,
-  resolveBenchRuntime,
   restoreMissingSourceStaticFiles,
   semanticTargetMetric,
   siteBuildPrompt,
@@ -27,7 +27,42 @@ const {
 
 const { collectLatestGeneratedTheme } = await import('./lib/design-gates.mjs');
 
-function withEnv(values, callback) {
+const invocationRuntimeHelper = `data:text/javascript,${encodeURIComponent(`
+export function resolveHomeboyInvocationRuntime({ namespace }) {
+  const state = process.env.HOMEBOY_INVOCATION_STATE_DIR ? process.env.HOMEBOY_INVOCATION_STATE_DIR + '/' + namespace : null;
+  const artifact = process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR ? process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR + '/' + namespace : null;
+  const tmp = process.env.HOMEBOY_INVOCATION_TMP_DIR ? process.env.HOMEBOY_INVOCATION_TMP_DIR + '/' + namespace : null;
+  return {
+    isolated: true,
+    namespace,
+    invocationId: process.env.HOMEBOY_INVOCATION_ID || null,
+    baseDirs: {
+      state: process.env.HOMEBOY_INVOCATION_STATE_DIR || null,
+      artifact: process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR || null,
+      tmp: process.env.HOMEBOY_INVOCATION_TMP_DIR || null,
+    },
+    dirs: { state, artifact, tmp },
+    portRange: {
+      base: Number(process.env.HOMEBOY_INVOCATION_PORT_BASE),
+      max: Number(process.env.HOMEBOY_INVOCATION_PORT_MAX),
+    },
+    childEnv(extra = {}) {
+      return {
+        HOMEBOY_INVOCATION_NAMESPACE: namespace,
+        HOMEBOY_INVOCATION_STATE_DIR: state,
+        HOMEBOY_INVOCATION_ARTIFACT_DIR: artifact,
+        HOMEBOY_INVOCATION_TMP_DIR: tmp,
+        TMPDIR: tmp,
+        ...extra,
+      };
+    },
+    async prepareDirs() {},
+    assertPort(port) { return Number(port); },
+  };
+}
+`)}`;
+
+async function withEnv(values, callback) {
   const previous = {};
   for (const key of Object.keys(values)) {
     previous[key] = process.env[key];
@@ -39,7 +74,7 @@ function withEnv(values, callback) {
   }
 
   try {
-    return callback();
+    return await callback();
   } finally {
     for (const [key, value] of Object.entries(previous)) {
       if (value === undefined) {
@@ -94,18 +129,13 @@ test('site-build prompt file override bypasses discovered variants', async () =>
   }
 });
 
-test('bench runtime falls back to shared-state artifacts without Homeboy invocation env', () => {
-  withEnv(
+test('bench runtime falls back to shared-state artifacts without invocation helper', async () => {
+  await withEnv(
     {
-      HOMEBOY_INVOCATION_ID: undefined,
-      HOMEBOY_INVOCATION_STATE_DIR: undefined,
-      HOMEBOY_INVOCATION_ARTIFACT_DIR: undefined,
-      HOMEBOY_INVOCATION_TMP_DIR: undefined,
-      HOMEBOY_INVOCATION_PORT_BASE: undefined,
-      HOMEBOY_INVOCATION_PORT_MAX: undefined,
+      HOMEBOY_NODEJS_INVOCATION_RUNTIME_HELPER: undefined,
     },
-    () => {
-      const runtime = resolveBenchRuntime('/tmp/shared-state');
+    async () => {
+      const runtime = await createStudioBenchRuntime('/tmp/shared-state');
 
       assert.equal(runtime.invocationId, '');
       assert.equal(runtime.artifactDir, '/tmp/shared-state/studio-agent-site-build-artifacts');
@@ -117,9 +147,10 @@ test('bench runtime falls back to shared-state artifacts without Homeboy invocat
   );
 });
 
-test('bench runtime consumes Homeboy invocation env for isolated paths and ports', () => {
-  withEnv(
+test('bench runtime composes the Homeboy invocation helper output for Studio', async () => {
+  await withEnv(
     {
+      HOMEBOY_NODEJS_INVOCATION_RUNTIME_HELPER: invocationRuntimeHelper,
       HOMEBOY_INVOCATION_ID: 'inv-test',
       HOMEBOY_INVOCATION_STATE_DIR: '/tmp/inv/state',
       HOMEBOY_INVOCATION_ARTIFACT_DIR: '/tmp/inv/artifacts',
@@ -127,8 +158,8 @@ test('bench runtime consumes Homeboy invocation env for isolated paths and ports
       HOMEBOY_INVOCATION_PORT_BASE: '20000',
       HOMEBOY_INVOCATION_PORT_MAX: '20009',
     },
-    () => {
-      const runtime = resolveBenchRuntime('/tmp/shared-state');
+    async () => {
+      const runtime = await createStudioBenchRuntime('/tmp/shared-state');
 
       assert.equal(runtime.invocationId, 'inv-test');
       assert.equal(runtime.artifactDir, '/tmp/inv/artifacts');
@@ -136,15 +167,19 @@ test('bench runtime consumes Homeboy invocation env for isolated paths and ports
       assert.equal(runtime.cliConfigDir, '/tmp/inv/state/studio-agent-site-build/cli-config');
       assert.equal(runtime.appDataDir, '/tmp/inv/state/studio-agent-site-build/appdata');
       assert.equal(runtime.processManagerHome, '/tmp/inv/state/studio-agent-site-build/daemon');
-      assert.equal(runtime.tmpDir, '/tmp/inv/tmp');
+      assert.equal(runtime.tmpDir, '/tmp/inv/tmp/studio-agent-site-build');
       assert.equal(runtime.portBase, 20000);
       assert.equal(runtime.portMax, 20009);
       assert.deepEqual(runtime.env, {
+        HOMEBOY_INVOCATION_NAMESPACE: 'studio-agent-site-build',
+        HOMEBOY_INVOCATION_STATE_DIR: '/tmp/inv/state/studio-agent-site-build',
+        HOMEBOY_INVOCATION_ARTIFACT_DIR: '/tmp/inv/artifacts/studio-agent-site-build',
+        HOMEBOY_INVOCATION_TMP_DIR: '/tmp/inv/tmp/studio-agent-site-build',
+        TMPDIR: '/tmp/inv/tmp/studio-agent-site-build',
         E2E: '1',
         E2E_CLI_CONFIG_PATH: '/tmp/inv/state/studio-agent-site-build/cli-config',
         E2E_APP_DATA_PATH: '/tmp/inv/state/studio-agent-site-build/appdata',
         STUDIO_PROCESS_MANAGER_HOME: '/tmp/inv/state/studio-agent-site-build/daemon',
-        TMPDIR: '/tmp/inv/tmp',
       });
     }
   );


### PR DESCRIPTION
## Summary
- Migrates the Studio site-build benchmark off local Homeboy invocation env parsing and onto the Node invocation runtime helper from Extra-Chill/homeboy-extensions#919.
- Keeps Studio-specific state, metadata, artifact naming, and reserved-port behavior while delegating namespace isolation and port validation to the helper.
- Updates the targeted benchmark tests to cover fallback behavior and helper-composed runtime paths.

## Verification
- `node --check Automattic/studio/bench/studio-agent-site-build.bench.mjs`
- `node --test Automattic/studio/bench/studio-agent-site-build.test.mjs`

## Not run
- Full `studio-agent-site-build` benchmark. It performs an actual agent-driven Studio site build with browser/visual/semantic validation, so the PR is verified with syntax/import checks and the existing targeted unit test instead.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the downstream consumer migration and targeted tests; Chris remains responsible for review and merge.