### PR TITLE
Add below-fold Stripe ECE scenarios

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-below-fold-load.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-below-fold-load.trace.mjs
@@ -1,0 +1,1 @@
+import './ece-product-page-waterfall.trace.mjs';

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-below-fold-scroll-to-ece.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-below-fold-scroll-to-ece.trace.mjs
@@ -1,0 +1,1 @@
+import './ece-product-page-waterfall.trace.mjs';

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-scenarios.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-scenarios.mjs
@@ -13,6 +13,20 @@ const SCENARIOS = {
     interaction: 'scroll-to-ece',
     description: 'Scroll the product-page ECE container into view after load.',
   },
+  'ece-product-page-below-fold-load': {
+    id: 'ece-product-page-below-fold-load',
+    profile: 'below-fold-load',
+    interaction: 'load-only',
+    layout: 'below-fold',
+    description: 'Load a product page with the cart form below the fold and record initial ECE fan-out without scrolling.',
+  },
+  'ece-product-page-below-fold-scroll-to-ece': {
+    id: 'ece-product-page-below-fold-scroll-to-ece',
+    profile: 'below-fold-scroll-to-ece',
+    interaction: 'scroll-to-ece',
+    layout: 'below-fold',
+    description: 'Load a product page with the cart form below the fold, then scroll to ECE and record initialization.',
+  },
   'ece-product-page-quantity-change': {
     id: 'ece-product-page-quantity-change',
     profile: 'quantity-change',
@@ -40,11 +54,12 @@ export function eceInteractionScript(scenario) {
     case 'scroll-to-ece':
       return `
         const container = document.querySelector('#wc-stripe-express-checkout-element');
+        const scrollTarget = container?.closest('form.cart') || container?.closest('.summary') || container?.parentElement || container;
         interactionSnapshot('before_scroll_to_ece');
-        if (container) {
-          container.scrollIntoView({ block: 'center', inline: 'nearest' });
+        if (scrollTarget) {
+          scrollTarget.scrollIntoView({ block: 'center', inline: 'nearest' });
           interactionEvents.push({ name: 'scroll_to_ece', t_ms: elapsed(), ok: true });
-          await sleep(750);
+          await sleep(1500);
           sample();
           interactionSnapshot('after_scroll_to_ece');
         } else {
@@ -90,4 +105,29 @@ export function eceInteractionScript(scenario) {
     default:
       return `interactionSnapshot('load_only_final');`;
   }
+}
+
+export function eceLayoutScript(scenario) {
+  if (scenario.layout !== 'below-fold') {
+    return '';
+  }
+
+  return `
+    const installBelowFoldLayout = () => {
+      if (document.getElementById('homeboy-ece-below-fold-layout')) {
+        return;
+      }
+
+      const style = document.createElement('style');
+      style.id = 'homeboy-ece-below-fold-layout';
+      style.textContent = 'form.cart { margin-top: 1400px !important; }';
+      document.head.appendChild(style);
+    };
+
+    if (document.head) {
+      installBelowFoldLayout();
+    } else {
+      document.addEventListener('DOMContentLoaded', installBelowFoldLayout, { once: true });
+    }
+  `;
 }

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import { buildEceProfileOptions } from './ece-product-page-profile.mjs';
-import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceProductPageScenario } from './ece-product-page-scenarios.mjs';
+import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceLayoutScript, eceProductPageScenario } from './ece-product-page-scenarios.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -166,6 +166,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   );
 
   const prePageScript = `(() => {
+  ${eceLayoutScript(scenario)}
   const state = window.__wcStripeEceRenderProbe = {
     startedAt: performance.now(),
     events: [],

--- a/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
+++ b/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
@@ -79,6 +79,64 @@
         }
       },
       {
+        "path": "${package.root}/bench/ece-product-page-below-fold-load.trace.mjs",
+        "check_groups": [],
+        "port_range_size": 1,
+        "trace_default_phase_preset": "browser-waterfall",
+        "trace_phase_presets": {
+          "browser-waterfall": [
+            "start:scenario.start",
+            "recipe:wp_codebox.recipe.start",
+            "setup:wordpress.fixture.ready",
+            "probe:browser.probe.ready",
+            "metrics:waterfall.metrics.ready"
+          ]
+        },
+        "trace_span_metadata": {
+          "phase.recipe_to_setup": {
+            "category": "runtime_setup",
+            "blocking": true
+          },
+          "phase.setup_to_probe": {
+            "category": "browser_probe",
+            "blocking": true
+          },
+          "phase.probe_to_metrics": {
+            "category": "artifact_extraction",
+            "blocking": true
+          }
+        }
+      },
+      {
+        "path": "${package.root}/bench/ece-product-page-below-fold-scroll-to-ece.trace.mjs",
+        "check_groups": [],
+        "port_range_size": 1,
+        "trace_default_phase_preset": "browser-waterfall",
+        "trace_phase_presets": {
+          "browser-waterfall": [
+            "start:scenario.start",
+            "recipe:wp_codebox.recipe.start",
+            "setup:wordpress.fixture.ready",
+            "probe:browser.probe.ready",
+            "metrics:waterfall.metrics.ready"
+          ]
+        },
+        "trace_span_metadata": {
+          "phase.recipe_to_setup": {
+            "category": "runtime_setup",
+            "blocking": true
+          },
+          "phase.setup_to_probe": {
+            "category": "browser_probe",
+            "blocking": true
+          },
+          "phase.probe_to_metrics": {
+            "category": "artifact_extraction",
+            "blocking": true
+          }
+        }
+      },
+      {
         "path": "${package.root}/bench/ece-product-page-quantity-change.trace.mjs",
         "check_groups": [],
         "port_range_size": 1,
@@ -153,6 +211,12 @@
     },
     "scroll-to-ece": {
       "scenario": "ece-product-page-scroll-to-ece"
+    },
+    "below-fold-load": {
+      "scenario": "ece-product-page-below-fold-load"
+    },
+    "below-fold-scroll-to-ece": {
+      "scenario": "ece-product-page-below-fold-scroll-to-ece"
     },
     "quantity-change": {
       "scenario": "ece-product-page-quantity-change"


### PR DESCRIPTION
## Summary
- Add below-fold load and below-fold scroll-to-ECE scenarios for the WooCommerce Stripe ECE product-page rig.
- Inject deterministic product-form spacing in the browser pre-page script so lazy product-page ECE initialization can be validated without ad-hoc local CSS.
- Scroll the same visible wrapper observed by the plugin so the scenario proves lazy initialization resumes when the shopper reaches the ECE area.

## Testing
- `node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`
- `node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-below-fold-load.trace.mjs`
- `node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-below-fold-scroll-to-ece.trace.mjs`
- `node scripts/lint-rig-packages.mjs`

## Evidence
- Baseline below-fold load: `50` Stripe responses / `128` total responses.
- Candidate below-fold load: `9` Stripe responses / `87` total responses.
- Candidate below-fold scroll-to-ECE: `35` Stripe responses / `113` total responses, with ECE child/iframe lifecycle appearing after scroll.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the rig scenario changes, ran local Homeboy/WP Codebox proof traces, and prepared the PR under Chris's direction.