### PR TITLE
Define Gutenberg RTC divergence semantics

### DIFF
--- a/WordPress/gutenberg/README.md
+++ b/WordPress/gutenberg/README.md
@@ -41,3 +41,15 @@ See `docs/rtc-rig-plan.md` for the implementation plan.
 - `gutenberg-rtc-protocol-load` runs inside WP Codebox, creates a draft post,
   enables RTC, and drives `/wp-sync/v1/updates` with configurable synthetic
   clients using opaque sync payloads.
+
+## Metric Semantics
+
+- `divergent_clients` is an opaque synthetic-payload stress signal for the
+  protocol-load workload. Opaque payloads are intentionally not a full Yjs
+  document model, so non-zero divergence means clients observed different
+  synthetic update sets under load; it is not by itself a correctness failure.
+- Pass/fail gates for opaque protocol-load runs stay tied to endpoint health,
+  request handling, and artifact capture. Track `divergent_clients` over time in
+  scale-matrix summaries to spot changes in sync behavior under load.
+- When the workload runs with real Yjs payloads, non-zero divergence is a
+  convergence failure because clients should reach the same document state.

--- a/WordPress/gutenberg/bench/gutenberg-rtc-protocol-load.bench.mjs
+++ b/WordPress/gutenberg/bench/gutenberg-rtc-protocol-load.bench.mjs
@@ -311,6 +311,7 @@ export default async function gutenbergRtcProtocolLoad() {
       expectedUpdateHashes.add(updateHash);
     }
   }
+  // Opaque payloads intentionally model endpoint stress, not document correctness.
   const texts = Y ? clients.map((client) => client.text.toString()) : clients.map((client) => [...client.seenUpdateHashes].sort().join(','));
   const finalTextHash = hash(texts[0] || '');
   const divergentClients = texts.filter((text) => hash(text) !== finalTextHash).length;
@@ -353,8 +354,8 @@ export default async function gutenbergRtcProtocolLoad() {
   await writeJson(rawResultFile, result);
   await writeText(responseLogFile, responseRows.map((row) => JSON.stringify(row)).join('\n'));
 
-  if (divergentClients > 0) {
-    throw new Error(`synthetic clients did not converge; divergent_clients=${divergentClients}; raw_result=${rawResultFile}`);
+  if (Y && divergentClients > 0) {
+    throw new Error(`Yjs clients did not converge; divergent_clients=${divergentClients}; raw_result=${rawResultFile}`);
   }
 
   return {

--- a/WordPress/gutenberg/bench/gutenberg-rtc-protocol-load.php
+++ b/WordPress/gutenberg/bench/gutenberg-rtc-protocol-load.php
@@ -179,7 +179,14 @@ return function (): array {
 		$clients
 	);
 	$unique_state_hashes = count( array_unique( $final_state_hashes ) );
-	$divergent_clients   = max( 0, $unique_state_hashes - 1 );
+	// Opaque payload divergence is a stress signal, not a correctness failure.
+	$baseline_hash       = $final_state_hashes[0] ?? '';
+	$divergent_clients   = count(
+		array_filter(
+			$final_state_hashes,
+			static fn ( string $state_hash ): bool => $state_hash !== $baseline_hash
+		)
+	);
 	sort( $latencies, SORT_NUMERIC );
 	$percentile = static function ( array $values, float $percentile ): float {
 		if ( empty( $values ) ) {

--- a/WordPress/gutenberg/docs/rtc-rig-plan.md
+++ b/WordPress/gutenberg/docs/rtc-rig-plan.md
@@ -85,7 +85,15 @@ Metrics:
 - `http_5xx_count`
 - `stored_update_count`
 - `compaction_count`
+- `divergent_clients`
 - `final_crdt_equal`
+
+`divergent_clients` is a tracked stress signal for opaque synthetic payloads,
+not a correctness gate. It counts clients whose observed synthetic update set
+differs from the baseline client after catch-up. Treat non-zero values as scale
+matrix evidence to compare across runs. In real Yjs payload mode, divergence is a
+convergence failure because all clients should share the same final document
+state.
 
 Artifacts:
 
@@ -154,6 +162,8 @@ Axes:
 - Use synthetic clients for 100/1000-client load while preserving the real
   WordPress REST server, auth, permission, storage, compaction, and payload
   limits.
+- Treat opaque synthetic-payload divergence as a metric, not a hard failure;
+  reserve convergence failure gates for realistic document payloads.
 - Keep scenario failures reproducible with `seed`, `client_count`, `operation`
   profile, and created post ID in the artifact.
 - Do not publish local-only artifact paths as maintainer-facing evidence; mirror


### PR DESCRIPTION
## Summary
- Define `divergent_clients` as an opaque synthetic-payload stress signal, not a correctness failure.
- Align workload gating so opaque divergence remains a metric while real Yjs divergence remains a convergence failure.
- Clarify scale-matrix interpretation in the Gutenberg RTC rig docs.

## Validation
- `node --check WordPress/gutenberg/bench/gutenberg-rtc-protocol-load.bench.mjs`
- `php -l WordPress/gutenberg/bench/gutenberg-rtc-protocol-load.php`
- `homeboy rig install /Users/chubes/Developer/homeboy-rigs@docs-gutenberg-rtc-divergence-semantics/WordPress/gutenberg && homeboy rig check gutenberg-rtc`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the documentation and workload semantics update; Chris remains responsible for review and merge.

Closes #154.