### PR TITLE
Expand WooCommerce Stripe ECE lifecycle rig

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,10 +270,24 @@ homeboy rig check woocommerce-stripe-ece-product-page
 homeboy trace --rig woocommerce-stripe-ece-product-page woocommerce-gateway-stripe ece-product-page-waterfall --output /tmp/wc-stripe-ece-waterfall.json
 ```
 
+Additional trace scenarios cover post-load interactions for scrolling to the ECE
+container, changing quantity, and attempting variation changes while preserving
+the original load-only `smoke` behavior.
+
+```bash
+homeboy trace --rig woocommerce-stripe-ece-product-page woocommerce-gateway-stripe ece-product-page-scroll-to-ece
+homeboy trace --rig woocommerce-stripe-ece-product-page woocommerce-gateway-stripe ece-product-page-quantity-change
+homeboy trace --rig woocommerce-stripe-ece-product-page woocommerce-gateway-stripe ece-product-page-variation-change
+```
+
 The `smoke` profile keeps the default WP Codebox browser behavior. The optional
 `secure-browser` profile depends on generic upstream preview/profile contracts
 from Extra-Chill/homeboy#3554 and Automattic/wp-codebox#651/#652 and keeps
 Stripe-specific scenario behavior in this rig package.
+Default local HTTP/headless traces are request/lifecycle evidence, not wallet
+eligibility proof. Secure-context evidence requires the `secure-browser` profile
+and an HTTPS public preview URL; each trace records requested/effective browser
+context metadata so the evidence type is explicit.
 
 ```bash
 homeboy trace --rig woocommerce-stripe-ece-product-page \

--- a/woocommerce/woocommerce-gateway-stripe/README.md
+++ b/woocommerce/woocommerce-gateway-stripe/README.md
@@ -14,6 +14,13 @@ runtime, mounts WooCommerce and WooCommerce Stripe, uses Stripe's benchmark
 fixture to create a purchasable product with product-page ECE enabled, opens the
 product page in a browser probe, and records waterfall metrics.
 
+The default `ece-product-page-waterfall` scenario remains load-only. Additional
+scenario IDs reuse the same fixture and add post-load product-page interactions:
+
+- `ece-product-page-scroll-to-ece`
+- `ece-product-page-quantity-change`
+- `ece-product-page-variation-change`
+
 Primary metrics:
 
 - `ece_render_container_seen_ms`
@@ -26,6 +33,10 @@ Primary metrics:
 - `ece_render_peak_visible_iframe_count`
 - `stripe_response_count`
 - `network_response_count`
+- `console_message_count`
+- `page_error_count`
+- `ece_interaction_event_count`
+- `ece_interaction_succeeded`
 - `browser_document_count`
 - `browser_js_event_listener_count`
 - `browser_dom_node_count`
@@ -78,6 +89,27 @@ Run a single trace:
 homeboy trace --rig woocommerce-stripe-ece-product-page woocommerce-gateway-stripe ece-product-page-waterfall
 ```
 
+Run the lifecycle matrix explicitly to compare load-only and interaction
+scenarios:
+
+```bash
+homeboy trace --rig woocommerce-stripe-ece-product-page \
+  woocommerce-gateway-stripe ece-product-page-waterfall
+homeboy trace --rig woocommerce-stripe-ece-product-page \
+  woocommerce-gateway-stripe ece-product-page-scroll-to-ece
+homeboy trace --rig woocommerce-stripe-ece-product-page \
+  woocommerce-gateway-stripe ece-product-page-quantity-change
+homeboy trace --rig woocommerce-stripe-ece-product-page \
+  woocommerce-gateway-stripe ece-product-page-variation-change
+```
+
+Run one interaction scenario directly:
+
+```bash
+homeboy trace --rig woocommerce-stripe-ece-product-page \
+  woocommerce-gateway-stripe ece-product-page-quantity-change
+```
+
 Pass `--path /path/to/woocommerce-gateway-stripe-worktree` when tracing a local
 candidate branch or proof worktree.
 
@@ -110,3 +142,11 @@ The ECE render metrics are captured by a `pre-page-script` observer injected
 before page scripts run. They are intended to match the merchant-visible symptom:
 how long it takes for Express Checkout containers, iframes, and visible button
 surfaces to appear after the browser starts loading the product page.
+
+The metadata artifact records requested and effective browser context, including
+requested viewport, effective viewport, browser profile, preview settings, final
+URL, user agent, and whether the page ran in `window.isSecureContext`. Treat the
+default local HTTP/headless profile as request/lifecycle evidence only. It can
+show Stripe requests, ECE containers, iframes, buttons, console output, and page
+errors, but it is not wallet-eligibility proof. Use the `secure-browser` profile
+with an HTTPS public preview URL when collecting secure-context wallet evidence.

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { buildEceProfileOptions } from './ece-product-page-profile.mjs';
+import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceProductPageScenario, eceProductPageScenarioIds } from './ece-product-page-scenarios.mjs';
 
 test('default smoke profile preserves browser probe defaults', () => {
   const options = buildEceProfileOptions('smoke');
@@ -52,4 +53,18 @@ test('secure-browser profile uses generic preview and browser profile args', () 
       }
     }
   }
+});
+
+test('ECE scenario registry preserves load-only default and exposes interactions', () => {
+  assert.equal(eceProductPageScenario().id, DEFAULT_ECE_SCENARIO_ID);
+  assert.equal(eceProductPageScenario(DEFAULT_ECE_SCENARIO_ID).interaction, 'load-only');
+  assert.equal(eceProductPageScenario('ece-product-page-scroll-to-ece').interaction, 'scroll-to-ece');
+  assert.equal(eceProductPageScenario('ece-product-page-quantity-change').interaction, 'quantity-change');
+  assert.ok(eceProductPageScenarioIds().includes(DEFAULT_ECE_SCENARIO_ID));
+  assert.ok(eceProductPageScenarioIds().includes('ece-product-page-scroll-to-ece'));
+});
+
+test('ECE interaction scripts keep Stripe selectors in the rig', () => {
+  assert.match(eceInteractionScript(eceProductPageScenario('ece-product-page-scroll-to-ece')), /#wc-stripe-express-checkout-element/);
+  assert.match(eceInteractionScript(eceProductPageScenario('ece-product-page-quantity-change')), /quantity_change/);
 });

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-quantity-change.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-quantity-change.trace.mjs
@@ -1,0 +1,1 @@
+import './ece-product-page-waterfall.trace.mjs';

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-scenarios.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-scenarios.mjs
@@ -1,0 +1,93 @@
+export const DEFAULT_ECE_SCENARIO_ID = 'ece-product-page-waterfall';
+
+const SCENARIOS = {
+  [DEFAULT_ECE_SCENARIO_ID]: {
+    id: DEFAULT_ECE_SCENARIO_ID,
+    profile: 'load-only',
+    interaction: 'load-only',
+    description: 'Load the product page and record the initial ECE render lifecycle.',
+  },
+  'ece-product-page-scroll-to-ece': {
+    id: 'ece-product-page-scroll-to-ece',
+    profile: 'scroll-to-ece',
+    interaction: 'scroll-to-ece',
+    description: 'Scroll the product-page ECE container into view after load.',
+  },
+  'ece-product-page-quantity-change': {
+    id: 'ece-product-page-quantity-change',
+    profile: 'quantity-change',
+    interaction: 'quantity-change',
+    description: 'Change the product quantity after load and record ECE lifecycle stability.',
+  },
+  'ece-product-page-variation-change': {
+    id: 'ece-product-page-variation-change',
+    profile: 'variation-change',
+    interaction: 'variation-change',
+    description: 'Attempt a product variation selection change when variation controls exist.',
+  },
+};
+
+export function eceProductPageScenario(scenarioId = DEFAULT_ECE_SCENARIO_ID) {
+  return SCENARIOS[scenarioId] || SCENARIOS[DEFAULT_ECE_SCENARIO_ID];
+}
+
+export function eceProductPageScenarioIds() {
+  return Object.keys(SCENARIOS);
+}
+
+export function eceInteractionScript(scenario) {
+  switch (scenario.interaction) {
+    case 'scroll-to-ece':
+      return `
+        const container = document.querySelector('#wc-stripe-express-checkout-element');
+        interactionSnapshot('before_scroll_to_ece');
+        if (container) {
+          container.scrollIntoView({ block: 'center', inline: 'nearest' });
+          interactionEvents.push({ name: 'scroll_to_ece', t_ms: elapsed(), ok: true });
+          await sleep(750);
+          sample();
+          interactionSnapshot('after_scroll_to_ece');
+        } else {
+          interactionEvents.push({ name: 'scroll_to_ece', t_ms: elapsed(), ok: false, reason: 'missing_ece_container' });
+        }
+      `;
+    case 'quantity-change':
+      return `
+        const quantity = document.querySelector('form.cart input.qty, input.qty[name="quantity"], input[name="quantity"]');
+        interactionSnapshot('before_quantity_change');
+        if (quantity) {
+          const before = Number.parseInt(quantity.value || quantity.getAttribute('value') || '1', 10) || 1;
+          quantity.value = String(before + 1);
+          quantity.dispatchEvent(new Event('input', { bubbles: true }));
+          quantity.dispatchEvent(new Event('change', { bubbles: true }));
+          interactionEvents.push({ name: 'quantity_change', t_ms: elapsed(), ok: true, before, after: before + 1 });
+          await sleep(750);
+          sample();
+          interactionSnapshot('after_quantity_change');
+        } else {
+          interactionEvents.push({ name: 'quantity_change', t_ms: elapsed(), ok: false, reason: 'missing_quantity_input' });
+        }
+      `;
+    case 'variation-change':
+      return `
+        const selects = Array.from(document.querySelectorAll('form.variations_form select'));
+        interactionSnapshot('before_variation_change');
+        const select = selects.find((candidate) => Array.from(candidate.options || []).some((option) => option.value && option.value !== candidate.value));
+        if (select) {
+          const option = Array.from(select.options || []).find((candidate) => candidate.value && candidate.value !== select.value);
+          const before = select.value;
+          select.value = option.value;
+          select.dispatchEvent(new Event('input', { bubbles: true }));
+          select.dispatchEvent(new Event('change', { bubbles: true }));
+          interactionEvents.push({ name: 'variation_change', t_ms: elapsed(), ok: true, before, after: select.value });
+          await sleep(1000);
+          sample();
+          interactionSnapshot('after_variation_change');
+        } else {
+          interactionEvents.push({ name: 'variation_change', t_ms: elapsed(), ok: false, reason: 'missing_variation_select' });
+        }
+      `;
+    default:
+      return `interactionSnapshot('load_only_final');`;
+  }
+}

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-scroll-to-ece.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-scroll-to-ece.trace.mjs
@@ -1,0 +1,1 @@
+import './ece-product-page-waterfall.trace.mjs';

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-variation-change.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-variation-change.trace.mjs
@@ -1,0 +1,1 @@
+import './ece-product-page-waterfall.trace.mjs';

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -5,12 +5,14 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import { buildEceProfileOptions } from './ece-product-page-profile.mjs';
+import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceProductPageScenario } from './ece-product-page-scenarios.mjs';
 
 const execFileAsync = promisify(execFile);
 
 const componentPath = process.env.HOMEBOY_COMPONENT_PATH;
 const componentId = process.env.HOMEBOY_COMPONENT_ID || 'woocommerce-gateway-stripe';
-const scenarioId = process.env.HOMEBOY_TRACE_SCENARIO || 'ece-product-page-waterfall';
+const scenarioId = process.env.HOMEBOY_TRACE_SCENARIO || DEFAULT_ECE_SCENARIO_ID;
+const scenario = eceProductPageScenario(scenarioId);
 const resultsFile = process.env.HOMEBOY_TRACE_RESULTS_FILE;
 const artifactDir = process.env.HOMEBOY_TRACE_ARTIFACT_DIR || path.join(tmpdir(), 'wc-stripe-ece-waterfall-artifacts');
 const wpCodeboxBin = process.env.HOMEBOY_WP_CODEBOX_BIN || 'wp-codebox';
@@ -107,6 +109,18 @@ function numberOrNull(value) {
   return typeof value === 'number' && Number.isFinite(value) ? Math.round(value) : null;
 }
 
+function parseViewport(value) {
+  const match = /^(\d+)x(\d+)$/.exec(value || '');
+  if (!match) {
+    return null;
+  }
+
+  return {
+    width: Number.parseInt(match[1], 10),
+    height: Number.parseInt(match[2], 10),
+  };
+}
+
 function peakSampleValue(samples, key) {
   if (!Array.isArray(samples)) {
     return null;
@@ -122,6 +136,8 @@ try {
     woocommerce_path: woocommercePath,
     ece_locations: csvToJsonArray(eceLocations),
     accepted_payment_methods: csvToJsonArray(acceptedPaymentMethods),
+    ece_scenario_profile: scenario.profile,
+    ece_interaction: scenario.interaction,
     browser_profile: profileOptions.profile,
   });
 
@@ -233,7 +249,72 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   window.setTimeout(() => window.clearInterval(state.interval), 15000);
   observe();
 })();`;
-  const browserProbeScript = "const probe = window.__wcStripeEceRenderProbe || null; if (probe && probe.interval) { window.clearInterval(probe.interval); } window.__wpCodeboxProbeCheckpoint && window.__wpCodeboxProbeCheckpoint('ece-waterfall-after-wait', { buttons: document.querySelectorAll('#wc-stripe-express-checkout-element iframe, #wc-stripe-express-checkout-element button').length, renderProbe: probe }); return { title: document.title, eceContainer: !!document.querySelector('#wc-stripe-express-checkout-element'), eceChildren: document.querySelectorAll('#wc-stripe-express-checkout-element > div').length, iframes: document.querySelectorAll('iframe').length, renderProbe: probe };";
+  const browserProbeScript = `
+    const probe = window.__wcStripeEceRenderProbe || null;
+    const interactionEvents = [];
+    const sleep = (ms) => new Promise((resolve) => window.setTimeout(resolve, ms));
+    const elapsed = () => probe?.startedAt ? Math.round(performance.now() - probe.startedAt) : null;
+    const sample = () => {
+      const container = document.querySelector('#wc-stripe-express-checkout-element');
+      const isVisible = (node) => {
+        if (!node || !(node instanceof Element)) {
+          return false;
+        }
+        const style = window.getComputedStyle(node);
+        const rect = node.getBoundingClientRect();
+        return style.visibility !== 'hidden' && style.display !== 'none' && rect.width > 0 && rect.height > 0;
+      };
+      if (!container) {
+        return {
+          ece_container: false,
+          ece_child_count: 0,
+          ece_iframe_count: 0,
+          ece_visible_iframe_count: 0,
+          ece_button_count: 0,
+          ece_visible_button_count: 0,
+        };
+      }
+      const iframes = Array.from(container.querySelectorAll('iframe'));
+      const buttons = Array.from(container.querySelectorAll('button'));
+      return {
+        ece_container: true,
+        ece_child_count: container.children?.length || 0,
+        ece_iframe_count: iframes.length,
+        ece_visible_iframe_count: iframes.filter(isVisible).length,
+        ece_button_count: buttons.length,
+        ece_visible_button_count: buttons.filter(isVisible).length,
+      };
+    };
+    const interactionSnapshot = (name) => {
+      interactionEvents.push({ name, t_ms: elapsed(), ...sample() });
+    };
+    ${eceInteractionScript(scenario)}
+    if (probe && probe.interval) {
+      window.clearInterval(probe.interval);
+    }
+    const finalSnapshot = sample();
+    window.__wpCodeboxProbeCheckpoint && window.__wpCodeboxProbeCheckpoint('ece-waterfall-after-wait', {
+      scenario: ${JSON.stringify(scenario.id)},
+      interaction: ${JSON.stringify(scenario.interaction)},
+      buttons: document.querySelectorAll('#wc-stripe-express-checkout-element iframe, #wc-stripe-express-checkout-element button').length,
+      interactionEvents,
+      renderProbe: probe,
+    });
+    return {
+      title: document.title,
+      scenario: ${JSON.stringify(scenario.id)},
+      interaction: ${JSON.stringify(scenario.interaction)},
+      interactionEvents,
+      isSecureContext: window.isSecureContext === true,
+      locationOrigin: window.location.origin,
+      userAgent: navigator.userAgent,
+      eceContainer: !!document.querySelector('#wc-stripe-express-checkout-element'),
+      eceChildren: document.querySelectorAll('#wc-stripe-express-checkout-element > div').length,
+      iframes: document.querySelectorAll('iframe').length,
+      finalSnapshot,
+      renderProbe: probe,
+    };
+  `;
   const recipe = {
     schema: 'wp-codebox/workspace-recipe/v1',
     runtime: {
@@ -289,7 +370,11 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   const networkPath = browserDir ? path.join(browserDir, 'network.jsonl') : '';
   const summaryPath = browserDir ? path.join(browserDir, 'summary.json') : '';
   const performancePath = browserDir ? path.join(browserDir, 'performance.json') : '';
+  const consolePath = browserDir ? path.join(browserDir, 'console.jsonl') : '';
+  const errorsPath = browserDir ? path.join(browserDir, 'errors.jsonl') : '';
   const network = await readJsonl(networkPath);
+  const consoleMessages = await readJsonl(consolePath);
+  const pageErrors = await readJsonl(errorsPath);
   const responses = network.filter((entry) => entry.type === 'response');
   const urls = responses.map((entry) => entry.url || entry.request?.url || '').filter(Boolean);
   const stripeUrls = urls.filter((url) => /(^|\.)stripe\.com|stripe\.network/.test(url));
@@ -304,6 +389,10 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   const renderMarks = renderProbe?.marks || {};
   const renderLatest = renderProbe?.latest || {};
   const renderSamples = renderProbe?.samples || [];
+  const requestedViewport = parseViewport(viewport);
+  const effectiveViewport = summary?.viewport || summary?.summary?.viewport || null;
+  const interactionEvents = Array.isArray(scriptResult?.interactionEvents) ? scriptResult.interactionEvents : [];
+  const interactionSucceeded = scenario.interaction === 'load-only' || interactionEvents.some((entry) => entry?.ok === true);
 
   event('browser', 'probe.ready', {
     total_responses: responses.length,
@@ -315,7 +404,14 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     stripe_response_count: stripeUrls.length,
     google_response_count: googleUrls.length,
     iframe_response_count: iframeResponses.length,
+    console_message_count: consoleMessages.length,
+    page_error_count: pageErrors.length,
     browser_probe_duration_ms: summary?.durationMs ?? null,
+    browser_requested_viewport_width: requestedViewport?.width ?? null,
+    browser_requested_viewport_height: requestedViewport?.height ?? null,
+    browser_effective_viewport_width: effectiveViewport?.width ?? null,
+    browser_effective_viewport_height: effectiveViewport?.height ?? null,
+    browser_secure_context_effective: scriptResult?.isSecureContext === true,
     browser_dom_content_loaded_ms: relativeTimingMs(cdpMetrics, 'DomContentLoaded'),
     browser_first_meaningful_paint_ms: relativeTimingMs(cdpMetrics, 'FirstMeaningfulPaint'),
     browser_iframe_count: browserMetrics.browser_iframe_count ?? null,
@@ -346,6 +442,8 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     ece_render_final_visible_iframe_count: renderLatest.visible_iframe_count ?? null,
     ece_render_final_button_count: renderLatest.button_count ?? null,
     ece_render_final_visible_button_count: renderLatest.visible_button_count ?? null,
+    ece_interaction_event_count: interactionEvents.length,
+    ece_interaction_succeeded: interactionSucceeded,
   };
 
   await writeFile(metricsPath, `${JSON.stringify(metrics, null, 2)}\n`);
@@ -354,12 +452,32 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     `${JSON.stringify(
       {
         final_url: summary?.summary?.finalUrl || summary?.finalUrl || null,
+        scenario: {
+          id: scenario.id,
+          profile: scenario.profile,
+          interaction: scenario.interaction,
+          description: scenario.description,
+        },
         browser_profile: profileOptions.profile,
-        runtime_preview: profileOptions.runtimePreview,
-        browser_probe_args: profileOptions.browserProbeArgs,
+        requested_browser_context: {
+          viewport,
+          browser_profile: profileOptions.profile,
+          runtime_preview: profileOptions.runtimePreview,
+          browser_probe_args: profileOptions.browserProbeArgs,
+          secure_context_profile: profileOptions.profile === 'secure-browser',
+        },
+        effective_browser_context: {
+          viewport: effectiveViewport,
+          is_secure_context: scriptResult?.isSecureContext === true,
+          location_origin: scriptResult?.locationOrigin || null,
+          user_agent: scriptResult?.userAgent || null,
+        },
         stripe_urls_sample: stripeUrls.slice(0, 20),
         google_urls_sample: googleUrls.slice(0, 20),
+        console_messages_sample: consoleMessages.slice(0, 20),
+        page_errors_sample: pageErrors.slice(0, 20),
         browser_script_result: scriptResult,
+        interaction_events: interactionEvents,
         render_probe_events: Array.isArray(renderProbe.events) ? renderProbe.events.slice(0, 100) : [],
       },
       null,
@@ -387,6 +505,16 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
         id: 'network-response-count',
         status: responses.length > 0 ? 'pass' : 'fail',
         message: `Observed ${responses.length} total network responses.`,
+      },
+      {
+        id: 'page-errors-recorded',
+        status: 'pass',
+        message: `Recorded ${pageErrors.length} page errors.`,
+      },
+      {
+        id: 'scenario-interaction',
+        status: 'pass',
+        message: `${scenario.interaction} interaction produced ${interactionEvents.length} event(s).`,
       },
     ],
     artifacts: [

--- a/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
+++ b/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
@@ -48,19 +48,118 @@
             "blocking": true
           }
         }
+      },
+      {
+        "path": "${package.root}/bench/ece-product-page-scroll-to-ece.trace.mjs",
+        "check_groups": [],
+        "port_range_size": 1,
+        "trace_default_phase_preset": "browser-waterfall",
+        "trace_phase_presets": {
+          "browser-waterfall": [
+            "start:scenario.start",
+            "recipe:wp_codebox.recipe.start",
+            "setup:wordpress.fixture.ready",
+            "probe:browser.probe.ready",
+            "metrics:waterfall.metrics.ready"
+          ]
+        },
+        "trace_span_metadata": {
+          "phase.recipe_to_setup": {
+            "category": "runtime_setup",
+            "blocking": true
+          },
+          "phase.setup_to_probe": {
+            "category": "browser_probe",
+            "blocking": true
+          },
+          "phase.probe_to_metrics": {
+            "category": "artifact_extraction",
+            "blocking": true
+          }
+        }
+      },
+      {
+        "path": "${package.root}/bench/ece-product-page-quantity-change.trace.mjs",
+        "check_groups": [],
+        "port_range_size": 1,
+        "trace_default_phase_preset": "browser-waterfall",
+        "trace_phase_presets": {
+          "browser-waterfall": [
+            "start:scenario.start",
+            "recipe:wp_codebox.recipe.start",
+            "setup:wordpress.fixture.ready",
+            "probe:browser.probe.ready",
+            "metrics:waterfall.metrics.ready"
+          ]
+        },
+        "trace_span_metadata": {
+          "phase.recipe_to_setup": {
+            "category": "runtime_setup",
+            "blocking": true
+          },
+          "phase.setup_to_probe": {
+            "category": "browser_probe",
+            "blocking": true
+          },
+          "phase.probe_to_metrics": {
+            "category": "artifact_extraction",
+            "blocking": true
+          }
+        }
+      },
+      {
+        "path": "${package.root}/bench/ece-product-page-variation-change.trace.mjs",
+        "check_groups": [],
+        "port_range_size": 1,
+        "trace_default_phase_preset": "browser-waterfall",
+        "trace_phase_presets": {
+          "browser-waterfall": [
+            "start:scenario.start",
+            "recipe:wp_codebox.recipe.start",
+            "setup:wordpress.fixture.ready",
+            "probe:browser.probe.ready",
+            "metrics:waterfall.metrics.ready"
+          ]
+        },
+        "trace_span_metadata": {
+          "phase.recipe_to_setup": {
+            "category": "runtime_setup",
+            "blocking": true
+          },
+          "phase.setup_to_probe": {
+            "category": "browser_probe",
+            "blocking": true
+          },
+          "phase.probe_to_metrics": {
+            "category": "artifact_extraction",
+            "blocking": true
+          }
+        }
       }
     ]
   },
   "trace_profiles": {
-    "smoke": [
-      "ece-product-page-waterfall"
-    ],
-    "secure-browser": [
-      "ece-product-page-waterfall"
-    ],
-    "hot": [
-      "ece-product-page-waterfall"
-    ]
+    "smoke": {
+      "scenario": "ece-product-page-waterfall"
+    },
+    "secure-browser": {
+      "scenario": "ece-product-page-waterfall",
+      "settings": {
+        "woocommerce_stripe_ece_browser_profile": "secure-browser"
+      }
+    },
+    "hot": {
+      "scenario": "ece-product-page-waterfall"
+    },
+    "scroll-to-ece": {
+      "scenario": "ece-product-page-scroll-to-ece"
+    },
+    "quantity-change": {
+      "scenario": "ece-product-page-quantity-change"
+    },
+    "variation-change": {
+      "scenario": "ece-product-page-variation-change"
+    }
   },
   "pipeline": {
     "check": [


### PR DESCRIPTION
## Summary
- Adds Stripe ECE product-page interaction trace scenarios for scroll-to-ECE, quantity changes, and variation changes while preserving the existing load-only smoke/default scenario.
- Records console/page errors, requested/effective browser context, secure-context state, interaction events, and ECE iframe/button lifecycle counts in the rig artifacts.
- Documents local HTTP/headless traces as request/lifecycle evidence and secure-browser HTTPS traces as the path for wallet-eligibility evidence.

Closes #177.

## Tests
- `node scripts/lint-rig-packages.mjs`
- `node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`
- `HOMEBOY_WC_STRIPE_COMPONENT_PATH=/Users/chubes/Developer/woocommerce-gateway-stripe@proof-stripe-ece-baseline-20260605 HOMEBOY_WC_STRIPE_WOOCOMMERCE_PATH=/Users/chubes/Developer/woocommerce/plugins/woocommerce homeboy rig check woocommerce-stripe-ece-product-page`
- `homeboy trace --rig woocommerce-stripe-ece-product-page woocommerce-gateway-stripe list --json-summary`
- `homeboy trace --rig woocommerce-stripe-ece-product-page --profiles list --json-summary`

## Notes
- The default `/Users/chubes/Developer/woocommerce-gateway-stripe` checkout does not include `tests/benchmarks/fixture-bootstrap.php`, so the rig check was verified against `/Users/chubes/Developer/woocommerce-gateway-stripe@proof-stripe-ece-baseline-20260605`, which includes the benchmark fixture required by the rig.
- Trace list commands emitted a warm-machine resource policy warning but completed successfully.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the rig scenario expansion, documentation updates, verification commands, and PR drafting for Chris to review.