### PR TITLE
feat(studio): expose Data Machine pipelines scale profile

### DIFF
--- a/Automattic/studio/bench/lib/datamachine-pipelines-scale-profile.mjs
+++ b/Automattic/studio/bench/lib/datamachine-pipelines-scale-profile.mjs
@@ -267,6 +267,7 @@ add_action('admin_init', function () {
 `;
 
   await mkdir(path.dirname(loaderPath), { recursive: true });
+  await mkdir(path.dirname(artifactPath), { recursive: true });
   await writeFile(loaderPath, php);
   await writeFile(
     artifactPath,

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -52,6 +52,10 @@ const {
 const {
   sanitizeArtifact,
 } = await import('./lib/studio-bench.mjs');
+const {
+  setupWordPressPageProfile: setupDatamachinePipelinesScaleProfile,
+  cleanupWordPressPageProfile: cleanupDatamachinePipelinesScaleProfile,
+} = await import('./lib/datamachine-pipelines-scale-profile.mjs');
 
 function withEnv(values, callback) {
   const previous = {};
@@ -204,6 +208,49 @@ test('wordpressPageProfilerSpec supports selector readiness and resource include
       assert.deepEqual(spec.resources.includeResourceSubstrings, ['/wp-json/', '/custom-cache/']);
     }
   );
+});
+
+test('Data Machine pipelines scale profile writes configurable seed loader and artifact', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'dm-pipelines-scale-'));
+  const sitePath = path.join(tempDir, 'site');
+  const artifactDir = path.join(tempDir, 'artifacts');
+
+  try {
+    const setupProfile = await withEnv(
+      {
+        HOMEBOY_DATAMACHINE_PIPELINE_COUNT: '2',
+        HOMEBOY_DATAMACHINE_FLOWS_PER_PIPELINE: '3',
+        HOMEBOY_DATAMACHINE_STEPS_PER_FLOW: '4',
+        HOMEBOY_DATAMACHINE_CONFIG_PAYLOAD_SIZE: '16',
+        HOMEBOY_DATAMACHINE_SCALE_SEED_SLUG: 'test-scale',
+      },
+      () => setupDatamachinePipelinesScaleProfile({ sitePath, artifactDir })
+    );
+
+    assert.equal(setupProfile.pipelineCount, 2);
+    assert.equal(setupProfile.flowsPerPipeline, 3);
+    assert.equal(setupProfile.stepsPerFlow, 4);
+    assert.equal(setupProfile.configPayloadSize, 16);
+    assert.equal(setupProfile.seedSlug, 'test-scale');
+
+    const loader = await readFile(setupProfile.loaderPath, 'utf8');
+    assert.match(loader, /Temporary Homeboy Data Machine scale profile loader/);
+    assert.match(loader, /test-scale/);
+    assert.match(loader, /datamachine_pipelines/);
+    assert.deepEqual(JSON.parse(await readFile(setupProfile.artifactPath, 'utf8')), {
+      pipelineCount: 2,
+      flowsPerPipeline: 3,
+      stepsPerFlow: 4,
+      configPayloadSize: 16,
+      seedSlug: 'test-scale',
+      loaderPath: setupProfile.loaderPath,
+    });
+
+    await cleanupDatamachinePipelinesScaleProfile({ setupProfile });
+    await assert.rejects(() => readFile(setupProfile.loaderPath, 'utf8'), { code: 'ENOENT' });
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
 });
 
 test('loadTimingCorrelator returns null module when the file is absent', () => {

--- a/Automattic/studio/rigs/studio-combined/rig.json
+++ b/Automattic/studio/rigs/studio-combined/rig.json
@@ -63,6 +63,10 @@
       "${package.root}/bench/studio-rest-latency-diagnostics.bench.mjs",
       "${package.root}/bench/studio-site-editor-browser.bench.mjs",
       "${package.root}/bench/studio-site-editor-diagnostics.bench.mjs",
+      {
+        "path": "${package.root}/bench/studio-datamachine-pipelines-scale-profile.bench.mjs",
+        "port_range_size": 10
+      },
       "${package.root}/bench/studio-site-editor-preload-comparison.bench.mjs",
       "${package.root}/bench/studio-site-editor-preload-diagnostics.bench.mjs"
     ]

--- a/Automattic/studio/rigs/studio-datamachine-pipelines-scale/rig.json
+++ b/Automattic/studio/rigs/studio-datamachine-pipelines-scale/rig.json
@@ -1,0 +1,26 @@
+{
+  "id": "studio-datamachine-pipelines-scale",
+  "description": "Studio WordPress admin profile for the Data Machine Pipelines page with a configurable scale fixture.",
+  "components": {
+    "studio": {
+      "path": "~/Developer/studio",
+      "branch": "dev/combined-fixes",
+      "extensions": {
+        "nodejs": {
+          "studio_bench_variant": "datamachine-pipelines-scale"
+        }
+      }
+    }
+  },
+  "bench": {
+    "default_component": "studio"
+  },
+  "bench_workloads": {
+    "nodejs": [
+      {
+        "path": "${package.root}/bench/studio-datamachine-pipelines-scale-profile.bench.mjs",
+        "port_range_size": 10
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Expose the existing Data Machine Pipelines scale profile as a dedicated Studio rig scenario.
- Add the profile to the Studio combined rig workload list so it is discoverable with the broader Studio diagnostics suite.
- Ensure the scale setup creates its seed artifact directory and add focused coverage for configurable seed loader/artifact generation and cleanup.

Closes #118.

## Tests
- `HOMEBOY_NODEJS_WORKLOAD_UTILS=\"file:///Users/chubes/Developer/homeboy-extensions@issue-939-shared-browser-trace-shapes/nodejs/scripts/bench/lib/workload-utils.mjs\" HOMEBOY_NODEJS_BROWSER_BENCH_HELPER=\"file:///Users/chubes/Developer/homeboy-extensions@issue-939-shared-browser-trace-shapes/nodejs/scripts/bench/browser-helper.mjs\" node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `git diff --check`
- `node --check Automattic/studio/bench/studio-datamachine-pipelines-scale-profile.bench.mjs`
- `node --check Automattic/studio/bench/lib/datamachine-pipelines-scale-profile.mjs`
- `node -e \"JSON.parse(require('node:fs').readFileSync('Automattic/studio/rigs/studio-datamachine-pipelines-scale/rig.json','utf8')); JSON.parse(require('node:fs').readFileSync('Automattic/studio/rigs/studio-combined/rig.json','utf8'));\"`

## Notes
- `homeboy bench list --rig studio-datamachine-pipelines-scale` could not verify locally because the rig is not installed in the local Homeboy rig registry yet. The PR adds the rig file and validates its JSON syntax.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Inspected the existing scale profile workload, wired it into rig scenarios, fixed setup artifact directory creation, and ran focused verification. Chris remains responsible for review and merge.