### PR TITLE
fix(gutenberg): restore rtc artifact directory import

### DIFF
--- a/WordPress/gutenberg/bench/lib/gutenberg-rtc-bench.mjs
+++ b/WordPress/gutenberg/bench/lib/gutenberg-rtc-bench.mjs
@@ -1,3 +1,4 @@
+import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
 
 export const GUTENBERG_PATH = process.env.HOMEBOY_COMPONENT_PATH;


### PR DESCRIPTION
## Summary
- Restores the `mkdir` import used by the Gutenberg RTC Playwright artifact directory setup.
- Keeps the shared workload utility migration intact.

## Verification
- `node --check WordPress/gutenberg/bench/lib/gutenberg-rtc-bench.mjs && node --check WordPress/gutenberg/bench/gutenberg-rtc-browser-basic.bench.mjs && node --check WordPress/gutenberg/bench/gutenberg-rtc-browser-tabs.bench.mjs && node --check WordPress/gutenberg/bench/gutenberg-rtc-conflict-fuzzer.bench.mjs && node --check WordPress/gutenberg/bench/gutenberg-rtc-settings-matrix.bench.mjs && node --check WordPress/gutenberg/bench/gutenberg-rtc-protocol-load.bench.mjs`
- Mock import smoke test for `HOMEBOY_NODEJS_WORKLOAD_UTILS`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Identified and patched the missing import regression; Chris remains responsible for review and merge.