### PR TITLE
Add deterministic Stripe ECE CLS profiles

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { buildEceProfileOptions } from './ece-product-page-profile.mjs';
-import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceProductPageScenario, eceProductPageScenarioIds } from './ece-product-page-scenarios.mjs';
+import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceProductPageScenario, eceProductPageScenarioIds, eceSimulatedClsScript } from './ece-product-page-scenarios.mjs';
 
 test('default smoke profile preserves browser probe defaults', () => {
   const options = buildEceProfileOptions('smoke');
@@ -162,11 +162,30 @@ test('ECE scenario registry preserves load-only default and exposes interactions
   assert.equal(eceProductPageScenario(DEFAULT_ECE_SCENARIO_ID).interaction, 'load-only');
   assert.equal(eceProductPageScenario('ece-product-page-scroll-to-ece').interaction, 'scroll-to-ece');
   assert.equal(eceProductPageScenario('ece-product-page-quantity-change').interaction, 'quantity-change');
+  assert.equal(eceProductPageScenario('ece-product-page-simulated-cls').simulatedCls, 'unreserved');
+  assert.equal(eceProductPageScenario('ece-product-page-simulated-cls-reserved').simulatedCls, 'reserved');
+  assert.equal(eceProductPageScenario('ece-product-page-simulated-cls').waitFor, 'load');
+  assert.equal(eceProductPageScenario('ece-product-page-simulated-cls-reserved').waitFor, 'load');
   assert.ok(eceProductPageScenarioIds().includes(DEFAULT_ECE_SCENARIO_ID));
   assert.ok(eceProductPageScenarioIds().includes('ece-product-page-scroll-to-ece'));
+  assert.ok(eceProductPageScenarioIds().includes('ece-product-page-simulated-cls'));
+  assert.ok(eceProductPageScenarioIds().includes('ece-product-page-simulated-cls-reserved'));
 });
 
 test('ECE interaction scripts keep Stripe selectors in the rig', () => {
   assert.match(eceInteractionScript(eceProductPageScenario('ece-product-page-scroll-to-ece')), /#wc-stripe-express-checkout-element/);
   assert.match(eceInteractionScript(eceProductPageScenario('ece-product-page-quantity-change')), /quantity_change/);
+  assert.match(eceInteractionScript(eceProductPageScenario('ece-product-page-simulated-cls')), /simulated_cls_render/);
+});
+
+test('ECE simulated CLS scripts track root and grouped ECE containers', () => {
+  const unreservedScript = eceSimulatedClsScript(eceProductPageScenario('ece-product-page-simulated-cls'));
+  const reservedScript = eceSimulatedClsScript(eceProductPageScenario('ece-product-page-simulated-cls-reserved'));
+
+  assert.match(unreservedScript, /homeboy-stripe-ece-simulated-button/);
+  assert.match(unreservedScript, /#wc-stripe-express-checkout-element/);
+  assert.match(unreservedScript, /#wc-stripe-express-checkout-element-wallets-link/);
+  assert.ok(!unreservedScript.includes("].join('\n');"));
+  assert.doesNotMatch(unreservedScript, /min-height: 48px/);
+  assert.match(reservedScript, /min-height: 48px/);
 });

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-scenarios.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-scenarios.mjs
@@ -39,6 +39,22 @@ const SCENARIOS = {
     interaction: 'variation-change',
     description: 'Attempt a product variation selection change when variation controls exist.',
   },
+  'ece-product-page-simulated-cls': {
+    id: 'ece-product-page-simulated-cls',
+    profile: 'simulated-cls',
+    interaction: 'load-only',
+    simulatedCls: 'unreserved',
+    waitFor: 'load',
+    description: 'Inject a delayed ECE-like button without reserved space and record deterministic CLS.',
+  },
+  'ece-product-page-simulated-cls-reserved': {
+    id: 'ece-product-page-simulated-cls-reserved',
+    profile: 'simulated-cls-reserved',
+    interaction: 'load-only',
+    simulatedCls: 'reserved',
+    waitFor: 'load',
+    description: 'Reserve ECE button space before injecting the delayed ECE-like button and record CLS.',
+  },
 };
 
 export function eceProductPageScenario(scenarioId = DEFAULT_ECE_SCENARIO_ID) {
@@ -50,6 +66,22 @@ export function eceProductPageScenarioIds() {
 }
 
 export function eceInteractionScript(scenario) {
+  if (scenario.simulatedCls) {
+    return `
+      interactionSnapshot('before_simulated_cls_render');
+      await sleep(250);
+      if (typeof window.__homeboyStripeEceSimulateButton === 'function') {
+        window.__homeboyStripeEceSimulateButton();
+        interactionEvents.push({ name: 'simulated_cls_render', t_ms: elapsed(), ok: true, reserved: ${scenario.simulatedCls === 'reserved' ? 'true' : 'false'} });
+        await sleep(500);
+        sample();
+        interactionSnapshot('after_simulated_cls_render');
+      } else {
+        interactionEvents.push({ name: 'simulated_cls_render', t_ms: elapsed(), ok: false, reason: 'missing_simulated_cls_hook' });
+      }
+    `;
+  }
+
   switch (scenario.interaction) {
     case 'scroll-to-ece':
       return `
@@ -128,6 +160,112 @@ export function eceLayoutScript(scenario) {
       installBelowFoldLayout();
     } else {
       document.addEventListener('DOMContentLoaded', installBelowFoldLayout, { once: true });
+    }
+  `;
+}
+
+export function eceSimulatedClsScript(scenario) {
+  if (!scenario.simulatedCls) {
+    return '';
+  }
+
+  const reserveSpace = scenario.simulatedCls === 'reserved';
+
+  return `
+    const installSimulatedClsProfile = () => {
+      if (window.__homeboyStripeEceSimulatedClsInstalled) {
+        return;
+      }
+      window.__homeboyStripeEceSimulatedClsInstalled = true;
+
+      const style = document.createElement('style');
+      style.id = 'homeboy-stripe-ece-simulated-cls-style';
+      style.textContent = [
+        '#wc-stripe-express-checkout-element { display: block !important; width: 100% !important; ${reserveSpace ? 'min-height: 48px !important;' : ''} }',
+        '#wc-stripe-express-checkout-element-wallets-link { display: block !important; width: 100% !important; ${reserveSpace ? 'min-height: 48px !important;' : ''} }',
+        '.homeboy-stripe-ece-simulated-button { display: block; width: 100%; height: 48px; margin: 0; border: 0; border-radius: 4px; background: #111; color: #fff; font: 600 16px/48px system-ui, sans-serif; text-align: center; }',
+        '.homeboy-stripe-ece-cls-sentinel { display: block; height: 120px; margin-top: 12px; padding: 16px; background: #f3f4f6; color: #111827; box-sizing: border-box; }',
+      ].join('\\n');
+      document.head.appendChild(style);
+
+      const ensureContainers = () => {
+        let root = document.querySelector('#wc-stripe-express-checkout-element');
+        if (!root) {
+          const anchor = document.querySelector('form.cart') || document.querySelector('.summary') || document.body;
+          if (!anchor) {
+            return null;
+          }
+          root = document.createElement('div');
+          root.id = 'wc-stripe-express-checkout-element';
+          root.setAttribute('data-homeboy-simulated-ece-root', '1');
+          anchor.insertAdjacentElement(anchor.matches?.('form.cart') ? 'beforebegin' : 'afterbegin', root);
+        }
+        if (!root) {
+          return null;
+        }
+
+        let grouped = document.querySelector('#wc-stripe-express-checkout-element-wallets-link');
+        if (!grouped) {
+          grouped = document.createElement('div');
+          grouped.id = 'wc-stripe-express-checkout-element-wallets-link';
+          root.appendChild(grouped);
+        }
+
+        let sentinel = document.querySelector('.homeboy-stripe-ece-cls-sentinel');
+        if (!sentinel) {
+          sentinel = document.createElement('div');
+          sentinel.className = 'homeboy-stripe-ece-cls-sentinel';
+          sentinel.textContent = 'Homeboy deterministic CLS sentinel below simulated ECE.';
+          root.insertAdjacentElement('afterend', sentinel);
+        }
+
+        return { root, grouped, sentinel };
+      };
+
+      const renderButton = () => {
+        const containers = ensureContainers();
+        if (!containers || containers.grouped.querySelector('.homeboy-stripe-ece-simulated-button')) {
+          return;
+        }
+
+        const probe = window.__wcStripeEceRenderProbe;
+        if (probe) {
+          probe.cls = 0;
+          probe.layoutShifts = [];
+          probe.events?.push({
+            name: 'simulated_cls_reset',
+            t_ms: Math.round(performance.now() - probe.startedAt),
+            data: { reserved: ${reserveSpace ? 'true' : 'false'} },
+          });
+        }
+
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'homeboy-stripe-ece-simulated-button';
+        button.textContent = 'Simulated Express Checkout';
+        containers.grouped.appendChild(button);
+        probe?.events?.push({
+          name: 'simulated_ece_button_inserted',
+          t_ms: Math.round(performance.now() - probe.startedAt),
+          data: { reserved: ${reserveSpace ? 'true' : 'false'} },
+        });
+      };
+
+      const waitForContainer = () => {
+        if (ensureContainers()) {
+          window.__homeboyStripeEceSimulateButton = renderButton;
+          return;
+        }
+        window.setTimeout(waitForContainer, 50);
+      };
+
+      waitForContainer();
+    };
+
+    if (document.head) {
+      installSimulatedClsProfile();
+    } else {
+      document.addEventListener('DOMContentLoaded', installSimulatedClsProfile, { once: true });
     }
   `;
 }

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-simulated-cls-reserved.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-simulated-cls-reserved.trace.mjs
@@ -1,0 +1,1 @@
+import './ece-product-page-waterfall.trace.mjs';

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-simulated-cls.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-simulated-cls.trace.mjs
@@ -1,0 +1,1 @@
+import './ece-product-page-waterfall.trace.mjs';

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import { buildEceProfileOptions } from './ece-product-page-profile.mjs';
-import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceLayoutScript, eceProductPageScenario } from './ece-product-page-scenarios.mjs';
+import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceLayoutScript, eceProductPageScenario, eceSimulatedClsScript } from './ece-product-page-scenarios.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -147,6 +147,15 @@ function stripeLoadMessages(messages) {
   return messages.filter((entry) => /stripe|express checkout|paymentrequest|apple pay|google pay/i.test(JSON.stringify(entry)));
 }
 
+function roundedNumberOrNull(value, places = 4) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null;
+  }
+
+  const multiplier = 10 ** places;
+  return Math.round(value * multiplier) / multiplier;
+}
+
 try {
   event('scenario', 'start', {
     component_path: componentPath,
@@ -198,11 +207,14 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
 
   const prePageScript = `(() => {
   ${eceLayoutScript(scenario)}
+  ${eceSimulatedClsScript(scenario)}
   const state = window.__wcStripeEceRenderProbe = {
     startedAt: performance.now(),
     events: [],
     marks: {},
     samples: [],
+    cls: 0,
+    layoutShifts: [],
   };
   const elapsed = () => Math.round(performance.now() - state.startedAt);
   const record = (name, data = {}) => {
@@ -222,6 +234,70 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     const rect = node.getBoundingClientRect();
     return style.visibility !== 'hidden' && style.display !== 'none' && rect.width > 0 && rect.height > 0;
   };
+  const selectorForNode = (node) => {
+    if (!node || !(node instanceof Element)) {
+      return null;
+    }
+    if (node.id) {
+      return '#' + node.id;
+    }
+    const className = Array.from(node.classList || []).slice(0, 3).join('.');
+    return node.tagName.toLowerCase() + (className ? '.' + className : '');
+  };
+  const rectForNode = (node) => {
+    if (!node || !(node instanceof Element)) {
+      return null;
+    }
+    const rect = node.getBoundingClientRect();
+    return {
+      x: Math.round(rect.x),
+      y: Math.round(rect.y),
+      width: Math.round(rect.width),
+      height: Math.round(rect.height),
+    };
+  };
+  const trackedContainerMetrics = () => {
+    const root = document.querySelector('#wc-stripe-express-checkout-element');
+    const grouped = document.querySelector('#wc-stripe-express-checkout-element-wallets-link');
+    const sentinel = document.querySelector('.homeboy-stripe-ece-cls-sentinel');
+    return {
+      ece_container_height: rectForNode(root)?.height ?? 0,
+      ece_container_rect: rectForNode(root),
+      ece_wallets_link_height: rectForNode(grouped)?.height ?? 0,
+      ece_wallets_link_rect: rectForNode(grouped),
+      ece_cls_sentinel_rect: rectForNode(sentinel),
+    };
+  };
+  try {
+    const layoutShiftObserver = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        if (entry.hadRecentInput) {
+          continue;
+        }
+        const sources = Array.from(entry.sources || []).map((source) => ({
+          selector: selectorForNode(source.node),
+          current_rect: source.currentRect
+            ? { x: Math.round(source.currentRect.x), y: Math.round(source.currentRect.y), width: Math.round(source.currentRect.width), height: Math.round(source.currentRect.height) }
+            : null,
+          previous_rect: source.previousRect
+            ? { x: Math.round(source.previousRect.x), y: Math.round(source.previousRect.y), width: Math.round(source.previousRect.width), height: Math.round(source.previousRect.height) }
+            : null,
+        }));
+        state.cls += entry.value;
+        state.layoutShifts.push({
+          t_ms: elapsed(),
+          value: entry.value,
+          sources,
+          tracked_containers: trackedContainerMetrics(),
+        });
+        record('layout_shift', { value: entry.value, sources, tracked_containers: trackedContainerMetrics() });
+      }
+    });
+    layoutShiftObserver.observe({ type: 'layout-shift', buffered: true });
+    state.layoutShiftObserver = layoutShiftObserver;
+  } catch (error) {
+    record('layout_shift_observer_unavailable', { message: error?.message || String(error) });
+  }
   const sample = () => {
     const container = document.querySelector('#wc-stripe-express-checkout-element');
     if (!container) {
@@ -256,6 +332,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
       button_count: buttons.length,
       visible_button_count: visibleButtons.length,
       container_visible: isVisible(container),
+      ...trackedContainerMetrics(),
     };
     state.samples.push(state.latest);
   };
@@ -324,6 +401,10 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     if (probe && probe.interval) {
       window.clearInterval(probe.interval);
     }
+    if (probe && probe.layoutShiftObserver) {
+      probe.layoutShiftObserver.disconnect();
+      delete probe.layoutShiftObserver;
+    }
     const finalSnapshot = sample();
     const stripeAvailability = {
       paymentRequestSupported: typeof window.PaymentRequest === 'function',
@@ -379,7 +460,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
           command: 'wordpress.browser-probe',
           args: [
             'url=/?product=stripe-benchmark-product',
-            'wait-for=networkidle',
+            `wait-for=${scenario.waitFor || 'networkidle'}`,
             `duration=${probeDuration}`,
             `viewport=${viewport}`,
             ...profileOptions.browserProbeArgs,
@@ -430,6 +511,18 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   const renderMarks = renderProbe?.marks || {};
   const renderLatest = renderProbe?.latest || {};
   const renderSamples = renderProbe?.samples || [];
+  const layoutShifts = Array.isArray(renderProbe?.layoutShifts) ? renderProbe.layoutShifts : [];
+  const layoutShiftSourceDetails = layoutShifts.flatMap((entry) =>
+    Array.isArray(entry.sources)
+      ? entry.sources.map((source) => ({
+          t_ms: entry.t_ms ?? null,
+          value: roundedNumberOrNull(entry.value),
+          selector: source.selector ?? null,
+          previous_rect: source.previous_rect ?? null,
+          current_rect: source.current_rect ?? null,
+        }))
+      : []
+  );
   const requestedViewport = parseViewport(viewport);
   const effectiveViewport = summary?.viewport || summary?.summary?.viewport || null;
   const interactionEvents = Array.isArray(scriptResult?.interactionEvents) ? scriptResult.interactionEvents : [];
@@ -457,6 +550,8 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     browser_effective_viewport_width: effectiveViewport?.width ?? null,
     browser_effective_viewport_height: effectiveViewport?.height ?? null,
     browser_secure_context_effective: scriptResult?.isSecureContext === true,
+    browser_cls: roundedNumberOrNull(renderProbe.cls),
+    browser_layout_shift_count: layoutShifts.length,
     ece_real_wallet_capable: profileOptions.realWalletCapable,
     ece_synthetic_only: profileOptions.syntheticOnly,
     ece_rendered_visible_button: eceRenderedVisibleButton,
@@ -498,6 +593,8 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     ece_render_final_visible_iframe_count: renderLatest.visible_iframe_count ?? null,
     ece_render_final_button_count: renderLatest.button_count ?? null,
     ece_render_final_visible_button_count: renderLatest.visible_button_count ?? null,
+    ece_render_final_container_height: numberOrNull(renderLatest.ece_container_height),
+    ece_render_final_wallets_link_height: numberOrNull(renderLatest.ece_wallets_link_height),
     ece_interaction_event_count: interactionEvents.length,
     ece_interaction_succeeded: interactionSucceeded,
   };
@@ -544,6 +641,8 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
         browser_script_result: scriptResult,
         interaction_events: interactionEvents,
         render_probe_events: Array.isArray(renderProbe.events) ? renderProbe.events.slice(0, 100) : [],
+        layout_shift_sources: layoutShiftSourceDetails.slice(0, 50),
+        layout_shifts: layoutShifts.slice(0, 50),
       },
       null,
       2
@@ -551,7 +650,13 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   );
   event('waterfall', 'metrics.ready', metrics);
 
-  const pass = output.success === true && stripeUrls.length > 0;
+  const simulatedClsPass =
+    scenario.simulatedCls === 'unreserved'
+      ? typeof metrics.browser_cls === 'number' && metrics.browser_cls > 0 && eceRenderedVisibleButton
+      : scenario.simulatedCls === 'reserved'
+        ? typeof metrics.browser_cls === 'number' && metrics.browser_cls <= 0.01 && eceRenderedVisibleButton
+        : true;
+  const pass = output.success === true && stripeUrls.length > 0 && simulatedClsPass;
   const traceResult = {
     component_id: componentId,
     scenario_id: scenarioId,
@@ -588,6 +693,18 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
           ? `Real-wallet-capable profile ran with secure context=${scriptResult?.isSecureContext === true} and visible button=${eceRenderedVisibleButton}.`
           : 'Synthetic-only profile ran without requiring real Stripe keys or wallet eligibility.',
       },
+      ...(scenario.simulatedCls
+        ? [
+            {
+              id: 'simulated-cls-profile',
+              status: simulatedClsPass ? 'pass' : 'fail',
+              message:
+                scenario.simulatedCls === 'reserved'
+                  ? `Reserved simulated ECE CLS was ${metrics.browser_cls} with visible button=${eceRenderedVisibleButton}; expected near zero (<= 0.01).`
+                  : `Unreserved simulated ECE CLS was ${metrics.browser_cls} with visible button=${eceRenderedVisibleButton}; expected non-zero deterministic CLS.`,
+            },
+          ]
+        : []),
     ],
     artifacts: [
       { label: 'WP Codebox output', path: relativeArtifactPath(outputFile) },

--- a/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
+++ b/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
@@ -71,6 +71,24 @@ homeboy trace --rig woocommerce-stripe-ece-product-page \
   --output /tmp/wc-stripe-ece-real-wallet.json
 ```
 
+Use `--profile simulated-cls` and `--profile simulated-cls-reserved` for
+deterministic product-page CLS evidence that does not depend on live Stripe
+wallet eligibility. Both profiles inject a delayed 48px ECE-like button into
+`#wc-stripe-express-checkout-element-wallets-link`; the reserved variant applies
+the matching ECE container height before the delayed render.
+
+```bash
+homeboy trace --rig woocommerce-stripe-ece-product-page \
+  --profile simulated-cls \
+  woocommerce-gateway-stripe ece-product-page-simulated-cls \
+  --output /tmp/wc-stripe-ece-simulated-cls.json
+
+homeboy trace --rig woocommerce-stripe-ece-product-page \
+  --profile simulated-cls-reserved \
+  woocommerce-gateway-stripe ece-product-page-simulated-cls-reserved \
+  --output /tmp/wc-stripe-ece-simulated-cls-reserved.json
+```
+
 ## Primary Signals
 
 The stable signals are structural:
@@ -85,6 +103,10 @@ The stable signals are structural:
 - Real-wallet evidence classification: `ece_real_wallet_capable` and
   `ece_synthetic_only`.
 - Stripe Elements session status/error counts and visible-button outcome.
+- Deterministic CLS fields for simulated profiles: `browser_cls`,
+  `browser_layout_shift_count`, `ece_render_final_container_height`,
+  `ece_render_final_wallets_link_height`, and metadata-level layout-shift source
+  rectangles for the ECE container/sentinel path.
 
 ## Secondary Signals
 

--- a/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
+++ b/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
@@ -193,6 +193,64 @@
             "blocking": true
           }
         }
+      },
+      {
+        "path": "${package.root}/bench/ece-product-page-simulated-cls.trace.mjs",
+        "check_groups": [],
+        "port_range_size": 1,
+        "trace_default_phase_preset": "browser-waterfall",
+        "trace_phase_presets": {
+          "browser-waterfall": [
+            "start:scenario.start",
+            "recipe:wp_codebox.recipe.start",
+            "setup:wordpress.fixture.ready",
+            "probe:browser.probe.ready",
+            "metrics:waterfall.metrics.ready"
+          ]
+        },
+        "trace_span_metadata": {
+          "phase.recipe_to_setup": {
+            "category": "runtime_setup",
+            "blocking": true
+          },
+          "phase.setup_to_probe": {
+            "category": "browser_probe",
+            "blocking": true
+          },
+          "phase.probe_to_metrics": {
+            "category": "artifact_extraction",
+            "blocking": true
+          }
+        }
+      },
+      {
+        "path": "${package.root}/bench/ece-product-page-simulated-cls-reserved.trace.mjs",
+        "check_groups": [],
+        "port_range_size": 1,
+        "trace_default_phase_preset": "browser-waterfall",
+        "trace_phase_presets": {
+          "browser-waterfall": [
+            "start:scenario.start",
+            "recipe:wp_codebox.recipe.start",
+            "setup:wordpress.fixture.ready",
+            "probe:browser.probe.ready",
+            "metrics:waterfall.metrics.ready"
+          ]
+        },
+        "trace_span_metadata": {
+          "phase.recipe_to_setup": {
+            "category": "runtime_setup",
+            "blocking": true
+          },
+          "phase.setup_to_probe": {
+            "category": "browser_probe",
+            "blocking": true
+          },
+          "phase.probe_to_metrics": {
+            "category": "artifact_extraction",
+            "blocking": true
+          }
+        }
       }
     ]
   },
@@ -229,6 +287,12 @@
     },
     "variation-change": {
       "scenario": "ece-product-page-variation-change"
+    },
+    "simulated-cls": {
+      "scenario": "ece-product-page-simulated-cls"
+    },
+    "simulated-cls-reserved": {
+      "scenario": "ece-product-page-simulated-cls-reserved"
     }
   },
   "pipeline": {


### PR DESCRIPTION
## Summary
- Adds `simulated-cls` and `simulated-cls-reserved` Stripe ECE product-page trace profiles.
- Records deterministic CLS metrics, layout-shift source details, and ECE root/grouped container heights without requiring live wallet eligibility.
- Documents the new profiles and covers the scenario/script plumbing with Node tests.

Closes #181.

## Verification
- `node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`
- `node scripts/lint-rig-packages.mjs`
- `HOMEBOY_WC_STRIPE_COMPONENT_PATH=/Users/chubes/Developer/woocommerce-gateway-stripe@fix-1439-ece-waterfall-rig homeboy rig check woocommerce-stripe-ece-product-page`
- `HOMEBOY_WC_STRIPE_ECE_PROBE_DURATION=2s HOMEBOY_WC_STRIPE_COMPONENT_PATH=/Users/chubes/Developer/woocommerce-gateway-stripe@fix-1439-ece-waterfall-rig homeboy trace --rig woocommerce-stripe-ece-product-page --path /Users/chubes/Developer/woocommerce-gateway-stripe@fix-1439-ece-waterfall-rig --profile simulated-cls woocommerce-gateway-stripe ece-product-page-simulated-cls --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/wc-stripe-ece-simulated-cls-final.json`
- `HOMEBOY_WC_STRIPE_ECE_PROBE_DURATION=2s HOMEBOY_WC_STRIPE_COMPONENT_PATH=/Users/chubes/Developer/woocommerce-gateway-stripe@fix-1439-ece-waterfall-rig homeboy trace --rig woocommerce-stripe-ece-product-page --path /Users/chubes/Developer/woocommerce-gateway-stripe@fix-1439-ece-waterfall-rig --profile simulated-cls-reserved woocommerce-gateway-stripe ece-product-page-simulated-cls-reserved --output /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/wc-stripe-ece-simulated-cls-reserved-final.json`

Observed metrics from the final trace pair:
- `simulated-cls`: `browser_cls=0.0351`, `browser_layout_shift_count=1`, `ece_rendered_visible_button=true`, `ece_render_final_container_height=48`, `ece_render_final_wallets_link_height=48`.
- `simulated-cls-reserved`: `browser_cls=0`, `browser_layout_shift_count=0`, `ece_rendered_visible_button=true`, `ece_render_final_container_height=48`, `ece_render_final_wallets_link_height=48`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and tested the rig profile changes; Chris remains responsible for review and acceptance.