### PR TITLE
Add WooCommerce layered nav cache proof workloads

### DIFF
--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -74,6 +74,7 @@ php bin/generate-feature-config.php
 homeboy rig up woocommerce-performance
 homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-bench
 homeboy bench --rig woocommerce-performance --scenario layered-nav-count-cache --iterations 1 --shared-state /tmp/woocommerce-layered-nav-cache --setting-json 'bench_env={"WC_LAYERED_NAV_CACHE_ITERATIONS":"150","WC_LAYERED_NAV_CACHE_LIMIT":"25"}'
+homeboy bench --rig woocommerce-performance --scenario layered-nav-catalog-crawl --iterations 1 --shared-state /tmp/woocommerce-layered-nav-crawl --setting-json 'bench_env={"WC_LAYERED_NAV_CRAWL_REQUESTS":"150","WC_LAYERED_NAV_CRAWL_LIMIT":"25"}'
 homeboy bench --rig woocommerce-performance --profile hot --iterations 1 --shared-state /tmp/woocommerce-performance-hot --setting-json 'bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"120","WC_SHIPPING_CACHE_PACKAGES":"24"}' --force-hot
 ```
 
@@ -94,6 +95,9 @@ into `tests/bench/`, and returns the normalized Homeboy `BenchResults` envelope.
   across many unique layered-nav count query hashes to measure growth of the
   single `wc_layered_nav_counts_*` taxonomy transient reported in WooCommerce
   issue #17355.
+- `layered-nav-catalog-crawl` uses real `filter_*` request combinations and
+  renders the layered-nav widget list path for each request shape, measuring
+  the same transient growth through a crawler/catalog-traffic-shaped path.
 
 ## Metrics
 

--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -17,6 +17,7 @@ performance bugs in disposable WordPress/WooCommerce runtimes.
 - https://github.com/woocommerce/woocommerce/issues/49259
 - https://github.com/woocommerce/woocommerce/issues/32055
 - https://github.com/woocommerce/woocommerce/issues/26569
+- https://github.com/woocommerce/woocommerce/issues/17355
 
 ## Install
 
@@ -72,6 +73,7 @@ php bin/generate-feature-config.php
 ```bash
 homeboy rig up woocommerce-performance
 homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-bench
+homeboy bench --rig woocommerce-performance --scenario layered-nav-count-cache --iterations 1 --shared-state /tmp/woocommerce-layered-nav-cache --setting-json 'bench_env={"WC_LAYERED_NAV_CACHE_ITERATIONS":"150","WC_LAYERED_NAV_CACHE_LIMIT":"25"}'
 homeboy bench --rig woocommerce-performance --profile hot --iterations 1 --shared-state /tmp/woocommerce-performance-hot --setting-json 'bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"120","WC_SHIPPING_CACHE_PACKAGES":"24"}' --force-hot
 ```
 
@@ -87,6 +89,11 @@ into `tests/bench/`, and returns the normalized Homeboy `BenchResults` envelope.
   packages, and measures cold, warm, totals-only churn, and address-rehashed
   shipping calculation passes through WooCommerce's checkout/cart shipping cache
   path.
+- `layered-nav-count-cache` seeds a real WooCommerce product attribute, terms,
+  and simple products, then exercises `Filterer::get_filtered_term_product_counts()`
+  across many unique layered-nav count query hashes to measure growth of the
+  single `wc_layered_nav_counts_*` taxonomy transient reported in WooCommerce
+  issue #17355.
 
 ## Metrics
 
@@ -98,6 +105,9 @@ The first slice reports:
   `total_churn_rate_calculation_calls` for package subtotal/total-only churn.
 - `rehash_shipping_p50_ms` and `rehash_to_warm_ratio` for address/hash changes.
 - Package, item, rate, and session-cache key counts.
+- `final_transient_entry_count`, `max_transient_entry_count`,
+  `final_serialized_value_bytes`, and `cache_exceeded_limit` for layered-nav
+  count cache growth.
 
 See `docs/checkout-shipping-cache.md` for workload details and current TODOs.
 

--- a/woocommerce/woocommerce/bench/layered-nav-catalog-crawl.php
+++ b/woocommerce/woocommerce/bench/layered-nav-catalog-crawl.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * WP Codebox-backed WooCommerce layered-nav catalog crawl workload.
+ *
+ * Exercises the real layered-nav widget path with many distinct filter request
+ * combinations to reproduce the cache-growth traffic shape from bots/crawlers.
+ */
+return function (): array {
+	if ( ! class_exists( 'WooCommerce' ) ) {
+		$woocommerce_entrypoint = WP_PLUGIN_DIR . '/woocommerce/woocommerce.php';
+		if ( ! file_exists( $woocommerce_entrypoint ) ) {
+			throw new RuntimeException( 'WooCommerce plugin entrypoint is not mounted.' );
+		}
+		require_once $woocommerce_entrypoint;
+	}
+
+	if ( ! class_exists( 'WooCommerce' ) || ! function_exists( 'WC' ) ) {
+		throw new RuntimeException( 'WooCommerce is not loaded.' );
+	}
+	if ( ! class_exists( 'WC_Widget_Layered_Nav' ) ) {
+		throw new RuntimeException( 'WooCommerce layered nav widget is not available.' );
+	}
+
+	global $wpdb, $wp_query, $wp_the_query;
+
+	$request_count = max( 1, min( 5000, (int) ( getenv( 'WC_LAYERED_NAV_CRAWL_REQUESTS' ) ?: 150 ) ) );
+	$term_count    = max( 2, min( 20, (int) ( getenv( 'WC_LAYERED_NAV_CRAWL_TERMS' ) ?: 12 ) ) );
+	$product_count = max( $term_count, min( 1000, (int) ( getenv( 'WC_LAYERED_NAV_CRAWL_PRODUCTS' ) ?: 120 ) ) );
+	$cache_limit   = max( 0, min( 5000, (int) ( getenv( 'WC_LAYERED_NAV_CRAWL_LIMIT' ) ?: 25 ) ) );
+	$run_id        = 'woocommerce-layered-nav-catalog-crawl-' . getmypid() . '-' . time() . '-' . wp_generate_password( 6, false );
+	$issues        = array( 'https://github.com/woocommerce/woocommerce/issues/17355' );
+
+	wp_set_current_user( 1 );
+	update_option( 'woocommerce_attribute_lookup_enabled', 'no' );
+	delete_transient( 'wc_layered_nav_counts_pa_homeboy_crawl' );
+
+	add_filter(
+		'woocommerce_layered_nav_count_cache_max_entries',
+		static function () use ( $cache_limit ): int {
+			return $cache_limit;
+		}
+	);
+
+	$attribute_id = wc_create_attribute(
+		array(
+			'name'         => 'Homeboy Crawl',
+			'slug'         => 'homeboy_crawl',
+			'type'         => 'select',
+			'order_by'     => 'menu_order',
+			'has_archives' => false,
+		)
+	);
+	if ( is_wp_error( $attribute_id ) ) {
+		throw new RuntimeException( 'Failed to create Homeboy crawl attribute: ' . $attribute_id->get_error_message() );
+	}
+	$facet_attribute_id = wc_create_attribute(
+		array(
+			'name'         => 'Homeboy Facet',
+			'slug'         => 'homeboy_facet',
+			'type'         => 'select',
+			'order_by'     => 'menu_order',
+			'has_archives' => false,
+		)
+	);
+	if ( is_wp_error( $facet_attribute_id ) ) {
+		throw new RuntimeException( 'Failed to create Homeboy facet attribute: ' . $facet_attribute_id->get_error_message() );
+	}
+
+	$taxonomy       = wc_attribute_taxonomy_name( 'homeboy_crawl' );
+	$facet_taxonomy = wc_attribute_taxonomy_name( 'homeboy_facet' );
+	foreach ( array( $taxonomy, $facet_taxonomy ) as $registered_taxonomy ) {
+		if ( taxonomy_exists( $registered_taxonomy ) ) {
+			continue;
+		}
+		register_taxonomy(
+			$registered_taxonomy,
+			array( 'product' ),
+			array(
+				'hierarchical' => false,
+				'public'       => false,
+				'query_var'    => true,
+				'rewrite'      => false,
+			)
+		);
+	}
+
+	$term_ids         = array();
+	$term_slugs       = array();
+	$facet_term_ids   = array();
+	$facet_term_slugs = array();
+	for ( $i = 0; $i < $term_count; $i++ ) {
+		$term = wp_insert_term( 'Homeboy Crawl ' . ( $i + 1 ) . ' ' . $run_id, $taxonomy, array( 'slug' => 'homeboy-crawl-' . $run_id . '-' . ( $i + 1 ) ) );
+		if ( is_wp_error( $term ) ) {
+			throw new RuntimeException( 'Failed to create Homeboy crawl term: ' . $term->get_error_message() );
+		}
+		$term_ids[]   = (int) $term['term_id'];
+		$term_slugs[] = get_term( $term['term_id'], $taxonomy )->slug;
+
+		$facet_term = wp_insert_term( 'Homeboy Facet ' . ( $i + 1 ) . ' ' . $run_id, $facet_taxonomy, array( 'slug' => 'homeboy-facet-' . $run_id . '-' . ( $i + 1 ) ) );
+		if ( is_wp_error( $facet_term ) ) {
+			throw new RuntimeException( 'Failed to create Homeboy facet term: ' . $facet_term->get_error_message() );
+		}
+		$facet_term_ids[]   = (int) $facet_term['term_id'];
+		$facet_term_slugs[] = get_term( $facet_term['term_id'], $facet_taxonomy )->slug;
+	}
+
+	$product_ids = array();
+	for ( $i = 0; $i < $product_count; $i++ ) {
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Homeboy Crawl Product ' . $run_id . ' #' . ( $i + 1 ) );
+		$product->set_slug( 'homeboy-layered-nav-crawl-' . $run_id . '-' . ( $i + 1 ) );
+		$product->set_status( 'publish' );
+		$product->set_sku( 'homeboy-layered-nav-crawl-' . $run_id . '-' . ( $i + 1 ) );
+		$product->set_regular_price( '10' );
+		$product->set_price( '10' );
+		$product->set_manage_stock( false );
+		$product->set_stock_status( 'instock' );
+		$product->save();
+
+		$product_ids[] = $product->get_id();
+		wp_set_object_terms( $product->get_id(), array( $term_ids[ $i % $term_count ] ), $taxonomy );
+		wp_set_object_terms( $product->get_id(), array( $facet_term_ids[ $i % $term_count ] ), $facet_taxonomy );
+	}
+
+	$widget      = new WC_Widget_Layered_Nav();
+	$reflection  = new ReflectionClass( $widget );
+	$list_method = $reflection->getMethod( 'layered_nav_list' );
+	$list_method->setAccessible( true );
+	$terms         = get_terms( $taxonomy, array( 'hide_empty' => '1' ) );
+	$filter_name   = 'filter_' . wc_attribute_taxonomy_slug( $facet_taxonomy );
+	$query_type    = 'and';
+	$transient_key = 'wc_layered_nav_counts_' . sanitize_title( $taxonomy );
+	$option_name   = '_transient_' . $transient_key;
+	$query_reflection = new ReflectionClass( 'WC_Query' );
+	$product_query_property = $query_reflection->getProperty( 'product_query' );
+	$product_query_property->setAccessible( true );
+
+	$build_terms_for_request = static function ( int $request_index ) use ( $facet_term_slugs ): array {
+		$selected = array();
+		$count    = count( $facet_term_slugs );
+		for ( $bit = 0; $bit < $count; $bit++ ) {
+			if ( 0 !== ( $request_index & ( 1 << $bit ) ) ) {
+				$selected[] = $facet_term_slugs[ $bit ];
+			}
+		}
+
+		return empty( $selected ) ? array( $facet_term_slugs[0] ) : $selected;
+	};
+
+	$rows    = array();
+	$started = microtime( true );
+
+	for ( $request_index = 1; $request_index <= $request_count; $request_index++ ) {
+		$selected_terms = $build_terms_for_request( $request_index );
+		$_GET           = array(
+			$filter_name                       => implode( ',', $selected_terms ),
+			'query_type_' . wc_attribute_taxonomy_slug( $taxonomy ) => $query_type,
+		);
+
+		WC_Query::reset_chosen_attributes();
+		$wp_query = new WP_Query(
+			array(
+				'post_type'      => 'product',
+				'post_status'    => 'publish',
+				'posts_per_page' => 12,
+				'tax_query'      => array(
+					array(
+						'taxonomy' => $facet_taxonomy,
+						'field'    => 'slug',
+						'terms'    => $selected_terms,
+						'operator' => 'AND',
+					),
+				),
+			)
+		);
+		$wp_the_query = $wp_query;
+		$product_query_property->setValue( null, $wp_query );
+
+		$before = microtime( true );
+		ob_start();
+		$list_method->invoke( $widget, $terms, $taxonomy, $query_type );
+		$rendered = ob_get_clean();
+		$cache    = (array) get_transient( $transient_key );
+		$stored   = $wpdb->get_var( $wpdb->prepare( "SELECT option_value FROM {$wpdb->options} WHERE option_name = %s", $option_name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		$rows[] = array(
+			'request_index'          => $request_index,
+			'filter_terms'           => $selected_terms,
+			'filter_taxonomy'        => $facet_taxonomy,
+			'filter_url'             => add_query_arg( $_GET, home_url( '/shop/' ) ),
+			'elapsed_ms'             => ( microtime( true ) - $before ) * 1000,
+			'rendered_bytes'         => strlen( $rendered ),
+			'transient_entry_count'  => count( $cache ),
+			'serialized_value_bytes' => is_string( $stored ) ? strlen( $stored ) : 0,
+		);
+	}
+
+	$_GET = array();
+	WC_Query::reset_chosen_attributes();
+	remove_all_filters( 'woocommerce_layered_nav_count_cache_max_entries' );
+
+	$final_cache          = (array) get_transient( $transient_key );
+	$final_serialized     = $wpdb->get_var( $wpdb->prepare( "SELECT option_value FROM {$wpdb->options} WHERE option_name = %s", $option_name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	$entry_counts         = wp_list_pluck( $rows, 'transient_entry_count' );
+	$serialized_bytes     = wp_list_pluck( $rows, 'serialized_value_bytes' );
+	$final_entry_count    = count( $final_cache );
+	$final_value_bytes    = is_string( $final_serialized ) ? strlen( $final_serialized ) : 0;
+	$expected_capped_max  = $cache_limit > 0 ? $cache_limit : $request_count;
+	$cache_exceeded_limit = $cache_limit > 0 && $final_entry_count > $cache_limit;
+	$summary              = array(
+		'success_rate'                 => 1,
+		'crawl_request_count'          => $request_count,
+		'cache_limit_setting'          => $cache_limit,
+		'term_count'                   => $term_count,
+		'product_count'                => $product_count,
+		'final_transient_entry_count'  => $final_entry_count,
+		'max_transient_entry_count'    => empty( $entry_counts ) ? 0 : max( $entry_counts ),
+		'expected_capped_entry_count'  => min( $request_count, $expected_capped_max ),
+		'cache_exceeded_limit'         => $cache_exceeded_limit ? 1 : 0,
+		'final_serialized_value_bytes' => $final_value_bytes,
+		'max_serialized_value_bytes'   => empty( $serialized_bytes ) ? 0 : max( $serialized_bytes ),
+		'total_elapsed_ms'             => ( microtime( true ) - $started ) * 1000,
+	);
+
+	$artifact_path = '';
+	$shared_state  = getenv( 'HOMEBOY_BENCH_SHARED_STATE' );
+	if ( $shared_state ) {
+		$artifact_dir = rtrim( $shared_state, '/' ) . '/layered-nav-catalog-crawl';
+		wp_mkdir_p( $artifact_dir );
+		$artifact_path = $artifact_dir . '/' . $run_id . '.json';
+		file_put_contents(
+			$artifact_path,
+			wp_json_encode(
+				array(
+					'run_id'        => $run_id,
+					'issues'        => $issues,
+					'transient_key' => $transient_key,
+					'option_name'   => $option_name,
+					'product_ids'   => $product_ids,
+					'term_ids'      => $term_ids,
+					'facet_term_ids' => $facet_term_ids,
+					'rows'          => $rows,
+					'metrics'       => $summary,
+				),
+				JSON_PRETTY_PRINT
+			) . "\n"
+		);
+	}
+
+	return array(
+		'metrics'   => $summary,
+		'metadata'  => array(
+			'runner'        => 'wp-codebox',
+			'workload'      => 'layered-nav-catalog-crawl',
+			'issues'        => $issues,
+			'transient_key' => $transient_key,
+			'cache_shape'   => 'many real filter request combinations rendered through layered nav widget',
+		),
+		'artifacts' => $artifact_path ? array( 'raw_result' => array( 'path' => $artifact_path, 'kind' => 'json' ) ) : array(),
+	);
+};

--- a/woocommerce/woocommerce/bench/layered-nav-count-cache.php
+++ b/woocommerce/woocommerce/bench/layered-nav-count-cache.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * WP Codebox-backed WooCommerce layered-nav count cache workload.
+ *
+ * Reproduces the unbounded `wc_layered_nav_counts_*` transient growth shape from
+ * https://github.com/woocommerce/woocommerce/issues/17355.
+ */
+return function (): array {
+	if ( ! class_exists( 'WooCommerce' ) ) {
+		$woocommerce_entrypoint = WP_PLUGIN_DIR . '/woocommerce/woocommerce.php';
+		if ( ! file_exists( $woocommerce_entrypoint ) ) {
+			throw new RuntimeException( 'WooCommerce plugin entrypoint is not mounted.' );
+		}
+		require_once $woocommerce_entrypoint;
+	}
+
+	if ( ! class_exists( 'WooCommerce' ) || ! function_exists( 'WC' ) ) {
+		throw new RuntimeException( 'WooCommerce is not loaded.' );
+	}
+	if ( ! class_exists( Automattic\WooCommerce\Internal\ProductAttributesLookup\Filterer::class ) ) {
+		throw new RuntimeException( 'WooCommerce product attribute filterer is not available.' );
+	}
+
+	global $wpdb;
+
+	$iterations  = max( 1, min( 5000, (int) ( getenv( 'WC_LAYERED_NAV_CACHE_ITERATIONS' ) ?: 150 ) ) );
+	$term_count  = max( 2, min( 100, (int) ( getenv( 'WC_LAYERED_NAV_CACHE_TERMS' ) ?: 6 ) ) );
+	$product_count = max( $term_count, min( 1000, (int) ( getenv( 'WC_LAYERED_NAV_CACHE_PRODUCTS' ) ?: 60 ) ) );
+	$cache_limit = max( 0, min( 5000, (int) ( getenv( 'WC_LAYERED_NAV_CACHE_LIMIT' ) ?: 25 ) ) );
+	$run_id      = 'woocommerce-layered-nav-count-cache-' . getmypid() . '-' . time() . '-' . wp_generate_password( 6, false );
+	$issues      = array( 'https://github.com/woocommerce/woocommerce/issues/17355' );
+
+	wp_set_current_user( 1 );
+	update_option( 'woocommerce_attribute_lookup_enabled', 'no' );
+	delete_transient( 'wc_layered_nav_counts_pa_homeboy_nav' );
+
+	add_filter(
+		'woocommerce_layered_nav_count_cache_max_entries',
+		static function () use ( $cache_limit ): int {
+			return $cache_limit;
+		}
+	);
+
+	$attribute_id = wc_create_attribute(
+		array(
+			'name'         => 'Homeboy Layered Nav',
+			'slug'         => 'homeboy_nav',
+			'type'         => 'select',
+			'order_by'     => 'menu_order',
+			'has_archives' => false,
+		)
+	);
+	if ( is_wp_error( $attribute_id ) ) {
+		throw new RuntimeException( 'Failed to create Homeboy layered-nav attribute: ' . $attribute_id->get_error_message() );
+	}
+
+	$taxonomy = wc_attribute_taxonomy_name( 'homeboy_nav' );
+	if ( ! taxonomy_exists( $taxonomy ) ) {
+		register_taxonomy(
+			$taxonomy,
+			array( 'product' ),
+			array(
+				'hierarchical' => false,
+				'public'       => false,
+				'query_var'    => true,
+				'rewrite'      => false,
+			)
+		);
+	}
+
+	$term_ids = array();
+	for ( $i = 0; $i < $term_count; $i++ ) {
+		$term = wp_insert_term( 'Homeboy Nav ' . ( $i + 1 ) . ' ' . $run_id, $taxonomy, array( 'slug' => 'homeboy-nav-' . $run_id . '-' . ( $i + 1 ) ) );
+		if ( is_wp_error( $term ) ) {
+			throw new RuntimeException( 'Failed to create Homeboy layered-nav term: ' . $term->get_error_message() );
+		}
+		$term_ids[] = (int) $term['term_id'];
+	}
+
+	$product_ids = array();
+	for ( $i = 0; $i < $product_count; $i++ ) {
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Homeboy Layered Nav Product ' . $run_id . ' #' . ( $i + 1 ) );
+		$product->set_slug( 'homeboy-layered-nav-' . $run_id . '-' . ( $i + 1 ) );
+		$product->set_status( 'publish' );
+		$product->set_sku( 'homeboy-layered-nav-' . $run_id . '-' . ( $i + 1 ) );
+		$product->set_regular_price( '10' );
+		$product->set_price( '10' );
+		$product->set_manage_stock( false );
+		$product->set_stock_status( 'instock' );
+		$product->save();
+
+		$product_ids[] = $product->get_id();
+		wp_set_object_terms( $product->get_id(), array( $term_ids[ $i % $term_count ] ), $taxonomy );
+	}
+
+	$transient_key = 'wc_layered_nav_counts_' . sanitize_title( $taxonomy );
+	$option_name   = '_transient_' . $transient_key;
+	$iteration     = 0;
+	$query_filter  = static function ( array $query ) use ( &$iteration, $wpdb ): array {
+		$query['where'] .= $wpdb->prepare( ' AND %d = %d', $iteration, $iteration );
+		return $query;
+	};
+	add_filter( 'woocommerce_get_filtered_term_product_counts_query', $query_filter );
+
+	$filterer = wc_get_container()->get( Automattic\WooCommerce\Internal\ProductAttributesLookup\Filterer::class );
+	$rows     = array();
+	$started  = microtime( true );
+
+	for ( $iteration = 1; $iteration <= $iterations; $iteration++ ) {
+		$before = microtime( true );
+		$counts = $filterer->get_filtered_term_product_counts( $term_ids, $taxonomy, 'and' );
+		$cache  = (array) get_transient( $transient_key );
+		$stored = $wpdb->get_var( $wpdb->prepare( "SELECT option_value FROM {$wpdb->options} WHERE option_name = %s", $option_name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		$rows[] = array(
+			'iteration'             => $iteration,
+			'elapsed_ms'            => ( microtime( true ) - $before ) * 1000,
+			'returned_term_count'    => count( $counts ),
+			'transient_entry_count'  => count( $cache ),
+			'serialized_value_bytes' => is_string( $stored ) ? strlen( $stored ) : 0,
+		);
+	}
+
+	remove_filter( 'woocommerce_get_filtered_term_product_counts_query', $query_filter );
+	remove_all_filters( 'woocommerce_layered_nav_count_cache_max_entries' );
+
+	$final_cache          = (array) get_transient( $transient_key );
+	$final_serialized     = $wpdb->get_var( $wpdb->prepare( "SELECT option_value FROM {$wpdb->options} WHERE option_name = %s", $option_name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	$entry_counts         = wp_list_pluck( $rows, 'transient_entry_count' );
+	$serialized_bytes     = wp_list_pluck( $rows, 'serialized_value_bytes' );
+	$final_entry_count    = count( $final_cache );
+	$final_value_bytes    = is_string( $final_serialized ) ? strlen( $final_serialized ) : 0;
+	$expected_capped_max  = $cache_limit > 0 ? $cache_limit : $iterations;
+	$cache_exceeded_limit = $cache_limit > 0 && $final_entry_count > $cache_limit;
+	$summary             = array(
+		'success_rate'                 => 1,
+		'iterations'                   => $iterations,
+		'cache_limit_setting'          => $cache_limit,
+		'term_count'                   => $term_count,
+		'product_count'                => $product_count,
+		'final_transient_entry_count'  => $final_entry_count,
+		'max_transient_entry_count'    => empty( $entry_counts ) ? 0 : max( $entry_counts ),
+		'expected_capped_entry_count'  => min( $iterations, $expected_capped_max ),
+		'cache_exceeded_limit'         => $cache_exceeded_limit ? 1 : 0,
+		'final_serialized_value_bytes' => $final_value_bytes,
+		'max_serialized_value_bytes'   => empty( $serialized_bytes ) ? 0 : max( $serialized_bytes ),
+		'total_elapsed_ms'             => ( microtime( true ) - $started ) * 1000,
+	);
+
+	$artifact_path = '';
+	$shared_state  = getenv( 'HOMEBOY_BENCH_SHARED_STATE' );
+	if ( $shared_state ) {
+		$artifact_dir = rtrim( $shared_state, '/' ) . '/layered-nav-count-cache';
+		wp_mkdir_p( $artifact_dir );
+		$artifact_path = $artifact_dir . '/' . $run_id . '.json';
+		file_put_contents(
+			$artifact_path,
+			wp_json_encode(
+				array(
+					'run_id'        => $run_id,
+					'issues'        => $issues,
+					'transient_key' => $transient_key,
+					'option_name'   => $option_name,
+					'product_ids'   => $product_ids,
+					'term_ids'      => $term_ids,
+					'rows'          => $rows,
+					'metrics'       => $summary,
+				),
+				JSON_PRETTY_PRINT
+			) . "\n"
+		);
+	}
+
+	return array(
+		'metrics'   => $summary,
+		'metadata'  => array(
+			'runner'        => 'wp-codebox',
+			'workload'      => 'layered-nav-count-cache',
+			'issues'        => $issues,
+			'transient_key' => $transient_key,
+			'cache_shape'   => 'many query hashes inside one taxonomy transient',
+		),
+		'artifacts' => $artifact_path ? array( 'raw_result' => array( 'path' => $artifact_path, 'kind' => 'json' ) ) : array(),
+	);
+};

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -33,15 +33,18 @@
   },
   "bench_workloads": {
     "wordpress": [
-      { "path": "${package.root}/bench/checkout-shipping-cache.php" }
+      { "path": "${package.root}/bench/checkout-shipping-cache.php" },
+      { "path": "${package.root}/bench/layered-nav-count-cache.php" }
     ]
   },
   "bench_profiles": {
     "smoke": [
-      "checkout-shipping-cache"
+      "checkout-shipping-cache",
+      "layered-nav-count-cache"
     ],
     "hot": [
-      "checkout-shipping-cache"
+      "checkout-shipping-cache",
+      "layered-nav-count-cache"
     ]
   },
   "pipeline": {

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -34,17 +34,20 @@
   "bench_workloads": {
     "wordpress": [
       { "path": "${package.root}/bench/checkout-shipping-cache.php" },
-      { "path": "${package.root}/bench/layered-nav-count-cache.php" }
+      { "path": "${package.root}/bench/layered-nav-count-cache.php" },
+      { "path": "${package.root}/bench/layered-nav-catalog-crawl.php" }
     ]
   },
   "bench_profiles": {
     "smoke": [
       "checkout-shipping-cache",
-      "layered-nav-count-cache"
+      "layered-nav-count-cache",
+      "layered-nav-catalog-crawl"
     ],
     "hot": [
       "checkout-shipping-cache",
-      "layered-nav-count-cache"
+      "layered-nav-count-cache",
+      "layered-nav-catalog-crawl"
     ]
   },
   "pipeline": {


### PR DESCRIPTION
## Summary
- Add a direct WooCommerce layered-nav count cache benchmark for `woocommerce/woocommerce#17355`.
- Add a catalog-crawl-shaped benchmark that renders the real layered-nav widget path across many `filter_*` request combinations.
- Document the new workloads in the WooCommerce performance rig.

## Evidence
Direct cache-path workload:

| Run | Woo | Iterations | Cap | Final entries | Serialized bytes | Exceeded cap | Run ID |
|---|---|---:|---:|---:|---:|---|---|
| direct cache | trunk | 150 | 25 | 151 | 15,916 | yes | `9b786582-1f33-41c3-a2e4-7e7ab7824da8` |
| direct cache | candidate | 150 | 25 | 25 | 2,657 | no | `da777062-497f-48bd-8098-a33dfc80700e` |
| direct cache | trunk | 1200 | 1000 | 1201 | 127,217 | yes | `718d4f94-4a9c-423c-b7bf-635268685c54` |
| direct cache | candidate | 1200 | 1000 | 1000 | 106,009 | no | `a90790cd-42e3-4ef6-9485-6ed6ebbeb248` |

Catalog-crawl workload:

| Run | Woo | Requests | Cap | Final entries | Serialized bytes | Exceeded cap | Run ID |
|---|---|---:|---:|---:|---:|---|---|
| catalog crawl | trunk | 150 | 25 | 151 | 6,996 | yes | `0e7d2e9a-c154-4633-9e79-0aac15906789` |
| catalog crawl | candidate | 150 | 25 | 25 | 1,167 | no | `12517768-7caa-42ca-8473-fa4614b66763` |
| catalog crawl | trunk | 1200 | 1000 | 1201 | 55,327 | yes | `f8ba4b8e-16ac-4739-b315-088213b51fb1` |
| catalog crawl | candidate | 1200 | 1000 | 1000 | 46,039 | no | `f92eb748-c3c7-41bb-89ab-f4853150797a` |

## Verification
- `php -l woocommerce/woocommerce/bench/layered-nav-count-cache.php`
- `php -l woocommerce/woocommerce/bench/layered-nav-catalog-crawl.php`
- `git diff --check origin/main...HEAD`
- Homeboy/WP Codebox runs listed above.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** implementation, benchmark workload design, evidence collection, and PR drafting under Chris review.