### PR TITLE
refactor(gutenberg): use shared node workload utilities

### DIFF
--- a/WordPress/gutenberg/bench/lib/gutenberg-rtc-bench.mjs
+++ b/WordPress/gutenberg/bench/lib/gutenberg-rtc-bench.mjs
@@ -1,106 +1,31 @@
-import { spawn } from 'node:child_process';
-import { mkdir, writeFile } from 'node:fs/promises';
-import os from 'node:os';
 import path from 'node:path';
-import { performance } from 'node:perf_hooks';
 
 export const GUTENBERG_PATH = process.env.HOMEBOY_COMPONENT_PATH;
-export const SHARED_STATE = process.env.HOMEBOY_BENCH_SHARED_STATE || os.tmpdir();
 
 if (!GUTENBERG_PATH) {
   throw new Error('HOMEBOY_COMPONENT_PATH is required');
 }
 
-export function setting(key, fallback = '') {
-  try {
-    const settings = JSON.parse(process.env.HOMEBOY_SETTINGS_JSON || '{}');
-    if (settings && settings[key] !== undefined) {
-      return String(settings[key]);
-    }
-  } catch {
-    // Ignore malformed settings and use direct env/defaults.
-  }
+const workloadUtilsPath = process.env.HOMEBOY_NODEJS_WORKLOAD_UTILS;
 
-  return process.env[`HOMEBOY_SETTINGS_${key.toUpperCase()}`] || fallback;
+if (!workloadUtilsPath) {
+  throw new Error('HOMEBOY_NODEJS_WORKLOAD_UTILS is required');
 }
 
-export function metric(value) {
-  const number = Number(value ?? 0);
-  return Number.isFinite(number) ? number : 0;
-}
+const workloadUtils = await import(workloadUtilsPath);
 
-export function artifactDir(name) {
-  return path.join(SHARED_STATE, name);
-}
+export const artifactDir = workloadUtils.artifactDir;
+export const metric = workloadUtils.metric;
+export const percentile = workloadUtils.percentile;
+export const runCommand = workloadUtils.runCommand;
+export const setting = workloadUtils.setting;
+export const writeJson = workloadUtils.writeJson;
+export const writeText = workloadUtils.writeText;
+
+export const redact = workloadUtils.redactText;
 
 export function runId(name) {
-  const namespace = setting('gutenberg_rtc_namespace', path.basename(GUTENBERG_PATH));
-  return `${namespace}-${name}-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-}
-
-export function redact(text) {
-  return String(text || '')
-    .replace(/(Authorization:\s*Basic\s+)[A-Za-z0-9+/=._:-]+/gi, '$1[redacted]')
-    .replace(/("password"\s*:\s*")[^"]+(")/gi, '$1[redacted]$2')
-    .replace(/([?&](?:_wpnonce|token|password|key)=)[^&#\s]+/gi, '$1[redacted]');
-}
-
-export function runCommand(command, args, options = {}) {
-  return new Promise((resolve, reject) => {
-    const started = performance.now();
-    let settled = false;
-    let stdout = '';
-    let stderr = '';
-    const child = spawn(command, args, {
-      cwd: options.cwd || GUTENBERG_PATH,
-      env: { ...process.env, ...(options.env || {}) },
-      shell: false,
-    });
-
-    const timer = options.timeoutMs
-      ? setTimeout(() => {
-          if (settled) {
-            return;
-          }
-          settled = true;
-          child.kill('SIGKILL');
-          reject(
-            new Error(
-              `${command} ${args.join(' ')} timed out after ${options.timeoutMs}ms; stdout=${redact(stdout).slice(-1200)}; stderr=${redact(stderr).slice(-1200)}`
-            )
-          );
-        }, options.timeoutMs)
-      : undefined;
-
-    child.stdout.on('data', (chunk) => {
-      stdout += String(chunk);
-    });
-    child.stderr.on('data', (chunk) => {
-      stderr += String(chunk);
-    });
-    child.on('error', (error) => {
-      if (timer) {
-        clearTimeout(timer);
-      }
-      reject(error);
-    });
-    child.on('close', (code) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      if (timer) {
-        clearTimeout(timer);
-      }
-      const elapsedMs = performance.now() - started;
-      const result = { code, stdout, stderr, elapsedMs };
-      if (code !== 0 && options.allowFailure !== true) {
-        reject(new Error(`${command} ${args.join(' ')} exited ${code}; stderr=${redact(stderr).slice(0, 2000)}`));
-        return;
-      }
-      resolve(result);
-    });
-  });
+  return workloadUtils.runId(name, { namespaceSetting: 'gutenberg_rtc_namespace' });
 }
 
 export async function runNpmScript(script, args = [], options = {}) {
@@ -109,34 +34,6 @@ export async function runNpmScript(script, args = [], options = {}) {
 
 export async function runWpEnvTest(args, options = {}) {
   return runNpmScript('wp-env-test', args, options);
-}
-
-export async function writeJson(file, data) {
-  await mkdir(path.dirname(file), { recursive: true });
-  await writeFile(file, `${JSON.stringify(data, null, 2)}\n`);
-}
-
-export async function writeText(file, data) {
-  await mkdir(path.dirname(file), { recursive: true });
-  await writeFile(file, redact(data));
-}
-
-export function percentile(values, pct) {
-  const sorted = values.filter((value) => Number.isFinite(value)).sort((a, b) => a - b);
-  if (sorted.length === 0) {
-    return 0;
-  }
-  if (sorted.length === 1) {
-    return sorted[0];
-  }
-  const rank = (pct / 100) * (sorted.length - 1);
-  const lower = Math.floor(rank);
-  const upper = Math.ceil(rank);
-  if (lower === upper) {
-    return sorted[lower];
-  }
-  const weight = rank - lower;
-  return sorted[lower] * (1 - weight) + sorted[upper] * weight;
 }
 
 export async function runPlaywrightSpecSuite({ id, specs, timeoutMs = 900000 }) {


### PR DESCRIPTION
## Summary
- Migrates the Gutenberg RTC bench helper to the shared Node workload utility module from homeboy-extensions.
- Keeps the local helper focused on Gutenberg-specific wrappers while preserving existing workload imports.

## Verification
- `node --check WordPress/gutenberg/bench/lib/gutenberg-rtc-bench.mjs && node --check WordPress/gutenberg/bench/gutenberg-rtc-browser-basic.bench.mjs && node --check WordPress/gutenberg/bench/gutenberg-rtc-browser-tabs.bench.mjs && node --check WordPress/gutenberg/bench/gutenberg-rtc-conflict-fuzzer.bench.mjs && node --check WordPress/gutenberg/bench/gutenberg-rtc-settings-matrix.bench.mjs && node --check WordPress/gutenberg/bench/gutenberg-rtc-protocol-load.bench.mjs`
- Mock import smoke test for `HOMEBOY_NODEJS_WORKLOAD_UTILS`
- `homeboy audit --path /Users/chubes/Developer/homeboy-rigs@migrate-gutenberg-rtc-node-workload --extension nodejs --changed-since origin/gutenberg-rtc-rig`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the helper migration and ran targeted verification; Chris remains responsible for review and merge.