### PR TITLE
Add WooCommerce Stripe ECE product page rig

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/README.md
+++ b/woocommerce/woocommerce-gateway-stripe/README.md
@@ -1,0 +1,99 @@
+# WooCommerce Stripe ECE Product Page Rig
+
+Durable Homeboy rig package for reproducing and measuring product-page
+Express Checkout Element page-load fan-out in WooCommerce Stripe.
+
+## Tracked Bug
+
+- https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1439
+
+## What It Measures
+
+The `ece-product-page-waterfall` trace creates a disposable WP Codebox WordPress
+runtime, mounts WooCommerce and WooCommerce Stripe, uses Stripe's benchmark
+fixture to create a purchasable product with product-page ECE enabled, opens the
+product page in a browser probe, and records waterfall metrics.
+
+Primary metrics:
+
+- `stripe_response_count`
+- `network_response_count`
+- `browser_document_count`
+- `browser_js_event_listener_count`
+- `browser_dom_node_count`
+- `browser_long_task_count`, `browser_long_task_total_ms`, and
+  `browser_long_task_max_ms`
+
+Secondary noisy metrics:
+
+- `browser_dom_content_loaded_ms`
+- `browser_first_meaningful_paint_ms`
+
+## Prerequisites
+
+The Stripe checkout must include `tests/benchmarks/fixture-bootstrap.php`, which
+is added by https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5522.
+
+For `homeboy rig check`, use `HOMEBOY_WC_STRIPE_COMPONENT_PATH` when the target
+Stripe checkout is a worktree instead of `~/Developer/woocommerce-gateway-stripe`:
+
+```bash
+export HOMEBOY_WC_STRIPE_COMPONENT_PATH=/path/to/woocommerce-gateway-stripe-worktree
+```
+
+The rig also needs a WooCommerce plugin directory. Prefer a packaged WooCommerce
+plugin build when tracing Stripe browser behavior:
+
+```bash
+export HOMEBOY_WC_STRIPE_WOOCOMMERCE_PATH=/path/to/woocommerce
+```
+
+If `wp-codebox` is not installed on `PATH`, point Homeboy at a built WP Codebox
+CLI:
+
+```bash
+export HOMEBOY_WP_CODEBOX_BIN=/path/to/wp-codebox/packages/cli/dist/index.js
+```
+
+## Install
+
+```bash
+homeboy rig install /Users/chubes/Developer/homeboy-rigs@<branch>/woocommerce/woocommerce-gateway-stripe
+homeboy rig check woocommerce-stripe-ece-product-page
+```
+
+## Trace Commands
+
+Run a single trace:
+
+```bash
+homeboy trace --rig woocommerce-stripe-ece-product-page woocommerce-gateway-stripe ece-product-page-waterfall
+```
+
+Pass `--path /path/to/woocommerce-gateway-stripe-worktree` when tracing a local
+candidate branch or proof worktree.
+
+Run repeated traces for noisy timing analysis:
+
+```bash
+homeboy trace \
+  --rig woocommerce-stripe-ece-product-page \
+  --repeat 5 \
+  --schedule interleaved \
+  --output /tmp/wc-stripe-ece-product-page.json \
+  woocommerce-gateway-stripe ece-product-page-waterfall
+```
+
+Useful settings:
+
+- `HOMEBOY_WC_STRIPE_ECE_LOCATIONS=product`
+- `HOMEBOY_WC_STRIPE_ACCEPTED_PAYMENT_METHODS=card,link`
+- `HOMEBOY_WC_STRIPE_ECE_PROBE_DURATION=7s`
+- `HOMEBOY_WC_STRIPE_ECE_VIEWPORT=1366x900`
+
+## Interpretation
+
+Use request-count and browser-object metrics as the primary signal. The browser
+timing metrics are intentionally secondary because this workload includes local
+WP Codebox/Playground runtime work, full WordPress/WooCommerce page load, and
+Stripe third-party iframe/network timing.

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -1,0 +1,296 @@
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const componentPath = process.env.HOMEBOY_COMPONENT_PATH;
+const componentId = process.env.HOMEBOY_COMPONENT_ID || 'woocommerce-gateway-stripe';
+const scenarioId = process.env.HOMEBOY_TRACE_SCENARIO || 'ece-product-page-waterfall';
+const resultsFile = process.env.HOMEBOY_TRACE_RESULTS_FILE;
+const artifactDir = process.env.HOMEBOY_TRACE_ARTIFACT_DIR || path.join(tmpdir(), 'wc-stripe-ece-waterfall-artifacts');
+const wpCodeboxBin = process.env.HOMEBOY_WP_CODEBOX_BIN || 'wp-codebox';
+const woocommercePath = process.env.HOMEBOY_WC_STRIPE_WOOCOMMERCE_PATH || path.join(process.env.HOME || '', 'Developer/woocommerce/plugins/woocommerce');
+const wpVersion = process.env.HOMEBOY_WC_STRIPE_WP_VERSION || '7.0';
+const eceLocations = process.env.HOMEBOY_WC_STRIPE_ECE_LOCATIONS || 'product';
+const acceptedPaymentMethods = process.env.HOMEBOY_WC_STRIPE_ACCEPTED_PAYMENT_METHODS || 'card,link';
+const probeDuration = process.env.HOMEBOY_WC_STRIPE_ECE_PROBE_DURATION || '7s';
+const viewport = process.env.HOMEBOY_WC_STRIPE_ECE_VIEWPORT || '1366x900';
+
+if (!componentPath) {
+  throw new Error('HOMEBOY_COMPONENT_PATH is required');
+}
+if (!resultsFile) {
+  throw new Error('HOMEBOY_TRACE_RESULTS_FILE is required');
+}
+if (!existsSync(path.join(componentPath, 'tests/benchmarks/fixture-bootstrap.php'))) {
+  throw new Error('Missing tests/benchmarks/fixture-bootstrap.php in the Stripe checkout. Run against woocommerce-gateway-stripe#5522 or later.');
+}
+if (!existsSync(path.join(woocommercePath, 'woocommerce.php'))) {
+  throw new Error(`Missing WooCommerce dependency plugin at ${woocommercePath}. Set HOMEBOY_WC_STRIPE_WOOCOMMERCE_PATH to a packaged WooCommerce plugin directory.`);
+}
+
+await mkdir(artifactDir, { recursive: true });
+await mkdir(path.dirname(resultsFile), { recursive: true });
+
+const workDir = await mkdtemp(path.join(tmpdir(), 'wc-stripe-ece-waterfall.'));
+const setupFile = path.join(workDir, 'setup.php');
+const recipeFile = path.join(workDir, 'recipe.json');
+const outputFile = path.join(artifactDir, 'wp-codebox-output.json');
+const codeboxArtifacts = path.join(artifactDir, 'wp-codebox-artifacts');
+const metricsPath = path.join(artifactDir, 'ece-waterfall-metrics.json');
+const metadataPath = path.join(artifactDir, 'ece-waterfall-metadata.json');
+
+const startedAt = performance.now();
+const timeline = [];
+
+function timestampMs() {
+  return Math.round(performance.now() - startedAt);
+}
+
+function event(source, name, data = {}) {
+	timeline.push({ t_ms: timestampMs(), source, event: name, data });
+}
+
+function csvToJsonArray(value) {
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+async function readJsonAsync(pathname) {
+  return existsSync(pathname) ? JSON.parse(await readFile(pathname, 'utf8')) : null;
+}
+
+async function readJsonl(pathname) {
+  if (!existsSync(pathname)) {
+    return [];
+  }
+
+  const contents = await readFile(pathname, 'utf8');
+  return contents
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function relativeTimingMs(cdpMetrics, metricName) {
+  const navigationStart = cdpMetrics.NavigationStart;
+  const value = cdpMetrics[metricName];
+  if (typeof value !== 'number' || typeof navigationStart !== 'number') {
+    return null;
+  }
+
+  return Math.round((value - navigationStart) * 1000);
+}
+
+function relativeArtifactPath(pathname) {
+  return path.relative(artifactDir, pathname);
+}
+
+function wpCodeboxCommand() {
+  if (wpCodeboxBin.endsWith('.js') || wpCodeboxBin.endsWith('.cjs') || wpCodeboxBin.endsWith('.mjs')) {
+    return { command: 'node', args: [wpCodeboxBin] };
+  }
+
+  return { command: wpCodeboxBin, args: [] };
+}
+
+try {
+  event('scenario', 'start', {
+    component_path: componentPath,
+    woocommerce_path: woocommercePath,
+    ece_locations: csvToJsonArray(eceLocations),
+    accepted_payment_methods: csvToJsonArray(acceptedPaymentMethods),
+  });
+
+  await writeFile(
+    setupFile,
+    `<?php
+require_once WP_PLUGIN_DIR . '/woocommerce-gateway-stripe/tests/benchmarks/fixture-bootstrap.php';
+
+$ece_locations = json_decode( '${JSON.stringify(csvToJsonArray(eceLocations))}', true );
+$accepted_payment_methods = json_decode( '${JSON.stringify(csvToJsonArray(acceptedPaymentMethods))}', true );
+
+$state = WC_Stripe_Benchmark_Fixture_Bootstrap::bootstrap(
+	array(
+		'ece_locations'            => $ece_locations,
+		'accepted_payment_methods' => $accepted_payment_methods,
+	)
+);
+
+update_option( 'permalink_structure', '/%postname%/' );
+flush_rewrite_rules();
+
+if ( ! get_permalink( (int) $state['product_id'] ) ) {
+	throw new RuntimeException( 'Could not resolve benchmark product URL.' );
+}
+`
+  );
+
+  const browserProbeScript = "window.__wpCodeboxProbeCheckpoint && window.__wpCodeboxProbeCheckpoint('ece-waterfall-after-wait', { buttons: document.querySelectorAll('#wc-stripe-express-checkout-element iframe, #wc-stripe-express-checkout-element button').length }); return { title: document.title, eceContainer: !!document.querySelector('#wc-stripe-express-checkout-element'), eceChildren: document.querySelectorAll('#wc-stripe-express-checkout-element > div').length, iframes: document.querySelectorAll('iframe').length };";
+  const recipe = {
+    schema: 'wp-codebox/workspace-recipe/v1',
+    runtime: {
+      wp: wpVersion,
+      blueprint: {
+        steps: [
+          { step: 'activatePlugin', pluginPath: '/wordpress/wp-content/plugins/woocommerce/woocommerce.php' },
+          { step: 'activatePlugin', pluginPath: '/wordpress/wp-content/plugins/woocommerce-gateway-stripe/woocommerce-gateway-stripe.php' },
+        ],
+      },
+    },
+    inputs: {
+      extraPlugins: [
+        { source: woocommercePath, slug: 'woocommerce', activate: true },
+        { source: componentPath, slug: 'woocommerce-gateway-stripe', pluginFile: 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php', activate: true },
+      ],
+    },
+    workflow: {
+      steps: [
+        { command: 'wordpress.run-php', args: [`code-file=${setupFile}`] },
+        {
+          command: 'wordpress.browser-probe',
+          args: [
+            'url=/?product=stripe-benchmark-product',
+            'wait-for=networkidle',
+            `duration=${probeDuration}`,
+            `viewport=${viewport}`,
+            'capture=console,errors,html,network,performance,memory,screenshot',
+            `script=${browserProbeScript}`,
+          ],
+        },
+      ],
+    },
+    artifacts: { directory: codeboxArtifacts },
+  };
+
+  await writeFile(recipeFile, `${JSON.stringify(recipe, null, 2)}\n`);
+
+  event('wp_codebox', 'recipe.start', { recipe_file: recipeFile });
+  const { command, args } = wpCodeboxCommand();
+  const result = await execFileAsync(command, [...args, 'recipe-run', '--recipe', recipeFile, '--artifacts', codeboxArtifacts, '--json'], {
+    maxBuffer: 1024 * 1024 * 50,
+  });
+  await writeFile(outputFile, result.stdout);
+  event('wordpress', 'fixture.ready');
+
+  const output = JSON.parse(result.stdout);
+  const bundleDir = output.artifacts?.directory;
+  const browserDir = bundleDir ? path.join(bundleDir, 'files', 'browser') : '';
+  const networkPath = browserDir ? path.join(browserDir, 'network.jsonl') : '';
+  const summaryPath = browserDir ? path.join(browserDir, 'summary.json') : '';
+  const performancePath = browserDir ? path.join(browserDir, 'performance.json') : '';
+  const network = await readJsonl(networkPath);
+  const responses = network.filter((entry) => entry.type === 'response');
+  const urls = responses.map((entry) => entry.url || entry.request?.url || '').filter(Boolean);
+  const stripeUrls = urls.filter((url) => /(^|\.)stripe\.com|stripe\.network/.test(url));
+  const googleUrls = urls.filter((url) => /(^|\.)google\.com|(^|\.)gstatic\.com|googleapis\.com/.test(url));
+  const iframeResponses = responses.filter((entry) => (entry.resourceType || entry.request?.resourceType) === 'iframe');
+  const summary = await readJsonAsync(summaryPath);
+  const performanceSummary = await readJsonAsync(performancePath);
+  const browserMetrics = summary?.summary?.metrics ?? {};
+  const cdpMetrics = performanceSummary?.final?.cdpMetrics ?? {};
+
+  event('browser', 'probe.ready', {
+    total_responses: responses.length,
+    stripe_responses: stripeUrls.length,
+  });
+
+  const metrics = {
+    network_response_count: responses.length,
+    stripe_response_count: stripeUrls.length,
+    google_response_count: googleUrls.length,
+    iframe_response_count: iframeResponses.length,
+    browser_probe_duration_ms: summary?.durationMs ?? null,
+    browser_dom_content_loaded_ms: relativeTimingMs(cdpMetrics, 'DomContentLoaded'),
+    browser_first_meaningful_paint_ms: relativeTimingMs(cdpMetrics, 'FirstMeaningfulPaint'),
+    browser_iframe_count: browserMetrics.browser_iframe_count ?? null,
+    browser_resource_count: browserMetrics.browser_resource_count ?? performanceSummary?.summary?.resources ?? null,
+    browser_transfer_size_bytes: browserMetrics.browser_transfer_size_bytes ?? performanceSummary?.summary?.transferSizeBytes ?? null,
+    browser_long_task_count: browserMetrics.browser_long_task_count ?? performanceSummary?.final?.longTasks?.count ?? null,
+    browser_long_task_total_ms: browserMetrics.browser_long_task_total_ms ?? performanceSummary?.final?.longTasks?.totalDurationMs ?? null,
+    browser_long_task_max_ms: performanceSummary?.final?.longTasks?.maxDurationMs ?? null,
+    browser_final_used_js_heap_bytes: browserMetrics.browser_final_used_js_heap_bytes ?? cdpMetrics.JSHeapUsedSize ?? null,
+    browser_peak_used_js_heap_bytes: browserMetrics.browser_peak_used_js_heap_bytes ?? performanceSummary?.peak?.cdpMetrics?.JSHeapUsedSize?.peak ?? null,
+    browser_dom_node_count: browserMetrics.browser_dom_node_count ?? performanceSummary?.final?.dom?.nodes ?? null,
+    browser_document_count: performanceSummary?.final?.dom?.documents ?? null,
+    browser_js_event_listener_count: cdpMetrics.JSEventListeners ?? null,
+  };
+
+  await writeFile(metricsPath, `${JSON.stringify(metrics, null, 2)}\n`);
+  await writeFile(
+    metadataPath,
+    `${JSON.stringify(
+      {
+        final_url: summary?.summary?.finalUrl || summary?.finalUrl || null,
+        stripe_urls_sample: stripeUrls.slice(0, 20),
+        google_urls_sample: googleUrls.slice(0, 20),
+        browser_script_result: summary?.summary?.scriptResult || summary?.scriptResult || null,
+      },
+      null,
+      2
+    )}\n`
+  );
+  event('waterfall', 'metrics.ready', metrics);
+
+  const pass = output.success === true && stripeUrls.length > 0;
+  const traceResult = {
+    component_id: componentId,
+    scenario_id: scenarioId,
+    status: pass ? 'pass' : 'fail',
+    summary: pass
+      ? `Captured Stripe ECE product-page browser waterfall: ${stripeUrls.length} Stripe responses across ${responses.length} total responses.`
+      : 'Browser waterfall capture did not observe Stripe network responses.',
+    timeline,
+    assertions: [
+      {
+        id: 'stripe-network-observed',
+        status: stripeUrls.length > 0 ? 'pass' : 'fail',
+        message: `Observed ${stripeUrls.length} Stripe/stripe.network responses.`,
+      },
+      {
+        id: 'network-response-count',
+        status: responses.length > 0 ? 'pass' : 'fail',
+        message: `Observed ${responses.length} total network responses.`,
+      },
+    ],
+    artifacts: [
+      { label: 'WP Codebox output', path: relativeArtifactPath(outputFile) },
+      { label: 'Waterfall metrics', path: relativeArtifactPath(metricsPath) },
+      { label: 'Waterfall metadata', path: relativeArtifactPath(metadataPath) },
+      ...(summaryPath && existsSync(summaryPath) ? [{ label: 'Browser summary', path: relativeArtifactPath(summaryPath) }] : []),
+      ...(networkPath && existsSync(networkPath) ? [{ label: 'Browser network log', path: relativeArtifactPath(networkPath) }] : []),
+      ...(performancePath && existsSync(performancePath) ? [{ label: 'Browser performance', path: relativeArtifactPath(performancePath) }] : []),
+    ],
+  };
+
+  await writeFile(resultsFile, `${JSON.stringify(traceResult, null, 2)}\n`);
+  process.exitCode = pass ? 0 : 1;
+} catch (error) {
+  const traceResult = {
+    component_id: componentId,
+    scenario_id: scenarioId,
+    status: 'fail',
+    summary: error instanceof Error ? error.message : String(error),
+    timeline,
+    assertions: [
+      {
+        id: 'trace-workload-completed',
+        status: 'fail',
+        message: error instanceof Error ? error.message : String(error),
+      },
+    ],
+    artifacts: existsSync(outputFile) ? [{ label: 'WP Codebox output', path: relativeArtifactPath(outputFile) }] : [],
+  };
+
+  await writeFile(resultsFile, `${JSON.stringify(traceResult, null, 2)}\n`);
+  throw error;
+} finally {
+  await rm(workDir, { recursive: true, force: true });
+}

--- a/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
+++ b/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
@@ -1,0 +1,43 @@
+# ECE Product Page Waterfall
+
+`ece-product-page-waterfall` is a browser trace workload for the WooCommerce
+Stripe product-page Express Checkout Element performance path reported in
+https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1439.
+
+## Scenario
+
+1. Start a disposable WP Codebox WordPress runtime.
+2. Activate WooCommerce and WooCommerce Stripe.
+3. Run `tests/benchmarks/fixture-bootstrap.php` from the Stripe checkout.
+4. Configure Stripe test/ECE settings with product-page ECE enabled.
+5. Create a simple purchasable product.
+6. Open the product page in a browser probe.
+7. Capture network, performance, memory, console, error, HTML, and screenshot
+   artifacts.
+8. Extract normalized waterfall metrics into `ece-waterfall-metrics.json`.
+
+## Primary Signals
+
+The stable signals are structural:
+
+- Stripe/Stripe Network response count.
+- Total network response count.
+- Browser document count.
+- JS event listener count.
+- DOM node count.
+- Long-task count and total duration.
+
+## Secondary Signals
+
+`DOMContentLoaded` and first meaningful paint are recorded, but they should be
+treated as secondary until a larger interleaved matrix proves stable medians.
+The local workload includes WordPress setup, WP Codebox runtime scheduling,
+browser scheduling, and third-party Stripe network variance.
+
+## Known Follow-Ups
+
+- Add named overlay variants for fan-out reduction and lazy product-page ECE
+  initialization once the Stripe PR stack settles.
+- Add an ECE-disabled control variant.
+- Add interaction probes that intentionally trigger deferred ECE initialization
+  and verify button availability after the trigger.

--- a/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
+++ b/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
@@ -1,0 +1,87 @@
+{
+  "id": "woocommerce-stripe-ece-product-page",
+  "description": "WooCommerce Stripe product-page Express Checkout Element waterfall rig for reproducing and measuring issue #1439 third-party page-load fan-out.",
+  "components": {
+    "woocommerce-gateway-stripe": {
+      "path": "~/Developer/woocommerce-gateway-stripe",
+      "branch": "develop"
+    }
+  },
+  "resources": {
+    "exclusive": [
+      "woocommerce-stripe-ece-product-page:${env.HOMEBOY_SETTINGS_WOOCOMMERCE_STRIPE_ECE_NAMESPACE}"
+    ],
+    "paths": [
+      "${components.woocommerce-gateway-stripe.path}"
+    ]
+  },
+  "trace": {
+    "default_component": "woocommerce-gateway-stripe"
+  },
+  "trace_workloads": {
+    "nodejs": [
+      {
+        "path": "${package.root}/bench/ece-product-page-waterfall.trace.mjs",
+        "check_groups": [],
+        "trace_default_phase_preset": "browser-waterfall",
+        "trace_phase_presets": {
+          "browser-waterfall": [
+            "start:scenario.start",
+            "recipe:wp_codebox.recipe.start",
+            "setup:wordpress.fixture.ready",
+            "probe:browser.probe.ready",
+            "metrics:waterfall.metrics.ready"
+          ]
+        },
+        "trace_span_metadata": {
+          "phase.recipe_to_setup": {
+            "category": "runtime_setup",
+            "blocking": true
+          },
+          "phase.setup_to_probe": {
+            "category": "browser_probe",
+            "blocking": true
+          },
+          "phase.probe_to_metrics": {
+            "category": "artifact_extraction",
+            "blocking": true
+          }
+        }
+      }
+    ]
+  },
+  "trace_profiles": {
+    "smoke": [
+      "ece-product-page-waterfall"
+    ],
+    "hot": [
+      "ece-product-page-waterfall"
+    ]
+  },
+  "pipeline": {
+    "check": [
+      {
+        "kind": "command",
+        "label": "Stripe checkout exists",
+        "command": "stripe_path=\"${HOMEBOY_WC_STRIPE_COMPONENT_PATH:-$HOME/Developer/woocommerce-gateway-stripe}\"; test -f \"$stripe_path/woocommerce-gateway-stripe.php\" || { printf '%s\\n' \"Missing WooCommerce Stripe checkout: expected $stripe_path/woocommerce-gateway-stripe.php. Set HOMEBOY_WC_STRIPE_COMPONENT_PATH for rig checks or pass --path for trace runs.\"; exit 1; }"
+      },
+      {
+        "kind": "command",
+        "label": "Stripe benchmark fixture exists",
+        "command": "stripe_path=\"${HOMEBOY_WC_STRIPE_COMPONENT_PATH:-$HOME/Developer/woocommerce-gateway-stripe}\"; test -f \"$stripe_path/tests/benchmarks/fixture-bootstrap.php\" || { printf '%s\\n' \"Missing Stripe benchmark fixture at $stripe_path/tests/benchmarks/fixture-bootstrap.php. Run against a checkout containing woocommerce-gateway-stripe#5522 or later.\"; exit 1; }"
+      },
+      {
+        "kind": "command",
+        "label": "WooCommerce dependency plugin exists",
+        "command": "woocommerce_path=\"${HOMEBOY_WC_STRIPE_WOOCOMMERCE_PATH:-$HOME/Developer/woocommerce/plugins/woocommerce}\"; test -f \"$woocommerce_path/woocommerce.php\" || { printf '%s\\n' \"Missing WooCommerce dependency plugin: expected $woocommerce_path/woocommerce.php. Set HOMEBOY_WC_STRIPE_WOOCOMMERCE_PATH to a packaged WooCommerce plugin directory before running this rig.\"; exit 1; }"
+      },
+      {
+        "kind": "command",
+        "label": "WP Codebox CLI available",
+        "command": "if [ -n \"${HOMEBOY_WP_CODEBOX_BIN:-}\" ]; then test -f \"$HOMEBOY_WP_CODEBOX_BIN\" || { printf '%s\\n' \"HOMEBOY_WP_CODEBOX_BIN is set but not found: $HOMEBOY_WP_CODEBOX_BIN\"; exit 1; }; else command -v wp-codebox >/dev/null 2>&1 || { printf '%s\\n' 'Missing wp-codebox CLI. Install WP Codebox or set HOMEBOY_WP_CODEBOX_BIN to packages/cli/dist/index.js.'; exit 1; }; fi"
+      }
+    ],
+    "up": [],
+    "down": []
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a durable `woocommerce-stripe-ece-product-page` Homeboy rig package for WooCommerce Stripe issue #1439.
- Adds a Node trace workload that mounts WooCommerce + WooCommerce Stripe in WP Codebox, runs the Stripe benchmark fixture, opens a product page, and extracts ECE waterfall metrics.
- Documents setup, trace commands, primary request/object-count signals, and timing caveats.

## Related Stripe work
- Fixture dependency: https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5522
- Current fan-out fix using this evidence path: https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5530
- Reported performance issue: https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1439

## Evidence
Validated locally against a WooCommerce Stripe proof worktree containing woocommerce-gateway-stripe#5522 and a packaged WooCommerce dependency.

Smoke trace result:
- Rig-backed `ece-product-page-waterfall` trace passed.
- Observed `31` Stripe/Stripe Network responses across `109` total responses on the current fan-out candidate branch.
- Captured metrics include total/Stripe response counts, browser document count, JS event listeners, DOM nodes, long tasks, DCL, and FMP.

## Testing
- `node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs`
- `homeboy rig install <homeboy-rigs>/woocommerce/woocommerce-gateway-stripe`
- `HOMEBOY_WC_STRIPE_COMPONENT_PATH=<woocommerce-gateway-stripe-worktree> HOMEBOY_WC_STRIPE_WOOCOMMERCE_PATH=<packaged-woocommerce-plugin> HOMEBOY_WP_CODEBOX_BIN=<wp-codebox-cli> homeboy rig check woocommerce-stripe-ece-product-page`
- Rig-backed smoke trace with the same dependency paths and `--path <woocommerce-gateway-stripe-worktree>`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the rig spec, Node trace workload, documentation, and local validation commands. Chris reviewed the direction and requested the PR.