### PR TITLE
Add real-wallet Stripe ECE profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,9 +285,9 @@ The `smoke` profile keeps the default WP Codebox browser behavior. The optional
 from Extra-Chill/homeboy#3554 and Automattic/wp-codebox#651/#652 and keeps
 Stripe-specific scenario behavior in this rig package.
 Default local HTTP/headless traces are request/lifecycle evidence, not wallet
-eligibility proof. Secure-context evidence requires the `secure-browser` profile
-and an HTTPS public preview URL; each trace records requested/effective browser
-context metadata so the evidence type is explicit.
+eligibility proof. Secure-context plumbing evidence requires the
+`secure-browser` profile and an HTTPS public preview URL; each trace records
+requested/effective browser context metadata so the evidence type is explicit.
 
 ```bash
 homeboy trace --rig woocommerce-stripe-ece-product-page \
@@ -295,6 +295,23 @@ homeboy trace --rig woocommerce-stripe-ece-product-page \
   --setting woocommerce_stripe_ece_preview_public_url=https://example.test \
   woocommerce-gateway-stripe ece-product-page-waterfall \
   --output /tmp/wc-stripe-ece-secure-browser.json
+```
+
+Use the `real-wallet` profile for real-wallet-capable evidence. It fails fast
+unless `STRIPE_PUBLISHABLE_KEY`, `STRIPE_SECRET_KEY`, and an HTTPS public
+`HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL` are present. Metrics explicitly mark
+real-wallet artifacts with `ece_real_wallet_capable: true` and synthetic traces
+with `ece_synthetic_only: true`.
+
+```bash
+export STRIPE_PUBLISHABLE_KEY=pk_test_...
+export STRIPE_SECRET_KEY=sk_test_...
+export HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL=https://example.test
+
+homeboy trace --rig woocommerce-stripe-ece-product-page \
+  --profile real-wallet \
+  woocommerce-gateway-stripe ece-product-page-waterfall \
+  --output /tmp/wc-stripe-ece-real-wallet.json
 ```
 
 ## chubes4/isolated-block-editor

--- a/woocommerce/woocommerce-gateway-stripe/README.md
+++ b/woocommerce/woocommerce-gateway-stripe/README.md
@@ -42,6 +42,14 @@ Primary metrics:
 - `browser_dom_node_count`
 - `browser_long_task_count`, `browser_long_task_total_ms`, and
   `browser_long_task_max_ms`
+- `ece_real_wallet_capable`
+- `ece_synthetic_only`
+- `ece_rendered_visible_button`
+- `stripe_elements_session_response_count`
+- `stripe_elements_session_status`
+- `stripe_elements_session_error_count`
+- `stripe_load_console_message_count`
+- `stripe_load_page_error_count`
 
 Secondary noisy metrics:
 
@@ -131,6 +139,43 @@ Useful settings:
 - `HOMEBOY_WC_STRIPE_ECE_PROBE_DURATION=7s`
 - `HOMEBOY_WC_STRIPE_ECE_VIEWPORT=1366x900`
 
+## Real Wallet Profile
+
+The default `smoke`, `hot`, and interaction profiles remain synthetic lifecycle
+evidence. They intentionally keep working with the Stripe benchmark fixture's
+placeholder keys so network, DOM, and CLS-style render timing can be collected
+without real Stripe credentials.
+
+Use the `real-wallet` profile when collecting real-wallet-capable ECE evidence:
+
+```bash
+export STRIPE_PUBLISHABLE_KEY=pk_test_...
+export STRIPE_SECRET_KEY=sk_test_...
+export HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL=https://your-public-preview.example
+
+homeboy trace --rig woocommerce-stripe-ece-product-page \
+  --profile real-wallet \
+  woocommerce-gateway-stripe ece-product-page-waterfall
+```
+
+The profile fails before WP Codebox starts when either `STRIPE_PUBLISHABLE_KEY`
+or `STRIPE_SECRET_KEY` is absent. It also requires
+`HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL` to be an HTTPS public origin; local
+HTTP origins and `localhost` are rejected because wallet eligibility requires a
+secure, public browser context.
+
+The real keys are injected only into the disposable WordPress setup step. They
+are not added to CLI arguments or recorded in metrics artifacts. Real-wallet
+artifacts explicitly report `ece_real_wallet_capable: true` and
+`ece_synthetic_only: false`; synthetic profiles report the inverse.
+
+Real-wallet evidence records:
+
+- Stripe Elements session response count, first status, and error count.
+- Stripe/ECE console and page-error counts.
+- Browser wallet capability flags such as Payment Request and Apple Pay support.
+- Whether a visible ECE button rendered by the end of the probe.
+
 ## Interpretation
 
 Use request-count and browser-object metrics as the primary signal. The browser
@@ -149,4 +194,6 @@ URL, user agent, and whether the page ran in `window.isSecureContext`. Treat the
 default local HTTP/headless profile as request/lifecycle evidence only. It can
 show Stripe requests, ECE containers, iframes, buttons, console output, and page
 errors, but it is not wallet-eligibility proof. Use the `secure-browser` profile
-with an HTTPS public preview URL when collecting secure-context wallet evidence.
+for secure-context browser plumbing checks, and use the `real-wallet` profile
+with Stripe test keys plus an HTTPS public preview URL when collecting
+real-wallet-capable evidence.

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.mjs
@@ -1,4 +1,5 @@
-const DEFAULT_PROFILE = 'smoke';
+export const DEFAULT_PROFILE = 'smoke';
+export const REAL_WALLET_PROFILE = 'real-wallet';
 
 export function setting(name, defaultValue = '') {
   const envName = `HOMEBOY_SETTINGS_${name.toUpperCase()}`;
@@ -30,10 +31,39 @@ export function previewPublicUrl() {
   return setting('woocommerce_stripe_ece_preview_public_url', process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL || '');
 }
 
+function validateHttpsPublicUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' && !['localhost', '127.0.0.1', '::1'].includes(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function requireRealWalletProfileEnv(publicUrl) {
+  const missing = ['STRIPE_PUBLISHABLE_KEY', 'STRIPE_SECRET_KEY'].filter((name) => !process.env[name]);
+
+  if (missing.length > 0) {
+    throw new Error(`real-wallet profile requires ${missing.join(' and ')} to render real Stripe Express Checkout wallet evidence.`);
+  }
+
+  if (!publicUrl) {
+    throw new Error('real-wallet profile requires HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL to be set to an HTTPS public preview origin.');
+  }
+
+  if (!validateHttpsPublicUrl(publicUrl)) {
+    throw new Error('real-wallet profile requires HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL to be an HTTPS public preview origin, not localhost or plain HTTP.');
+  }
+}
+
 export function buildEceProfileOptions(profile = eceBrowserProfile()) {
-  if (profile !== 'secure-browser') {
+  if (!['secure-browser', REAL_WALLET_PROFILE].includes(profile)) {
     return {
       profile,
+      realWalletCapable: false,
+      syntheticOnly: true,
+      stripePublishableKey: null,
+      stripeSecretKey: null,
       runtimePreview: null,
       recipeRunArgs: [],
       browserProbeArgs: [],
@@ -43,6 +73,11 @@ export function buildEceProfileOptions(profile = eceBrowserProfile()) {
   const port = previewPort();
   const bind = previewBind();
   const publicUrl = previewPublicUrl();
+
+  if (profile === REAL_WALLET_PROFILE) {
+    requireRealWalletProfileEnv(publicUrl);
+  }
+
   const runtimePreview = {
     ...(port ? { port: Number.parseInt(port, 10) } : {}),
     ...(bind ? { bind } : {}),
@@ -51,6 +86,10 @@ export function buildEceProfileOptions(profile = eceBrowserProfile()) {
 
   return {
     profile,
+    realWalletCapable: profile === REAL_WALLET_PROFILE,
+    syntheticOnly: profile !== REAL_WALLET_PROFILE,
+    stripePublishableKey: profile === REAL_WALLET_PROFILE ? process.env.STRIPE_PUBLISHABLE_KEY : null,
+    stripeSecretKey: profile === REAL_WALLET_PROFILE ? process.env.STRIPE_SECRET_KEY : null,
     runtimePreview: Object.keys(runtimePreview).length > 0 ? runtimePreview : null,
     recipeRunArgs: [
       ...(port ? ['--preview-port', port] : []),

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
@@ -55,6 +55,108 @@ test('secure-browser profile uses generic preview and browser profile args', () 
   }
 });
 
+test('real-wallet profile fails fast when Stripe keys are missing', () => {
+  const previous = {
+    STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY,
+    STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
+    HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL: process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL,
+  };
+
+  delete process.env.STRIPE_PUBLISHABLE_KEY;
+  delete process.env.STRIPE_SECRET_KEY;
+  process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL = 'https://example.test';
+
+  try {
+    assert.throws(
+      () => buildEceProfileOptions('real-wallet'),
+      /real-wallet profile requires STRIPE_PUBLISHABLE_KEY and STRIPE_SECRET_KEY/
+    );
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+});
+
+test('real-wallet profile requires an HTTPS public preview origin', () => {
+  const previous = {
+    STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY,
+    STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
+    HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL: process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL,
+  };
+
+  process.env.STRIPE_PUBLISHABLE_KEY = 'pk_test_real_fixture';
+  process.env.STRIPE_SECRET_KEY = 'sk_test_real_fixture';
+  process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL = 'http://localhost:49800';
+
+  try {
+    assert.throws(
+      () => buildEceProfileOptions('real-wallet'),
+      /HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL to be an HTTPS public preview origin/
+    );
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+});
+
+test('real-wallet profile carries real-wallet evidence settings without leaking keys into CLI args', () => {
+  const previous = {
+    STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY,
+    STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
+    HOMEBOY_WC_STRIPE_ECE_PREVIEW_PORT: process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_PORT,
+    HOMEBOY_WC_STRIPE_ECE_PREVIEW_BIND: process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_BIND,
+    HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL: process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL,
+  };
+
+  process.env.STRIPE_PUBLISHABLE_KEY = 'pk_test_real_fixture';
+  process.env.STRIPE_SECRET_KEY = 'sk_test_real_fixture';
+  process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_PORT = '49800';
+  process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_BIND = '127.0.0.1';
+  process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL = 'https://ece-wallet.example.test';
+
+  try {
+    const options = buildEceProfileOptions('real-wallet');
+
+    assert.equal(options.profile, 'real-wallet');
+    assert.equal(options.realWalletCapable, true);
+    assert.equal(options.syntheticOnly, false);
+    assert.equal(options.stripePublishableKey, 'pk_test_real_fixture');
+    assert.equal(options.stripeSecretKey, 'sk_test_real_fixture');
+    assert.deepEqual(options.runtimePreview, {
+      port: 49800,
+      bind: '127.0.0.1',
+      publicUrl: 'https://ece-wallet.example.test',
+    });
+    assert.deepEqual(options.recipeRunArgs, [
+      '--preview-port',
+      '49800',
+      '--preview-bind',
+      '127.0.0.1',
+      '--preview-public-url',
+      'https://ece-wallet.example.test',
+    ]);
+    assert.ok(!options.recipeRunArgs.join(' ').includes('sk_test_real_fixture'));
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+});
+
 test('ECE scenario registry preserves load-only default and exposes interactions', () => {
   assert.equal(eceProductPageScenario().id, DEFAULT_ECE_SCENARIO_ID);
   assert.equal(eceProductPageScenario(DEFAULT_ECE_SCENARIO_ID).interaction, 'load-only');

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -23,6 +23,8 @@ const acceptedPaymentMethods = process.env.HOMEBOY_WC_STRIPE_ACCEPTED_PAYMENT_ME
 const probeDuration = process.env.HOMEBOY_WC_STRIPE_ECE_PROBE_DURATION || '7s';
 const viewport = process.env.HOMEBOY_WC_STRIPE_ECE_VIEWPORT || '1366x900';
 const profileOptions = buildEceProfileOptions();
+const encodedStripePublishableKey = profileOptions.stripePublishableKey ? Buffer.from(profileOptions.stripePublishableKey).toString('base64') : '';
+const encodedStripeSecretKey = profileOptions.stripeSecretKey ? Buffer.from(profileOptions.stripeSecretKey).toString('base64') : '';
 
 if (!componentPath) {
   throw new Error('HOMEBOY_COMPONENT_PATH is required');
@@ -130,6 +132,21 @@ function peakSampleValue(samples, key) {
   return values.length > 0 ? Math.max(...values) : null;
 }
 
+function stripeElementsSessionResponses(networkEntries) {
+  return networkEntries.filter((entry) => {
+    const url = entry.url || entry.request?.url || '';
+    return /api\.stripe\.com\/v1\/elements\/sessions/.test(url);
+  });
+}
+
+function responseStatus(entry) {
+  return entry.status ?? entry.response?.status ?? entry.responseStatus ?? null;
+}
+
+function stripeLoadMessages(messages) {
+  return messages.filter((entry) => /stripe|express checkout|paymentrequest|apple pay|google pay/i.test(JSON.stringify(entry)));
+}
+
 try {
   event('scenario', 'start', {
     component_path: componentPath,
@@ -139,6 +156,8 @@ try {
     ece_scenario_profile: scenario.profile,
     ece_interaction: scenario.interaction,
     browser_profile: profileOptions.profile,
+    real_wallet_capable: profileOptions.realWalletCapable,
+    synthetic_only: profileOptions.syntheticOnly,
   });
 
   await writeFile(
@@ -155,6 +174,18 @@ $state = WC_Stripe_Benchmark_Fixture_Bootstrap::bootstrap(
 		'accepted_payment_methods' => $accepted_payment_methods,
 	)
 );
+
+if ( ${profileOptions.realWalletCapable ? 'true' : 'false'} ) {
+	$stripe_settings = get_option( 'woocommerce_stripe_settings', array() );
+	if ( ! is_array( $stripe_settings ) ) {
+		$stripe_settings = array();
+	}
+	$stripe_settings['enabled']              = 'yes';
+	$stripe_settings['testmode']             = 'yes';
+	$stripe_settings['test_publishable_key'] = base64_decode( '${encodedStripePublishableKey}', true );
+	$stripe_settings['test_secret_key']      = base64_decode( '${encodedStripeSecretKey}', true );
+	update_option( 'woocommerce_stripe_settings', $stripe_settings );
+}
 
 update_option( 'permalink_structure', '/%postname%/' );
 flush_rewrite_rules();
@@ -294,12 +325,18 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
       window.clearInterval(probe.interval);
     }
     const finalSnapshot = sample();
+    const stripeAvailability = {
+      paymentRequestSupported: typeof window.PaymentRequest === 'function',
+      applePaySessionSupported: typeof window.ApplePaySession === 'function',
+      securePaymentConfirmationSupported: typeof window.SecurePaymentConfirmationRequest === 'function',
+    };
     window.__wpCodeboxProbeCheckpoint && window.__wpCodeboxProbeCheckpoint('ece-waterfall-after-wait', {
       scenario: ${JSON.stringify(scenario.id)},
       interaction: ${JSON.stringify(scenario.interaction)},
       buttons: document.querySelectorAll('#wc-stripe-express-checkout-element iframe, #wc-stripe-express-checkout-element button').length,
       interactionEvents,
       renderProbe: probe,
+      stripeAvailability,
     });
     return {
       title: document.title,
@@ -313,6 +350,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
       eceChildren: document.querySelectorAll('#wc-stripe-express-checkout-element > div').length,
       iframes: document.querySelectorAll('iframe').length,
       finalSnapshot,
+      stripeAvailability,
       renderProbe: probe,
     };
   `;
@@ -379,6 +417,8 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   const responses = network.filter((entry) => entry.type === 'response');
   const urls = responses.map((entry) => entry.url || entry.request?.url || '').filter(Boolean);
   const stripeUrls = urls.filter((url) => /(^|\.)stripe\.com|stripe\.network/.test(url));
+  const elementsSessionResponses = stripeElementsSessionResponses(responses);
+  const elementsSessionStatuses = elementsSessionResponses.map(responseStatus).filter((status) => status !== null);
   const googleUrls = urls.filter((url) => /(^|\.)google\.com|(^|\.)gstatic\.com|googleapis\.com/.test(url));
   const iframeResponses = responses.filter((entry) => (entry.resourceType || entry.request?.resourceType) === 'iframe');
   const summary = await readJsonAsync(summaryPath);
@@ -394,6 +434,10 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   const effectiveViewport = summary?.viewport || summary?.summary?.viewport || null;
   const interactionEvents = Array.isArray(scriptResult?.interactionEvents) ? scriptResult.interactionEvents : [];
   const interactionSucceeded = scenario.interaction === 'load-only' || interactionEvents.some((entry) => entry?.ok === true);
+  const stripeLoadConsoleMessages = stripeLoadMessages(consoleMessages);
+  const stripeLoadPageErrors = stripeLoadMessages(pageErrors);
+  const finalVisibleButtonCount = scriptResult?.finalSnapshot?.ece_visible_button_count ?? renderLatest.visible_button_count ?? 0;
+  const eceRenderedVisibleButton = finalVisibleButtonCount > 0 || peakSampleValue(renderSamples, 'visible_button_count') > 0;
 
   event('browser', 'probe.ready', {
     total_responses: responses.length,
@@ -413,6 +457,17 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     browser_effective_viewport_width: effectiveViewport?.width ?? null,
     browser_effective_viewport_height: effectiveViewport?.height ?? null,
     browser_secure_context_effective: scriptResult?.isSecureContext === true,
+    ece_real_wallet_capable: profileOptions.realWalletCapable,
+    ece_synthetic_only: profileOptions.syntheticOnly,
+    ece_rendered_visible_button: eceRenderedVisibleButton,
+    stripe_elements_session_response_count: elementsSessionResponses.length,
+    stripe_elements_session_status: elementsSessionStatuses[0] ?? null,
+    stripe_elements_session_error_count: elementsSessionStatuses.filter((status) => status >= 400).length,
+    stripe_load_console_message_count: stripeLoadConsoleMessages.length,
+    stripe_load_page_error_count: stripeLoadPageErrors.length,
+    stripe_payment_request_supported: scriptResult?.stripeAvailability?.paymentRequestSupported === true,
+    stripe_apple_pay_session_supported: scriptResult?.stripeAvailability?.applePaySessionSupported === true,
+    stripe_secure_payment_confirmation_supported: scriptResult?.stripeAvailability?.securePaymentConfirmationSupported === true,
     browser_dom_content_loaded_ms: relativeTimingMs(cdpMetrics, 'DomContentLoaded'),
     browser_first_meaningful_paint_ms: relativeTimingMs(cdpMetrics, 'FirstMeaningfulPaint'),
     browser_iframe_count: browserMetrics.browser_iframe_count ?? null,
@@ -465,7 +520,10 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
           browser_profile: profileOptions.profile,
           runtime_preview: profileOptions.runtimePreview,
           browser_probe_args: profileOptions.browserProbeArgs,
-          secure_context_profile: profileOptions.profile === 'secure-browser',
+          secure_context_profile: ['secure-browser', 'real-wallet'].includes(profileOptions.profile),
+          real_wallet_capable: profileOptions.realWalletCapable,
+          synthetic_only: profileOptions.syntheticOnly,
+          required_env: profileOptions.realWalletCapable ? ['STRIPE_PUBLISHABLE_KEY', 'STRIPE_SECRET_KEY', 'HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL'] : [],
         },
         effective_browser_context: {
           viewport: effectiveViewport,
@@ -474,6 +532,12 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
           user_agent: scriptResult?.userAgent || null,
         },
         stripe_urls_sample: stripeUrls.slice(0, 20),
+        stripe_elements_session: {
+          response_count: elementsSessionResponses.length,
+          statuses: elementsSessionStatuses,
+        },
+        stripe_load_console_messages_sample: stripeLoadConsoleMessages.slice(0, 20),
+        stripe_load_page_errors_sample: stripeLoadPageErrors.slice(0, 20),
         google_urls_sample: googleUrls.slice(0, 20),
         console_messages_sample: consoleMessages.slice(0, 20),
         page_errors_sample: pageErrors.slice(0, 20),
@@ -516,6 +580,13 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
         id: 'scenario-interaction',
         status: 'pass',
         message: `${scenario.interaction} interaction produced ${interactionEvents.length} event(s).`,
+      },
+      {
+        id: 'evidence-classification',
+        status: profileOptions.realWalletCapable ? (scriptResult?.isSecureContext === true ? 'pass' : 'fail') : 'pass',
+        message: profileOptions.realWalletCapable
+          ? `Real-wallet-capable profile ran with secure context=${scriptResult?.isSecureContext === true} and visible button=${eceRenderedVisibleButton}.`
+          : 'Synthetic-only profile ran without requiring real Stripe keys or wallet eligibility.',
       },
     ],
     artifacts: [

--- a/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
+++ b/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
@@ -53,6 +53,24 @@ If `woocommerce_stripe_ece_preview_port` is not set, the workload uses
 `HOMEBOY_INVOCATION_PORT_BASE` when Homeboy provides it. The preview bind
 defaults to `127.0.0.1`.
 
+Set `woocommerce_stripe_ece_browser_profile=real-wallet` or use
+`--profile real-wallet` to collect real-wallet-capable ECE evidence. This
+profile refuses to run unless `STRIPE_PUBLISHABLE_KEY`, `STRIPE_SECRET_KEY`,
+and an HTTPS public `HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL` are present.
+The keys are written only into the temporary WordPress setup script for the
+disposable run.
+
+```bash
+export STRIPE_PUBLISHABLE_KEY=pk_test_...
+export STRIPE_SECRET_KEY=sk_test_...
+export HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL=https://example.test
+
+homeboy trace --rig woocommerce-stripe-ece-product-page \
+  --profile real-wallet \
+  woocommerce-gateway-stripe ece-product-page-waterfall \
+  --output /tmp/wc-stripe-ece-real-wallet.json
+```
+
 ## Primary Signals
 
 The stable signals are structural:
@@ -64,6 +82,9 @@ The stable signals are structural:
 - JS event listener count.
 - DOM node count.
 - Long-task count and total duration.
+- Real-wallet evidence classification: `ece_real_wallet_capable` and
+  `ece_synthetic_only`.
+- Stripe Elements session status/error counts and visible-button outcome.
 
 ## Secondary Signals
 

--- a/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
+++ b/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
@@ -206,6 +206,12 @@
         "woocommerce_stripe_ece_browser_profile": "secure-browser"
       }
     },
+    "real-wallet": {
+      "scenario": "ece-product-page-waterfall",
+      "settings": {
+        "woocommerce_stripe_ece_browser_profile": "real-wallet"
+      }
+    },
     "hot": {
       "scenario": "ece-product-page-waterfall"
     },


### PR DESCRIPTION
## Summary
- Add a key-required `real-wallet` profile for the WooCommerce Stripe ECE rig while preserving existing synthetic smoke/browser profiles.
- Fail fast when `STRIPE_PUBLISHABLE_KEY`, `STRIPE_SECRET_KEY`, or an HTTPS public preview URL are missing.
- Record real-wallet evidence classification, Stripe Elements session status/error counts, wallet capability flags, and visible-button outcome in trace metrics/metadata.

## Verification
- `node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`
- `node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs`
- `node -e "JSON.parse(require('fs').readFileSync('woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json','utf8'))"`
- `git diff --check`
- `node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs Automattic/studio/bench/studio-agent-site-build.test.mjs`

Closes #182.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the rig profile validation, trace metric additions, docs, tests, and verification commands for Chris to review.