### PR TITLE
refactor(studio): adopt WordPress helper discovery

### DIFF
--- a/Automattic/studio/bench/lib/site-editor-timing-deltas.mjs
+++ b/Automattic/studio/bench/lib/site-editor-timing-deltas.mjs
@@ -16,27 +16,11 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 import { setting } from './studio-bench.mjs';
+import { wordpressHelperPath } from './wordpress-helper-discovery.mjs';
 
 const require = createRequire(import.meta.url);
 
 const TIMING_CORRELATOR_FILENAME = 'timing-correlator.js';
-
-function wordpressHelperManifestPath() {
-  return setting('wordpress_helper_manifest_path') || process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST || '';
-}
-
-export function wordpressHelperPath(name) {
-  const manifestPath = wordpressHelperManifestPath();
-  if (!manifestPath || !existsSync(manifestPath)) {
-    return '';
-  }
-
-  const manifest = require(manifestPath);
-  const resolved = typeof manifest.getWordPressHelperManifest === 'function'
-    ? manifest.getWordPressHelperManifest()
-    : manifest.WORDPRESS_HELPER_MANIFEST || manifest;
-  return typeof resolved?.helpers?.[name] === 'string' ? resolved.helpers[name] : '';
-}
 
 /**
  * Resolve the WordPress request profiler path used by the diagnostics
@@ -45,9 +29,9 @@ export function wordpressHelperPath(name) {
  * @returns {string}
  */
 export function requestProfilerPath() {
-  return setting('wordpress_request_profiler_path') ||
-    process.env.HOMEBOY_WORDPRESS_REQUEST_PROFILER_HELPER ||
-    wordpressHelperPath('requestProfiler');
+  return setting('wordpress_request_profiler_path') || wordpressHelperPath('requestProfiler', {
+    envVar: 'HOMEBOY_WORDPRESS_REQUEST_PROFILER_HELPER',
+  });
 }
 
 /**
@@ -65,13 +49,11 @@ export function requestProfilerPath() {
  * @returns {string}
  */
 export function timingCorrelatorPath(options = {}) {
-  const explicit = options.override ?? setting('wordpress_timing_correlator_path');
+  const explicit = options.override ?? (setting('wordpress_timing_correlator_path') || wordpressHelperPath('timingCorrelator', {
+    envVar: 'HOMEBOY_WORDPRESS_TIMING_CORRELATOR_HELPER',
+  }));
   if (explicit) {
     return explicit;
-  }
-  const helper = process.env.HOMEBOY_WORDPRESS_TIMING_CORRELATOR_HELPER || wordpressHelperPath('timingCorrelator');
-  if (helper) {
-    return helper;
   }
   const profiler = options.profilerPath ?? requestProfilerPath();
   if (!profiler) {

--- a/Automattic/studio/bench/lib/visual-fidelity.mjs
+++ b/Automattic/studio/bench/lib/visual-fidelity.mjs
@@ -5,6 +5,7 @@ import zlib from 'node:zlib';
 
 import { STUDIO_PATH } from './studio-bench.mjs';
 import { asArray, comparisonTargets, safeSlug, stringArray, surfaceUrl } from './fidelity-targets.mjs';
+import { loadWordPressLibHelper } from './wordpress-helper-discovery.mjs';
 
 const requireFromBench = createRequire(import.meta.url);
 export const VISUAL_VIEWPORT = { width: 1440, height: 1100 };
@@ -45,141 +46,25 @@ export async function loadVisualSurface(page, url) {
   await page.waitForTimeout(300);
 }
 
-async function loadEditorSurface(page, url) {
-  await page.emulateMedia({ reducedMotion: 'reduce' });
-  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 45_000 });
-  await page.waitForSelector('iframe[name="editor-canvas"]', { timeout: 30_000 });
-
-  const frameHandle = await page.locator('iframe[name="editor-canvas"]').elementHandle();
-  const frame = await frameHandle?.contentFrame();
-  if (!frame) {
-    throw new Error('Editor canvas iframe did not expose a content frame.');
+function loadEditorCanvasProbes() {
+  const { module } = loadWordPressLibHelper('editor-canvas-probes.js');
+  if (!module) {
+    throw new Error('Homeboy WordPress editor canvas probes are unavailable. Update homeboy-extensions or set HOMEBOY_WORDPRESS_HELPER_MANIFEST.');
   }
-
-  await frame.waitForFunction(
-    () => {
-      const layout = document.querySelector('.block-editor-block-list__layout');
-      if (!layout) {
-        return false;
-      }
-
-      const rect = layout.getBoundingClientRect();
-      const isLoading =
-        layout.matches('.is-loading, [aria-busy="true"]') ||
-        layout.querySelector('.is-loading, [aria-busy="true"], .components-spinner');
-      const blockCount = layout.querySelectorAll('.block-editor-block-list__block, [data-block]').length;
-      return rect.width > 0 && rect.height > 0 && !isLoading && blockCount > 0;
-    },
-    { timeout: 30_000 }
-  );
-
-  await frame.addStyleTag({
-    content: `
-      *, *::before, *::after {
-        animation-delay: 0s !important;
-        animation-duration: 0.001ms !important;
-        caret-color: transparent !important;
-        transition-delay: 0s !important;
-        transition-duration: 0.001ms !important;
-      }
-      .block-editor-block-list__block,
-      .block-editor-block-list__block::before,
-      .block-editor-block-list__block::after,
-      .is-selected,
-      .is-highlighted,
-      .has-child-selected {
-        box-shadow: none !important;
-        outline: 0 !important;
-      }
-      .block-editor-block-contextual-toolbar,
-      .block-editor-block-list__insertion-point,
-      .block-editor-block-list__breadcrumb,
-      .block-editor-inserter,
-      .block-editor-inserter__quick-inserter,
-      .block-editor-rich-text__editable::after,
-      .components-popover,
-      .components-toolbar,
-      .components-toolbar-group,
-      .is-root-container > .block-list-appender {
-        display: none !important;
-      }
-    `,
-  });
-  await frame.waitForTimeout(300);
-  return frame;
+  return module;
 }
 
 async function captureEditorScreenshot(page, url, screenshotPath) {
-  const frame = await loadEditorSurface(page, url);
-  const layout = frame.locator('.block-editor-block-list__layout').first();
-  await layout.screenshot({ path: screenshotPath, timeout: 30_000 });
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await loadEditorCanvasProbes().captureWordPressEditorCanvasScreenshot(page, screenshotPath, {
+    url,
+    waitUntil: 'domcontentloaded',
+    timeoutMs: 30_000,
+  });
 }
 
 async function evaluateVisualSurface(page, groups) {
-  const evaluatedGroups = [];
-
-  for (const group of groups) {
-    const selectors = [];
-
-    for (const selector of group.selectors) {
-      try {
-        const matches = await page.$$eval(selector, (elements) =>
-          elements.map((element) => {
-            const rect = element.getBoundingClientRect();
-            const style = window.getComputedStyle(element);
-            const visible =
-              rect.width > 0 &&
-              rect.height > 0 &&
-              style.display !== 'none' &&
-              style.visibility !== 'hidden' &&
-              Number(style.opacity || '1') > 0;
-
-            return {
-              visible,
-              boundingBox: {
-                x: Math.round(rect.x),
-                y: Math.round(rect.y),
-                width: Math.round(rect.width),
-                height: Math.round(rect.height),
-              },
-              text: String(element.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 160),
-            };
-          })
-        );
-        selectors.push({
-          selector,
-          count: matches.length,
-          visible_count: matches.filter((match) => match.visible).length,
-          nonzero_bounding_box_count: matches.filter(
-            (match) => match.boundingBox.width > 0 && match.boundingBox.height > 0
-          ).length,
-          first_match: matches[0] || null,
-        });
-      } catch (error) {
-        selectors.push({
-          selector,
-          count: 0,
-          visible_count: 0,
-          nonzero_bounding_box_count: 0,
-          error: error instanceof Error ? error.message : String(error),
-          first_match: null,
-        });
-      }
-    }
-
-    evaluatedGroups.push({
-      name: group.name,
-      selectors,
-      selector_count: selectors.length,
-      missing_selector_count: selectors.filter((item) => item.count === 0).length,
-      errored_selector_count: selectors.filter((item) => item.error).length,
-      matched_selector_count: selectors.filter((item) => item.count > 0).length,
-      visible_selector_count: selectors.filter((item) => item.visible_count > 0).length,
-      nonzero_bounding_box_selector_count: selectors.filter((item) => item.nonzero_bounding_box_count > 0).length,
-    });
-  }
-
-  return evaluatedGroups;
+  return loadEditorCanvasProbes().summarizeVisibleSelectors(page, groups).then((summary) => summary.groups);
 }
 
 function visualSurfaceTotals(groups) {

--- a/Automattic/studio/bench/lib/wordpress-bootstrap-timeline.mjs
+++ b/Automattic/studio/bench/lib/wordpress-bootstrap-timeline.mjs
@@ -2,22 +2,18 @@ import { createRequire } from 'node:module';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 
-import { requestProfilerPath, wordpressHelperPath } from './site-editor-timing-deltas.mjs';
+import { requestProfilerPath } from './site-editor-timing-deltas.mjs';
+import { wordpressHelperPath } from './wordpress-helper-discovery.mjs';
 
 const require = createRequire(import.meta.url);
 const BOOTSTRAP_TIMELINE_FILENAME = 'wordpress-bootstrap-timeline.js';
 
 function bootstrapTimelinePath(options = {}) {
-  const explicit = options.override ||
-    process.env.HOMEBOY_WORDPRESS_BOOTSTRAP_TIMELINE_PATH ||
-    process.env.HOMEBOY_WORDPRESS_BOOTSTRAP_TIMELINE_HELPER;
+  const explicit = options.override || process.env.HOMEBOY_WORDPRESS_BOOTSTRAP_TIMELINE_PATH || wordpressHelperPath('bootstrapTimeline', {
+    envVar: 'HOMEBOY_WORDPRESS_BOOTSTRAP_TIMELINE_HELPER',
+  });
   if (explicit) {
     return explicit;
-  }
-
-  const helper = wordpressHelperPath('bootstrapTimeline');
-  if (helper) {
-    return helper;
   }
 
   const profiler = options.profilerPath || requestProfilerPath();

--- a/Automattic/studio/bench/lib/wordpress-helper-discovery.mjs
+++ b/Automattic/studio/bench/lib/wordpress-helper-discovery.mjs
@@ -1,0 +1,46 @@
+import { createRequire } from 'node:module';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+export function loadWordPressHelperManifest(options = {}) {
+  const manifestPath = options.manifestPath || process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST;
+  if (!manifestPath || !existsSync(manifestPath)) {
+    return { path: manifestPath || '', manifest: null };
+  }
+
+  const module = require(manifestPath);
+  const manifest = typeof module.getWordPressHelperManifest === 'function'
+    ? module.getWordPressHelperManifest()
+    : module.WORDPRESS_HELPER_MANIFEST;
+  return { path: manifestPath, manifest: manifest || null };
+}
+
+export function wordpressHelperPath(key, options = {}) {
+  const explicit = options.override || (options.envVar ? process.env[options.envVar] : '');
+  if (explicit) {
+    return explicit;
+  }
+
+  const { manifest } = loadWordPressHelperManifest(options);
+  return manifest?.helpers?.[key] || '';
+}
+
+export function wordpressLibHelperPath(fileName, options = {}) {
+  const explicit = options.override || (options.envVar ? process.env[options.envVar] : '');
+  if (explicit) {
+    return explicit;
+  }
+
+  const { manifest } = loadWordPressHelperManifest(options);
+  return manifest?.extensionRoot ? path.join(manifest.extensionRoot, 'lib', fileName) : '';
+}
+
+export function loadWordPressLibHelper(fileName, options = {}) {
+  const helperPath = wordpressLibHelperPath(fileName, options);
+  if (!helperPath || !existsSync(helperPath)) {
+    return { path: helperPath, module: null };
+  }
+  return { path: helperPath, module: require(helperPath) };
+}

--- a/Automattic/studio/bench/lib/wordpress-page-profiler.mjs
+++ b/Automattic/studio/bench/lib/wordpress-page-profiler.mjs
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 import { requestProfilerPath } from './site-editor-timing-deltas.mjs';
+import { wordpressLibHelperPath } from './wordpress-helper-discovery.mjs';
 
 const require = createRequire(import.meta.url);
 const PAGE_PROFILER_FILENAME = 'page-profiler.js';
@@ -77,6 +78,11 @@ export function pageProfilerPath(options = {}) {
     return explicit;
   }
 
+  const manifestPath = wordpressLibHelperPath(PAGE_PROFILER_FILENAME, options);
+  if (manifestPath) {
+    return manifestPath;
+  }
+
   const profiler = options.profilerPath || requestProfilerPath();
   if (!profiler) {
     return '';
@@ -88,6 +94,11 @@ export function adminPageScenariosPath(options = {}) {
   const explicit = options.override || process.env.HOMEBOY_WORDPRESS_ADMIN_PAGE_SCENARIOS_PATH;
   if (explicit) {
     return explicit;
+  }
+
+  const manifestPath = wordpressLibHelperPath(ADMIN_PAGE_SCENARIOS_FILENAME, options);
+  if (manifestPath) {
+    return manifestPath;
   }
 
   const profiler = options.pageProfilerPath || pageProfilerPath(options);

--- a/Automattic/studio/bench/lib/wordpress-quality.mjs
+++ b/Automattic/studio/bench/lib/wordpress-quality.mjs
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises';
 
 import { runCli as defaultRunCli } from './studio-bench.mjs';
 import { collectLatestGeneratedTheme } from './design-gates.mjs';
+import { loadWordPressLibHelper } from './wordpress-helper-discovery.mjs';
 
 export {
   collectGeneratedThemeUxGates,
@@ -97,53 +98,6 @@ $counts['target_core_html_without_bfb_fallback'] = max( 0, $counts['target_core_
 echo wp_json_encode( $counts, JSON_PRETTY_PRINT ) . PHP_EOL;
 `;
 
-export function pageQualityProbeCode(pageId) {
-  const encodedPageId = Buffer.from(String(pageId)).toString('base64');
-
-  return String.raw`
-function bench_count_blocks( $blocks, &$counts ) {
-    foreach ( $blocks as $block ) {
-        $name = isset( $block['blockName'] ) ? (string) $block['blockName'] : '';
-        if ( '' !== $name ) {
-            $counts['total_blocks']++;
-            if ( 'core/html' === $name ) {
-                $counts['core_html_blocks']++;
-            }
-        }
-        if ( ! empty( $block['innerBlocks'] ) ) {
-            bench_count_blocks( $block['innerBlocks'], $counts );
-        }
-    }
-}
-
-$page_id = absint( base64_decode( '${encodedPageId}' ) );
-$post = get_post( $page_id );
-if ( ! $post ) {
-    fwrite( STDERR, 'Inserted page not found: ' . $page_id );
-    exit( 1 );
-}
-
-$content = (string) $post->post_content;
-$counts = array(
-    'posts_seen' => '' === trim( $content ) ? 0 : 1,
-    'posts_with_blocks' => false !== strpos( $content, '<!-- wp:' ) ? 1 : 0,
-    'total_blocks' => 0,
-    'core_html_blocks' => 0,
-    'serialized_block_comments' => substr_count( $content, '<!-- wp:' ),
-    'bfb_fallback_count' => (int) get_option( 'studio_bfb_unsupported_fallback_count', 0 ),
-    'stored_content_hash' => hash( 'sha256', $content ),
-    'stored_content_bytes' => strlen( $content ),
-    'stored_content_preview' => substr( $content, 0, 2000 ),
-);
-
-if ( '' !== trim( $content ) ) {
-    bench_count_blocks( parse_blocks( $content ), $counts );
-}
-
-echo wp_json_encode( $counts, JSON_PRETTY_PRINT ) . PHP_EOL;
-`;
-}
-
 export async function probeQuality(sitePath, options = {}) {
   const runCli = options.runCli || defaultRunCli;
   const { stdout } = await runCli(['wp', '--path', sitePath, '--php-version', '8.3', 'eval', QUALITY_PROBE]);
@@ -152,8 +106,27 @@ export async function probeQuality(sitePath, options = {}) {
 
 export async function probePageQuality(sitePath, pageId, options = {}) {
   const runCli = options.runCli || defaultRunCli;
-  const { stdout } = await runCli(['wp', '--path', sitePath, '--php-version', '8.3', 'eval', pageQualityProbeCode(pageId)]);
-  return parseQualityProbeOutput(stdout);
+  const { module: blockQuality } = loadWordPressLibHelper('block-quality.js', options);
+  if (!blockQuality?.wordpressPostBlockQualityProbeCode || !blockQuality?.parseWordPressBlockQualityProbeOutput) {
+    throw new Error('Homeboy WordPress block quality helper is unavailable. Update homeboy-extensions or set HOMEBOY_WORDPRESS_HELPER_MANIFEST.');
+  }
+  const { stdout } = await runCli([
+    'wp',
+    '--path',
+    sitePath,
+    '--php-version',
+    '8.3',
+    'eval',
+    blockQuality.wordpressPostBlockQualityProbeCode(pageId, {
+      fallbackOptionNames: ['studio_bfb_unsupported_fallback_count'],
+    }),
+  ]);
+  const quality = blockQuality.parseWordPressBlockQualityProbeOutput(stdout);
+  return {
+    ...quality,
+    bfb_fallback_count: quality.fallback_count || 0,
+    core_html_without_bfb_fallback: quality.core_html_without_fallback || 0,
+  };
 }
 
 function parseQualityProbeOutput(stdout) {

--- a/Automattic/studio/bench/playground-web-startup.trace.mjs
+++ b/Automattic/studio/bench/playground-web-startup.trace.mjs
@@ -7,7 +7,10 @@ import { pathToFileURL } from 'node:url';
 import { spawn } from 'node:child_process';
 
 const require = createRequire(import.meta.url);
-const HELPER_DIR = process.env.HOMEBOY_TRACE_HELPER_DIR || '/Users/chubes/Developer/homeboy-extensions/nodejs/scripts/trace/lib';
+const HELPER_DIR = process.env.HOMEBOY_TRACE_HELPER_DIR;
+if (!HELPER_DIR) {
+	throw new Error('HOMEBOY_TRACE_HELPER_DIR is required');
+}
 const PLAYGROUND_PATH = process.env.PLAYGROUND_WEB_TRACE_PLAYGROUND_PATH || '/Users/chubes/Developer/wordpress-playground@investigate-preinstalled-sqlite-template';
 const BASE_URL = process.env.PLAYGROUND_WEB_TRACE_BASE_URL || 'http://127.0.0.1:5400/website-server/';
 const WP_VERSION = process.env.PLAYGROUND_WEB_TRACE_WP_VERSION || '6.8';

--- a/Automattic/studio/bench/studio-cli-seeded-template-comparison.trace.mjs
+++ b/Automattic/studio/bench/studio-cli-seeded-template-comparison.trace.mjs
@@ -14,9 +14,10 @@ import {
 	stopStudioSite,
 } from './lib/studio-bench.mjs';
 
-const HELPER_DIR =
-	process.env.HOMEBOY_TRACE_HELPER_DIR ||
-	'/Users/chubes/Developer/homeboy-extensions/nodejs/scripts/trace/lib';
+const HELPER_DIR = process.env.HOMEBOY_TRACE_HELPER_DIR;
+if (!HELPER_DIR) {
+	throw new Error('HOMEBOY_TRACE_HELPER_DIR is required');
+}
 const ARTIFACT_DIR =
 	process.env.HOMEBOY_TRACE_ARTIFACT_DIR ||
 	path.join(tmpdir(), 'studio-seeded-template-trace-artifacts');

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -46,6 +46,7 @@ const {
   wordpressAdminPageScenario,
   wordpressPageProfilerSpec,
 } = await import('./lib/wordpress-page-profiler.mjs');
+const { probePageQuality } = await import('./lib/wordpress-quality.mjs');
 const {
   normalizeWordPressAdminScaleSweepManifest,
 } = await import('./lib/wordpress-admin-scale-sweep.mjs');
@@ -80,42 +81,102 @@ function withEnv(values, callback) {
   }
 }
 
-async function withBootstrapTimelineHelper(callback) {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'homeboy-bootstrap-helper-'));
-  const helperPath = path.join(tempDir, 'wordpress-bootstrap-timeline.cjs');
-  const manifestPath = path.join(tempDir, 'helper-manifest.cjs');
-  await writeFile(
-    helperPath,
-    `module.exports = {
-      instrumentIndexPhp(source) {
-        return source.includes('HOMEBOY_BOOTSTRAP_TIMELINE') ? source : source + ${JSON.stringify('\n/* HOMEBOY_BOOTSTRAP_TIMELINE entry.start entry.shutdown */\n')};
-      },
-      instrumentWpSettingsPhp(source) {
-        return source.includes('wp-settings.after_muplugins_loaded') ? source : source + ${JSON.stringify('\n/* wp-settings.start wp-settings.after_require_wp_db wp-settings.before_load_most wp-settings.after_blocks_index wp-settings.after_muplugins_loaded */\n')};
-      },
-      summarizeWordPressBootstrapTimeline(rows) {
-        const groups = new Map();
-        for (const row of rows) {
-          const group = groups.get(row.request_id) || { uri: row.uri, method: row.method, durationMs: 0, events: [] };
-          group.durationMs = Math.max(group.durationMs, row.t_ms);
-          const previous = group.events[group.events.length - 1];
-          group.events.push({ event: row.event, tMs: row.t_ms, deltaFromPreviousMs: previous ? row.t_ms - previous.tMs : row.t_ms });
-          groups.set(row.request_id, group);
-        }
-        return Array.from(groups.values()).sort((a, b) => b.durationMs - a.durationMs);
-      },
-    };`
-  );
-  await writeFile(
-    manifestPath,
-    `module.exports = { getWordPressHelperManifest: () => ({ helpers: { bootstrapTimeline: ${JSON.stringify(helperPath)} } }) };`
-  );
-
-  try {
-    return await withEnv({ HOMEBOY_WORDPRESS_HELPER_MANIFEST: manifestPath }, callback);
-  } finally {
-    await rm(tempDir, { recursive: true, force: true });
+async function withEnvAsync(values, callback) {
+  const previous = {};
+  for (const key of Object.keys(values)) {
+    previous[key] = process.env[key];
+    if (values[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = values[key];
+    }
   }
+  try {
+    return await callback();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+async function writeFakeWordPressManifest() {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'homeboy-wordpress-manifest-'));
+  const extensionRoot = path.join(tempDir, 'wordpress');
+  const libDir = path.join(extensionRoot, 'lib');
+  await import('node:fs/promises').then(({ mkdir }) => mkdir(libDir, { recursive: true }));
+  const requestProfiler = path.join(libDir, 'request-profiler.js');
+  const timingCorrelator = path.join(libDir, 'timing-correlator.js');
+  const bootstrapTimeline = path.join(libDir, 'wordpress-bootstrap-timeline.js');
+  const pageProfiler = path.join(libDir, 'page-profiler.js');
+  const adminPageScenarios = path.join(libDir, 'admin-page-scenarios.js');
+  const blockQuality = path.join(libDir, 'block-quality.js');
+  const manifestPath = path.join(libDir, 'helper-manifest.js');
+
+  await writeFile(requestProfiler, "module.exports = { installWordPressRequestProfiler() {} };\n");
+  await writeFile(timingCorrelator, "module.exports = { correlateBrowserAndWordPressTimings: () => ({ correlated: [], unmatchedBrowser: [], unmatchedWordPress: [] }) };\n");
+  await writeFile(pageProfiler, "module.exports = { DEFAULT_RESOURCE_INCLUDE: ['/wp-json/'] };\n");
+  await writeFile(adminPageScenarios, "module.exports = { normalizeWordPressAdminPageScenarioInput: (spec) => spec, profileWordPressAdminPageScenario: async () => ({ status: 200 }) };\n");
+  await writeFile(blockQuality, `
+module.exports = {
+  wordpressPostBlockQualityProbeCode: (postId) => 'fake probe for ' + postId,
+  parseWordPressBlockQualityProbeOutput: () => ({ fallback_count: 2, core_html_without_fallback: 3, stored_content_hash: 'abc' }),
+};
+`);
+  await writeFile(bootstrapTimeline, `
+module.exports = {
+  instrumentIndexPhp(source) {
+    if (source.includes('HOMEBOY_BOOTSTRAP_TIMELINE')) return source;
+    return source.replace('<?php', "<?php /* HOMEBOY_BOOTSTRAP_TIMELINE */ homeboy_bootstrap_timeline_record( 'entry.start' ); homeboy_bootstrap_timeline_record( 'entry.shutdown' ); ");
+  },
+  instrumentWpSettingsPhp(source) {
+    if (source.includes('HOMEBOY_BOOTSTRAP_TIMELINE')) return source;
+    return source.replace('<?php', "<?php /* HOMEBOY_BOOTSTRAP_TIMELINE */ homeboy_bootstrap_timeline_mark( 'wp-settings.start' ); homeboy_bootstrap_timeline_mark( 'wp-settings.after_require_wp_db' ); homeboy_bootstrap_timeline_mark( 'wp-settings.before_load_most' ); homeboy_bootstrap_timeline_mark( 'wp-settings.after_blocks_index' ); homeboy_bootstrap_timeline_mark( 'wp-settings.after_muplugins_loaded' ); ");
+  },
+  summarizeWordPressBootstrapTimeline(rows) {
+    const byRequest = new Map();
+    for (const row of rows) {
+      const id = row.request_id || 'unknown';
+      byRequest.set(id, [...(byRequest.get(id) || []), row]);
+    }
+    return [...byRequest.values()].map((events) => {
+      events.sort((a, b) => (a.t_ms || 0) - (b.t_ms || 0));
+      const last = events.at(-1) || {};
+      let previous = 0;
+      return {
+        uri: last.uri || '',
+        method: last.method || '',
+        durationMs: last.t_ms || 0,
+        events: events.map((event) => {
+          const tMs = event.t_ms || 0;
+          const deltaFromPreviousMs = tMs - previous;
+          previous = tMs;
+          return { event: event.event, tMs, deltaFromPreviousMs };
+        }),
+      };
+    }).sort((a, b) => b.durationMs - a.durationMs);
+  },
+};
+`);
+  await writeFile(manifestPath, `
+module.exports = {
+  getWordPressHelperManifest: () => ({
+    version: 1,
+    extensionRoot: ${JSON.stringify(extensionRoot)},
+    helpers: {
+      requestProfiler: ${JSON.stringify(requestProfiler)},
+      timingCorrelator: ${JSON.stringify(timingCorrelator)},
+      bootstrapTimeline: ${JSON.stringify(bootstrapTimeline)},
+    },
+  }),
+};
+`);
+
+  return { tempDir, manifestPath, requestProfiler, timingCorrelator, bootstrapTimeline, pageProfiler, adminPageScenarios, blockQuality };
 }
 
 // --- path resolution -------------------------------------------------------
@@ -175,29 +236,34 @@ test('requestProfilerPath honors the wordpress_request_profiler_path setting', (
   );
 });
 
-test('requestProfilerPath uses the WordPress helper manifest when no explicit path is configured', async () => {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'homeboy-helper-manifest-'));
-  const manifestPath = path.join(tempDir, 'helper-manifest.cjs');
-  await writeFile(
-    manifestPath,
-    `module.exports = { getWordPressHelperManifest: () => ({ helpers: { requestProfiler: ${JSON.stringify(path.join(tempDir, 'request-profiler.js'))}, timingCorrelator: ${JSON.stringify(path.join(tempDir, 'timing-correlator.js'))} } }) };`
-  );
-
+test('requestProfilerPath uses the WordPress helper discovery contract', async () => {
+  const fixture = await writeFakeWordPressManifest();
   try {
-    withEnv(
+    await withEnvAsync(
       {
         HOMEBOY_SETTINGS_JSON: undefined,
-        HOMEBOY_WORDPRESS_HELPER_MANIFEST: manifestPath,
+        HOMEBOY_WORDPRESS_HELPER_MANIFEST: fixture.manifestPath,
         HOMEBOY_WORDPRESS_REQUEST_PROFILER_HELPER: undefined,
       },
-      () => {
-        assert.equal(requestProfilerPath(), path.join(tempDir, 'request-profiler.js'));
-        assert.equal(timingCorrelatorPath(), path.join(tempDir, 'timing-correlator.js'));
+      async () => {
+        assert.equal(requestProfilerPath(), fixture.requestProfiler);
       }
     );
   } finally {
-    await rm(tempDir, { recursive: true, force: true });
+    await rm(fixture.tempDir, { recursive: true, force: true });
   }
+});
+
+test('timingCorrelatorPath honors the direct WordPress helper env var', () => {
+  withEnv(
+    {
+      HOMEBOY_SETTINGS_JSON: undefined,
+      HOMEBOY_WORDPRESS_TIMING_CORRELATOR_HELPER: '/tmp/direct/timing-correlator.js',
+    },
+    () => {
+      assert.equal(timingCorrelatorPath(), '/tmp/direct/timing-correlator.js');
+    }
+  );
 });
 
 test('pageProfilerPath sits next to the request profiler by default', () => {
@@ -625,6 +691,33 @@ test('profileWordPressPage delegates page readiness to the Homeboy Extensions pa
   assert.equal(result, profile);
 });
 
+test('probePageQuality delegates post-scoped block probing to the WordPress helper', async () => {
+  const fixture = await writeFakeWordPressManifest();
+  try {
+    await withEnvAsync(
+      { HOMEBOY_WORDPRESS_HELPER_MANIFEST: fixture.manifestPath },
+      async () => {
+        const calls = [];
+        const quality = await probePageQuality('/tmp/site', 123, {
+          runCli: async (args) => {
+            calls.push(args);
+            return { stdout: '{"ignored":true}' };
+          },
+        });
+
+        assert.equal(calls.length, 1);
+        assert.deepEqual(calls[0].slice(0, 5), ['wp', '--path', '/tmp/site', '--php-version', '8.3']);
+        assert.match(calls[0].at(-1), /fake probe for 123/);
+        assert.equal(quality.bfb_fallback_count, 2);
+        assert.equal(quality.core_html_without_bfb_fallback, 3);
+        assert.equal(quality.stored_content_hash, 'abc');
+      }
+    );
+  } finally {
+    await rm(fixture.tempDir, { recursive: true, force: true });
+  }
+});
+
 // --- WordPress admin scale sweep ------------------------------------------
 
 test('normalizeWordPressAdminScaleSweepManifest accepts page manifests and adds defaults', () => {
@@ -652,17 +745,28 @@ test('normalizeWordPressAdminScaleSweepManifest accepts page manifests and adds 
 
 // --- WordPress bootstrap timeline -----------------------------------------
 
-test('instrumentIndexPhp adds entry and shutdown timeline hooks once', async () => {
-  const source = "<?php\ndefine( 'WP_USE_THEMES', true );\nrequire __DIR__ . '/wp-blog-header.php';\n";
-  const instrumented = await withBootstrapTimelineHelper(() => instrumentIndexPhp(source));
-  assert.match(instrumented, /HOMEBOY_BOOTSTRAP_TIMELINE/);
-  assert.match(instrumented, /entry\.start/);
-  assert.match(instrumented, /entry\.shutdown/);
-  assert.equal(await withBootstrapTimelineHelper(() => instrumentIndexPhp(instrumented)), instrumented);
+test('instrumentIndexPhp adds entry and shutdown timeline hooks once', () => {
+  return writeFakeWordPressManifest().then(async (fixture) => {
+    try {
+      await withEnvAsync({ HOMEBOY_WORDPRESS_HELPER_MANIFEST: fixture.manifestPath }, async () => {
+        const source = "<?php\ndefine( 'WP_USE_THEMES', true );\nrequire __DIR__ . '/wp-blog-header.php';\n";
+        const instrumented = instrumentIndexPhp(source);
+        assert.match(instrumented, /HOMEBOY_BOOTSTRAP_TIMELINE/);
+        assert.match(instrumented, /entry\.start/);
+        assert.match(instrumented, /entry\.shutdown/);
+        assert.equal(instrumentIndexPhp(instrumented), instrumented);
+      });
+    } finally {
+      await rm(fixture.tempDir, { recursive: true, force: true });
+    }
+  });
 });
 
-test('instrumentWpSettingsPhp adds early WordPress bootstrap marks once', async () => {
-  const source = `<?php
+test('instrumentWpSettingsPhp adds early WordPress bootstrap marks once', () => {
+  return writeFakeWordPressManifest().then(async (fixture) => {
+    try {
+      await withEnvAsync({ HOMEBOY_WORDPRESS_HELPER_MANIFEST: fixture.manifestPath }, async () => {
+        const source = `<?php
 define( 'WPINC', 'wp-includes' );
 require_wp_db();
 wp_start_object_cache();
@@ -680,27 +784,39 @@ wp_plugin_directory_constants();
 unset( $mu_plugin, $_wp_plugin_file );
 do_action( 'muplugins_loaded' );
 `;
-  const instrumented = await withBootstrapTimelineHelper(() => instrumentWpSettingsPhp(source));
-  assert.match(instrumented, /wp-settings\.start/);
-  assert.match(instrumented, /wp-settings\.after_require_wp_db/);
-  assert.match(instrumented, /wp-settings\.before_load_most/);
-  assert.match(instrumented, /wp-settings\.after_blocks_index/);
-  assert.match(instrumented, /wp-settings\.after_muplugins_loaded/);
-  assert.equal(await withBootstrapTimelineHelper(() => instrumentWpSettingsPhp(instrumented)), instrumented);
+        const instrumented = instrumentWpSettingsPhp(source);
+        assert.match(instrumented, /wp-settings\.start/);
+        assert.match(instrumented, /wp-settings\.after_require_wp_db/);
+        assert.match(instrumented, /wp-settings\.before_load_most/);
+        assert.match(instrumented, /wp-settings\.after_blocks_index/);
+        assert.match(instrumented, /wp-settings\.after_muplugins_loaded/);
+        assert.equal(instrumentWpSettingsPhp(instrumented), instrumented);
+      });
+    } finally {
+      await rm(fixture.tempDir, { recursive: true, force: true });
+    }
+  });
 });
 
-test('summarizeWordPressBootstrapTimeline groups requests and reports per-event deltas', async () => {
-  const summary = await withBootstrapTimelineHelper(() => summarizeWordPressBootstrapTimeline([
-    { request_id: 'fast', uri: '/wp-json/fast', method: 'GET', event: 'entry.start', t_ms: 0 },
-    { request_id: 'fast', uri: '/wp-json/fast', method: 'GET', event: 'entry.shutdown', t_ms: 20 },
-    { request_id: 'slow', uri: '/wp-json/slow', method: 'GET', event: 'entry.start', t_ms: 0 },
-    { request_id: 'slow', uri: '/wp-json/slow', method: 'GET', event: 'wp-settings.start', t_ms: 2 },
-    { request_id: 'slow', uri: '/wp-json/slow', method: 'GET', event: 'entry.shutdown', t_ms: 75 },
-  ]));
-  assert.equal(summary.length, 2);
-  assert.equal(summary[0].uri, '/wp-json/slow');
-  assert.equal(summary[0].duration_ms, 75);
-  assert.equal(summary[0].events[2].delta_from_previous_ms, 73);
+test('summarizeWordPressBootstrapTimeline normalizes upstream camelCase summaries', async () => {
+  const fixture = await writeFakeWordPressManifest();
+  try {
+    await withEnvAsync({ HOMEBOY_WORDPRESS_HELPER_MANIFEST: fixture.manifestPath }, async () => {
+      const summary = summarizeWordPressBootstrapTimeline([
+        { request_id: 'fast', uri: '/wp-json/fast', method: 'GET', event: 'entry.start', t_ms: 0 },
+        { request_id: 'fast', uri: '/wp-json/fast', method: 'GET', event: 'entry.shutdown', t_ms: 20 },
+        { request_id: 'slow', uri: '/wp-json/slow', method: 'GET', event: 'entry.start', t_ms: 0 },
+        { request_id: 'slow', uri: '/wp-json/slow', method: 'GET', event: 'wp-settings.start', t_ms: 2 },
+        { request_id: 'slow', uri: '/wp-json/slow', method: 'GET', event: 'entry.shutdown', t_ms: 75 },
+      ]);
+      assert.equal(summary.length, 2);
+      assert.equal(summary[0].uri, '/wp-json/slow');
+      assert.equal(summary[0].duration_ms, 75);
+      assert.equal(summary[0].events[2].delta_from_previous_ms, 73);
+    });
+  } finally {
+    await rm(fixture.tempDir, { recursive: true, force: true });
+  }
 });
 
 // --- Site Editor preload comparison ---------------------------------------


### PR DESCRIPTION
## Summary
- Adopts the Homeboy Extensions WordPress helper manifest/direct helper env vars for request profiler, timing correlator, bootstrap timeline, page profiler, and admin page scenarios.
- Replaces duplicated post-scoped block quality, editor canvas readiness/screenshot, and visible selector probe logic with reusable WordPress helpers.
- Removes hardcoded `/Users/chubes/Developer/homeboy-extensions/...` fallbacks from Studio bench/trace workloads now that upstream helper discovery has landed.

## Verification
- `node --check Automattic/studio/bench/lib/site-editor-timing-deltas.mjs && node --check Automattic/studio/bench/lib/wordpress-helper-discovery.mjs && node --check Automattic/studio/bench/lib/wordpress-quality.mjs && node --check Automattic/studio/bench/lib/visual-fidelity.mjs`
- `node --check Automattic/studio/bench/studio-cli-seeded-template-comparison.trace.mjs && node --check Automattic/studio/bench/playground-web-startup.trace.mjs && node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `node --test Automattic/studio/bench/studio-agent-site-build.test.mjs`
- `git diff --check`

## Upstream dependencies
- Extra-Chill/homeboy-extensions#1006 landed in Extra-Chill/homeboy-extensions#1013.
- Extra-Chill/homeboy-extensions#1009 landed in Extra-Chill/homeboy-extensions#1015.

Closes #158.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the downstream helper discovery/probe adoption, updated targeted tests, and prepared the PR summary for Chris to review.