### PR TITLE
feat(woocommerce): add shipping cache evidence package tooling

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint rig packages
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+      - run: node scripts/lint-rig-packages.mjs

--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ cp Automattic/studio/stacks/*.json ~/.config/homeboy/stacks/
 cp WordPress/wordpress-playground/stacks/*.json ~/.config/homeboy/stacks/
 ```
 
+## Lint
+
+Run the repo-local package lint before opening rig package PRs:
+
+```bash
+node scripts/lint-rig-packages.mjs
+```
+
+The lint path scans for unresolved conflict markers, validates JSON specs, and
+runs `php -l` against PHP bench workloads when PHP is available. GitHub Actions
+runs the same script with PHP installed.
+
 ## Automattic/studio
 
 `rigs/studio-combined/rig.json` is the Studio + Playground combined-fixes dev environment: forks rebased onto trunk, open PRs cherry-picked, Docker-compiled PHP-WASM glue, tarball server, and Studio CLI rewired to local tarballs.

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const root = process.argv[2] ? join(process.cwd(), process.argv[2]) : process.cwd();
+const ignoredDirectories = new Set([
+	'.git',
+	'.claude',
+	'.datamachine',
+	'.opencode',
+	'node_modules',
+	'vendor',
+]);
+const conflictMarkerPattern = /^(<<<<<<<|=======|>>>>>>>)($|\s)/;
+const jsonFiles = [];
+const phpFiles = [];
+const failures = [];
+
+if (!existsSync(root)) {
+	console.error(`Lint root does not exist: ${root}`);
+	process.exit(1);
+}
+
+function walk(directory) {
+	for (const entry of readdirSync(directory, { withFileTypes: true })) {
+		if (entry.isDirectory()) {
+			if (!ignoredDirectories.has(entry.name)) {
+				walk(join(directory, entry.name));
+			}
+			continue;
+		}
+
+		if (!entry.isFile()) {
+			continue;
+		}
+
+		const file = join(directory, entry.name);
+		const relativePath = relative(root, file);
+		checkConflictMarkers(file, relativePath);
+
+		if (entry.name.endsWith('.json')) {
+			jsonFiles.push(file);
+		}
+		if (entry.name.endsWith('.php')) {
+			phpFiles.push(file);
+		}
+	}
+}
+
+function checkConflictMarkers(file, relativePath) {
+	const lines = readFileSync(file, 'utf8').split(/\r?\n/);
+	lines.forEach((line, index) => {
+		if (conflictMarkerPattern.test(line)) {
+			failures.push(`${relativePath}:${index + 1}: unresolved conflict marker: ${line}`);
+		}
+	});
+}
+
+function validateJson(file) {
+	try {
+		JSON.parse(readFileSync(file, 'utf8'));
+	} catch (error) {
+		failures.push(`${relative(root, file)}: invalid JSON: ${error.message}`);
+	}
+}
+
+function lintPhp(file) {
+	const result = spawnSync('php', ['-l', file], { encoding: 'utf8' });
+	if (result.status !== 0) {
+		const output = `${result.stdout || ''}${result.stderr || ''}`.trim();
+		failures.push(`${relative(root, file)}: PHP syntax check failed${output ? `: ${output}` : ''}`);
+	}
+}
+
+walk(root);
+jsonFiles.forEach(validateJson);
+
+const hasPhp = (() => {
+	try {
+		execFileSync('php', ['-v'], { stdio: 'ignore' });
+		return true;
+	} catch {
+		return false;
+	}
+})();
+
+if (hasPhp) {
+	phpFiles.forEach(lintPhp);
+} else {
+	console.warn(`PHP not found; skipped syntax checks for ${phpFiles.length} PHP file(s).`);
+}
+
+if (failures.length > 0) {
+	console.error('Rig package lint failed:');
+	for (const failure of failures) {
+		console.error(`- ${failure}`);
+	}
+	process.exit(1);
+}
+
+console.log('Rig package lint passed.');
+console.log(`- Conflict marker scan: ${countFiles(root)} file(s)`);
+console.log(`- JSON validation: ${jsonFiles.length} file(s)`);
+console.log(`- PHP syntax: ${hasPhp ? phpFiles.length : 0} file(s)${hasPhp ? '' : ' (skipped; php unavailable)'}`);
+
+function countFiles(directory) {
+	let count = 0;
+	for (const entry of readdirSync(directory, { withFileTypes: true })) {
+		if (entry.isDirectory()) {
+			if (!ignoredDirectories.has(entry.name)) {
+				count += countFiles(join(directory, entry.name));
+			}
+		} else if (entry.isFile() && statSync(join(directory, entry.name)).isFile()) {
+			count++;
+		}
+	}
+	return count;
+}

--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -100,3 +100,18 @@ The first slice reports:
 - Package, item, rate, and session-cache key counts.
 
 See `docs/checkout-shipping-cache.md` for workload details and current TODOs.
+
+## Matrix Report
+
+Use the report generator to prepare compact Markdown evidence for WooCommerce PR
+comments without inventing missing baseline/candidate numbers:
+
+```bash
+node woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs \
+  --input /tmp/woocommerce-performance-bench
+```
+
+The report separates timing evidence from shipping-rate call-count evidence and
+documents the cache invalidation controls covered by the current workload. See
+`docs/checkout-shipping-cache-matrix-report.md` for the planned matrix commands
+and current dependency blockers.

--- a/woocommerce/woocommerce/docs/checkout-shipping-cache-matrix-report.md
+++ b/woocommerce/woocommerce/docs/checkout-shipping-cache-matrix-report.md
@@ -1,0 +1,47 @@
+# Checkout Shipping Cache Matrix Report
+
+This is the report shell for WooCommerce shipping-cache evidence packages. It is
+safe to paste into WooCommerce PR comments after replacing planned rows with real
+baseline/candidate artifacts.
+
+Generate the current report shape locally:
+
+```bash
+node woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs
+```
+
+Generate from one shared-state directory:
+
+```bash
+node woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs \
+  --input /tmp/woocommerce-performance-bench
+```
+
+Generate baseline/candidate deltas when Homeboy comparison/export artifacts are
+available:
+
+```bash
+node woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs \
+  --baseline /tmp/woocommerce-performance-baseline \
+  --candidate /tmp/woocommerce-performance-candidate
+```
+
+## Matrix Commands
+
+```bash
+homeboy rig up woocommerce-performance
+homeboy rig check woocommerce-performance
+
+homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-40x1 --setting-json 'bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"40","WC_SHIPPING_CACHE_PACKAGES":"1","WC_SHIPPING_CACHE_TOTAL_CHURN_RUNS":"3"}'
+homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-40x8 --setting-json 'bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"40","WC_SHIPPING_CACHE_PACKAGES":"8","WC_SHIPPING_CACHE_TOTAL_CHURN_RUNS":"3"}'
+homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-200x8 --setting-json 'bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"200","WC_SHIPPING_CACHE_PACKAGES":"8","WC_SHIPPING_CACHE_TOTAL_CHURN_RUNS":"5"}' --force-hot
+homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-200x40 --setting-json 'bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"200","WC_SHIPPING_CACHE_PACKAGES":"40","WC_SHIPPING_CACHE_TOTAL_CHURN_RUNS":"5"}' --force-hot
+homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-1000x40 --setting-json 'bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"1000","WC_SHIPPING_CACHE_PACKAGES":"40","WC_SHIPPING_CACHE_TOTAL_CHURN_RUNS":"5"}' --force-hot
+```
+
+## Dependency Blockers
+
+- Extra-Chill/homeboy#3516 is needed before this report can consume canonical
+  Homeboy baseline/candidate exports instead of local shared-state directories.
+- Extra-Chill/homeboy-extensions#1089 is needed for the deterministic expensive
+  shipping method fixture matrix dimension.

--- a/woocommerce/woocommerce/docs/checkout-shipping-cache.md
+++ b/woocommerce/woocommerce/docs/checkout-shipping-cache.md
@@ -57,6 +57,7 @@ The rig sets conservative defaults through `bench_env`:
 - `WC_SHIPPING_CACHE_CART_ITEMS=40`
 - `WC_SHIPPING_CACHE_PACKAGES=8`
 - `WC_SHIPPING_CACHE_WARM_RUNS=5`
+- `WC_SHIPPING_CACHE_TOTAL_CHURN_RUNS=3`
 - `WC_SHIPPING_CACHE_REHASH_RUNS=3`
 
 Override them with Homeboy settings, for example:
@@ -82,6 +83,21 @@ When `HOMEBOY_BENCH_SHARED_STATE` is set, the workload writes:
 The artifact contains the run ID, issue URLs, seeded product IDs, shipping zone
 ID, per-pass timing rows, session cache keys observed, and the same summary
 metrics returned in the Homeboy BenchResults envelope.
+
+## Matrix Report
+
+Use `tools/checkout-shipping-cache-matrix-report.mjs` to generate the compact
+Markdown report shell and to summarize real shared-state artifacts when they are
+available:
+
+```bash
+node woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs \
+  --input /tmp/woocommerce-performance-bench
+```
+
+The report keeps timing evidence separate from shipping-rate call-count evidence
+and leaves baseline/candidate red-green deltas empty unless real artifacts are
+provided.
 
 ## Current TODOs
 

--- a/woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs
+++ b/woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+
+const issues = [
+	'https://github.com/woocommerce/woocommerce/issues/26569',
+	'https://github.com/woocommerce/woocommerce/issues/32055',
+	'https://github.com/woocommerce/woocommerce/issues/49259',
+];
+
+const plannedMatrix = [
+	{ cartItems: 40, packages: 1, totalChurnRuns: 3, profile: 'smoke' },
+	{ cartItems: 40, packages: 8, totalChurnRuns: 3, profile: 'smoke' },
+	{ cartItems: 200, packages: 8, totalChurnRuns: 5, profile: 'hot' },
+	{ cartItems: 200, packages: 40, totalChurnRuns: 5, profile: 'hot' },
+	{ cartItems: 1000, packages: 40, totalChurnRuns: 5, profile: 'hot' },
+];
+
+const args = parseArgs(process.argv.slice(2));
+const baselineRuns = readRuns(args.baseline || args.input);
+const candidateRuns = readRuns(args.candidate);
+const hasComparison = baselineRuns.length > 0 && candidateRuns.length > 0;
+const hasSingleSet = baselineRuns.length > 0 && !hasComparison;
+
+process.stdout.write(renderReport());
+
+function renderReport() {
+	const lines = [];
+	lines.push('# WooCommerce Shipping Cache Matrix Report');
+	lines.push('');
+	lines.push('## Issue Links');
+	lines.push('');
+	for (const issue of issues) {
+		lines.push(`- ${issue}`);
+	}
+	lines.push('');
+	lines.push('## Status');
+	lines.push('');
+	if (hasComparison) {
+		lines.push('- Mode: baseline/candidate comparison from real workload artifacts.');
+	} else if (hasSingleSet) {
+		lines.push('- Mode: single artifact set. Baseline/candidate red-green deltas are omitted until comparison exports are available.');
+	} else {
+		lines.push('- Mode: planned matrix only. No baseline or candidate values are present.');
+	}
+	lines.push('- Timing evidence and shipping-rate call-count evidence are reported separately.');
+	lines.push('- Deterministic expensive shipping-method fixture is pending Extra-Chill/homeboy-extensions#1089.');
+	lines.push('- Baseline/candidate export wiring is pending Extra-Chill/homeboy#3516.');
+	lines.push('');
+	lines.push('## Matrix Knobs');
+	lines.push('');
+	lines.push('| Profile | Cart items | Packages | Total churn runs | Command settings |');
+	lines.push('|---|---:|---:|---:|---|');
+	for (const row of plannedMatrix) {
+		const settings = `bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"${row.cartItems}","WC_SHIPPING_CACHE_PACKAGES":"${row.packages}","WC_SHIPPING_CACHE_TOTAL_CHURN_RUNS":"${row.totalChurnRuns}"}`;
+		lines.push(`| ${row.profile} | ${row.cartItems} | ${row.packages} | ${row.totalChurnRuns} | \`${settings}\` |`);
+	}
+	lines.push('');
+	lines.push('## Timing Evidence');
+	lines.push('');
+	lines.push(...renderTimingTable());
+	lines.push('');
+	lines.push('## Call-Count Evidence');
+	lines.push('');
+	lines.push(...renderCallTable());
+	lines.push('');
+	lines.push('## Cache Invalidation Controls');
+	lines.push('');
+	lines.push('| Control | Expected cache behavior | Current coverage |');
+	lines.push('|---|---|---|');
+	lines.push('| Warm repeat, unchanged package hash | Stay cached | Covered by `warm_*` rows |');
+	lines.push('| Package subtotal/total-only churn | Should stay cached if shipping inputs are unchanged | Covered by `total_churn_*` rows; sharpening tracked in homeboy-rigs#166 |');
+	lines.push('| Destination/postcode changes | Invalidate cache | Covered by `rehash_*` rows |');
+	lines.push('| Cart contents changes | Invalidate cache | Planned follow-up |');
+	lines.push('| Contents cost, coupon, tax, fee inputs | Validate expected behavior per WooCommerce cache key contract | Planned follow-up |');
+	lines.push('| Expensive deterministic shipping method | Amplify call-count regressions without browser noise | Blocked on Extra-Chill/homeboy-extensions#1089 |');
+	lines.push('');
+	return `${lines.join('\n')}\n`;
+}
+
+function renderTimingTable() {
+	if (!hasSingleSet && !hasComparison) {
+		return [
+			'| Status | Cart items | Packages | Cold ms | Warm p50 ms | Total churn p50 ms | Rehash p50 ms |',
+			'|---|---:|---:|---:|---:|---:|---:|',
+			...plannedMatrix.map((row) => `| pending | ${row.cartItems} | ${row.packages} |  |  |  |  |`),
+		];
+	}
+
+	if (hasComparison) {
+		return [
+			'| Run | Cart items | Packages | Baseline warm p50 ms | Candidate warm p50 ms | Warm delta | Baseline total churn p50 ms | Candidate total churn p50 ms | Total churn delta |',
+			'|---|---:|---:|---:|---:|---:|---:|---:|---:|',
+			...pairRuns(baselineRuns, candidateRuns).map(({ baseline, candidate }) => renderTimingComparisonRow(baseline, candidate)),
+		];
+	}
+
+	return [
+		'| Run | Cart items | Packages | Cold ms | Warm p50 ms | Total churn p50 ms | Rehash p50 ms |',
+		'|---|---:|---:|---:|---:|---:|---:|',
+		...baselineRuns.map((run) => {
+			const metrics = run.metrics;
+			return `| ${run.label} | ${metrics.cart_items ?? ''} | ${metrics.actual_package_count ?? metrics.configured_package_target ?? ''} | ${formatNumber(metrics.cold_shipping_ms)} | ${formatNumber(metrics.warm_shipping_p50_ms)} | ${formatNumber(metrics.total_churn_shipping_p50_ms)} | ${formatNumber(metrics.rehash_shipping_p50_ms)} |`;
+		}),
+	];
+}
+
+function renderCallTable() {
+	if (!hasSingleSet && !hasComparison) {
+		return [
+			'| Status | Cart items | Packages | Cold rate calls | Warm rate calls | Total churn rate calls | Rehash rate calls |',
+			'|---|---:|---:|---:|---:|---:|---:|',
+			...plannedMatrix.map((row) => `| pending | ${row.cartItems} | ${row.packages} |  |  |  |  |`),
+		];
+	}
+
+	if (hasComparison) {
+		return [
+			'| Run | Cart items | Packages | Baseline warm calls | Candidate warm calls | Warm call delta | Baseline total churn calls | Candidate total churn calls | Total churn call delta |',
+			'|---|---:|---:|---:|---:|---:|---:|---:|---:|',
+			...pairRuns(baselineRuns, candidateRuns).map(({ baseline, candidate }) => renderCallComparisonRow(baseline, candidate)),
+		];
+	}
+
+	return [
+		'| Run | Cart items | Packages | Cold rate calls | Warm rate calls | Total churn rate calls | Rehash rate calls |',
+		'|---|---:|---:|---:|---:|---:|---:|',
+		...baselineRuns.map((run) => {
+			const metrics = run.metrics;
+			return `| ${run.label} | ${metrics.cart_items ?? ''} | ${metrics.actual_package_count ?? metrics.configured_package_target ?? ''} | ${metrics.cold_rate_calculation_calls ?? ''} | ${metrics.warm_rate_calculation_calls ?? ''} | ${metrics.total_churn_rate_calculation_calls ?? ''} | ${metrics.rehash_rate_calculation_calls ?? ''} |`;
+		}),
+	];
+}
+
+function renderTimingComparisonRow(baseline, candidate) {
+	const base = baseline.metrics;
+	const next = candidate.metrics;
+	return `| ${candidate.label} | ${next.cart_items ?? base.cart_items ?? ''} | ${next.actual_package_count ?? base.actual_package_count ?? ''} | ${formatNumber(base.warm_shipping_p50_ms)} | ${formatNumber(next.warm_shipping_p50_ms)} | ${formatDelta(base.warm_shipping_p50_ms, next.warm_shipping_p50_ms)} | ${formatNumber(base.total_churn_shipping_p50_ms)} | ${formatNumber(next.total_churn_shipping_p50_ms)} | ${formatDelta(base.total_churn_shipping_p50_ms, next.total_churn_shipping_p50_ms)} |`;
+}
+
+function renderCallComparisonRow(baseline, candidate) {
+	const base = baseline.metrics;
+	const next = candidate.metrics;
+	return `| ${candidate.label} | ${next.cart_items ?? base.cart_items ?? ''} | ${next.actual_package_count ?? base.actual_package_count ?? ''} | ${base.warm_rate_calculation_calls ?? ''} | ${next.warm_rate_calculation_calls ?? ''} | ${formatDelta(base.warm_rate_calculation_calls, next.warm_rate_calculation_calls)} | ${base.total_churn_rate_calculation_calls ?? ''} | ${next.total_churn_rate_calculation_calls ?? ''} | ${formatDelta(base.total_churn_rate_calculation_calls, next.total_churn_rate_calculation_calls)} |`;
+}
+
+function readRuns(input) {
+	if (!input || !existsSync(input)) {
+		return [];
+	}
+
+	const files = collectJsonFiles(input);
+	return files.map((file) => {
+		const payload = JSON.parse(readFileSync(file, 'utf8'));
+		return {
+			file,
+			label: payload.run_id || basename(file, '.json'),
+			metrics: payload.metrics || payload.results?.scenarios?.[0]?.metrics || {},
+		};
+	});
+}
+
+function collectJsonFiles(input) {
+	if (input.endsWith('.json')) {
+		return [input];
+	}
+	const direct = join(input, 'checkout-shipping-cache');
+	const searchRoot = existsSync(direct) ? direct : input;
+	return readdirSafe(searchRoot)
+		.filter((entry) => entry.endsWith('.json'))
+		.map((entry) => join(searchRoot, entry));
+}
+
+function readdirSafe(directory) {
+	try {
+		return readdirSync(directory);
+	} catch {
+		return [];
+	}
+}
+
+function pairRuns(baseline, candidate) {
+	return candidate.map((candidateRun, index) => ({
+		baseline: baseline[index] || { metrics: {}, label: 'missing-baseline' },
+		candidate: candidateRun,
+	}));
+}
+
+function formatNumber(value) {
+	if (typeof value !== 'number' || !Number.isFinite(value)) {
+		return '';
+	}
+	return value.toFixed(2);
+}
+
+function formatDelta(before, after) {
+	if (typeof before !== 'number' || typeof after !== 'number' || !Number.isFinite(before) || !Number.isFinite(after)) {
+		return '';
+	}
+	const delta = after - before;
+	const marker = delta <= 0 ? 'green' : 'red';
+	return `${marker} ${delta >= 0 ? '+' : ''}${delta.toFixed(2)}`;
+}
+
+function parseArgs(rawArgs) {
+	const parsed = {};
+	for (let i = 0; i < rawArgs.length; i++) {
+		const arg = rawArgs[i];
+		if (arg === '--input' || arg === '--baseline' || arg === '--candidate') {
+			parsed[arg.slice(2)] = rawArgs[++i];
+		}
+	}
+	return parsed;
+}


### PR DESCRIPTION
## Summary
- Adds a dependency-free rig package lint path for conflict markers, JSON specs, and PHP bench syntax when PHP is available.
- Adds GitHub Actions coverage for the same lint path.
- Adds a WooCommerce shipping-cache matrix report generator and docs for planned matrix knobs, timing/call-count tables, cache invalidation controls, and current dependency blockers.

## Issue links
- Closes #170
- Refs #169
- Refs #166

## Testing
- `node --check scripts/lint-rig-packages.mjs`
- `node --check woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs`
- `node scripts/lint-rig-packages.mjs`
- `node woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs`
- synthetic shared-state artifact run for `checkout-shipping-cache-matrix-report.mjs --input`

## Dependency blockers
- Extra-Chill/homeboy#3516 is still needed before the report can consume canonical Homeboy baseline/candidate exports.
- Extra-Chill/homeboy-extensions#1089 is still needed for the deterministic expensive shipping-method fixture matrix dimension.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the lint script, matrix report generator, documentation updates, and verification commands for Chris to review.