### PR TITLE
Adopt promoted WordPress quality helper

### DIFF
--- a/Automattic/studio/bench/lib/wordpress-quality.mjs
+++ b/Automattic/studio/bench/lib/wordpress-quality.mjs
@@ -1,8 +1,10 @@
+import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
+import path from 'node:path';
 
 import { runCli as defaultRunCli } from './studio-bench.mjs';
 import { collectLatestGeneratedTheme } from './design-gates.mjs';
-import { loadWordPressLibHelper } from './wordpress-helper-discovery.mjs';
+import { loadWordPressHelperManifest, loadWordPressLibHelper } from './wordpress-helper-discovery.mjs';
 
 export {
   collectGeneratedThemeUxGates,
@@ -12,95 +14,45 @@ export {
   structuralSelectorDriftDiagnostics,
 } from './design-gates.mjs';
 
-export const QUALITY_PROBE = String.raw`
-function bench_count_blocks( $blocks, &$counts ) {
-    foreach ( $blocks as $block ) {
-        $name = isset( $block['blockName'] ) ? (string) $block['blockName'] : '';
-        if ( '' !== $name ) {
-            $counts['total_blocks']++;
-            if ( 'core/html' === $name ) {
-                $counts['core_html_blocks']++;
-            }
-        }
-        if ( ! empty( $block['innerBlocks'] ) ) {
-            bench_count_blocks( $block['innerBlocks'], $counts );
-        }
-    }
+function blockThemeQualityProbePath(options = {}) {
+  const explicit = options.blockThemeQualityProbePath || process.env.HOMEBOY_WORDPRESS_BLOCK_THEME_QUALITY_PROBE;
+  if (explicit) {
+    return explicit;
+  }
+
+  const { manifest } = loadWordPressHelperManifest(options);
+  return manifest?.extensionRoot
+    ? path.join(manifest.extensionRoot, 'scripts', 'bench', 'lib', 'block-theme-quality-probe.php')
+    : '';
 }
 
-$counts = array(
-    'posts_seen' => 0,
-    'posts_with_blocks' => 0,
-    'pages_seen' => 0,
-    'templates_seen' => 0,
-    'template_parts_seen' => 0,
-    'target_pages_seen' => 0,
-    'target_posts_with_blocks' => 0,
-    'target_raw_html_unconverted' => 0,
-    'target_total_blocks' => 0,
-    'target_core_html_blocks' => 0,
-    'target_serialized_block_comments' => 0,
-    'total_blocks' => 0,
-    'core_html_blocks' => 0,
-    'serialized_block_comments' => 0,
-    'bfb_fallback_count' => (int) get_option( 'studio_bfb_unsupported_fallback_count', 0 ),
-);
-
-$front_page_id = (int) get_option( 'page_on_front', 0 );
-
-$posts = get_posts( array(
-    'post_type' => array( 'page', 'wp_template', 'wp_template_part' ),
-    'post_status' => 'any',
-    'numberposts' => -1,
+function blockThemeQualityProbeCode(probePath) {
+  const encodedPath = Buffer.from(probePath).toString('base64');
+  return String.raw`
+$homeboy_probe_path = base64_decode( '${encodedPath}', true );
+if ( ! is_string( $homeboy_probe_path ) || ! is_readable( $homeboy_probe_path ) ) {
+    fwrite( STDERR, 'Homeboy WordPress block theme quality probe is unavailable: ' . (string) $homeboy_probe_path );
+    exit( 1 );
+}
+require_once $homeboy_probe_path;
+$counts = homeboy_wordpress_collect_block_theme_quality( array(
+    'target_post_titles' => array( 'Studio Code' ),
+    'post_types'         => array( 'page', 'wp_template', 'wp_template_part' ),
 ) );
-
-foreach ( $posts as $post ) {
-    $content = (string) $post->post_content;
-    if ( '' === trim( $content ) ) {
-        continue;
-    }
-    $counts['posts_seen']++;
-    if ( 'page' === $post->post_type ) {
-        $counts['pages_seen']++;
-    }
-    if ( 'wp_template' === $post->post_type ) {
-        $counts['templates_seen']++;
-    }
-    if ( 'wp_template_part' === $post->post_type ) {
-        $counts['template_parts_seen']++;
-    }
-    $counts['serialized_block_comments'] += substr_count( $content, '<!-- wp:' );
-    if ( false !== strpos( $content, '<!-- wp:' ) ) {
-        $counts['posts_with_blocks']++;
-    }
-    $before_total     = $counts['total_blocks'];
-    $before_core_html = $counts['core_html_blocks'];
-    bench_count_blocks( parse_blocks( $content ), $counts );
-
-    $is_target_page = 'page' === $post->post_type && ( (int) $post->ID === $front_page_id || 'Studio Code' === $post->post_title );
-    if ( $is_target_page ) {
-        $counts['target_pages_seen']++;
-        $counts['target_serialized_block_comments'] += substr_count( $content, '<!-- wp:' );
-        if ( false !== strpos( $content, '<!-- wp:' ) ) {
-            $counts['target_posts_with_blocks']++;
-        }
-        if ( false === strpos( $content, '<!-- wp:' ) && preg_match( '/<\/?[a-z][\s>]/i', $content ) ) {
-            $counts['target_raw_html_unconverted']++;
-        }
-        $counts['target_total_blocks'] += $counts['total_blocks'] - $before_total;
-        $counts['target_core_html_blocks'] += $counts['core_html_blocks'] - $before_core_html;
-    }
-}
-
+$counts['bfb_fallback_count'] = (int) get_option( 'studio_bfb_unsupported_fallback_count', 0 );
 $counts['core_html_without_bfb_fallback'] = max( 0, $counts['core_html_blocks'] - $counts['bfb_fallback_count'] );
 $counts['target_core_html_without_bfb_fallback'] = max( 0, $counts['target_core_html_blocks'] - $counts['bfb_fallback_count'] );
-
 echo wp_json_encode( $counts, JSON_PRETTY_PRINT ) . PHP_EOL;
 `;
+}
 
 export async function probeQuality(sitePath, options = {}) {
   const runCli = options.runCli || defaultRunCli;
-  const { stdout } = await runCli(['wp', '--path', sitePath, '--php-version', '8.3', 'eval', QUALITY_PROBE]);
+  const probePath = blockThemeQualityProbePath(options);
+  if (!probePath || !existsSync(probePath)) {
+    throw new Error('Homeboy WordPress block theme quality helper is unavailable. Update homeboy-extensions or set HOMEBOY_WORDPRESS_HELPER_MANIFEST.');
+  }
+  const { stdout } = await runCli(['wp', '--path', sitePath, '--php-version', '8.3', 'eval', blockThemeQualityProbeCode(probePath)]);
   return parseQualityProbeOutput(stdout);
 }
 

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -46,7 +46,7 @@ const {
   wordpressAdminPageScenario,
   wordpressPageProfilerSpec,
 } = await import('./lib/wordpress-page-profiler.mjs');
-const { probePageQuality } = await import('./lib/wordpress-quality.mjs');
+const { probePageQuality, probeQuality } = await import('./lib/wordpress-quality.mjs');
 const {
   normalizeWordPressAdminScaleSweepManifest,
 } = await import('./lib/wordpress-admin-scale-sweep.mjs');
@@ -108,13 +108,16 @@ async function writeFakeWordPressManifest() {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'homeboy-wordpress-manifest-'));
   const extensionRoot = path.join(tempDir, 'wordpress');
   const libDir = path.join(extensionRoot, 'lib');
+  const benchLibDir = path.join(extensionRoot, 'scripts', 'bench', 'lib');
   await import('node:fs/promises').then(({ mkdir }) => mkdir(libDir, { recursive: true }));
+  await import('node:fs/promises').then(({ mkdir }) => mkdir(benchLibDir, { recursive: true }));
   const requestProfiler = path.join(libDir, 'request-profiler.js');
   const timingCorrelator = path.join(libDir, 'timing-correlator.js');
   const bootstrapTimeline = path.join(libDir, 'wordpress-bootstrap-timeline.js');
   const pageProfiler = path.join(libDir, 'page-profiler.js');
   const adminPageScenarios = path.join(libDir, 'admin-page-scenarios.js');
   const blockQuality = path.join(libDir, 'block-quality.js');
+  const blockThemeQualityProbe = path.join(benchLibDir, 'block-theme-quality-probe.php');
   const manifestPath = path.join(libDir, 'helper-manifest.js');
 
   await writeFile(requestProfiler, "module.exports = { installWordPressRequestProfiler() {} };\n");
@@ -127,6 +130,7 @@ module.exports = {
   parseWordPressBlockQualityProbeOutput: () => ({ fallback_count: 2, core_html_without_fallback: 3, stored_content_hash: 'abc' }),
 };
 `);
+  await writeFile(blockThemeQualityProbe, "<?php // fake block theme quality probe\n");
   await writeFile(bootstrapTimeline, `
 module.exports = {
   instrumentIndexPhp(source) {
@@ -176,7 +180,7 @@ module.exports = {
 };
 `);
 
-  return { tempDir, manifestPath, requestProfiler, timingCorrelator, bootstrapTimeline, pageProfiler, adminPageScenarios, blockQuality };
+  return { tempDir, manifestPath, requestProfiler, timingCorrelator, bootstrapTimeline, pageProfiler, adminPageScenarios, blockQuality, blockThemeQualityProbe };
 }
 
 // --- path resolution -------------------------------------------------------
@@ -711,6 +715,45 @@ test('probePageQuality delegates post-scoped block probing to the WordPress help
         assert.equal(quality.bfb_fallback_count, 2);
         assert.equal(quality.core_html_without_bfb_fallback, 3);
         assert.equal(quality.stored_content_hash, 'abc');
+      }
+    );
+  } finally {
+    await rm(fixture.tempDir, { recursive: true, force: true });
+  }
+});
+
+test('probeQuality delegates site block probing to the promoted block theme helper', async () => {
+  const fixture = await writeFakeWordPressManifest();
+  try {
+    await withEnvAsync(
+      {
+        HOMEBOY_WORDPRESS_HELPER_MANIFEST: fixture.manifestPath,
+        HOMEBOY_WORDPRESS_BLOCK_THEME_QUALITY_PROBE: undefined,
+      },
+      async () => {
+        const calls = [];
+        const quality = await probeQuality('/tmp/site', {
+          runCli: async (args) => {
+            calls.push(args);
+            return {
+              stdout: JSON.stringify({
+                target_pages_seen: 1,
+                target_posts_with_blocks: 1,
+                bfb_fallback_count: 0,
+                core_html_without_bfb_fallback: 0,
+              }),
+            };
+          },
+        });
+
+        assert.equal(calls.length, 1);
+        assert.deepEqual(calls[0].slice(0, 5), ['wp', '--path', '/tmp/site', '--php-version', '8.3']);
+        const encodedPath = /base64_decode\( '([^']+)'/.exec(calls[0].at(-1))?.[1] || '';
+        assert.equal(Buffer.from(encodedPath, 'base64').toString(), fixture.blockThemeQualityProbe);
+        assert.match(calls[0].at(-1), /homeboy_wordpress_collect_block_theme_quality/);
+        assert.match(calls[0].at(-1), /Studio Code/);
+        assert.equal(quality.target_pages_seen, 1);
+        assert.equal(quality.target_posts_with_blocks, 1);
       }
     );
   } finally {

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ Keep the Studio bench harness layered so each repo owns the smallest stable surf
 - `homeboy-extensions/wordpress` is the future home for generic WordPress and block quality probes once their contracts are stable.
 - `homeboy` core owns benchmark orchestration only; it should stay generic and substrate-agnostic.
 
+Issue [#185](https://github.com/chubes4/homeboy-rigs/issues/185) tracks thinning duplicated helper logic after upstream promotion. Studio native-block quality probing now uses the promoted Homeboy Extensions block theme quality probe from `Extra-Chill/homeboy-extensions#1018`. Fixture plugin install/restore, browser waterfall collection, and trace reporter adoption remain blocked until `Extra-Chill/homeboy-extensions#1132`, `#1131`, and `#1133` land; rigs should not add local fallback shims for those contracts.
+
 Cleanup should move in small waves:
 
 1. Build a shared local Studio bench helper foundation for repeated filesystem, artifact, CLI, and appdata setup.


### PR DESCRIPTION
## Summary
- Replaces the Studio-local site block quality PHP probe with the promoted Homeboy Extensions block theme quality probe exposed through the WordPress helper manifest.
- Keeps Studio-specific fallback-option and target-title gates in the rig while relying on the upstream target-page quality helper from Extra-Chill/homeboy-extensions#1018.
- Documents the remaining homeboy-rigs#185 adoption plan as blocked on Extra-Chill/homeboy-extensions#1131, #1132, and #1133 instead of adding local workaround shims.

## Verification
- `node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `node scripts/lint-rig-packages.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Inspected the upstream helper availability, drafted the targeted helper adoption, updated tests/docs, and ran verification; Chris remains responsible for review and merge.