### PR TITLE
Capture WooCommerce Stripe ECE render timing

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/README.md
+++ b/woocommerce/woocommerce-gateway-stripe/README.md
@@ -16,6 +16,14 @@ product page in a browser probe, and records waterfall metrics.
 
 Primary metrics:
 
+- `ece_render_container_seen_ms`
+- `ece_render_first_child_ms`
+- `ece_render_first_iframe_ms`
+- `ece_render_first_visible_iframe_ms`
+- `ece_render_first_visible_button_ms`
+- `ece_render_peak_child_count`
+- `ece_render_peak_iframe_count`
+- `ece_render_peak_visible_iframe_count`
 - `stripe_response_count`
 - `network_response_count`
 - `browser_document_count`
@@ -97,3 +105,8 @@ Use request-count and browser-object metrics as the primary signal. The browser
 timing metrics are intentionally secondary because this workload includes local
 WP Codebox/Playground runtime work, full WordPress/WooCommerce page load, and
 Stripe third-party iframe/network timing.
+
+The ECE render metrics are captured by a `pre-page-script` observer injected
+before page scripts run. They are intended to match the merchant-visible symptom:
+how long it takes for Express Checkout containers, iframes, and visible button
+surfaces to appear after the browser starts loading the product page.

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -101,6 +101,19 @@ function wpCodeboxCommand() {
   return { command: wpCodeboxBin, args: [] };
 }
 
+function numberOrNull(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.round(value) : null;
+}
+
+function peakSampleValue(samples, key) {
+  if (!Array.isArray(samples)) {
+    return null;
+  }
+
+  const values = samples.map((sample) => sample?.[key]).filter((value) => typeof value === 'number' && Number.isFinite(value));
+  return values.length > 0 ? Math.max(...values) : null;
+}
+
 try {
   event('scenario', 'start', {
     component_path: componentPath,
@@ -133,7 +146,91 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
 `
   );
 
-  const browserProbeScript = "window.__wpCodeboxProbeCheckpoint && window.__wpCodeboxProbeCheckpoint('ece-waterfall-after-wait', { buttons: document.querySelectorAll('#wc-stripe-express-checkout-element iframe, #wc-stripe-express-checkout-element button').length }); return { title: document.title, eceContainer: !!document.querySelector('#wc-stripe-express-checkout-element'), eceChildren: document.querySelectorAll('#wc-stripe-express-checkout-element > div').length, iframes: document.querySelectorAll('iframe').length };";
+  const prePageScript = `(() => {
+  const state = window.__wcStripeEceRenderProbe = {
+    startedAt: performance.now(),
+    events: [],
+    marks: {},
+    samples: [],
+  };
+  const elapsed = () => Math.round(performance.now() - state.startedAt);
+  const record = (name, data = {}) => {
+    state.events.push({ name, t_ms: elapsed(), data });
+  };
+  const mark = (name, data = {}) => {
+    if (state.marks[name] === undefined) {
+      state.marks[name] = elapsed();
+      record(name, data);
+    }
+  };
+  const isVisible = (node) => {
+    if (!node || !(node instanceof Element)) {
+      return false;
+    }
+    const style = window.getComputedStyle(node);
+    const rect = node.getBoundingClientRect();
+    return style.visibility !== 'hidden' && style.display !== 'none' && rect.width > 0 && rect.height > 0;
+  };
+  const sample = () => {
+    const container = document.querySelector('#wc-stripe-express-checkout-element');
+    if (!container) {
+      return;
+    }
+    mark('container_seen');
+    if (isVisible(container)) {
+      mark('container_visible');
+    }
+    const children = Array.from(container.children || []);
+    const iframes = Array.from(container.querySelectorAll('iframe'));
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const visibleIframes = iframes.filter(isVisible);
+    const visibleButtons = buttons.filter(isVisible);
+    if (children.length > 0) {
+      mark('first_child', { child_count: children.length });
+    }
+    if (iframes.length > 0) {
+      mark('first_iframe', { iframe_count: iframes.length });
+    }
+    if (visibleIframes.length > 0) {
+      mark('first_visible_iframe', { visible_iframe_count: visibleIframes.length });
+    }
+    if (visibleButtons.length > 0) {
+      mark('first_visible_button', { visible_button_count: visibleButtons.length });
+    }
+    state.latest = {
+      t_ms: elapsed(),
+      child_count: children.length,
+      iframe_count: iframes.length,
+      visible_iframe_count: visibleIframes.length,
+      button_count: buttons.length,
+      visible_button_count: visibleButtons.length,
+      container_visible: isVisible(container),
+    };
+    state.samples.push(state.latest);
+  };
+  const observer = new MutationObserver(sample);
+  const observe = () => {
+    if (!document.documentElement) {
+      window.setTimeout(observe, 0);
+      return;
+    }
+    observer.observe(document.documentElement, { childList: true, subtree: true, attributes: true, attributeFilter: ['style', 'class', 'height', 'width'] });
+    sample();
+  };
+  window.addEventListener('DOMContentLoaded', () => { record('domcontentloaded'); sample(); }, { once: true });
+  window.addEventListener('load', () => { record('load'); sample(); }, { once: true });
+  document.addEventListener('transitionend', (event) => {
+    const container = document.querySelector('#wc-stripe-express-checkout-element');
+    if (container && event.target instanceof Node && container.contains(event.target)) {
+      mark('first_transitionend', { property_name: event.propertyName || null });
+      sample();
+    }
+  }, true);
+  state.interval = window.setInterval(sample, 50);
+  window.setTimeout(() => window.clearInterval(state.interval), 15000);
+  observe();
+})();`;
+  const browserProbeScript = "const probe = window.__wcStripeEceRenderProbe || null; if (probe && probe.interval) { window.clearInterval(probe.interval); } window.__wpCodeboxProbeCheckpoint && window.__wpCodeboxProbeCheckpoint('ece-waterfall-after-wait', { buttons: document.querySelectorAll('#wc-stripe-express-checkout-element iframe, #wc-stripe-express-checkout-element button').length, renderProbe: probe }); return { title: document.title, eceContainer: !!document.querySelector('#wc-stripe-express-checkout-element'), eceChildren: document.querySelectorAll('#wc-stripe-express-checkout-element > div').length, iframes: document.querySelectorAll('iframe').length, renderProbe: probe };";
   const recipe = {
     schema: 'wp-codebox/workspace-recipe/v1',
     runtime: {
@@ -162,6 +259,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
             `duration=${probeDuration}`,
             `viewport=${viewport}`,
             'capture=console,errors,html,network,performance,memory,screenshot',
+            `pre-page-script=${prePageScript}`,
             `script=${browserProbeScript}`,
           ],
         },
@@ -196,6 +294,11 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   const performanceSummary = await readJsonAsync(performancePath);
   const browserMetrics = summary?.summary?.metrics ?? {};
   const cdpMetrics = performanceSummary?.final?.cdpMetrics ?? {};
+  const scriptResult = summary?.summary?.scriptResult || summary?.scriptResult || {};
+  const renderProbe = scriptResult?.renderProbe || {};
+  const renderMarks = renderProbe?.marks || {};
+  const renderLatest = renderProbe?.latest || {};
+  const renderSamples = renderProbe?.samples || [];
 
   event('browser', 'probe.ready', {
     total_responses: responses.length,
@@ -221,6 +324,23 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     browser_dom_node_count: browserMetrics.browser_dom_node_count ?? performanceSummary?.final?.dom?.nodes ?? null,
     browser_document_count: performanceSummary?.final?.dom?.documents ?? null,
     browser_js_event_listener_count: cdpMetrics.JSEventListeners ?? null,
+    ece_render_container_seen_ms: numberOrNull(renderMarks.container_seen),
+    ece_render_container_visible_ms: numberOrNull(renderMarks.container_visible),
+    ece_render_first_child_ms: numberOrNull(renderMarks.first_child),
+    ece_render_first_iframe_ms: numberOrNull(renderMarks.first_iframe),
+    ece_render_first_visible_iframe_ms: numberOrNull(renderMarks.first_visible_iframe),
+    ece_render_first_visible_button_ms: numberOrNull(renderMarks.first_visible_button),
+    ece_render_first_transitionend_ms: numberOrNull(renderMarks.first_transitionend),
+    ece_render_peak_child_count: peakSampleValue(renderSamples, 'child_count'),
+    ece_render_peak_iframe_count: peakSampleValue(renderSamples, 'iframe_count'),
+    ece_render_peak_visible_iframe_count: peakSampleValue(renderSamples, 'visible_iframe_count'),
+    ece_render_peak_button_count: peakSampleValue(renderSamples, 'button_count'),
+    ece_render_peak_visible_button_count: peakSampleValue(renderSamples, 'visible_button_count'),
+    ece_render_final_child_count: renderLatest.child_count ?? null,
+    ece_render_final_iframe_count: renderLatest.iframe_count ?? null,
+    ece_render_final_visible_iframe_count: renderLatest.visible_iframe_count ?? null,
+    ece_render_final_button_count: renderLatest.button_count ?? null,
+    ece_render_final_visible_button_count: renderLatest.visible_button_count ?? null,
   };
 
   await writeFile(metricsPath, `${JSON.stringify(metrics, null, 2)}\n`);
@@ -231,7 +351,8 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
         final_url: summary?.summary?.finalUrl || summary?.finalUrl || null,
         stripe_urls_sample: stripeUrls.slice(0, 20),
         google_urls_sample: googleUrls.slice(0, 20),
-        browser_script_result: summary?.summary?.scriptResult || summary?.scriptResult || null,
+        browser_script_result: scriptResult,
+        render_probe_events: Array.isArray(renderProbe.events) ? renderProbe.events.slice(0, 100) : [],
       },
       null,
       2

--- a/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
+++ b/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
@@ -20,6 +20,7 @@ https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1439.
 
 The stable signals are structural:
 
+- ECE container, child, iframe, visible iframe, and visible button timing.
 - Stripe/Stripe Network response count.
 - Total network response count.
 - Browser document count.
@@ -33,6 +34,19 @@ The stable signals are structural:
 treated as secondary until a larger interleaved matrix proves stable medians.
 The local workload includes WordPress setup, WP Codebox runtime scheduling,
 browser scheduling, and third-party Stripe network variance.
+
+## Render Timing Instrumentation
+
+The browser probe injects a pre-page observer before WooCommerce or Stripe page
+scripts run. It records the first time the ECE container is seen, becomes
+visible, receives children, receives Stripe iframes, receives visible iframes,
+receives visible buttons, and fires a transition event inside the ECE container.
+It also records peak child/iframe/button counts because Stripe can add and then
+remove surfaces during wallet eligibility checks.
+
+These fields are written to `ece-waterfall-metrics.json` with the
+`ece_render_*` prefix. The raw observer events are also preserved in
+`ece-waterfall-metadata.json` for debugging false positives or missing marks.
 
 ## Known Follow-Ups
 


### PR DESCRIPTION
## Summary
- Adds pre-page render instrumentation to the WooCommerce Stripe ECE product-page waterfall rig.
- Captures first container/child/iframe/visible-button timings plus peak/final ECE surface counts.
- Documents the new render metrics as the merchant-visible signal for issue #1439.

## Evidence
Validated locally against the WooCommerce Stripe fan-out candidate branch and packaged WooCommerce dependency.

Smoke trace result:
- Rig-backed `ece-product-page-waterfall` trace passed.
- Observed `32` Stripe/Stripe Network responses across `110` total responses on the current fan-out candidate branch.
- Render metrics populated: `ece_render_container_seen_ms=41`, `ece_render_first_child_ms=486`, `ece_render_first_iframe_ms=486`, `ece_render_peak_child_count=1`, `ece_render_peak_iframe_count=1`.
- Browser page errors log was empty.

## Related work
- Original rig PR: https://github.com/chubes4/homeboy-rigs/pull/173
- Stripe fixture dependency: https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5522
- Stripe fan-out fix using this evidence path: https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5530
- Reported performance issue: https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1439

## Testing
- `node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs`
- Rig-backed smoke trace with `HOMEBOY_WC_STRIPE_COMPONENT_PATH`, `HOMEBOY_WC_STRIPE_WOOCOMMERCE_PATH`, `HOMEBOY_WP_CODEBOX_BIN`, `--allow-local-toolchain`, and scenario `woocommerce-gateway-stripe ece-product-page-waterfall`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the render observer, metrics extraction, documentation updates, and local validation commands. Chris remains responsible for review and final acceptance.