### PR TITLE
Add WooCommerce performance rig prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,24 @@ homeboy rig check playground-cli-diagnostics
 homeboy bench --rig playground-cli-diagnostics --scenario playground-cli-runphp-errors --iterations 1 --shared-state /tmp/playground-cli-diagnostics
 ```
 
+## woocommerce/woocommerce
+
+`rigs/woocommerce-performance/rig.json` runs WooCommerce checkout/shipping cache
+performance workloads against a local WooCommerce monorepo checkout mounted into
+the WP Codebox WordPress bench runtime.
+
+```bash
+homeboy rig install /Users/chubes/Developer/homeboy-rigs@<branch>/woocommerce/woocommerce
+homeboy rig check woocommerce-performance
+homeboy rig up woocommerce-performance
+homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-bench
+```
+
+The runner must provide `~/Developer/woocommerce/plugins/woocommerce`. The rig
+check reports missing checkout, Composer dependency, and generated feature-config
+prerequisites with targeted messages. Use `homeboy rig up` for the safe dependency
+prep path before benchmarking.
+
 ## chubes4/isolated-block-editor
 
 `rigs/isolated-block-editor/rig.json` runs the checks used while shaving Isolated Block Editor toward modern Gutenberg APIs.

--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -1,0 +1,99 @@
+# WooCommerce Performance Homeboy Rig
+
+Durable Homeboy rig package for reproducing WooCommerce large-merchant
+performance bugs in disposable WordPress/WooCommerce runtimes.
+
+## Goals
+
+- Exercise concrete WooCommerce checkout and shipping performance paths against a
+  real mounted WooCommerce checkout.
+- Capture bounded JSON metrics and artifacts that can be linked back to upstream
+  WooCommerce issues and PRs.
+- Keep reusable Homeboy or WordPress helper extraction out of the first rig until
+  repeated WooCommerce workloads make the helper shape obvious.
+
+## Tracked Bug Cluster
+
+- https://github.com/woocommerce/woocommerce/issues/49259
+- https://github.com/woocommerce/woocommerce/issues/32055
+- https://github.com/woocommerce/woocommerce/issues/26569
+
+## Install
+
+```bash
+homeboy rig install /Users/chubes/Developer/homeboy-rigs@<branch>/woocommerce/woocommerce
+homeboy rig check woocommerce-performance
+```
+
+## Runner Prerequisites
+
+The rig mounts a local WooCommerce checkout into the disposable WP Codebox
+WordPress runtime. On local and Lab runners, the checkout must exist at:
+
+```text
+~/Developer/woocommerce/plugins/woocommerce
+```
+
+This path mirrors the WooCommerce monorepo layout after cloning
+https://github.com/woocommerce/woocommerce into `~/Developer/woocommerce`.
+Homeboy core Lab offload provisioning gaps are tracked in:
+
+- https://github.com/Extra-Chill/homeboy/issues/3474
+- https://github.com/Extra-Chill/homeboy/issues/3475
+- https://github.com/Extra-Chill/homeboy/issues/3476
+
+Fresh WooCommerce source checkouts also need PHP package dependencies and the
+generated React admin feature config before the plugin can load in WP Codebox.
+Run the rig-owned deterministic prep pipeline:
+
+```bash
+homeboy rig up woocommerce-performance
+homeboy rig check woocommerce-performance
+```
+
+`homeboy rig up woocommerce-performance` is intentionally bounded:
+
+- It runs `composer install --no-interaction --no-progress` only when
+  `vendor/autoload_packages.php` is missing.
+- It runs `php bin/generate-feature-config.php` only when
+  `includes/react-admin/feature-config.php` is missing.
+- It does not modify WooCommerce source files or switch branches.
+
+Equivalent manual prep, when needed for debugging:
+
+```bash
+cd ~/Developer/woocommerce/plugins/woocommerce
+XDEBUG_MODE=off composer install --no-interaction --no-progress
+php bin/generate-feature-config.php
+```
+
+## Benchmark Commands
+
+```bash
+homeboy rig up woocommerce-performance
+homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-bench
+homeboy bench --rig woocommerce-performance --profile hot --iterations 1 --shared-state /tmp/woocommerce-performance-hot --setting-json 'bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"120","WC_SHIPPING_CACHE_PACKAGES":"24"}' --force-hot
+```
+
+`homeboy bench --rig woocommerce-performance` runs through Homeboy Extensions'
+`wordpress.bench` / WP Codebox backend. WP Codebox owns the disposable WordPress
+runtime, mounts WooCommerce as the runtime plugin, mounts the rig's PHP workload
+into `tests/bench/`, and returns the normalized Homeboy `BenchResults` envelope.
+
+## Current Workloads
+
+- `checkout-shipping-cache` seeds simple physical products, configures a flat-rate
+  US shipping zone, builds a cart, splits cart contents into configurable shipping
+  packages, and measures cold, warm, and address-rehashed shipping calculation
+  passes through WooCommerce's checkout/cart shipping cache path.
+
+## Metrics
+
+The first slice reports:
+
+- `cold_shipping_ms`, `warm_shipping_p50_ms`, `warm_shipping_p95_ms`, and
+  `warm_to_cold_ratio`.
+- `rehash_shipping_p50_ms` and `rehash_to_warm_ratio` for address/hash changes.
+- Package, item, rate, and session-cache key counts.
+
+See `docs/checkout-shipping-cache.md` for workload details and current TODOs.

--- a/woocommerce/woocommerce/bench/checkout-shipping-cache.php
+++ b/woocommerce/woocommerce/bench/checkout-shipping-cache.php
@@ -1,0 +1,282 @@
+<?php
+/**
+ * WP Codebox-backed WooCommerce checkout shipping-cache workload.
+ *
+ * Runs inside the disposable WordPress runtime owned by `wordpress.bench`.
+ */
+return function (): array {
+	if ( ! class_exists( 'WooCommerce' ) ) {
+		$woocommerce_entrypoint = WP_PLUGIN_DIR . '/woocommerce/woocommerce.php';
+		if ( ! file_exists( $woocommerce_entrypoint ) ) {
+			throw new RuntimeException( 'WooCommerce plugin entrypoint is not mounted.' );
+		}
+		require_once $woocommerce_entrypoint;
+	}
+
+	if ( ! class_exists( 'WooCommerce' ) || ! function_exists( 'WC' ) ) {
+		throw new RuntimeException( 'WooCommerce is not loaded.' );
+	}
+	if ( ! function_exists( 'wc_load_cart' ) ) {
+		throw new RuntimeException( 'WooCommerce cart loader is not available.' );
+	}
+
+	$cart_items  = max( 1, min( 1000, (int) ( getenv( 'WC_SHIPPING_CACHE_CART_ITEMS' ) ?: 40 ) ) );
+	$packages    = max( 1, min( $cart_items, (int) ( getenv( 'WC_SHIPPING_CACHE_PACKAGES' ) ?: 8 ) ) );
+	$warm_runs   = max( 1, min( 100, (int) ( getenv( 'WC_SHIPPING_CACHE_WARM_RUNS' ) ?: 5 ) ) );
+	$rehash_runs = max( 1, min( 100, (int) ( getenv( 'WC_SHIPPING_CACHE_REHASH_RUNS' ) ?: 3 ) ) );
+	$run_id      = 'woocommerce-checkout-shipping-cache-' . getmypid() . '-' . time() . '-' . wp_generate_password( 6, false );
+	$issues      = array(
+		'https://github.com/woocommerce/woocommerce/issues/49259',
+		'https://github.com/woocommerce/woocommerce/issues/32055',
+		'https://github.com/woocommerce/woocommerce/issues/26569',
+	);
+
+	wp_set_current_user( 1 );
+	update_option( 'woocommerce_store_address', '123 Performance Way' );
+	update_option( 'woocommerce_store_city', 'San Francisco' );
+	update_option( 'woocommerce_default_country', 'US:CA' );
+	update_option( 'woocommerce_currency', 'USD' );
+	update_option( 'woocommerce_weight_unit', 'lbs' );
+	update_option( 'woocommerce_dimension_unit', 'in' );
+
+	if ( ! WC()->session ) {
+		if ( method_exists( WC(), 'initialize_session' ) ) {
+			WC()->initialize_session();
+		} elseif ( class_exists( 'WC_Session_Handler' ) ) {
+			WC()->session = new WC_Session_Handler();
+			WC()->session->init();
+		}
+	}
+	if ( WC()->session ) {
+		WC()->session->set_customer_session_cookie( true );
+	}
+	wc_load_cart();
+	WC()->cart->empty_cart();
+
+	if ( WC()->customer ) {
+		WC()->customer->set_billing_country( 'US' );
+		WC()->customer->set_billing_state( 'CA' );
+		WC()->customer->set_billing_postcode( '94107' );
+		WC()->customer->set_shipping_country( 'US' );
+		WC()->customer->set_shipping_state( 'CA' );
+		WC()->customer->set_shipping_postcode( '94107' );
+		WC()->customer->set_shipping_city( 'San Francisco' );
+		WC()->customer->set_shipping_address( '123 Performance Way' );
+		WC()->customer->save();
+	}
+
+	$zone = new WC_Shipping_Zone();
+	$zone->set_zone_name( 'Homeboy Performance US ' . $run_id );
+	$zone->set_zone_order( 0 );
+	$zone->add_location( 'US', 'country' );
+	$zone->save();
+	$flat_rate_instance_id = $zone->add_shipping_method( 'flat_rate' );
+	update_option(
+		'woocommerce_flat_rate_' . $flat_rate_instance_id . '_settings',
+		array(
+			'enabled'    => 'yes',
+			'title'      => 'Homeboy Flat Rate',
+			'tax_status' => 'none',
+			'cost'       => '5',
+		)
+	);
+	if ( class_exists( 'WC_Cache_Helper' ) ) {
+		WC_Cache_Helper::get_transient_version( 'shipping', true );
+	}
+
+	$product_ids = array();
+	for ( $i = 0; $i < $cart_items; $i++ ) {
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Homeboy Shipping Cache Product ' . $run_id . ' #' . ( $i + 1 ) );
+		$product->set_slug( 'homeboy-shipping-cache-' . $run_id . '-' . ( $i + 1 ) );
+		$product->set_sku( 'homeboy-shipping-cache-' . $run_id . '-' . ( $i + 1 ) );
+		$product->set_regular_price( '10' );
+		$product->set_price( '10' );
+		$product->set_virtual( false );
+		$product->set_weight( '1' );
+		$product->set_length( '4' );
+		$product->set_width( '4' );
+		$product->set_height( '4' );
+		$product->set_manage_stock( false );
+		$product->set_stock_status( 'instock' );
+		$product->save();
+		$product_ids[] = $product->get_id();
+
+		WC()->cart->add_to_cart(
+			$product->get_id(),
+			1,
+			0,
+			array(),
+			array( 'homeboy_line' => $i )
+		);
+	}
+
+	$split_packages = static function ( array $cart_packages ) use ( $packages ): array {
+		$base_package = $cart_packages[0] ?? array();
+		$contents     = array_values( $base_package['contents'] ?? array() );
+		if ( empty( $contents ) ) {
+			return $cart_packages;
+		}
+
+		$chunk_size = max( 1, (int) ceil( count( $contents ) / $packages ) );
+		$split      = array();
+		foreach ( array_chunk( $contents, $chunk_size ) as $index => $chunk ) {
+			$package             = $base_package;
+			$package['contents'] = array();
+			foreach ( $chunk as $item_index => $item ) {
+				$package['contents'][ 'homeboy_' . $index . '_' . $item_index ] = $item;
+			}
+			$package['homeboy_package_index'] = $index;
+			$split[]                          = $package;
+		}
+
+		return $split;
+	};
+	add_filter( 'woocommerce_cart_shipping_packages', $split_packages, 100 );
+
+	$clear_shipping_cache = static function () use ( $packages ): void {
+		if ( ! WC()->session ) {
+			return;
+		}
+		for ( $i = 0; $i < $packages; $i++ ) {
+			WC()->session->__unset( 'shipping_for_package_' . $i );
+		}
+		WC()->session->__unset( 'chosen_shipping_methods' );
+	};
+
+	$session_cache_keys = static function () use ( $packages ): array {
+		$keys = array();
+		if ( ! WC()->session ) {
+			return $keys;
+		}
+		for ( $i = 0; $i < $packages; $i++ ) {
+			$key = 'shipping_for_package_' . $i;
+			if ( null !== WC()->session->get( $key, null ) ) {
+				$keys[] = $key;
+			}
+		}
+		return $keys;
+	};
+
+	$measure_shipping = static function ( string $label ) use ( $session_cache_keys ): array {
+		$before   = microtime( true );
+		$packages = WC()->cart->calculate_shipping();
+		$elapsed  = ( microtime( true ) - $before ) * 1000;
+		$rates    = 0;
+		foreach ( $packages as $package ) {
+			if ( $package instanceof WC_Shipping_Rate ) {
+				$rates++;
+				continue;
+			}
+			if ( is_array( $package ) ) {
+				$rates += count( $package['rates'] ?? array() );
+			}
+		}
+
+		return array(
+			'label'              => $label,
+			'elapsed_ms'         => $elapsed,
+			'package_count'      => count( $packages ),
+			'rate_count'         => $rates,
+			'session_cache_keys' => $session_cache_keys(),
+		);
+	};
+
+	WC()->cart->calculate_totals();
+	$rows = array();
+
+	$clear_shipping_cache();
+	$rows[] = $measure_shipping( 'cold' );
+
+	for ( $i = 0; $i < $warm_runs; $i++ ) {
+		$rows[] = $measure_shipping( 'warm_' . ( $i + 1 ) );
+	}
+
+	for ( $i = 0; $i < $rehash_runs; $i++ ) {
+		WC()->customer->set_shipping_postcode( '941' . str_pad( (string) ( 10 + $i ), 2, '0', STR_PAD_LEFT ) );
+		WC()->customer->save();
+		$rows[] = $measure_shipping( 'rehash_' . ( $i + 1 ) );
+	}
+
+	remove_filter( 'woocommerce_cart_shipping_packages', $split_packages, 100 );
+
+	$percentile = static function ( array $values, float $percentile ): float {
+		if ( empty( $values ) ) {
+			return 0.0;
+		}
+		sort( $values, SORT_NUMERIC );
+		$index = (int) floor( ( count( $values ) - 1 ) * $percentile );
+		return (float) $values[ $index ];
+	};
+	$only_elapsed = static function ( array $rows, string $prefix ): array {
+		$values = array();
+		foreach ( $rows as $row ) {
+			if ( 0 === strpos( $row['label'], $prefix ) ) {
+				$values[] = (float) $row['elapsed_ms'];
+			}
+		}
+		return $values;
+	};
+
+	$cold_row      = $rows[0];
+	$warm_values   = $only_elapsed( $rows, 'warm_' );
+	$rehash_values = $only_elapsed( $rows, 'rehash_' );
+	$warm_p50      = $percentile( $warm_values, 0.50 );
+	$warm_p95      = $percentile( $warm_values, 0.95 );
+	$rehash_p50    = $percentile( $rehash_values, 0.50 );
+	$final_cache   = $session_cache_keys();
+	$summary       = array(
+		'success_rate'              => 1,
+		'cart_items'                => $cart_items,
+		'configured_package_target' => $packages,
+		'actual_package_count'      => (int) $cold_row['package_count'],
+		'shipping_rate_count'       => (int) $cold_row['rate_count'],
+		'warm_runs'                 => $warm_runs,
+		'rehash_runs'               => $rehash_runs,
+		'cold_shipping_ms'          => (float) $cold_row['elapsed_ms'],
+		'warm_shipping_p50_ms'      => $warm_p50,
+		'warm_shipping_p95_ms'      => $warm_p95,
+		'warm_shipping_max_ms'      => empty( $warm_values ) ? 0 : max( $warm_values ),
+		'rehash_shipping_p50_ms'    => $rehash_p50,
+		'rehash_shipping_max_ms'    => empty( $rehash_values ) ? 0 : max( $rehash_values ),
+		'warm_to_cold_ratio'        => (float) $cold_row['elapsed_ms'] > 0 ? $warm_p50 / (float) $cold_row['elapsed_ms'] : 0,
+		'rehash_to_warm_ratio'      => $warm_p50 > 0 ? $rehash_p50 / $warm_p50 : 0,
+		'session_cache_key_count'   => count( $final_cache ),
+	);
+
+	$artifact_path = '';
+	$shared_state  = getenv( 'HOMEBOY_BENCH_SHARED_STATE' );
+	if ( $shared_state ) {
+		$artifact_dir = rtrim( $shared_state, '/' ) . '/checkout-shipping-cache';
+		wp_mkdir_p( $artifact_dir );
+		$artifact_path = $artifact_dir . '/' . $run_id . '.json';
+		file_put_contents(
+			$artifact_path,
+			wp_json_encode(
+				array(
+					'run_id'             => $run_id,
+					'issues'             => $issues,
+					'product_ids'        => $product_ids,
+					'shipping_zone_id'   => $zone->get_id(),
+					'shipping_method_id' => $flat_rate_instance_id,
+					'rows'               => $rows,
+					'final_cache_keys'   => $final_cache,
+					'metrics'            => $summary,
+				),
+				JSON_PRETTY_PRINT
+			) . "\n"
+		);
+	}
+
+	return array(
+		'metrics'   => $summary,
+		'metadata'  => array(
+			'runner'       => 'wp-codebox',
+			'workload'     => 'checkout-shipping-cache',
+			'issues'       => $issues,
+			'zone_id'      => $zone->get_id(),
+			'product_seed' => 'simple-physical',
+		),
+		'artifacts' => $artifact_path ? array( 'raw_result' => array( 'path' => $artifact_path, 'kind' => 'json' ) ) : array(),
+	);
+};

--- a/woocommerce/woocommerce/docs/checkout-shipping-cache.md
+++ b/woocommerce/woocommerce/docs/checkout-shipping-cache.md
@@ -1,0 +1,93 @@
+# Checkout Shipping Cache Workload
+
+`checkout-shipping-cache` is the first WooCommerce performance rig workload for
+large-merchant checkout/shipping cache bugs.
+
+## Issue Links
+
+- https://github.com/woocommerce/woocommerce/issues/49259
+- https://github.com/woocommerce/woocommerce/issues/32055
+- https://github.com/woocommerce/woocommerce/issues/26569
+
+## What It Does
+
+The workload runs inside Homeboy Extensions' `wordpress.bench` runtime with the
+local WooCommerce checkout mounted as an active plugin.
+
+It performs this practical first slice:
+
+1. Verifies WooCommerce is loaded and the cart/session APIs are available.
+2. Seeds configurable simple physical products with deterministic SKUs.
+3. Configures WooCommerce base/customer location and a flat-rate US shipping zone.
+4. Builds a cart with configurable line-item cardinality.
+5. Splits cart contents into configurable synthetic shipping packages with the
+   `woocommerce_cart_shipping_packages` filter.
+6. Measures one cold `WC()->cart->calculate_shipping()` pass after clearing known
+   session cache keys.
+7. Measures repeated warm passes against the same package hash.
+8. Measures repeated address/postcode changes that force package-hash rechecks.
+9. Writes raw timing rows to `HOMEBOY_BENCH_SHARED_STATE` when provided.
+
+## Runner Prep
+
+Before running the workload, `homeboy rig check woocommerce-performance` verifies
+that the runner has:
+
+- The WooCommerce monorepo checkout at `~/Developer/woocommerce`.
+- The plugin path at `~/Developer/woocommerce/plugins/woocommerce`.
+- Composer-generated PHP dependencies, especially `vendor/autoload_packages.php`.
+- Generated feature config at `includes/react-admin/feature-config.php`.
+
+Use the rig-owned prep pipeline when dependency artifacts are missing:
+
+```bash
+homeboy rig up woocommerce-performance
+homeboy rig check woocommerce-performance
+```
+
+This intentionally avoids browser checkout automation in the first pass. The
+target bug cluster is the server-side shipping cache path, and direct WooCommerce
+cart/checkout API calls make the signal faster and less brittle while still using
+real WooCommerce internals.
+
+## Settings
+
+The rig sets conservative defaults through `bench_env`:
+
+- `WC_SHIPPING_CACHE_CART_ITEMS=40`
+- `WC_SHIPPING_CACHE_PACKAGES=8`
+- `WC_SHIPPING_CACHE_WARM_RUNS=5`
+- `WC_SHIPPING_CACHE_REHASH_RUNS=3`
+
+Override them with Homeboy settings, for example:
+
+```bash
+homeboy bench \
+  --rig woocommerce-performance \
+  --scenario checkout-shipping-cache \
+  --iterations 1 \
+  --shared-state /tmp/woocommerce-performance-hot \
+  --setting-json 'bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"200","WC_SHIPPING_CACHE_PACKAGES":"40"}' \
+  --force-hot
+```
+
+## Artifact Shape
+
+When `HOMEBOY_BENCH_SHARED_STATE` is set, the workload writes:
+
+```text
+<shared-state>/checkout-shipping-cache/<run-id>.json
+```
+
+The artifact contains the run ID, issue URLs, seeded product IDs, shipping zone
+ID, per-pass timing rows, session cache keys observed, and the same summary
+metrics returned in the Homeboy BenchResults envelope.
+
+## Current TODOs
+
+- Add a browser checkout Store API or shortcode checkout variant after the direct
+  server-side signal is stable.
+- Promote repeated cart/product/shipping seed helpers into Homeboy Extensions'
+  WordPress package only after a second WooCommerce workload needs them.
+- Add an upstream WooCommerce issue/PR comment template once artifact hosting for
+  this rig is settled.

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -1,0 +1,100 @@
+{
+  "id": "woocommerce-performance",
+  "description": "WooCommerce large-merchant performance rig. Uses the WordPress/WP Codebox bench runtime for checkout and shipping cache workloads tied to concrete WooCommerce performance issues.",
+  "components": {
+    "woocommerce": {
+      "path": "~/Developer/woocommerce/plugins/woocommerce",
+      "branch": "trunk",
+      "extensions": {
+        "wordpress": {
+          "wp_codebox_wordpress_version": "7.0",
+          "bench_env": {
+            "WC_SHIPPING_CACHE_CART_ITEMS": "40",
+            "WC_SHIPPING_CACHE_PACKAGES": "8",
+            "WC_SHIPPING_CACHE_WARM_RUNS": "5",
+            "WC_SHIPPING_CACHE_REHASH_RUNS": "3"
+          }
+        }
+      }
+    }
+  },
+  "resources": {
+    "exclusive": [
+      "woocommerce-performance:${env.HOMEBOY_SETTINGS_WOOCOMMERCE_PERFORMANCE_NAMESPACE}"
+    ],
+    "paths": [
+      "${components.woocommerce.path}"
+    ]
+  },
+  "bench": {
+    "default_component": "woocommerce",
+    "warmup_iterations": 0
+  },
+  "bench_workloads": {
+    "wordpress": [
+      { "path": "${package.root}/bench/checkout-shipping-cache.php" }
+    ]
+  },
+  "bench_profiles": {
+    "smoke": [
+      "checkout-shipping-cache"
+    ],
+    "hot": [
+      "checkout-shipping-cache"
+    ]
+  },
+  "pipeline": {
+    "check": [
+      {
+        "kind": "command",
+        "label": "WooCommerce runner checkout exists",
+        "command": "test -f \"$HOME/Developer/woocommerce/plugins/woocommerce/woocommerce.php\" || { printf '%s\\n' 'Missing WooCommerce runner checkout: expected ~/Developer/woocommerce/plugins/woocommerce/woocommerce.php. Clone WooCommerce at ~/Developer/woocommerce or provision this path through Homeboy Lab offload before running woocommerce-performance. Core offload trackers: Extra-Chill/homeboy#3474, Extra-Chill/homeboy#3475, Extra-Chill/homeboy#3476.'; exit 1; }"
+      },
+      {
+        "kind": "command",
+        "label": "WooCommerce cart class exists",
+        "command": "test -f \"$HOME/Developer/woocommerce/plugins/woocommerce/includes/class-wc-cart.php\" || { printf '%s\\n' 'Missing WooCommerce cart class: expected ~/Developer/woocommerce/plugins/woocommerce/includes/class-wc-cart.php. Verify the runner checkout is the WooCommerce monorepo plugin directory, not an empty or partial clone.'; exit 1; }"
+      },
+      {
+        "kind": "command",
+        "label": "WooCommerce shipping class exists",
+        "command": "test -f \"$HOME/Developer/woocommerce/plugins/woocommerce/includes/class-wc-shipping.php\" || { printf '%s\\n' 'Missing WooCommerce shipping class: expected ~/Developer/woocommerce/plugins/woocommerce/includes/class-wc-shipping.php. Verify the runner checkout is the WooCommerce monorepo plugin directory, not an empty or partial clone.'; exit 1; }"
+      },
+      {
+        "kind": "command",
+        "label": "WooCommerce Composer package autoloader exists or can be prepared",
+        "command": "woocommerce_dir=\"$HOME/Developer/woocommerce/plugins/woocommerce\"; test -d \"$woocommerce_dir\" || { printf '%s\\n' 'Cannot check WooCommerce Composer dependencies because ~/Developer/woocommerce/plugins/woocommerce is missing. Provision the runner checkout first.'; exit 1; }; test -f \"$woocommerce_dir/vendor/autoload_packages.php\" || command -v composer >/dev/null 2>&1 || { printf '%s\\n' 'Missing WooCommerce Composer dependencies: vendor/autoload_packages.php is absent and composer is not available. Install Composer on the runner, then run: homeboy rig up woocommerce-performance'; exit 1; }"
+      },
+      {
+        "kind": "command",
+        "label": "WooCommerce generated feature config exists or can be prepared",
+        "command": "woocommerce_dir=\"$HOME/Developer/woocommerce/plugins/woocommerce\"; test -d \"$woocommerce_dir\" || { printf '%s\\n' 'Cannot check WooCommerce generated feature config because ~/Developer/woocommerce/plugins/woocommerce is missing. Provision the runner checkout first.'; exit 1; }; test -f \"$woocommerce_dir/includes/react-admin/feature-config.php\" || { test -f \"$woocommerce_dir/bin/generate-feature-config.php\" && command -v php >/dev/null 2>&1; } || { printf '%s\\n' 'Missing WooCommerce generated feature config: includes/react-admin/feature-config.php is absent. Ensure PHP is available, then run: homeboy rig up woocommerce-performance'; exit 1; }"
+      }
+    ],
+    "up": [
+      {
+        "kind": "command",
+        "label": "Prepare WooCommerce Composer dependencies when missing",
+        "command": "woocommerce_dir=\"$HOME/Developer/woocommerce/plugins/woocommerce\"; cd \"$woocommerce_dir\" || { printf '%s\\n' 'Missing WooCommerce runner checkout: expected ~/Developer/woocommerce/plugins/woocommerce before rig up.'; exit 1; }; if [ -f vendor/autoload_packages.php ]; then printf '%s\\n' 'WooCommerce Composer dependencies already prepared.'; else XDEBUG_MODE=off composer install --no-interaction --no-progress; fi"
+      },
+      {
+        "kind": "command",
+        "label": "Generate WooCommerce feature config when missing",
+        "command": "woocommerce_dir=\"$HOME/Developer/woocommerce/plugins/woocommerce\"; cd \"$woocommerce_dir\" || { printf '%s\\n' 'Missing WooCommerce runner checkout: expected ~/Developer/woocommerce/plugins/woocommerce before rig up.'; exit 1; }; if [ -f includes/react-admin/feature-config.php ]; then printf '%s\\n' 'WooCommerce feature config already generated.'; else php bin/generate-feature-config.php; fi"
+      }
+    ],
+    "bench_prepare": [
+      {
+        "kind": "command",
+        "label": "Prepare WooCommerce Composer dependencies when missing",
+        "command": "woocommerce_dir=\"$HOME/Developer/woocommerce/plugins/woocommerce\"; cd \"$woocommerce_dir\" || { printf '%s\\n' 'Missing WooCommerce runner checkout: expected ~/Developer/woocommerce/plugins/woocommerce before bench_prepare.'; exit 1; }; if [ -f vendor/autoload_packages.php ]; then printf '%s\\n' 'WooCommerce Composer dependencies already prepared.'; else XDEBUG_MODE=off composer install --no-interaction --no-progress; fi"
+      },
+      {
+        "kind": "command",
+        "label": "Generate WooCommerce feature config when missing",
+        "command": "woocommerce_dir=\"$HOME/Developer/woocommerce/plugins/woocommerce\"; cd \"$woocommerce_dir\" || { printf '%s\\n' 'Missing WooCommerce runner checkout: expected ~/Developer/woocommerce/plugins/woocommerce before bench_prepare.'; exit 1; }; if [ -f includes/react-admin/feature-config.php ]; then printf '%s\\n' 'WooCommerce feature config already generated.'; else php bin/generate-feature-config.php; fi"
+      }
+    ],
+    "down": []
+  }
+}


### PR DESCRIPTION
## Summary
- Adds the WooCommerce performance rig package with the `checkout-shipping-cache` workload.
- Encodes runner prerequisites in `woocommerce-performance` checks with targeted missing-checkout, Composer dependency, and generated feature-config messages.
- Documents and automates bounded dependency preparation through `homeboy rig up woocommerce-performance` while preserving `bench_prepare` for benchmark integrations.

## Verification
- `jq empty woocommerce/woocommerce/rigs/woocommerce-performance/rig.json`
- `php -l woocommerce/woocommerce/bench/checkout-shipping-cache.php`
- `homeboy rig install /Users/chubes/Developer/homeboy-rigs@issue-164-woocommerce-performance-prereqs/woocommerce/woocommerce && homeboy rig up woocommerce-performance && homeboy rig check woocommerce-performance`
- Temp HOME missing-runner simulation confirmed targeted `homeboy rig check woocommerce-performance` prerequisite messages.

## Related
- Closes #164
- Extra-Chill/homeboy#3474
- Extra-Chill/homeboy#3475
- Extra-Chill/homeboy#3476

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the rig package prerequisite checks, dependency prep pipeline/docs, validation, and PR drafting for Chris to review.