### PR TITLE
fix(studio): normalize site-build import reports

### DIFF
--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -89,7 +89,17 @@ export {
 
 const requireFromBench = createRequire(import.meta.url);
 
+export function normalizeImportReport(importReport) {
+  return {
+    report: null,
+    error: '',
+    ...(importReport && typeof importReport === 'object' ? importReport : {}),
+    reportPath: typeof importReport?.reportPath === 'string' ? importReport.reportPath : '',
+  };
+}
+
 export async function restoreMissingSourceStaticFiles(importReport, sitePath, result) {
+  const normalizedImportReport = normalizeImportReport(importReport);
   const writes = new Map();
   for (const call of Array.isArray(result?.toolCalls) ? result.toolCalls : []) {
     const filePath = call?.input?.file_path || call?.input?.path || '';
@@ -103,10 +113,10 @@ export async function restoreMissingSourceStaticFiles(importReport, sitePath, re
     return;
   }
 
-  for (const target of comparisonTargets(importReport)) {
+  for (const target of comparisonTargets(normalizedImportReport)) {
     const surfaces = target?.comparison_hooks?.render_surfaces || {};
     const sourceFile = surfaces.source_static?.url || target?.source_file || '';
-    const hostPath = resolveSourceStaticFile(sourceFile, importReport.reportPath, sitePath);
+    const hostPath = resolveSourceStaticFile(sourceFile, normalizedImportReport.reportPath, sitePath);
     if (!hostPath) {
       continue;
     }
@@ -129,7 +139,7 @@ export async function restoreMissingSourceStaticFiles(importReport, sitePath, re
 }
 
 export async function compareSemanticFidelity(importReport, artifactDir, sitePath) {
-  return compareSemanticFidelityImpl(importReport, artifactDir, sitePath, {
+  return compareSemanticFidelityImpl(normalizeImportReport(importReport), artifactDir, sitePath, {
     studioPath: STUDIO_PATH,
     viewport: VISUAL_VIEWPORT,
   });
@@ -427,7 +437,7 @@ export default async function studioAgentSiteBuildBench() {
   const qualityProbeMs = Date.now() - qualityProbeStarted;
   const status = await siteStatus(sitePath);
   runtime.assertPort(statusPort(status));
-  const importReport = await collectLatestImportReport(sitePath);
+  const importReport = normalizeImportReport(await collectLatestImportReport(sitePath));
   const importerTimings = importerTimingMetrics(importReport);
   await mkdir(artifactDir, { recursive: true });
   await restoreMissingSourceStaticFiles(importReport, sitePath, result);

--- a/Automattic/studio/bench/studio-agent-site-build.test.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.test.mjs
@@ -14,6 +14,7 @@ const {
   importerBlockQualityFailureDetails,
   importerBlockQualityMetrics,
   importerTimingMetrics,
+  normalizeImportReport,
   promptVariantCatalog,
   restoreMissingSourceStaticFiles,
   semanticTargetMetric,
@@ -228,6 +229,34 @@ test('bench restores missing SSI source files from Studio Write tool path input'
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
+});
+
+test('bench normalizes import reports without a reportPath', async () => {
+  const importReport = normalizeImportReport({ report: { quality: {} } });
+
+  assert.deepEqual(importReport, {
+    report: { quality: {} },
+    reportPath: '',
+    error: '',
+  });
+});
+
+test('bench source restore tolerates import reports without a reportPath', async () => {
+  await restoreMissingSourceStaticFiles(
+    {
+      report: {
+        visual_fidelity: {
+          comparison_targets: [
+            {
+              source_file: '/wordpress/tmp/static-site/index.html',
+            },
+          ],
+        },
+      },
+    },
+    '/tmp/studio-site',
+    { toolCalls: [] }
+  );
 });
 
 test('generated-theme discovery reports missing SSI import instead of throwing', async () => {


### PR DESCRIPTION
## Summary
- Normalize Studio site-build import report objects before downstream fidelity and source-restore helpers consume them.
- Add regression coverage for import reports that do not include `reportPath`, matching the warmup-path failure mode from #100.

Closes #100.

## Tests
- `HOMEBOY_NODEJS_WORKLOAD_UTILS=\"file:///Users/chubes/Developer/homeboy-extensions@issue-939-shared-browser-trace-shapes/nodejs/scripts/bench/lib/workload-utils.mjs\" HOMEBOY_NODEJS_INVOCATION_RUNTIME_HELPER=\"file:///Users/chubes/Developer/homeboy-extensions@issue-939-shared-browser-trace-shapes/nodejs/scripts/runtime/invocation-runtime.mjs\" node --test Automattic/studio/bench/studio-agent-site-build.test.mjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Investigated the Studio site-build warmup failure path, drafted the focused import-report normalization and regression tests, and ran targeted verification. Chris remains responsible for review and merge.