### PR TITLE
fix(gutenberg): run RTC rig through Codebox

### DIFF
--- a/WordPress/gutenberg/README.md
+++ b/WordPress/gutenberg/README.md
@@ -5,9 +5,8 @@ in the post editor.
 
 ## Goals
 
-- Exercise real editor behavior with Playwright for small and medium scenarios.
-- Exercise the real `/wp-sync/v1/updates` WordPress endpoint with synthetic Yjs
-  clients for high-cardinality load.
+- Exercise the real `/wp-sync/v1/updates` WordPress endpoint inside the
+  WP Codebox-backed WordPress bench runtime.
 - Capture benchmark metrics, traces, final document snapshots, seeds, and
   reproduction commands as Homeboy artifacts.
 - Keep repeatable failures tied to Gutenberg issues or PRs before using rig
@@ -18,31 +17,27 @@ in the post editor.
 ```bash
 homeboy rig install /Users/chubes/Developer/homeboy-rigs@<branch>/WordPress/gutenberg
 homeboy rig check gutenberg-rtc
-homeboy bench --rig gutenberg-rtc --scenario gutenberg-rtc-browser-basic --iterations 1
-homeboy bench --rig gutenberg-rtc --scenario gutenberg-rtc-protocol-load --iterations 1 --setting rtc_clients=100
-homeboy bench --rig gutenberg-rtc --profile hot --iterations 1 --setting rtc_clients=1000 --force-hot
+homeboy bench --rig gutenberg-rtc --scenario gutenberg-rtc-protocol-load --iterations 1
+homeboy bench --rig gutenberg-rtc --profile hot --iterations 1 --setting-json 'bench_env={"GUTENBERG_RTC_CLIENTS":"1000"}' --force-hot
 ```
 
-`homeboy bench --rig gutenberg-rtc` runs the rig's `bench_prepare` pipeline before
-the timed workload. That pipeline installs Gutenberg npm dependencies when
-`node_modules/.bin/wp-env` is missing, then Homeboy runs the normal rig health
-check before benchmark timing starts.
+`homeboy bench --rig gutenberg-rtc` runs through Homeboy Extensions'
+`wordpress.bench` / WP Codebox backend. WP Codebox owns the disposable WordPress
+runtime, mounts Gutenberg as the runtime plugin, mounts the rig's PHP workload
+into `tests/bench/`, and returns the normalized Homeboy `BenchResults` envelope.
 
 ## Layers
 
 ```text
-Playwright editor sessions        2-25 clients, real UI correctness
-Synthetic Yjs/REST clients        10-1000 clients, real WP sync endpoint load
-Seeded conflict fuzzer            deterministic operation streams
-Settings matrix                   roles, post states, metaboxes, autosave, doc size
+WP Codebox WordPress runtime      disposable WP 7.1 runtime, no Docker/wp-env
+Synthetic REST clients            10-1000 clients, real WP sync endpoint load
+Homeboy BenchResults              normalized metrics, metadata, artifacts
 ```
 
 See `docs/rtc-rig-plan.md` for the implementation plan.
 
 ## Current Workloads
 
-- `gutenberg-rtc-browser-basic` runs core two-user collaboration Playwright specs.
-- `gutenberg-rtc-browser-tabs` runs reload, self-presence, and cursor-awareness specs.
-- `gutenberg-rtc-protocol-load` starts `wp-env-test`, creates a draft post, enables RTC, then drives `/wp-sync/v1/updates` with configurable synthetic clients. It uses Yjs when Gutenberg dependencies expose `yjs`, and falls back to opaque sync payloads so endpoint/storage load still runs on lean installs.
-- `gutenberg-rtc-conflict-fuzzer` runs the existing stress, undo/redo, and block-gauntlet specs as the first correctness gauntlet.
-- `gutenberg-rtc-settings-matrix` runs metabox, document-size, sync-error, and autodraft specs.
+- `gutenberg-rtc-protocol-load` runs inside WP Codebox, creates a draft post,
+  enables RTC, and drives `/wp-sync/v1/updates` with configurable synthetic
+  clients using opaque sync payloads.

--- a/WordPress/gutenberg/bench/gutenberg-rtc-protocol-load.php
+++ b/WordPress/gutenberg/bench/gutenberg-rtc-protocol-load.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * WP Codebox-backed Gutenberg RTC protocol workload.
+ *
+ * Runs inside the disposable WordPress runtime owned by `wordpress.bench`.
+ */
+return function (): array {
+	$client_count = max( 1, min( 5000, (int) ( getenv( 'GUTENBERG_RTC_CLIENTS' ) ?: 10 ) ) );
+	$rounds       = max( 1, min( 100, (int) ( getenv( 'GUTENBERG_RTC_ROUNDS' ) ?: 3 ) ) );
+	$batch_size   = max( 1, min( 50, (int) ( getenv( 'GUTENBERG_RTC_BATCH_SIZE' ) ?: 25 ) ) );
+	$run_id       = 'gutenberg-rtc-codebox-' . getmypid() . '-' . time() . '-' . wp_generate_password( 6, false );
+
+	if ( ! function_exists( 'rest_do_request' ) ) {
+		throw new RuntimeException( 'WordPress REST API is not available.' );
+	}
+
+	wp_set_current_user( 1 );
+	update_option( 'wp_collaboration_enabled', '1' );
+
+	$post_id = wp_insert_post(
+		array(
+			'post_type'   => 'post',
+			'post_status' => 'draft',
+			'post_title'  => 'Homeboy RTC Protocol Load ' . $run_id,
+		),
+		true
+	);
+	if ( is_wp_error( $post_id ) ) {
+		throw new RuntimeException( $post_id->get_error_message() );
+	}
+
+	$room              = 'postType/post:' . (int) $post_id;
+	$clients           = array();
+	$latencies         = array();
+	$statuses          = array();
+	$response_rows     = array();
+	$requests_total    = 0;
+	$updates_sent      = 0;
+	$updates_applied   = 0;
+	$http_4xx          = 0;
+	$http_5xx          = 0;
+	$started           = microtime( true );
+
+	for ( $i = 0; $i < $client_count; $i++ ) {
+		$clients[] = array(
+			'client_id' => $i + 1,
+			'cursor'    => 0,
+			'seen'      => array(),
+		);
+	}
+
+	$dispatch = static function ( array $rooms ) use ( &$latencies, &$statuses, &$requests_total, &$http_4xx, &$http_5xx ): array {
+		$request = new WP_REST_Request( 'POST', '/wp-sync/v1/updates' );
+		$request->set_body_params( array( 'rooms' => $rooms ) );
+
+		$before   = microtime( true );
+		$response = rest_do_request( $request );
+		$elapsed  = ( microtime( true ) - $before ) * 1000;
+		$status   = is_wp_error( $response ) ? 500 : (int) $response->get_status();
+		$data     = is_wp_error( $response ) ? array( 'error' => $response->get_error_message() ) : rest_get_server()->response_to_data( $response, false );
+
+		$requests_total++;
+		$latencies[]        = $elapsed;
+		$statuses[ $status ] = ( $statuses[ $status ] ?? 0 ) + 1;
+		if ( $status >= 400 && $status < 500 ) {
+			$http_4xx++;
+		}
+		if ( $status >= 500 ) {
+			$http_5xx++;
+		}
+
+		return array(
+			'status'     => $status,
+			'elapsed_ms' => $elapsed,
+			'data'       => $data,
+		);
+	};
+
+	for ( $round = 0; $round < $rounds; $round++ ) {
+		for ( $offset = 0; $offset < $client_count; $offset += $batch_size ) {
+			$batch = array_slice( $clients, $offset, $batch_size, true );
+			$rooms = array();
+			foreach ( $batch as $index => $client ) {
+				$payload = base64_encode( 'client:' . $client['client_id'] . ':round:' . $round . ':run:' . $run_id );
+				$clients[ $index ]['seen'][ sha1( $payload ) ] = true;
+				$updates_sent++;
+				$rooms[] = array(
+					'after'     => $client['cursor'],
+					'awareness' => array(
+						'user'   => array( 'name' => 'RTC ' . $client['client_id'] ),
+						'cursor' => array( 'round' => $round, 'offset' => $client['client_id'] ),
+					),
+					'client_id' => $client['client_id'],
+					'room'      => $room,
+					'updates'   => array(
+						array(
+							'data' => $payload,
+							'type' => 'update',
+						),
+					),
+				);
+			}
+
+			$result          = $dispatch( $rooms );
+			$response_rows[] = array(
+				'round'      => $round,
+				'offset'     => $offset,
+				'status'     => $result['status'],
+				'elapsed_ms' => $result['elapsed_ms'],
+				'room_count' => count( $rooms ),
+			);
+			if ( $result['status'] < 200 || $result['status'] >= 300 || empty( $result['data']['rooms'] ) || ! is_array( $result['data']['rooms'] ) ) {
+				throw new RuntimeException( 'sync request failed with HTTP ' . $result['status'] );
+			}
+
+			foreach ( array_values( $batch ) as $batch_index => $client ) {
+				$room_response = $result['data']['rooms'][ $batch_index ] ?? array();
+				$client_index  = $offset + $batch_index;
+				if ( isset( $room_response['end_cursor'] ) ) {
+					$clients[ $client_index ]['cursor'] = (int) $room_response['end_cursor'];
+				}
+				foreach ( $room_response['updates'] ?? array() as $update ) {
+					if ( isset( $update['data'] ) ) {
+						$clients[ $client_index ]['seen'][ sha1( (string) $update['data'] ) ] = true;
+						$updates_applied++;
+					}
+				}
+			}
+		}
+	}
+
+	for ( $offset = 0; $offset < $client_count; $offset += $batch_size ) {
+		$batch = array_slice( $clients, $offset, $batch_size, true );
+		$rooms = array();
+		foreach ( $batch as $client ) {
+			$rooms[] = array(
+				'after'     => $client['cursor'],
+				'awareness' => null,
+				'client_id' => $client['client_id'],
+				'room'      => $room,
+				'updates'   => array(),
+			);
+		}
+		$result = $dispatch( $rooms );
+		if ( $result['status'] < 200 || $result['status'] >= 300 || empty( $result['data']['rooms'] ) || ! is_array( $result['data']['rooms'] ) ) {
+			throw new RuntimeException( 'catch-up request failed with HTTP ' . $result['status'] );
+		}
+		foreach ( array_values( $batch ) as $batch_index => $client ) {
+			$room_response = $result['data']['rooms'][ $batch_index ] ?? array();
+			$client_index  = $offset + $batch_index;
+			if ( isset( $room_response['end_cursor'] ) ) {
+				$clients[ $client_index ]['cursor'] = (int) $room_response['end_cursor'];
+			}
+			foreach ( $room_response['updates'] ?? array() as $update ) {
+				if ( isset( $update['data'] ) ) {
+					$clients[ $client_index ]['seen'][ sha1( (string) $update['data'] ) ] = true;
+					$updates_applied++;
+				}
+			}
+		}
+	}
+
+	$elapsed_ms          = ( microtime( true ) - $started ) * 1000;
+	$final_state_hashes  = array_map(
+		static fn ( array $client ): string => sha1( implode( ',', array_keys( $client['seen'] ) ) ),
+		$clients
+	);
+	$unique_state_hashes = count( array_unique( $final_state_hashes ) );
+	$divergent_clients   = max( 0, $unique_state_hashes - 1 );
+	sort( $latencies, SORT_NUMERIC );
+	$percentile = static function ( array $values, float $percentile ): float {
+		if ( empty( $values ) ) {
+			return 0.0;
+		}
+		$index = (int) floor( ( count( $values ) - 1 ) * $percentile );
+		return (float) $values[ $index ];
+	};
+
+	$artifact_path = '';
+	$shared_state  = getenv( 'HOMEBOY_BENCH_SHARED_STATE' );
+	if ( $shared_state ) {
+		$artifact_dir = rtrim( $shared_state, '/' ) . '/gutenberg-rtc-protocol-load';
+		wp_mkdir_p( $artifact_dir );
+		$artifact_path = $artifact_dir . '/' . $run_id . '.json';
+		file_put_contents(
+			$artifact_path,
+			wp_json_encode(
+				array(
+					'run_id'        => $run_id,
+					'post_id'       => (int) $post_id,
+					'room'          => $room,
+					'response_rows' => $response_rows,
+					'statuses'      => $statuses,
+				),
+				JSON_PRETTY_PRINT
+			) . "\n"
+		);
+	}
+
+	if ( $divergent_clients > 0 ) {
+		throw new RuntimeException( 'synthetic clients did not converge; divergent_clients=' . $divergent_clients );
+	}
+
+	return array(
+		'metrics'   => array(
+			'success_rate'              => 1,
+			'client_count'              => $client_count,
+			'rounds'                    => $rounds,
+			'batch_size'                => $batch_size,
+			'requests_total'            => $requests_total,
+			'requests_per_second'       => $elapsed_ms > 0 ? $requests_total / ( $elapsed_ms / 1000 ) : 0,
+			'updates_sent'              => $updates_sent,
+			'updates_applied'           => $updates_applied,
+			'sync_p50_ms'               => $percentile( $latencies, 0.50 ),
+			'sync_p95_ms'               => $percentile( $latencies, 0.95 ),
+			'sync_p99_ms'               => $percentile( $latencies, 0.99 ),
+			'sync_max_ms'               => empty( $latencies ) ? 0 : max( $latencies ),
+			'http_4xx_count'            => $http_4xx,
+			'http_5xx_count'            => $http_5xx,
+			'divergent_clients'         => $divergent_clients,
+			'unique_final_state_hashes' => $unique_state_hashes,
+			'total_elapsed_ms'          => $elapsed_ms,
+		),
+		'metadata'  => array(
+			'runner'       => 'wp-codebox',
+			'payload_mode' => 'opaque',
+			'room'         => $room,
+			'post_id'      => (int) $post_id,
+		),
+		'artifacts' => $artifact_path ? array( 'raw_result' => array( 'path' => $artifact_path, 'kind' => 'json' ) ) : array(),
+	);
+};

--- a/WordPress/gutenberg/docs/rtc-rig-plan.md
+++ b/WordPress/gutenberg/docs/rtc-rig-plan.md
@@ -3,17 +3,13 @@
 ## 1. Rig Contract
 
 Create a package installable with `homeboy rig install ./WordPress/gutenberg`.
-The rig points at the local Gutenberg checkout and runs Homeboy Node benchmark
-workloads from this package.
+The rig points at the local Gutenberg checkout and runs WordPress benchmark
+workloads through Homeboy Extensions' WP Codebox backend.
 
 ```text
 WordPress/gutenberg/
   rigs/gutenberg-rtc/rig.json
-  bench/gutenberg-rtc-browser-basic.bench.mjs
-  bench/gutenberg-rtc-browser-tabs.bench.mjs
-  bench/gutenberg-rtc-protocol-load.bench.mjs
-  bench/gutenberg-rtc-conflict-fuzzer.bench.mjs
-  bench/gutenberg-rtc-settings-matrix.bench.mjs
+  bench/gutenberg-rtc-protocol-load.php
 ```
 
 ## 2. Benchmark Pyramid
@@ -139,15 +135,14 @@ Axes:
 
 ## 3. Implementation Sequence
 
-1. Make `homeboy bench list --rig gutenberg-rtc` discover all scenario IDs.
-2. Implement `browser-basic` by reusing Gutenberg's existing collaboration e2e
-   helpers where possible.
-3. Implement `protocol-load` with synthetic Yjs clients that authenticate once,
-   create one post, and hit `/wp-sync/v1/updates` directly.
+1. Make `homeboy bench list --rig gutenberg-rtc` discover the WP Codebox-backed
+   protocol scenario.
+2. Implement `protocol-load` as a PHP `wordpress.bench` workload mounted from
+   the rig package into the disposable Codebox runtime.
+3. Create one post, enable collaboration, and hit `/wp-sync/v1/updates` directly
+   through the WordPress REST server.
 4. Add artifact capture and deterministic seeds.
-5. Use the rig `bench_prepare` pipeline to bootstrap Gutenberg dependencies
-   before timed workload execution when `wp-env` is missing.
-6. Run local smoke: 2 browser users, 10 synthetic clients.
+5. Run local smoke with 10 synthetic clients.
 7. Add hot profiles: 100 synthetic clients and 1000 synthetic clients, intended
    for `homeboy bench --runner <lab-runner>` or `--force-hot`.
 8. Promote recurring failures into Gutenberg issues/PRs with artifact links.

--- a/WordPress/gutenberg/rigs/gutenberg-rtc/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-rtc/rig.json
@@ -1,13 +1,18 @@
 {
   "id": "gutenberg-rtc",
-  "description": "Gutenberg real-time collaboration stress rig. Uses Playwright for small/medium editor correctness scenarios and synthetic Yjs/REST clients for high-cardinality sync endpoint load.",
+  "description": "Gutenberg real-time collaboration stress rig. Uses the WordPress/WP Codebox bench runtime for synthetic high-cardinality sync endpoint load.",
   "components": {
     "gutenberg": {
       "path": "~/Developer/gutenberg",
       "branch": "trunk",
       "extensions": {
-        "nodejs": {
-          "gutenberg_rtc_component_path": "~/Developer/gutenberg"
+        "wordpress": {
+          "wp_codebox_wordpress_version": "7.1",
+          "bench_env": {
+            "GUTENBERG_RTC_CLIENTS": "10",
+            "GUTENBERG_RTC_ROUNDS": "3",
+            "GUTENBERG_RTC_BATCH_SIZE": "25"
+          }
         }
       }
     }
@@ -25,22 +30,16 @@
     "warmup_iterations": 0
   },
   "bench_workloads": {
-    "nodejs": [
-      { "path": "${package.root}/bench/gutenberg-rtc-browser-basic.bench.mjs" },
-      { "path": "${package.root}/bench/gutenberg-rtc-browser-tabs.bench.mjs" },
-      { "path": "${package.root}/bench/gutenberg-rtc-protocol-load.bench.mjs" },
-      { "path": "${package.root}/bench/gutenberg-rtc-conflict-fuzzer.bench.mjs" },
-      { "path": "${package.root}/bench/gutenberg-rtc-settings-matrix.bench.mjs" }
+    "wordpress": [
+      { "path": "${package.root}/bench/gutenberg-rtc-protocol-load.php" }
     ]
   },
   "bench_profiles": {
     "smoke": [
-      "gutenberg-rtc-browser-basic",
       "gutenberg-rtc-protocol-load"
     ],
     "hot": [
-      "gutenberg-rtc-protocol-load",
-      "gutenberg-rtc-conflict-fuzzer"
+      "gutenberg-rtc-protocol-load"
     ]
   },
   "pipeline": {
@@ -68,20 +67,7 @@
         "command": "test -f lib/compat/wordpress-7.1/class-wp-http-polling-sync-server.php || test -f lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php"
       }
     ],
-    "bench_prepare": [
-      {
-        "kind": "check",
-        "label": "Gutenberg checkout exists",
-        "file": "${components.gutenberg.path}/package.json",
-        "contains": "\"name\": \"gutenberg\""
-      },
-      {
-        "kind": "command",
-        "label": "Install Gutenberg npm dependencies when missing",
-        "cwd": "${components.gutenberg.path}",
-        "command": "if [ ! -x node_modules/.bin/wp-env ]; then npm install; fi"
-      }
-    ],
+    "bench_prepare": [],
     "up": [],
     "down": []
   }


### PR DESCRIPTION
## Summary
- Move the Gutenberg RTC protocol benchmark off the Node/wp-env path and onto the WordPress/WP Codebox bench backend.
- Add a PHP `wordpress.bench` workload that enables collaboration, creates a draft post, and drives `/wp-sync/v1/updates` in the disposable Codebox runtime.
- Remove the rig's npm/wp-env `bench_prepare` step and update docs to describe the Codebox runtime path.

## Verification
- `jq empty WordPress/gutenberg/rigs/gutenberg-rtc/rig.json`
- `php -l WordPress/gutenberg/bench/gutenberg-rtc-protocol-load.php`
- With paired Homeboy and Homeboy Extensions branches installed locally: `homeboy rig install ...`, `homeboy rig check gutenberg-rtc`, and `homeboy bench list --rig gutenberg-rtc --extension wordpress` report the Codebox scenario.
- Local execution now enters the Codebox path; the one-iteration smoke exceeded the tool timeout and was reconciled stale, so runtime execution still needs follow-up after the paired upstream PRs land.

## Dependencies
- Requires Extra-Chill/homeboy-extensions PR for mounting rig-provided workloads into WP Codebox.
- Benefits from Extra-Chill/homeboy PR for reinstalling over stale broken rig symlinks during local iteration.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Migrated the rig shape and workload away from `wp-env`, drafted docs, and ran local syntax/list verification; Chris remains responsible for review and merge.