### PR TITLE
Clarify Gutenberg RTC Codebox boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ WooCommerce site-generation benchmarks are tracked as future work until the Stud
 
 ## WordPress/gutenberg
 
-`rigs/gutenberg-rtc/rig.json` is the planned Gutenberg real-time collaboration stress rig. It currently exposes one WP Codebox-backed WordPress bench workload, `gutenberg-rtc-protocol-load`, for high-cardinality synthetic REST load against the real WordPress sync endpoint.
+`rigs/gutenberg-rtc/rig.json` is the planned Gutenberg real-time collaboration stress rig. It currently exposes one `homeboy-rigs` workload, `gutenberg-rtc-protocol-load`, that runs through the Homeboy Extensions WordPress bench adapter on a disposable WP Codebox runtime for high-cardinality synthetic REST load against the real WordPress sync endpoint.
 
 ```bash
 homeboy rig install ./WordPress/gutenberg

--- a/WordPress/gutenberg/README.md
+++ b/WordPress/gutenberg/README.md
@@ -5,8 +5,8 @@ in the post editor.
 
 ## Goals
 
-- Exercise the real `/wp-sync/v1/updates` WordPress endpoint inside the
-  WP Codebox-backed WordPress bench runtime.
+- Exercise the real `/wp-sync/v1/updates` WordPress endpoint through the
+  Homeboy Extensions WordPress bench adapter on a disposable WP Codebox runtime.
 - Capture benchmark metrics, traces, final document snapshots, seeds, and
   reproduction commands as Homeboy artifacts.
 - Keep repeatable failures tied to Gutenberg issues or PRs before using rig
@@ -21,26 +21,29 @@ homeboy bench --rig gutenberg-rtc --scenario gutenberg-rtc-protocol-load --itera
 homeboy bench --rig gutenberg-rtc --profile hot --iterations 1 --setting-json 'bench_env={"GUTENBERG_RTC_CLIENTS":"1000"}' --force-hot
 ```
 
-`homeboy bench --rig gutenberg-rtc` runs through Homeboy Extensions'
-`wordpress.bench` / WP Codebox backend. WP Codebox owns the disposable WordPress
-runtime, mounts Gutenberg as the runtime plugin, mounts the rig's PHP workload
-into `tests/bench/`, and returns the normalized Homeboy `BenchResults` envelope.
+`homeboy-rigs` owns the RTC workload. `homeboy bench --rig gutenberg-rtc`
+runs it through Homeboy Extensions' `wordpress.bench` adapter, which uses
+WP Codebox as a disposable WordPress runtime substrate. The adapter mounts
+Gutenberg as the runtime plugin, mounts the rig's PHP workload into
+`tests/bench/`, and returns the normalized Homeboy `BenchResults` envelope.
 
 ## Layers
 
 ```text
-WP Codebox WordPress runtime      disposable WP 7.0 runtime, no Docker/wp-env
+homeboy-rigs workload             Gutenberg-specific protocol-load PHP workload
+Homeboy Extensions wordpress.bench adapter and BenchResults envelope
+WP Codebox runtime substrate      disposable WP 7.0 runtime, no Docker/wp-env
 Synthetic REST clients            10-1000 clients, real WP sync endpoint load
-Homeboy BenchResults              normalized metrics, metadata, artifacts
 ```
 
 See `docs/rtc-rig-plan.md` for the implementation plan.
 
 ## Current Workloads
 
-- `gutenberg-rtc-protocol-load` runs inside WP Codebox, creates a draft post,
-  enables RTC, and drives `/wp-sync/v1/updates` with configurable synthetic
-  clients using opaque sync payloads.
+- `gutenberg-rtc-protocol-load` is a `homeboy-rigs` PHP workload that runs in
+  the disposable WP Codebox runtime, creates a draft post, enables RTC, and
+  drives `/wp-sync/v1/updates` with configurable synthetic clients using opaque
+  sync payloads.
 
 ## Metric Semantics
 

--- a/WordPress/gutenberg/docs/rtc-rig-plan.md
+++ b/WordPress/gutenberg/docs/rtc-rig-plan.md
@@ -3,8 +3,9 @@
 ## 1. Rig Contract
 
 Create a package installable with `homeboy rig install ./WordPress/gutenberg`.
-The rig points at the local Gutenberg checkout and runs WordPress benchmark
-workloads through Homeboy Extensions' WP Codebox backend.
+The rig points at the local Gutenberg checkout and owns the Gutenberg-specific
+protocol-load workload. Homeboy Extensions' `wordpress.bench` adapter runs that
+workload on a disposable WP Codebox WordPress runtime.
 
 ```text
 WordPress/gutenberg/
@@ -55,7 +56,7 @@ Artifacts:
 
 ## 3. Implementation Sequence
 
-1. Make `homeboy bench list --rig gutenberg-rtc` discover the WP Codebox-backed
+1. Make `homeboy bench list --rig gutenberg-rtc` discover the `homeboy-rigs`
    protocol scenario.
 2. Implement `protocol-load` as a PHP `wordpress.bench` workload mounted from
    the rig package into the disposable Codebox runtime.


### PR DESCRIPTION
## Summary
- Clarify that `homeboy-rigs` owns the Gutenberg RTC workload.
- Describe Homeboy Extensions' `wordpress.bench` adapter as the bench composition layer and WP Codebox as the disposable WordPress runtime substrate.
- Avoid wording that implies WP Codebox owns RTC load semantics or benchmark policy.

Follow-up to #160.

## Verification
- `jq empty WordPress/gutenberg/rigs/gutenberg-rtc/rig.json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the documentation boundary clarification and prepared the PR description for Chris to review.