### PR TITLE
fix(studio): treat button wrappers as link-preserving

### DIFF
--- a/Automattic/studio/bench/lib/semantic-fidelity.mjs
+++ b/Automattic/studio/bench/lib/semantic-fidelity.mjs
@@ -209,6 +209,7 @@ function semanticFingerprintExtractor(groups) {
       role: roleOf(element),
       text: normalizeText(element.textContent),
       href: element.getAttribute('href') || '',
+      descendant_href: clickable.find((item) => item.getAttribute('href'))?.getAttribute('href') || '',
       own_classes: classTokens(element),
       child_classes: childClassTokens(element),
       contains_logo: containsLogo(element),
@@ -367,6 +368,25 @@ function semanticAllowsNavigationClassRoleChange(sourceOwner, frontendOwner) {
   );
 }
 
+function semanticAllowsLinkPreservingWrapper(sourceOwner, frontendOwner) {
+  if (semanticRole(sourceOwner) !== 'link' || semanticRole(frontendOwner) === 'link') {
+    return false;
+  }
+
+  if (Number(frontendOwner.clickable_descendant_count || 0) < 1) {
+    return false;
+  }
+
+  const sourceHref = String(sourceOwner.href || '');
+  const frontendHref = String(frontendOwner.href || frontendOwner.descendant_href || '');
+  if (sourceHref && sourceHref !== frontendHref) {
+    return false;
+  }
+
+  const frontendTokens = new Set(semanticTextTokens(frontendOwner.text));
+  return semanticTextTokens(sourceOwner.text).every((token) => frontendTokens.has(token));
+}
+
 function semanticMismatch(type, reason, source, frontend, extra = {}) {
   return {
     type,
@@ -380,7 +400,7 @@ function semanticMismatch(type, reason, source, frontend, extra = {}) {
   };
 }
 
-function compareSemanticFingerprints(source, frontend) {
+export function compareSemanticFingerprints(source, frontend) {
   const mismatches = [];
   const optionalSelectorAbsences = [];
   const counts = {
@@ -431,7 +451,7 @@ function compareSemanticFingerprints(source, frontend) {
     const sourceClickable = Number(sourceOwner.clickable_descendant_count || 0);
     const frontendClickable = Number(frontendOwner.clickable_descendant_count || 0);
 
-    if (sourceRole === 'link' && frontendRole !== 'link') {
+    if (sourceRole === 'link' && frontendRole !== 'link' && !semanticAllowsLinkPreservingWrapper(sourceOwner, frontendOwner)) {
       counts.role_mismatch_count++;
       counts.class_owner_changed_count++;
       if (frontendClickable > sourceClickable) {
@@ -448,6 +468,7 @@ function compareSemanticFingerprints(source, frontend) {
     if (
       roleChanged &&
       !semanticAllowsNavigationClassRoleChange(sourceOwner, frontendOwner) &&
+      !semanticAllowsLinkPreservingWrapper(sourceOwner, frontendOwner) &&
       (sourceInteractive || frontendInteractive || sourceOwner.concept || frontendOwner.concept)
     ) {
       counts.role_mismatch_count++;

--- a/Automattic/studio/bench/studio-agent-site-build.bench.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.bench.mjs
@@ -35,7 +35,7 @@ import {
   compareSemanticFidelity as compareSemanticFidelityImpl,
   semanticTargetMetric,
 } from './lib/semantic-fidelity.mjs';
-export { semanticMismatchFailureDetails, semanticTargetMetric } from './lib/semantic-fidelity.mjs';
+export { compareSemanticFingerprints, semanticMismatchFailureDetails, semanticTargetMetric } from './lib/semantic-fidelity.mjs';
 
 import { comparisonTargets, resolveSourceStaticFile } from './lib/fidelity-targets.mjs';
 export { resolveSourceStaticFile } from './lib/fidelity-targets.mjs';

--- a/Automattic/studio/bench/studio-agent-site-build.test.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.test.mjs
@@ -9,6 +9,7 @@ process.env.HOMEBOY_COMPONENT_PATH ||= '/tmp/homeboy-rigs-test-component';
 const {
   agentSuccessGate,
   availablePromptVariants,
+  compareSemanticFingerprints,
   createStudioBenchRuntime,
   hiddenEditorContentDiagnostics,
   importerBlockQualityFailureDetails,
@@ -310,6 +311,74 @@ test('zero semantic-fidelity mismatches keep successful agent runs green', () =>
   assert.equal(gate.metrics.agent_error_rate, 0);
   assert.equal(gate.semanticMismatchCount, 0);
   assert.deepEqual(gate.semanticFailureDetails, []);
+});
+
+test('semantic fidelity treats core/button wrappers as link-preserving', () => {
+  const comparison = compareSemanticFingerprints(
+    {
+      class_owners: [
+        {
+          role: 'link',
+          tag: 'a',
+          href: '#cta',
+          text: 'Start generating faster',
+          own_classes: ['button'],
+          clickable_descendant_count: 1,
+        },
+      ],
+    },
+    {
+      class_owners: [
+        {
+          role: 'group',
+          tag: 'div',
+          href: '',
+          descendant_href: '#cta',
+          text: 'Start generating faster',
+          own_classes: ['button'],
+          child_classes: ['wp-block-button__link', 'wp-element-button'],
+          clickable_descendant_count: 1,
+        },
+      ],
+    }
+  );
+
+  assert.equal(comparison.mismatch_count, 0);
+  assert.equal(comparison.role_mismatch_count, 0);
+  assert.equal(comparison.class_owner_changed_count, 0);
+});
+
+test('semantic fidelity still reports wrappers that lose link hrefs', () => {
+  const comparison = compareSemanticFingerprints(
+    {
+      class_owners: [
+        {
+          role: 'link',
+          tag: 'a',
+          href: '#cta',
+          text: 'Start generating faster',
+          own_classes: ['button'],
+          clickable_descendant_count: 1,
+        },
+      ],
+    },
+    {
+      class_owners: [
+        {
+          role: 'group',
+          tag: 'div',
+          href: '',
+          descendant_href: '',
+          text: 'Start generating faster',
+          own_classes: ['button'],
+          clickable_descendant_count: 1,
+        },
+      ],
+    }
+  );
+
+  assert.equal(comparison.mismatch_count, 1);
+  assert.equal(comparison.mismatches[0].reason, 'classed_link_became_non_link');
 });
 
 test('importer block-quality counters hard-fail the agent success gate', () => {


### PR DESCRIPTION
## Summary
- Treat generated Gutenberg `core/button` wrappers as link-preserving when their clickable descendant keeps the source link text and href.
- Preserve failure reporting when a wrapper loses the source link href.
- Add focused semantic-fidelity regression tests for both paths.

Closes #98.

## Tests
- `HOMEBOY_NODEJS_WORKLOAD_UTILS=\"file:///Users/chubes/Developer/homeboy-extensions@issue-939-shared-browser-trace-shapes/nodejs/scripts/bench/lib/workload-utils.mjs\" HOMEBOY_NODEJS_INVOCATION_RUNTIME_HELPER=\"file:///Users/chubes/Developer/homeboy-extensions@issue-939-shared-browser-trace-shapes/nodejs/scripts/runtime/invocation-runtime.mjs\" node --test Automattic/studio/bench/studio-agent-site-build.test.mjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Inspected the semantic comparator, drafted the wrapper-preservation check and regression tests, and ran focused verification. Chris remains responsible for review and merge.