### PR TITLE
refactor(studio): move site-build runtime helpers

### DIFF
--- a/Automattic/studio/bench/lib/site-build-runtime.mjs
+++ b/Automattic/studio/bench/lib/site-build-runtime.mjs
@@ -1,0 +1,295 @@
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import {
+  SHARED_STATE,
+  STUDIO_PATH,
+  createStudioSite,
+  expandHome,
+  runCli as sharedRunCli,
+  runEval as sharedRunEval,
+  setting,
+  studioSiteStatusJson,
+  variant,
+} from './studio-bench.mjs';
+
+const DEFAULT_STUDIO_PORT = 8881;
+const INVOCATION_NAMESPACE = 'studio-agent-site-build';
+const PROMPT_VARIANT_SETTING = 'studio_site_build_prompt_variant';
+const PROMPT_FILE_SETTING = 'studio_site_build_prompt_file';
+const MODEL_SETTING = 'studio_agent_model';
+const DEFAULT_PROMPT_VARIANT = 'studio-code';
+const SYSTEM_PROMPT_FILES = ['apps/cli/ai/system-prompt.ts'];
+
+export const PROMPT_CATEGORY = 'site-build';
+
+export { variant };
+
+export function evalModel() {
+  return setting(MODEL_SETTING) || process.env.STUDIO_EVAL_MODEL || '';
+}
+
+function envPath(key) {
+  return typeof process.env[key] === 'string' && process.env[key] ? process.env[key] : '';
+}
+
+export async function createStudioBenchRuntime(sharedState = SHARED_STATE) {
+  const helperPath = envPath('HOMEBOY_NODEJS_INVOCATION_RUNTIME_HELPER');
+  if (!helperPath) {
+    const artifactDir = path.join(sharedState, 'studio-agent-site-build-artifacts');
+    return {
+      invocationId: '',
+      artifactDir,
+      siteRoot: path.join(artifactDir, 'sites'),
+      stateDir: '',
+      cliConfigDir: '',
+      appDataDir: '',
+      processManagerHome: '',
+      tmpDir: '',
+      portBase: null,
+      portMax: null,
+      env: {},
+      async prepareDirs() {},
+      assertPort() {},
+    };
+  }
+
+  const { resolveHomeboyInvocationRuntime } = await import(helperPath);
+  const invocationRuntime = resolveHomeboyInvocationRuntime({ namespace: INVOCATION_NAMESPACE });
+  const stateDir = invocationRuntime.dirs.state || '';
+  const artifactDir =
+    invocationRuntime.baseDirs.artifact || path.join(sharedState, 'studio-agent-site-build-artifacts');
+  const tmpDir = invocationRuntime.dirs.tmp || (stateDir ? path.join(stateDir, 'tmp') : '');
+  const cliConfigDir = stateDir ? path.join(stateDir, 'cli-config') : '';
+  const appDataDir = stateDir ? path.join(stateDir, 'appdata') : '';
+  const processManagerHome = stateDir ? path.join(stateDir, 'daemon') : '';
+  const portBase = invocationRuntime.portRange?.base ?? null;
+  const portMax = invocationRuntime.portRange?.max ?? null;
+
+  return {
+    invocationId: invocationRuntime.invocationId || '',
+    artifactDir,
+    siteRoot: stateDir ? path.join(stateDir, 'sites') : path.join(artifactDir, 'sites'),
+    stateDir,
+    cliConfigDir,
+    appDataDir,
+    processManagerHome,
+    tmpDir,
+    portBase,
+    portMax,
+    env: invocationRuntime.isolated
+      ? invocationRuntime.childEnv({
+          E2E: '1',
+          E2E_CLI_CONFIG_PATH: cliConfigDir,
+          E2E_APP_DATA_PATH: appDataDir,
+          STUDIO_PROCESS_MANAGER_HOME: processManagerHome,
+          ...(tmpDir ? { TMPDIR: tmpDir } : {}),
+        })
+      : {},
+    prepareDirs: () => invocationRuntime.prepareDirs(),
+    assertPort: invocationRuntime.assertPort,
+  };
+}
+
+async function cliEnv(extra = {}) {
+  const staticSiteImporterPath = expandHome(setting('studio_static_site_importer_plugin_path') || '');
+  const runtime = await createStudioBenchRuntime();
+  return {
+    ...process.env,
+    ...(staticSiteImporterPath
+      ? { STUDIO_STATIC_SITE_IMPORTER_PLUGIN_PATH: staticSiteImporterPath }
+      : {}),
+    ...runtime.env,
+    ...extra,
+  };
+}
+
+export async function prepareStudioRuntime(runtime) {
+  if (!runtime.stateDir) {
+    return;
+  }
+
+  await runtime.prepareDirs();
+  await mkdir(runtime.cliConfigDir, { recursive: true });
+  await mkdir(runtime.appDataDir, { recursive: true });
+  await mkdir(runtime.processManagerHome, { recursive: true });
+  if (runtime.tmpDir) {
+    await mkdir(runtime.tmpDir, { recursive: true });
+  }
+  await mkdir(runtime.siteRoot, { recursive: true });
+
+  const reservedSites = [];
+  if (runtime.portBase !== null) {
+    for (let port = DEFAULT_STUDIO_PORT; port < runtime.portBase; port++) {
+      reservedSites.push({
+        id: `bench-reserved-${runtime.invocationId || 'invocation'}-${port}`,
+        name: `Bench reserved ${port}`,
+        path: path.join(runtime.stateDir, 'reserved-ports', String(port)),
+        port,
+        phpVersion: '8.3',
+        url: `http://localhost:${port}`,
+        running: false,
+      });
+    }
+  }
+
+  const configPath = path.join(runtime.cliConfigDir, 'cli.json');
+  await writeFile(configPath, JSON.stringify({ version: 1, sites: reservedSites, snapshots: [] }, null, 2) + '\n');
+}
+
+export function statusPort(status) {
+  const siteUrl = String(status?.siteUrl || status?.url || '');
+  let urlPort = 0;
+  try {
+    urlPort = Number(new URL(siteUrl).port || 0);
+  } catch {
+    urlPort = 0;
+  }
+  return Number(status?.port || urlPort || 0);
+}
+
+export async function runCli(args, options = {}) {
+  return sharedRunCli(args, { ...options, env: await cliEnv(options.env) });
+}
+
+export async function runEval(prompt, vars) {
+  return sharedRunEval(prompt, vars, { env: await cliEnv() });
+}
+
+function promptVariant() {
+  return setting(PROMPT_VARIANT_SETTING) || DEFAULT_PROMPT_VARIANT;
+}
+
+export async function availablePromptVariants() {
+  return validatePromptVariantCatalog();
+}
+
+export async function validatePromptVariantCatalog() {
+  const promptsDir = new URL('../prompts/site-build/', import.meta.url);
+  const files = await promptFiles(promptsDir);
+  return Object.keys(promptVariantCatalog(files));
+}
+
+export function promptVariantCatalog(files) {
+  const variants = {};
+  const duplicatePaths = new Map();
+
+  for (const relativePath of files) {
+    const variantName = path.posix.basename(relativePath, '.md');
+    if (variants[variantName]) {
+      if (!duplicatePaths.has(variantName)) {
+        duplicatePaths.set(variantName, [variants[variantName]]);
+      }
+      duplicatePaths.get(variantName).push(relativePath);
+      continue;
+    }
+
+    variants[variantName] = relativePath;
+  }
+
+  if (duplicatePaths.size) {
+    const duplicates = [...duplicatePaths.entries()]
+      .map(([variantName, paths]) => `${variantName} (${paths.join(', ')})`)
+      .join('; ');
+    throw new Error(
+      `Studio site-build prompt catalog has duplicate basename-derived variant IDs. Rename prompt files so each basename is unique. Duplicates: ${duplicates}.`
+    );
+  }
+
+  return variants;
+}
+
+async function promptFiles(directoryUrl, prefix = '') {
+  const entries = await readdir(directoryUrl, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      files.push(...(await promptFiles(new URL(`${entry.name}/`, directoryUrl), relativePath)));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      files.push(relativePath);
+    }
+  }
+
+  return files.sort();
+}
+
+export async function promptTemplatePath() {
+  const explicitPromptFile = expandHome(setting(PROMPT_FILE_SETTING) || '');
+  if (explicitPromptFile) {
+    return explicitPromptFile;
+  }
+
+  const variantName = promptVariant();
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(variantName)) {
+    throw new Error(`Invalid ${PROMPT_VARIANT_SETTING}: ${variantName}`);
+  }
+  const promptsDir = new URL('../prompts/site-build/', import.meta.url);
+  const relativePromptPath = promptVariantCatalog(await promptFiles(promptsDir))[variantName];
+  if (!relativePromptPath) {
+    const variants = await availablePromptVariants();
+    throw new Error(`Unknown ${PROMPT_VARIANT_SETTING}: ${variantName}. Available variants: ${variants.join(', ')}.`);
+  }
+
+  return new URL(`../prompts/site-build/${relativePromptPath}`, import.meta.url);
+}
+
+export async function siteBuildPrompt(sitePath) {
+  const promptPath = await promptTemplatePath();
+  let template;
+  try {
+    template = await readFile(promptPath, 'utf8');
+  } catch (error) {
+    const variants = await availablePromptVariants().catch(() => []);
+    const hint = variants.length ? ` Available variants: ${variants.join(', ')}.` : '';
+    throw new Error(
+      `Failed to read Studio site-build prompt for variant "${promptVariant()}" from ${String(promptPath)}.${hint} ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+
+  return template.trim().replaceAll('{{sitePath}}', sitePath).replaceAll('${sitePath}', sitePath);
+}
+
+export async function systemPromptFingerprint() {
+  const hash = createHash('sha256');
+  const manifest = [];
+  let sizeBytes = 0;
+
+  for (const relativePath of SYSTEM_PROMPT_FILES) {
+    const content = await readFile(path.join(STUDIO_PATH, relativePath));
+    const contentSha = createHash('sha256').update(content).digest('hex');
+    sizeBytes += content.byteLength;
+    manifest.push({
+      path: relativePath,
+      sha256: contentSha,
+      size_bytes: content.byteLength,
+    });
+
+    hash.update(relativePath, 'utf8');
+    hash.update('\0');
+    hash.update(String(content.byteLength), 'utf8');
+    hash.update('\0');
+    hash.update(content);
+    hash.update('\0');
+  }
+
+  return {
+    system_prompt_sha: hash.digest('hex'),
+    system_prompt_file: SYSTEM_PROMPT_FILES.length === 1 ? SYSTEM_PROMPT_FILES[0] : undefined,
+    system_prompt_files: SYSTEM_PROMPT_FILES,
+    system_prompt_manifest: manifest,
+    system_prompt_size_bytes: sizeBytes,
+  };
+}
+
+export async function createFreshSite(sitePath) {
+  await createStudioSite(sitePath, { name: `Studio Bench ${variant()} ${process.pid}`, env: cliEnv() });
+}
+
+export async function siteStatus(sitePath) {
+  return studioSiteStatusJson(sitePath, { env: cliEnv() });
+}

--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -1,5 +1,4 @@
-import { mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
-import { createHash } from 'node:crypto';
+import { mkdir, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 
@@ -42,16 +41,31 @@ import { comparisonTargets, resolveSourceStaticFile } from './lib/fidelity-targe
 export { resolveSourceStaticFile } from './lib/fidelity-targets.mjs';
 
 import {
-  SHARED_STATE,
-  STUDIO_PATH,
-  createStudioSite,
-  expandHome,
-  runCli as sharedRunCli,
-  runEval as sharedRunEval,
-  setting,
-  studioSiteStatusJson,
+  PROMPT_CATEGORY,
+  availablePromptVariants,
+  createFreshSite,
+  createStudioBenchRuntime,
+  evalModel,
+  prepareStudioRuntime,
+  promptTemplatePath,
+  promptVariantCatalog,
+  runCli,
+  runEval,
+  siteBuildPrompt,
+  siteStatus,
+  statusPort,
+  systemPromptFingerprint,
+  validatePromptVariantCatalog,
   variant,
-} from './lib/studio-bench.mjs';
+} from './lib/site-build-runtime.mjs';
+
+export {
+  availablePromptVariants,
+  createStudioBenchRuntime,
+  promptVariantCatalog,
+  siteBuildPrompt,
+  validatePromptVariantCatalog,
+} from './lib/site-build-runtime.mjs';
 
 import {
   agentSuccessGate,
@@ -73,283 +87,7 @@ export {
   visualPixelDiffFailureDetails,
 } from './lib/site-build-gates.mjs';
 
-const DEFAULT_STUDIO_PORT = 8881;
-const INVOCATION_NAMESPACE = 'studio-agent-site-build';
-const PROMPT_VARIANT_SETTING = 'studio_site_build_prompt_variant';
-const PROMPT_FILE_SETTING = 'studio_site_build_prompt_file';
-const MODEL_SETTING = 'studio_agent_model';
-const DEFAULT_PROMPT_VARIANT = 'studio-code';
-const PROMPT_CATEGORY = 'site-build';
-const SYSTEM_PROMPT_FILES = ['apps/cli/ai/system-prompt.ts'];
 const requireFromBench = createRequire(import.meta.url);
-
-function evalModel() {
-  return setting(MODEL_SETTING) || process.env.STUDIO_EVAL_MODEL || '';
-}
-
-function envPath(key) {
-  return typeof process.env[key] === 'string' && process.env[key] ? process.env[key] : '';
-}
-
-export async function createStudioBenchRuntime(sharedState = SHARED_STATE) {
-  const helperPath = envPath('HOMEBOY_NODEJS_INVOCATION_RUNTIME_HELPER');
-  if (!helperPath) {
-    const artifactDir = path.join(sharedState, 'studio-agent-site-build-artifacts');
-    return {
-      invocationId: '',
-      artifactDir,
-      siteRoot: path.join(artifactDir, 'sites'),
-      stateDir: '',
-      cliConfigDir: '',
-      appDataDir: '',
-      processManagerHome: '',
-      tmpDir: '',
-      portBase: null,
-      portMax: null,
-      env: {},
-      async prepareDirs() {},
-      assertPort() {},
-    };
-  }
-
-  const { resolveHomeboyInvocationRuntime } = await import(helperPath);
-  const invocationRuntime = resolveHomeboyInvocationRuntime({ namespace: INVOCATION_NAMESPACE });
-  const stateDir = invocationRuntime.dirs.state || '';
-  const artifactDir =
-    invocationRuntime.baseDirs.artifact || path.join(sharedState, 'studio-agent-site-build-artifacts');
-  const tmpDir = invocationRuntime.dirs.tmp || (stateDir ? path.join(stateDir, 'tmp') : '');
-  const cliConfigDir = stateDir ? path.join(stateDir, 'cli-config') : '';
-  const appDataDir = stateDir ? path.join(stateDir, 'appdata') : '';
-  const processManagerHome = stateDir ? path.join(stateDir, 'daemon') : '';
-  const portBase = invocationRuntime.portRange?.base ?? null;
-  const portMax = invocationRuntime.portRange?.max ?? null;
-
-  return {
-    invocationId: invocationRuntime.invocationId || '',
-    artifactDir,
-    siteRoot: stateDir ? path.join(stateDir, 'sites') : path.join(artifactDir, 'sites'),
-    stateDir,
-    cliConfigDir,
-    appDataDir,
-    processManagerHome,
-    tmpDir,
-    portBase,
-    portMax,
-    env: invocationRuntime.isolated
-      ? invocationRuntime.childEnv({
-          E2E: '1',
-          E2E_CLI_CONFIG_PATH: cliConfigDir,
-          E2E_APP_DATA_PATH: appDataDir,
-          STUDIO_PROCESS_MANAGER_HOME: processManagerHome,
-          ...(tmpDir ? { TMPDIR: tmpDir } : {}),
-        })
-      : {},
-    prepareDirs: () => invocationRuntime.prepareDirs(),
-    assertPort: invocationRuntime.assertPort,
-  };
-}
-
-async function cliEnv(extra = {}) {
-  const staticSiteImporterPath = expandHome(setting('studio_static_site_importer_plugin_path') || '');
-  const runtime = await createStudioBenchRuntime();
-  return {
-    ...process.env,
-    ...(staticSiteImporterPath
-      ? { STUDIO_STATIC_SITE_IMPORTER_PLUGIN_PATH: staticSiteImporterPath }
-      : {}),
-    ...runtime.env,
-    ...extra,
-  };
-}
-
-async function prepareStudioRuntime(runtime) {
-  if (!runtime.stateDir) {
-    return;
-  }
-
-  await runtime.prepareDirs();
-  await mkdir(runtime.cliConfigDir, { recursive: true });
-  await mkdir(runtime.appDataDir, { recursive: true });
-  await mkdir(runtime.processManagerHome, { recursive: true });
-  if (runtime.tmpDir) {
-    await mkdir(runtime.tmpDir, { recursive: true });
-  }
-  await mkdir(runtime.siteRoot, { recursive: true });
-
-  const reservedSites = [];
-  if (runtime.portBase !== null) {
-    for (let port = DEFAULT_STUDIO_PORT; port < runtime.portBase; port++) {
-      reservedSites.push({
-        id: `bench-reserved-${runtime.invocationId || 'invocation'}-${port}`,
-        name: `Bench reserved ${port}`,
-        path: path.join(runtime.stateDir, 'reserved-ports', String(port)),
-        port,
-        phpVersion: '8.3',
-        url: `http://localhost:${port}`,
-        running: false,
-      });
-    }
-  }
-
-  const configPath = path.join(runtime.cliConfigDir, 'cli.json');
-  await writeFile(configPath, JSON.stringify({ version: 1, sites: reservedSites, snapshots: [] }, null, 2) + '\n');
-}
-
-function statusPort(status) {
-  const siteUrl = String(status?.siteUrl || status?.url || '');
-  let urlPort = 0;
-  try {
-    urlPort = Number(new URL(siteUrl).port || 0);
-  } catch {
-    urlPort = 0;
-  }
-  return Number(status?.port || urlPort || 0);
-}
-
-async function runCli(args, options = {}) {
-  return sharedRunCli(args, { ...options, env: await cliEnv(options.env) });
-}
-
-async function runEval(prompt, vars) {
-  return sharedRunEval(prompt, vars, { env: await cliEnv() });
-}
-
-function promptVariant() {
-  return setting(PROMPT_VARIANT_SETTING) || DEFAULT_PROMPT_VARIANT;
-}
-
-export async function availablePromptVariants() {
-  return validatePromptVariantCatalog();
-}
-
-export async function validatePromptVariantCatalog() {
-  const promptsDir = new URL('./prompts/site-build/', import.meta.url);
-  const files = await promptFiles(promptsDir);
-  return Object.keys(promptVariantCatalog(files));
-}
-
-export function promptVariantCatalog(files) {
-  const variants = {};
-  const duplicatePaths = new Map();
-
-  for (const relativePath of files) {
-    const variantName = path.posix.basename(relativePath, '.md');
-    if (variants[variantName]) {
-      if (!duplicatePaths.has(variantName)) {
-        duplicatePaths.set(variantName, [variants[variantName]]);
-      }
-      duplicatePaths.get(variantName).push(relativePath);
-      continue;
-    }
-
-    variants[variantName] = relativePath;
-  }
-
-  if (duplicatePaths.size) {
-    const duplicates = [...duplicatePaths.entries()]
-      .map(([variantName, paths]) => `${variantName} (${paths.join(', ')})`)
-      .join('; ');
-    throw new Error(
-      `Studio site-build prompt catalog has duplicate basename-derived variant IDs. Rename prompt files so each basename is unique. Duplicates: ${duplicates}.`
-    );
-  }
-
-  return variants;
-}
-
-async function promptFiles(directoryUrl, prefix = '') {
-  const entries = await readdir(directoryUrl, { withFileTypes: true });
-  const files = [];
-
-  for (const entry of entries) {
-    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
-    if (entry.isDirectory()) {
-      files.push(...(await promptFiles(new URL(`${entry.name}/`, directoryUrl), relativePath)));
-    } else if (entry.isFile() && entry.name.endsWith('.md')) {
-      files.push(relativePath);
-    }
-  }
-
-  return files.sort();
-}
-
-async function promptTemplatePath() {
-  const explicitPromptFile = expandHome(setting(PROMPT_FILE_SETTING) || '');
-  if (explicitPromptFile) {
-    return explicitPromptFile;
-  }
-
-  const variantName = promptVariant();
-  if (!/^[a-z0-9][a-z0-9-]*$/.test(variantName)) {
-    throw new Error(`Invalid ${PROMPT_VARIANT_SETTING}: ${variantName}`);
-  }
-  const promptsDir = new URL('./prompts/site-build/', import.meta.url);
-  const relativePromptPath = promptVariantCatalog(await promptFiles(promptsDir))[variantName];
-  if (!relativePromptPath) {
-    const variants = await availablePromptVariants();
-    throw new Error(`Unknown ${PROMPT_VARIANT_SETTING}: ${variantName}. Available variants: ${variants.join(', ')}.`);
-  }
-
-  return new URL(`./prompts/site-build/${relativePromptPath}`, import.meta.url);
-}
-
-export async function siteBuildPrompt(sitePath) {
-  const promptPath = await promptTemplatePath();
-  let template;
-  try {
-    template = await readFile(promptPath, 'utf8');
-  } catch (error) {
-    const variants = await availablePromptVariants().catch(() => []);
-    const hint = variants.length ? ` Available variants: ${variants.join(', ')}.` : '';
-    throw new Error(
-      `Failed to read Studio site-build prompt for variant "${promptVariant()}" from ${String(promptPath)}.${hint} ${
-        error instanceof Error ? error.message : String(error)
-      }`
-    );
-  }
-
-  return template.trim().replaceAll('{{sitePath}}', sitePath).replaceAll('${sitePath}', sitePath);
-}
-
-export async function systemPromptFingerprint() {
-  const hash = createHash('sha256');
-  const manifest = [];
-  let sizeBytes = 0;
-
-  for (const relativePath of SYSTEM_PROMPT_FILES) {
-    const content = await readFile(path.join(STUDIO_PATH, relativePath));
-    const contentSha = createHash('sha256').update(content).digest('hex');
-    sizeBytes += content.byteLength;
-    manifest.push({
-      path: relativePath,
-      sha256: contentSha,
-      size_bytes: content.byteLength,
-    });
-
-    hash.update(relativePath, 'utf8');
-    hash.update('\0');
-    hash.update(String(content.byteLength), 'utf8');
-    hash.update('\0');
-    hash.update(content);
-    hash.update('\0');
-  }
-
-  return {
-    system_prompt_sha: hash.digest('hex'),
-    system_prompt_file: SYSTEM_PROMPT_FILES.length === 1 ? SYSTEM_PROMPT_FILES[0] : undefined,
-    system_prompt_files: SYSTEM_PROMPT_FILES,
-    system_prompt_manifest: manifest,
-    system_prompt_size_bytes: sizeBytes,
-  };
-}
-
-async function createFreshSite(sitePath) {
-  await createStudioSite(sitePath, { name: `Studio Bench ${variant()} ${process.pid}`, env: cliEnv() });
-}
-
-async function siteStatus(sitePath) {
-  return studioSiteStatusJson(sitePath, { env: cliEnv() });
-}
 
 export async function restoreMissingSourceStaticFiles(importReport, sitePath, result) {
   const writes = new Map();


### PR DESCRIPTION
## Summary
- Move Studio site-build runtime setup, prompt catalog, prompt rendering, and system-prompt fingerprinting into `bench/lib/site-build-runtime.mjs`.
- Keep the workload's public helper exports and benchmark output contract stable while shrinking the orchestrator.
- Preserve the existing Homeboy invocation runtime helper path for isolated dirs, env, and port assertions.

## Verification
- `node --test Automattic/studio/bench/studio-agent-site-build.test.mjs` passed.
- `git diff --check` passed.

## Residual risk
- `homeboy bench list --rig studio-bfb --scenario studio-agent-site-build` could not run locally because the installed Homeboy rig registry does not resolve `studio-bfb` even though it appears in suggestions.
- The nearest registered Studio agent rig also failed before listing due an existing rig-spec parse error for string workload shorthand, so full Homeboy scenario discovery was not proven in this checkout.

Closes #78.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the focused helper extraction, ran targeted verification, and prepared the PR summary for Chris to review.