### PR TITLE
Use promoted WordPress helper manifest paths

### DIFF
--- a/Automattic/studio/bench/lib/wordpress-helper-discovery.mjs
+++ b/Automattic/studio/bench/lib/wordpress-helper-discovery.mjs
@@ -4,6 +4,15 @@ import path from 'node:path';
 
 const require = createRequire(import.meta.url);
 
+const WORDPRESS_LIB_HELPER_KEYS = new Map([
+  ['block-quality.js', 'blockQuality'],
+  ['editor-canvas-probes.js', 'editorCanvasProbes'],
+  ['fixture-setup.js', 'fixtureSetup'],
+  ['request-profiler.js', 'requestProfiler'],
+  ['timing-correlator.js', 'timingCorrelator'],
+  ['wordpress-bootstrap-timeline.js', 'bootstrapTimeline'],
+]);
+
 export function loadWordPressHelperManifest(options = {}) {
   const manifestPath = options.manifestPath || process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST;
   if (!manifestPath || !existsSync(manifestPath)) {
@@ -34,6 +43,11 @@ export function wordpressLibHelperPath(fileName, options = {}) {
   }
 
   const { manifest } = loadWordPressHelperManifest(options);
+  const helperKey = options.helperKey || WORDPRESS_LIB_HELPER_KEYS.get(fileName);
+  if (helperKey && manifest?.helpers?.[helperKey]) {
+    return manifest.helpers[helperKey];
+  }
+
   return manifest?.extensionRoot ? path.join(manifest.extensionRoot, 'lib', fileName) : '';
 }
 

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -199,6 +199,9 @@ module.exports = {
       requestProfiler: ${JSON.stringify(requestProfiler)},
       timingCorrelator: ${JSON.stringify(timingCorrelator)},
       bootstrapTimeline: ${JSON.stringify(bootstrapTimeline)},
+      blockQuality: ${JSON.stringify(blockQuality)},
+      editorCanvasProbes: ${JSON.stringify(path.join(libDir, 'editor-canvas-probes.js'))},
+      fixtureSetup: ${JSON.stringify(fixtureSetup)},
     },
   }),
 };

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Keep the Studio bench harness layered so each repo owns the smallest stable surf
 - `homeboy-extensions/wordpress` is the future home for generic WordPress and block quality probes once their contracts are stable.
 - `homeboy` core owns benchmark orchestration only; it should stay generic and substrate-agnostic.
 
-Issue [#185](https://github.com/chubes4/homeboy-rigs/issues/185) tracks thinning duplicated helper logic after upstream promotion. Studio native-block quality probing now uses the promoted Homeboy Extensions block theme quality probe from `Extra-Chill/homeboy-extensions#1018`. Fixture plugin install/restore, browser waterfall collection, and trace reporter adoption remain blocked until `Extra-Chill/homeboy-extensions#1132`, `#1131`, and `#1133` land; rigs should not add local fallback shims for those contracts.
+Issue [#185](https://github.com/chubes4/homeboy-rigs/issues/185) tracks thinning duplicated helper logic after upstream promotion. Studio native-block quality probing now uses the promoted Homeboy Extensions block theme quality probe from `Extra-Chill/homeboy-extensions#1018`. Studio fixture plugin install/restore now delegates to the Homeboy Extensions fixture setup helper from `Extra-Chill/homeboy-extensions#1134`, and helper discovery consumes promoted helper-manifest paths from `Extra-Chill/homeboy-extensions#1141`; rigs should not add local fallback shims for those contracts.
 
 Cleanup should move in small waves:
 


### PR DESCRIPTION
## Summary
- Prefer promoted `helpers.*` entries from the Homeboy Extensions WordPress helper manifest for known WordPress helpers.
- Keep the existing `extensionRoot/lib/<file>` fallback for older manifests and helpers that are not yet listed.
- Update the Studio cleanup note now that fixture setup and helper-manifest adoption are available.

## Verification
- `node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Inspected the merged Homeboy Extensions helper APIs, selected the smallest helper-manifest adoption slice, implemented the change, and ran targeted verification for Chris to review.