### PR TITLE
Add secure Stripe ECE browser profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,31 @@ check reports missing checkout, Composer dependency, and generated feature-confi
 prerequisites with targeted messages. Use `homeboy rig up` for the safe dependency
 prep path before benchmarking.
 
+## woocommerce/woocommerce-gateway-stripe
+
+`rigs/woocommerce-stripe-ece-product-page/rig.json` runs the product-page
+Express Checkout Element browser waterfall trace against a local WooCommerce
+Stripe checkout plus a packaged WooCommerce dependency.
+
+```bash
+homeboy rig install /Users/chubes/Developer/homeboy-rigs@<branch>/woocommerce/woocommerce-gateway-stripe
+homeboy rig check woocommerce-stripe-ece-product-page
+homeboy trace --rig woocommerce-stripe-ece-product-page woocommerce-gateway-stripe ece-product-page-waterfall --output /tmp/wc-stripe-ece-waterfall.json
+```
+
+The `smoke` profile keeps the default WP Codebox browser behavior. The optional
+`secure-browser` profile depends on generic upstream preview/profile contracts
+from Extra-Chill/homeboy#3554 and Automattic/wp-codebox#651/#652 and keeps
+Stripe-specific scenario behavior in this rig package.
+
+```bash
+homeboy trace --rig woocommerce-stripe-ece-product-page \
+  --setting woocommerce_stripe_ece_browser_profile=secure-browser \
+  --setting woocommerce_stripe_ece_preview_public_url=https://example.test \
+  woocommerce-gateway-stripe ece-product-page-waterfall \
+  --output /tmp/wc-stripe-ece-secure-browser.json
+```
+
 ## chubes4/isolated-block-editor
 
 `rigs/isolated-block-editor/rig.json` runs the checks used while shaving Isolated Block Editor toward modern Gutenberg APIs.

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.mjs
@@ -1,0 +1,69 @@
+const DEFAULT_PROFILE = 'smoke';
+
+export function setting(name, defaultValue = '') {
+  const envName = `HOMEBOY_SETTINGS_${name.toUpperCase()}`;
+  if (process.env[envName]) {
+    return process.env[envName];
+  }
+
+  try {
+    const settings = JSON.parse(process.env.HOMEBOY_SETTINGS_JSON || '{}');
+    return settings[name] ?? defaultValue;
+  } catch {
+    return defaultValue;
+  }
+}
+
+export function eceBrowserProfile() {
+  return setting('woocommerce_stripe_ece_browser_profile', process.env.HOMEBOY_WC_STRIPE_ECE_BROWSER_PROFILE || DEFAULT_PROFILE) || DEFAULT_PROFILE;
+}
+
+export function previewPort() {
+  return setting('woocommerce_stripe_ece_preview_port', process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_PORT || process.env.HOMEBOY_INVOCATION_PORT_BASE || '');
+}
+
+export function previewBind() {
+  return setting('woocommerce_stripe_ece_preview_bind', process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_BIND || '127.0.0.1');
+}
+
+export function previewPublicUrl() {
+  return setting('woocommerce_stripe_ece_preview_public_url', process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL || '');
+}
+
+export function buildEceProfileOptions(profile = eceBrowserProfile()) {
+  if (profile !== 'secure-browser') {
+    return {
+      profile,
+      runtimePreview: null,
+      recipeRunArgs: [],
+      browserProbeArgs: [],
+    };
+  }
+
+  const port = previewPort();
+  const bind = previewBind();
+  const publicUrl = previewPublicUrl();
+  const runtimePreview = {
+    ...(port ? { port: Number.parseInt(port, 10) } : {}),
+    ...(bind ? { bind } : {}),
+    ...(publicUrl ? { publicUrl } : {}),
+  };
+
+  return {
+    profile,
+    runtimePreview: Object.keys(runtimePreview).length > 0 ? runtimePreview : null,
+    recipeRunArgs: [
+      ...(port ? ['--preview-port', port] : []),
+      ...(bind ? ['--preview-bind', bind] : []),
+      ...(publicUrl ? ['--preview-public-url', publicUrl] : []),
+    ],
+    browserProbeArgs: [
+      'browser=chromium',
+      'device=Desktop Chrome',
+      'locale=en-US',
+      'timezone=America/New_York',
+      'mobile=0',
+      'touch=0',
+    ],
+  };
+}

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildEceProfileOptions } from './ece-product-page-profile.mjs';
+
+test('default smoke profile preserves browser probe defaults', () => {
+  const options = buildEceProfileOptions('smoke');
+
+  assert.equal(options.profile, 'smoke');
+  assert.equal(options.runtimePreview, null);
+  assert.deepEqual(options.recipeRunArgs, []);
+  assert.deepEqual(options.browserProbeArgs, []);
+});
+
+test('secure-browser profile uses generic preview and browser profile args', () => {
+  const previous = {
+    HOMEBOY_WC_STRIPE_ECE_PREVIEW_PORT: process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_PORT,
+    HOMEBOY_WC_STRIPE_ECE_PREVIEW_BIND: process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_BIND,
+    HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL: process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL,
+  };
+
+  process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_PORT = '49800';
+  process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_BIND = '127.0.0.1';
+  process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL = 'https://example.test';
+
+  try {
+    const options = buildEceProfileOptions('secure-browser');
+
+    assert.equal(options.profile, 'secure-browser');
+    assert.deepEqual(options.runtimePreview, {
+      port: 49800,
+      bind: '127.0.0.1',
+      publicUrl: 'https://example.test',
+    });
+    assert.deepEqual(options.recipeRunArgs, [
+      '--preview-port',
+      '49800',
+      '--preview-bind',
+      '127.0.0.1',
+      '--preview-public-url',
+      'https://example.test',
+    ]);
+    assert.ok(options.browserProbeArgs.includes('browser=chromium'));
+    assert.ok(options.browserProbeArgs.includes('device=Desktop Chrome'));
+    assert.ok(options.browserProbeArgs.includes('locale=en-US'));
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+});

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -4,6 +4,7 @@ import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
+import { buildEceProfileOptions } from './ece-product-page-profile.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -19,6 +20,7 @@ const eceLocations = process.env.HOMEBOY_WC_STRIPE_ECE_LOCATIONS || 'product';
 const acceptedPaymentMethods = process.env.HOMEBOY_WC_STRIPE_ACCEPTED_PAYMENT_METHODS || 'card,link';
 const probeDuration = process.env.HOMEBOY_WC_STRIPE_ECE_PROBE_DURATION || '7s';
 const viewport = process.env.HOMEBOY_WC_STRIPE_ECE_VIEWPORT || '1366x900';
+const profileOptions = buildEceProfileOptions();
 
 if (!componentPath) {
   throw new Error('HOMEBOY_COMPONENT_PATH is required');
@@ -120,6 +122,7 @@ try {
     woocommerce_path: woocommercePath,
     ece_locations: csvToJsonArray(eceLocations),
     accepted_payment_methods: csvToJsonArray(acceptedPaymentMethods),
+    browser_profile: profileOptions.profile,
   });
 
   await writeFile(
@@ -235,6 +238,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     schema: 'wp-codebox/workspace-recipe/v1',
     runtime: {
       wp: wpVersion,
+      ...(profileOptions.runtimePreview ? { preview: profileOptions.runtimePreview } : {}),
       blueprint: {
         steps: [
           { step: 'activatePlugin', pluginPath: '/wordpress/wp-content/plugins/woocommerce/woocommerce.php' },
@@ -258,6 +262,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
             'wait-for=networkidle',
             `duration=${probeDuration}`,
             `viewport=${viewport}`,
+            ...profileOptions.browserProbeArgs,
             'capture=console,errors,html,network,performance,memory,screenshot',
             `pre-page-script=${prePageScript}`,
             `script=${browserProbeScript}`,
@@ -272,7 +277,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
 
   event('wp_codebox', 'recipe.start', { recipe_file: recipeFile });
   const { command, args } = wpCodeboxCommand();
-  const result = await execFileAsync(command, [...args, 'recipe-run', '--recipe', recipeFile, '--artifacts', codeboxArtifacts, '--json'], {
+  const result = await execFileAsync(command, [...args, 'recipe-run', '--recipe', recipeFile, '--artifacts', codeboxArtifacts, ...profileOptions.recipeRunArgs, '--json'], {
     maxBuffer: 1024 * 1024 * 50,
   });
   await writeFile(outputFile, result.stdout);
@@ -349,6 +354,9 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     `${JSON.stringify(
       {
         final_url: summary?.summary?.finalUrl || summary?.finalUrl || null,
+        browser_profile: profileOptions.profile,
+        runtime_preview: profileOptions.runtimePreview,
+        browser_probe_args: profileOptions.browserProbeArgs,
         stripe_urls_sample: stripeUrls.slice(0, 20),
         google_urls_sample: googleUrls.slice(0, 20),
         browser_script_result: scriptResult,

--- a/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
+++ b/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
@@ -16,6 +16,43 @@ https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1439.
    artifacts.
 8. Extract normalized waterfall metrics into `ece-waterfall-metrics.json`.
 
+## Browser Profiles
+
+The default `smoke` profile preserves the existing WP Codebox browser-probe
+defaults: local Playground origin, default Chromium context, and the rig's fixed
+`1366x900` viewport.
+
+Set `woocommerce_stripe_ece_browser_profile=secure-browser` to run the same
+Stripe product-page scenario through generic secure/browser-visible upstream
+knobs:
+
+- Homeboy trace `port_range_size` allocates a preview port and exposes it as
+  `HOMEBOY_INVOCATION_PORT_BASE/MAX` once Extra-Chill/homeboy#3554 lands.
+- WP Codebox recipe/CLI preview routing receives `preview.port`,
+  `preview.bind`, and `preview.publicUrl` from generic preview settings once
+  Automattic/wp-codebox#651 lands.
+- `wordpress.browser-probe` receives generic browser context args such as
+  `browser=chromium`, `device=Desktop Chrome`, `locale=en-US`, and `timezone`
+  once Automattic/wp-codebox#652 lands.
+
+The profile does not encode Stripe, wallet, or payment semantics in WP Codebox.
+Those decisions stay in this Homeboy Rigs workload.
+
+Example secure-profile run against upstream branches that provide the generic
+contracts:
+
+```bash
+homeboy trace --rig woocommerce-stripe-ece-product-page \
+  --setting woocommerce_stripe_ece_browser_profile=secure-browser \
+  --setting woocommerce_stripe_ece_preview_public_url=https://example.test \
+  woocommerce-gateway-stripe ece-product-page-waterfall \
+  --output /tmp/wc-stripe-ece-secure-browser.json
+```
+
+If `woocommerce_stripe_ece_preview_port` is not set, the workload uses
+`HOMEBOY_INVOCATION_PORT_BASE` when Homeboy provides it. The preview bind
+defaults to `127.0.0.1`.
+
 ## Primary Signals
 
 The stable signals are structural:

--- a/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
+++ b/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
@@ -23,6 +23,7 @@
       {
         "path": "${package.root}/bench/ece-product-page-waterfall.trace.mjs",
         "check_groups": [],
+        "port_range_size": 1,
         "trace_default_phase_preset": "browser-waterfall",
         "trace_phase_presets": {
           "browser-waterfall": [
@@ -52,6 +53,9 @@
   },
   "trace_profiles": {
     "smoke": [
+      "ece-product-page-waterfall"
+    ],
+    "secure-browser": [
       "ece-product-page-waterfall"
     ],
     "hot": [


### PR DESCRIPTION
## Summary
- Adds an opt-in `secure-browser` profile for the WooCommerce Stripe ECE product-page trace while preserving the default `smoke` browser probe behavior.
- Wires the profile through generic Homeboy/WP Codebox preview and browser-context knobs: trace `port_range_size`, recipe/CLI preview settings, and `wordpress.browser-probe` context args.
- Documents the upstream dependency shape and adds focused tests for default vs secure profile argument generation.

## Links
- Closes #175
- Depends on Extra-Chill/homeboy#3554 / Extra-Chill/homeboy#3555 (merged)
- Depends on Automattic/wp-codebox#651 / Automattic/wp-codebox#654 (merged)
- Depends on Automattic/wp-codebox#652 / Automattic/wp-codebox#656 (merged)
- Related WooCommerce Stripe fixture dependency: woocommerce/woocommerce-gateway-stripe#5522

## Verification
- `node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`
- `node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs`
- `node scripts/lint-rig-packages.mjs`
- `HOMEBOY_WC_STRIPE_COMPONENT_PATH=<woocommerce-gateway-stripe fixture/fan-out checkout> HOMEBOY_WC_STRIPE_WOOCOMMERCE_PATH=<packaged WooCommerce plugin> homeboy rig install <homeboy-rigs>/woocommerce/woocommerce-gateway-stripe && ... homeboy rig check woocommerce-stripe-ece-product-page`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implementing the secure-browser Homeboy Rigs profile wiring, docs, tests, and verification notes; Chris directed the upstream-boundary constraints and final review remains Chris's responsibility.