### PR TITLE
Use Homeboy Extensions fixture plugin helper

### DIFF
--- a/Automattic/studio/bench/lib/wordpress-fixture-plugins.mjs
+++ b/Automattic/studio/bench/lib/wordpress-fixture-plugins.mjs
@@ -1,0 +1,67 @@
+import { expandHome, runCli } from './studio-bench.mjs';
+import { loadWordPressLibHelper } from './wordpress-helper-discovery.mjs';
+
+function fixturePluginsFromEnv({ jsonEnv, pathsEnv, fallbackJsonEnv = '', fallbackPathsEnv = '' }) {
+  const json = process.env[jsonEnv] || (fallbackJsonEnv ? process.env[fallbackJsonEnv] : '');
+  if (json) {
+    const parsed = JSON.parse(json);
+    if (!Array.isArray(parsed)) {
+      throw new Error(`${jsonEnv} must be an array`);
+    }
+    return parsed.map((plugin) => {
+      if (typeof plugin === 'string') {
+        return { path: expandHome(plugin) };
+      }
+      return { ...plugin, path: expandHome(plugin.path) };
+    });
+  }
+
+  const paths = process.env[pathsEnv] || (fallbackPathsEnv ? process.env[fallbackPathsEnv] : '');
+  if (!paths) {
+    return [];
+  }
+  return paths
+    .split(',')
+    .map((pluginPath) => ({ path: expandHome(pluginPath.trim()) }))
+    .filter((plugin) => plugin.path);
+}
+
+function loadFixtureSetupHelper() {
+  const { path: helperPath, module: helper } = loadWordPressLibHelper('fixture-setup.js', {
+    envVar: 'HOMEBOY_WORDPRESS_FIXTURE_SETUP_PATH',
+  });
+  if (!helper?.installWordPressFixturePlugins || !helper?.restoreWordPressFixturePlugins) {
+    throw new Error(
+      `Homeboy WordPress fixture setup helper is unavailable${helperPath ? ` at ${helperPath}` : ''}. ` +
+        'Update homeboy-extensions or set HOMEBOY_WORDPRESS_FIXTURE_SETUP_PATH.'
+    );
+  }
+  return helper;
+}
+
+function wpCliArgs(command) {
+  return ['wp', ...String(command || '').trim().split(/\s+/).filter(Boolean)];
+}
+
+export async function installStudioWordPressFixturePlugins(sitePath, options = {}) {
+  const plugins = fixturePluginsFromEnv(options);
+  if (plugins.length === 0) {
+    return [];
+  }
+
+  const helper = loadFixtureSetupHelper();
+  return helper.installWordPressFixturePlugins({
+    sitePath,
+    plugins,
+    activateTimeoutMs: Number(process.env[options.activateTimeoutEnv] || process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGIN_ACTIVATE_TIMEOUT_MS || 420000),
+    runCli: (command, context = {}) => runCli(wpCliArgs(command), { cwd: sitePath, timeoutMs: context.timeoutMs }),
+  });
+}
+
+export async function restoreStudioWordPressFixturePlugins(installedPlugins) {
+  if (!installedPlugins.length) {
+    return;
+  }
+  const helper = loadFixtureSetupHelper();
+  await helper.restoreWordPressFixturePlugins(installedPlugins);
+}

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
@@ -1,4 +1,4 @@
-import { cp, mkdir, rename, rm, symlink, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 import { pathToFileURL } from 'node:url';
@@ -6,7 +6,6 @@ import {
   STUDIO_PATH,
   artifactDir as studioArtifactDir,
   createStudioSite,
-  expandHome,
   metric,
   parseStudioSiteStatus,
   redact,
@@ -18,6 +17,10 @@ import {
   studioSiteStatus,
   variant,
 } from './lib/studio-bench.mjs';
+import {
+  installStudioWordPressFixturePlugins,
+  restoreStudioWordPressFixturePlugins,
+} from './lib/wordpress-fixture-plugins.mjs';
 import {
   buildTimingDeltaSummary,
   flattenPhasedResourceTimings,
@@ -60,95 +63,6 @@ async function siteStatus(sitePath) {
 
 async function stopSite(sitePath) {
   return stopStudioSite(sitePath, { timeoutMs: 90000 });
-}
-
-function profilePlugins() {
-  const json = process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGINS_JSON;
-  if (json) {
-    const parsed = JSON.parse(json);
-    if (!Array.isArray(parsed)) {
-      throw new Error('HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGINS_JSON must be an array');
-    }
-    return parsed.map((plugin) => {
-      if (typeof plugin === 'string') {
-        return { path: expandHome(plugin) };
-      }
-      return { ...plugin, path: expandHome(plugin.path) };
-    });
-  }
-
-  const paths = process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGIN_PATHS;
-  if (!paths) {
-    return [];
-  }
-  return paths
-    .split(',')
-    .map((pluginPath) => ({ path: expandHome(pluginPath.trim()) }))
-    .filter((plugin) => plugin.path);
-}
-
-async function installProfilePlugins(sitePath) {
-  const plugins = profilePlugins();
-  if (plugins.length === 0) {
-    return [];
-  }
-
-  const pluginDir = path.join(sitePath, 'wp-content', 'plugins');
-  await mkdir(pluginDir, { recursive: true });
-
-  const installed = [];
-  for (const plugin of plugins) {
-    if (!plugin.path) {
-      throw new Error('Profile plugin entry requires a path');
-    }
-    const slug = plugin.slug || path.basename(plugin.path);
-    const linkPath = path.join(pluginDir, slug);
-    const backupPath = `${linkPath}.homeboy-profile-backup-${process.pid}-${Date.now()}`;
-    let hadExistingPath = false;
-
-    try {
-      await rename(linkPath, backupPath);
-      hadExistingPath = true;
-    } catch (error) {
-      if (error?.code !== 'ENOENT') {
-        throw error;
-      }
-    }
-
-    await rm(linkPath, { recursive: true, force: true });
-    if (plugin.copy === true) {
-      await cp(plugin.path, linkPath, { recursive: true, force: true });
-    } else {
-      await symlink(plugin.path, linkPath, 'dir');
-    }
-    installed.push({ ...plugin, slug, linkPath, backupPath, hadExistingPath });
-  }
-
-  const activate = installed.filter((plugin) => plugin.activate !== false);
-  const activateTimeoutMs = Number(process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGIN_ACTIVATE_TIMEOUT_MS || 420000);
-  for (const plugin of activate) {
-    await runCli(
-      ['wp', 'plugin', 'activate', plugin.plugin || plugin.slug],
-      { cwd: sitePath, timeoutMs: activateTimeoutMs }
-    );
-  }
-
-  return installed.map((plugin) => ({
-    slug: plugin.slug,
-    path: plugin.path,
-    linkPath: plugin.linkPath,
-    backupPath: plugin.backupPath,
-    hadExistingPath: plugin.hadExistingPath,
-  }));
-}
-
-async function restoreProfilePlugins(installedPlugins) {
-  for (const plugin of [...installedPlugins].reverse()) {
-    await rm(plugin.linkPath, { recursive: true, force: true });
-    if (plugin.hadExistingPath) {
-      await rename(plugin.backupPath, plugin.linkPath);
-    }
-  }
 }
 
 function siteAdminUrl(siteUrl, relativePath = '') {
@@ -259,7 +173,11 @@ export default async function studioSiteEditorDiagnosticsBench() {
       start = await startStudioSite(sitePath, { timeoutMs: 240000 });
     }
     initialStatusResult = await siteStatus(sitePath);
-    installedPlugins = await installProfilePlugins(sitePath);
+    installedPlugins = await installStudioWordPressFixturePlugins(sitePath, {
+      jsonEnv: 'HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGINS_JSON',
+      pathsEnv: 'HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGIN_PATHS',
+      activateTimeoutEnv: 'HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGIN_ACTIVATE_TIMEOUT_MS',
+    });
     profileExtension = await loadProfileExtensionModule();
     if (profileExtension?.setupWordPressPageProfile) {
       const startedSetup = Date.now();
@@ -526,7 +444,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
       profiler.uninstallWordPressRequestProfiler?.(sitePath);
     }
     await uninstallWordPressBootstrapTimeline(sitePath);
-    await restoreProfilePlugins(installedPlugins);
+    await restoreStudioWordPressFixturePlugins(installedPlugins);
     if (createdSite && !stop) {
       stop = await stopSite(sitePath);
     }

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -57,6 +57,10 @@ const {
   setupWordPressPageProfile: setupDatamachinePipelinesScaleProfile,
   cleanupWordPressPageProfile: cleanupDatamachinePipelinesScaleProfile,
 } = await import('./lib/datamachine-pipelines-scale-profile.mjs');
+const {
+  installStudioWordPressFixturePlugins,
+  restoreStudioWordPressFixturePlugins,
+} = await import('./lib/wordpress-fixture-plugins.mjs');
 
 function withEnv(values, callback) {
   const previous = {};
@@ -117,6 +121,8 @@ async function writeFakeWordPressManifest() {
   const pageProfiler = path.join(libDir, 'page-profiler.js');
   const adminPageScenarios = path.join(libDir, 'admin-page-scenarios.js');
   const blockQuality = path.join(libDir, 'block-quality.js');
+  const fixtureSetup = path.join(libDir, 'fixture-setup.js');
+  const fixtureSetupRestoreLog = path.join(tempDir, 'fixture-restore.json');
   const blockThemeQualityProbe = path.join(benchLibDir, 'block-theme-quality-probe.php');
   const manifestPath = path.join(libDir, 'helper-manifest.js');
 
@@ -128,6 +134,24 @@ async function writeFakeWordPressManifest() {
 module.exports = {
   wordpressPostBlockQualityProbeCode: (postId) => 'fake probe for ' + postId,
   parseWordPressBlockQualityProbeOutput: () => ({ fallback_count: 2, core_html_without_fallback: 3, stored_content_hash: 'abc' }),
+};
+`);
+  await writeFile(fixtureSetup, `
+const fs = require('node:fs');
+
+module.exports = {
+  async installWordPressFixturePlugins(options) {
+    return options.plugins.map((plugin) => ({
+      ...plugin,
+      activateTimeoutMs: options.activateTimeoutMs,
+      linkPath: options.sitePath + '/wp-content/plugins/' + (plugin.slug || 'plugin'),
+      backupPath: options.sitePath + '/wp-content/plugins/' + (plugin.slug || 'plugin') + '.backup',
+      hadExistingPath: false,
+    }));
+  },
+  async restoreWordPressFixturePlugins(installedPlugins) {
+    fs.writeFileSync(${JSON.stringify(fixtureSetupRestoreLog)}, JSON.stringify(installedPlugins, null, 2));
+  },
 };
 `);
   await writeFile(blockThemeQualityProbe, "<?php // fake block theme quality probe\n");
@@ -180,7 +204,7 @@ module.exports = {
 };
 `);
 
-  return { tempDir, manifestPath, requestProfiler, timingCorrelator, bootstrapTimeline, pageProfiler, adminPageScenarios, blockQuality, blockThemeQualityProbe };
+  return { tempDir, manifestPath, requestProfiler, timingCorrelator, bootstrapTimeline, pageProfiler, adminPageScenarios, blockQuality, fixtureSetup, fixtureSetupRestoreLog, blockThemeQualityProbe };
 }
 
 // --- path resolution -------------------------------------------------------
@@ -251,6 +275,43 @@ test('requestProfilerPath uses the WordPress helper discovery contract', async (
       },
       async () => {
         assert.equal(requestProfilerPath(), fixture.requestProfiler);
+      }
+    );
+  } finally {
+    await rm(fixture.tempDir, { recursive: true, force: true });
+  }
+});
+
+test('Studio WordPress fixture plugins delegate install and restore to Homeboy Extensions helper', async () => {
+  const fixture = await writeFakeWordPressManifest();
+  try {
+    await withEnvAsync(
+      {
+        HOMEBOY_WORDPRESS_HELPER_MANIFEST: fixture.manifestPath,
+        HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGINS_JSON: JSON.stringify([
+          { path: '~/fixture-plugin', slug: 'fixture-slug', plugin: 'fixture/main.php', copy: true, activate: false },
+        ]),
+        HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGIN_PATHS: undefined,
+        HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGIN_ACTIVATE_TIMEOUT_MS: '1234',
+        HOMEBOY_WORDPRESS_FIXTURE_SETUP_PATH: undefined,
+      },
+      async () => {
+        const installed = await installStudioWordPressFixturePlugins('/tmp/site', {
+          jsonEnv: 'HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGINS_JSON',
+          pathsEnv: 'HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGIN_PATHS',
+          activateTimeoutEnv: 'HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGIN_ACTIVATE_TIMEOUT_MS',
+        });
+
+        assert.equal(installed[0].path, path.join(os.homedir(), 'fixture-plugin'));
+        assert.equal(installed[0].slug, 'fixture-slug');
+        assert.equal(installed[0].plugin, 'fixture/main.php');
+        assert.equal(installed[0].copy, true);
+        assert.equal(installed[0].activate, false);
+        assert.equal(installed[0].activateTimeoutMs, 1234);
+
+        await restoreStudioWordPressFixturePlugins(installed);
+        const restored = JSON.parse(await readFile(fixture.fixtureSetupRestoreLog, 'utf8'));
+        assert.equal(restored[0].slug, 'fixture-slug');
       }
     );
   } finally {

--- a/Automattic/studio/bench/studio-wordpress-admin-scale-sweep.bench.mjs
+++ b/Automattic/studio/bench/studio-wordpress-admin-scale-sweep.bench.mjs
@@ -1,4 +1,4 @@
-import { cp, mkdir, rename, rm, symlink, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -18,6 +18,10 @@ import {
   studioSiteStatus,
   variant,
 } from './lib/studio-bench.mjs';
+import {
+  installStudioWordPressFixturePlugins,
+  restoreStudioWordPressFixturePlugins,
+} from './lib/wordpress-fixture-plugins.mjs';
 import {
   loadWordPressAdminScaleSweepManifest,
 } from './lib/wordpress-admin-scale-sweep.mjs';
@@ -49,92 +53,6 @@ async function siteStatus(sitePath) {
 
 async function stopSite(sitePath) {
   return stopStudioSite(sitePath, { timeoutMs: 90000 });
-}
-
-function profilePlugins() {
-  const json = process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_PLUGINS_JSON || process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGINS_JSON;
-  if (json) {
-    const parsed = JSON.parse(json);
-    if (!Array.isArray(parsed)) {
-      throw new Error('HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_PLUGINS_JSON must be an array');
-    }
-    return parsed.map((plugin) => {
-      if (typeof plugin === 'string') {
-        return { path: expandHome(plugin) };
-      }
-      return { ...plugin, path: expandHome(plugin.path) };
-    });
-  }
-
-  const paths = process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_PLUGIN_PATHS || process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGIN_PATHS;
-  if (!paths) {
-    return [];
-  }
-  return paths
-    .split(',')
-    .map((pluginPath) => ({ path: expandHome(pluginPath.trim()) }))
-    .filter((plugin) => plugin.path);
-}
-
-async function installProfilePlugins(sitePath) {
-  const plugins = profilePlugins();
-  if (plugins.length === 0) {
-    return [];
-  }
-
-  const pluginDir = path.join(sitePath, 'wp-content', 'plugins');
-  await mkdir(pluginDir, { recursive: true });
-
-  const installed = [];
-  for (const plugin of plugins) {
-    if (!plugin.path) {
-      throw new Error('Profile plugin entry requires a path');
-    }
-    const slug = plugin.slug || path.basename(plugin.path);
-    const linkPath = path.join(pluginDir, slug);
-    const backupPath = `${linkPath}.homeboy-profile-backup-${process.pid}-${Date.now()}`;
-    let hadExistingPath = false;
-
-    try {
-      await rename(linkPath, backupPath);
-      hadExistingPath = true;
-    } catch (error) {
-      if (error?.code !== 'ENOENT') {
-        throw error;
-      }
-    }
-
-    await rm(linkPath, { recursive: true, force: true });
-    if (plugin.copy === true) {
-      await cp(plugin.path, linkPath, { recursive: true, force: true });
-    } else {
-      await symlink(plugin.path, linkPath, 'dir');
-    }
-    installed.push({ ...plugin, slug, linkPath, backupPath, hadExistingPath });
-  }
-
-  const activate = installed.filter((plugin) => plugin.activate !== false);
-  const activateTimeoutMs = Number(process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_PLUGIN_ACTIVATE_TIMEOUT_MS || process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGIN_ACTIVATE_TIMEOUT_MS || 420000);
-  for (const plugin of activate) {
-    await runCli(['wp', 'plugin', 'activate', plugin.plugin || plugin.slug], { cwd: sitePath, timeoutMs: activateTimeoutMs });
-  }
-
-  return installed.map((plugin) => ({
-    slug: plugin.slug,
-    path: plugin.path,
-    linkPath: plugin.linkPath,
-    backupPath: plugin.backupPath,
-    hadExistingPath: plugin.hadExistingPath,
-  }));
-}
-
-async function restoreProfilePlugins(installedPlugins) {
-  for (const plugin of [...installedPlugins].reverse()) {
-    await rm(plugin.linkPath, { recursive: true, force: true });
-    if (plugin.hadExistingPath) {
-      await rename(plugin.backupPath, plugin.linkPath);
-    }
-  }
 }
 
 async function loadProfileExtensionModule() {
@@ -275,7 +193,13 @@ export default async function studioWordPressAdminScaleSweepBench() {
       start = await startStudioSite(sitePath, { timeoutMs: 240000 });
     }
     initialStatusResult = await siteStatus(sitePath);
-    installedPlugins = await installProfilePlugins(sitePath);
+    installedPlugins = await installStudioWordPressFixturePlugins(sitePath, {
+      jsonEnv: 'HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_PLUGINS_JSON',
+      pathsEnv: 'HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_PLUGIN_PATHS',
+      fallbackJsonEnv: 'HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGINS_JSON',
+      fallbackPathsEnv: 'HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGIN_PATHS',
+      activateTimeoutEnv: 'HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_PLUGIN_ACTIVATE_TIMEOUT_MS',
+    });
     profileExtension = await loadProfileExtensionModule();
     assertInteractionSupport({ manifest, pageProfiler, profileExtension });
     assertAdminSweepSummarySupport({ pageProfiler, profileExtension });
@@ -447,7 +371,7 @@ export default async function studioWordPressAdminScaleSweepBench() {
     if (profiler) {
       profiler.uninstallWordPressRequestProfiler?.(sitePath);
     }
-    await restoreProfilePlugins(installedPlugins);
+    await restoreStudioWordPressFixturePlugins(installedPlugins);
     if (createdSite && !stop) {
       stop = await stopSite(sitePath);
     }


### PR DESCRIPTION
## Summary
- Replace duplicate Studio bench fixture plugin install/restore code with a shared rig adapter that delegates to Homeboy Extensions' promoted `fixture-setup.js` helper.
- Preserve existing page-profile and admin-scale env inputs for plugin JSON/paths, copy/activate/plugin slug options, and activation timeout overrides.
- Add a node:test smoke covering helper-based install/restore delegation through the WordPress helper manifest.

Closes https://github.com/chubes4/homeboy-rigs/issues/185

## Tests
- `node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `node scripts/lint-rig-packages.mjs`
- `node --check Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs`
- `node --check Automattic/studio/bench/studio-wordpress-admin-scale-sweep.bench.mjs`
- `node --check Automattic/studio/bench/lib/wordpress-fixture-plugins.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the refactor, targeted test coverage, local verification, and PR description; Chris remains responsible for review and merge.