### PR TITLE
Adopt WordPress helper consumer primitives

### DIFF
--- a/Automattic/studio/bench/lib/wordpress-helper-discovery.mjs
+++ b/Automattic/studio/bench/lib/wordpress-helper-discovery.mjs
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 const require = createRequire(import.meta.url);
+const WORDPRESS_HELPER_CONSUMER_FILENAME = 'wordpress-helper-consumer.js';
 
 const WORDPRESS_LIB_HELPER_KEYS = new Map([
   ['block-quality.js', 'blockQuality'],
@@ -13,8 +14,12 @@ const WORDPRESS_LIB_HELPER_KEYS = new Map([
   ['wordpress-bootstrap-timeline.js', 'bootstrapTimeline'],
 ]);
 
-export function loadWordPressHelperManifest(options = {}) {
-  const manifestPath = options.manifestPath || process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST;
+function resolveManifestPath(options = {}) {
+  return options.manifestPath || process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST || '';
+}
+
+function localManifestForConsumerDiscovery(options = {}) {
+  const manifestPath = resolveManifestPath(options);
   if (!manifestPath || !existsSync(manifestPath)) {
     return { path: manifestPath || '', manifest: null };
   }
@@ -26,23 +31,63 @@ export function loadWordPressHelperManifest(options = {}) {
   return { path: manifestPath, manifest: manifest || null };
 }
 
+export function wordpressHelperConsumerPath(options = {}) {
+  const explicit = options.consumerPath || process.env.HOMEBOY_WORDPRESS_HELPER_CONSUMER;
+  if (explicit) {
+    return explicit;
+  }
+
+  const { manifest } = localManifestForConsumerDiscovery(options);
+  return manifest?.extensionRoot
+    ? path.join(manifest.extensionRoot, 'lib', WORDPRESS_HELPER_CONSUMER_FILENAME)
+    : '';
+}
+
+export function loadWordPressHelperConsumer(options = {}) {
+  const helperConsumerPath = wordpressHelperConsumerPath(options);
+  if (!helperConsumerPath || !existsSync(helperConsumerPath)) {
+    return { path: helperConsumerPath, module: null };
+  }
+
+  return { path: helperConsumerPath, module: require(helperConsumerPath) };
+}
+
+export function loadWordPressHelperManifest(options = {}) {
+  const { module: helperConsumer } = loadWordPressHelperConsumer(options);
+  if (typeof helperConsumer?.loadWordPressHelperManifest === 'function') {
+    return helperConsumer.loadWordPressHelperManifest(options);
+  }
+
+  return localManifestForConsumerDiscovery(options);
+}
+
 export function wordpressHelperPath(key, options = {}) {
+  const { module: helperConsumer } = loadWordPressHelperConsumer(options);
+  if (typeof helperConsumer?.wordpressHelperPath === 'function') {
+    return helperConsumer.wordpressHelperPath(key, options);
+  }
+
   const explicit = options.override || (options.envVar ? process.env[options.envVar] : '');
   if (explicit) {
     return explicit;
   }
 
-  const { manifest } = loadWordPressHelperManifest(options);
+  const { manifest } = localManifestForConsumerDiscovery(options);
   return manifest?.helpers?.[key] || '';
 }
 
 export function wordpressLibHelperPath(fileName, options = {}) {
+  const { module: helperConsumer } = loadWordPressHelperConsumer(options);
+  if (typeof helperConsumer?.wordpressLibHelperPath === 'function') {
+    return helperConsumer.wordpressLibHelperPath(fileName, options);
+  }
+
   const explicit = options.override || (options.envVar ? process.env[options.envVar] : '');
   if (explicit) {
     return explicit;
   }
 
-  const { manifest } = loadWordPressHelperManifest(options);
+  const { manifest } = localManifestForConsumerDiscovery(options);
   const helperKey = options.helperKey || WORDPRESS_LIB_HELPER_KEYS.get(fileName);
   if (helperKey && manifest?.helpers?.[helperKey]) {
     return manifest.helpers[helperKey];
@@ -52,6 +97,11 @@ export function wordpressLibHelperPath(fileName, options = {}) {
 }
 
 export function loadWordPressLibHelper(fileName, options = {}) {
+  const { module: helperConsumer } = loadWordPressHelperConsumer(options);
+  if (typeof helperConsumer?.loadWordPressLibHelper === 'function') {
+    return helperConsumer.loadWordPressLibHelper(fileName, options);
+  }
+
   const helperPath = wordpressLibHelperPath(fileName, options);
   if (!helperPath || !existsSync(helperPath)) {
     return { path: helperPath, module: null };

--- a/Automattic/studio/bench/studio-rest-latency-diagnostics.bench.mjs
+++ b/Automattic/studio/bench/studio-rest-latency-diagnostics.bench.mjs
@@ -102,7 +102,7 @@ function avg(values) {
   return values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : 0;
 }
 
-function summarizeProfilerRows(rows) {
+function summarizePriorityBands(rows) {
   const byRequest = new Map();
   for (const row of rows || []) {
     if (!byRequest.has(row.request_id)) {
@@ -111,9 +111,8 @@ function summarizeProfilerRows(rows) {
     byRequest.get(row.request_id).push(row);
   }
 
-  return [...byRequest.values()].map((events) => {
+  return [...byRequest.entries()].map(([requestId, events]) => {
     events.sort((a, b) => (a.t_ms || 0) - (b.t_ms || 0));
-    const last = events[events.length - 1] || {};
     const bands = [];
     for (const start of events.filter((event) => event.event === 'hook.priority_band.start')) {
       const end = events.find(
@@ -123,8 +122,24 @@ function summarizeProfilerRows(rows) {
         bands.push({ hook: start.data?.hook, duration_ms: end.t_ms - start.t_ms });
       }
     }
-    return { uri: last.uri || '', method: last.method || '', duration_ms: last.t_ms || 0, priority_bands: bands };
+    return [requestId, bands];
   });
+}
+
+function summarizeProfilerRows(rows, requestProfiler) {
+  if (typeof requestProfiler?.summarizeWordPressRequestProfilerRows !== 'function') {
+    throw new Error('Homeboy WordPress request profiler must export summarizeWordPressRequestProfilerRows. Update homeboy-extensions.');
+  }
+
+  const summary = requestProfiler.summarizeWordPressRequestProfilerRows(rows || [], { limit: 10000 });
+  const priorityBandsByRequest = new Map(summarizePriorityBands(rows));
+
+  return (summary.requests || []).map((request) => ({
+    uri: request.uri || '',
+    method: request.method || '',
+    duration_ms: request.duration_ms || 0,
+    priority_bands: priorityBandsByRequest.get(request.request_id) || [],
+  }));
 }
 
 function averageBootstrapDeltas(rows) {
@@ -269,7 +284,7 @@ export default async function studioRestLatencyDiagnosticsBench() {
     await sanitizeArtifact(browserResult.artifacts?.network);
 
     const wpSummaries = profileWordPress && profiler?.module?.collectWordPressRequestProfiles
-      ? summarizeProfilerRows(profiler.module.collectWordPressRequestProfiles(sitePath))
+      ? summarizeProfilerRows(profiler.module.collectWordPressRequestProfiles(sitePath), profiler.module)
       : [];
     const bootstrapSummaries = profileWordPress
       ? summarizeWordPressBootstrapTimeline(await collectWordPressBootstrapTimeline(sitePath), { limit: 10000 })

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -125,6 +125,7 @@ async function writeFakeWordPressManifest() {
   const fixtureSetupRestoreLog = path.join(tempDir, 'fixture-restore.json');
   const blockThemeQualityProbe = path.join(benchLibDir, 'block-theme-quality-probe.php');
   const manifestPath = path.join(libDir, 'helper-manifest.js');
+  const helperConsumer = path.join(libDir, 'wordpress-helper-consumer.js');
 
   await writeFile(requestProfiler, "module.exports = { installWordPressRequestProfiler() {} };\n");
   await writeFile(timingCorrelator, "module.exports = { correlateBrowserAndWordPressTimings: () => ({ correlated: [], unmatchedBrowser: [], unmatchedWordPress: [] }) };\n");
@@ -206,8 +207,40 @@ module.exports = {
   }),
 };
 `);
+  await writeFile(helperConsumer, `
+const path = require('node:path');
 
-  return { tempDir, manifestPath, requestProfiler, timingCorrelator, bootstrapTimeline, pageProfiler, adminPageScenarios, blockQuality, fixtureSetup, fixtureSetupRestoreLog, blockThemeQualityProbe };
+function loadWordPressHelperManifest() {
+  const manifestModule = require(${JSON.stringify(manifestPath)});
+  return {
+    path: ${JSON.stringify(manifestPath)},
+    manifest: manifestModule.getWordPressHelperManifest(),
+    found: true,
+    reason: '',
+  };
+}
+
+function wordpressHelperPath(name, options = {}) {
+  const explicit = options.override || (options.envVar ? process.env[options.envVar] : '');
+  if (explicit) return explicit;
+  return loadWordPressHelperManifest().manifest.helpers[name] || '';
+}
+
+function wordpressLibHelperPath(fileName, options = {}) {
+  const explicit = options.override || (options.envVar ? process.env[options.envVar] : '');
+  if (explicit) return explicit;
+  return path.join(loadWordPressHelperManifest().manifest.extensionRoot, 'lib', fileName);
+}
+
+function loadWordPressLibHelper(fileName, options = {}) {
+  const helperPath = wordpressLibHelperPath(fileName, options);
+  return { path: helperPath, module: require(helperPath), found: true, reason: '' };
+}
+
+module.exports = { loadWordPressHelperManifest, wordpressHelperPath, wordpressLibHelperPath, loadWordPressLibHelper };
+`);
+
+  return { tempDir, manifestPath, requestProfiler, timingCorrelator, bootstrapTimeline, pageProfiler, adminPageScenarios, blockQuality, fixtureSetup, fixtureSetupRestoreLog, blockThemeQualityProbe, helperConsumer };
 }
 
 // --- path resolution -------------------------------------------------------


### PR DESCRIPTION
## Summary
- Route Studio WordPress helper discovery through the promoted Homeboy Extensions `wordpress-helper-consumer.js` when available.
- Keep the existing manifest fallback for older helper bundles while preserving Studio-specific page specs, route attribution, and gate logic downstream.
- Reuse the promoted request-profiler summary helper in the REST latency diagnostics bench, retaining Studio-specific priority-band route summaries.

## Verification
- `node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `node --check Automattic/studio/bench/studio-rest-latency-diagnostics.bench.mjs`
- `node scripts/lint-rig-packages.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the helper adoption refactor and targeted verification; Chris remains responsible for review and merge.