### PR TITLE
Fix stale promotion tracker references

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Keep the Studio bench harness layered so each repo owns the smallest stable surf
 - `homeboy-extensions/wordpress` is the future home for generic WordPress and block quality probes once their contracts are stable.
 - `homeboy` core owns benchmark orchestration only; it should stay generic and substrate-agnostic.
 
-Issue [#185](https://github.com/chubes4/homeboy-rigs/issues/185) tracks thinning duplicated helper logic after upstream promotion. Studio native-block quality probing now uses the promoted Homeboy Extensions block theme quality probe from `Extra-Chill/homeboy-extensions#1018`. Studio fixture plugin install/restore now delegates to the Homeboy Extensions fixture setup helper from `Extra-Chill/homeboy-extensions#1134`, and helper discovery consumes promoted helper-manifest paths from `Extra-Chill/homeboy-extensions#1141`; rigs should not add local fallback shims for those contracts.
+Issue [#185](https://github.com/chubes4/homeboy-rigs/issues/185) tracks thinning duplicated helper logic after upstream promotion. Studio native-block quality probing now uses the promoted Homeboy Extensions block quality probes from `Extra-Chill/homeboy-extensions#1009`; target post metrics remain tracked in `Extra-Chill/homeboy-extensions#1018`. Studio fixture plugin install/restore now delegates to the Homeboy Extensions fixture setup helper from `Extra-Chill/homeboy-extensions#1134`, and helper discovery consumes promoted helper-manifest paths from `Extra-Chill/homeboy-extensions#1141`; rigs should not add local fallback shims for those contracts.
 
 Cleanup should move in small waves:
 

--- a/woocommerce/woocommerce/docs/checkout-shipping-cache-matrix-report.md
+++ b/woocommerce/woocommerce/docs/checkout-shipping-cache-matrix-report.md
@@ -43,5 +43,5 @@ homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache -
 
 - Extra-Chill/homeboy#3516 is needed before this report can consume canonical
   Homeboy baseline/candidate exports instead of local shared-state directories.
-- Extra-Chill/homeboy-extensions#1089 is needed for the deterministic expensive
-  shipping method fixture matrix dimension.
+- Extra-Chill/homeboy-extensions#1089 added deterministic expensive shipping
+  method fixture support for the matrix dimension.

--- a/woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs
+++ b/woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs
@@ -45,7 +45,7 @@ function renderReport() {
 		lines.push('- Mode: planned matrix only. No baseline or candidate values are present.');
 	}
 	lines.push('- Timing evidence and shipping-rate call-count evidence are reported separately.');
-	lines.push('- Deterministic expensive shipping-method fixture is pending Extra-Chill/homeboy-extensions#1089.');
+	lines.push('- Deterministic expensive shipping-method fixture support landed in Extra-Chill/homeboy-extensions#1089.');
 	lines.push('- Baseline/candidate export wiring is pending Extra-Chill/homeboy#3516.');
 	lines.push('');
 	lines.push('## Matrix Knobs');
@@ -74,7 +74,7 @@ function renderReport() {
 	lines.push('| Destination/postcode changes | Invalidate cache | Covered by `rehash_*` rows |');
 	lines.push('| Cart contents changes | Invalidate cache | Planned follow-up |');
 	lines.push('| Contents cost, coupon, tax, fee inputs | Validate expected behavior per WooCommerce cache key contract | Planned follow-up |');
-	lines.push('| Expensive deterministic shipping method | Amplify call-count regressions without browser noise | Blocked on Extra-Chill/homeboy-extensions#1089 |');
+	lines.push('| Expensive deterministic shipping method | Amplify call-count regressions without browser noise | Available via Extra-Chill/homeboy-extensions#1089 |');
 	lines.push('');
 	return `${lines.join('\n')}\n`;
 }


### PR DESCRIPTION
## Summary
- Update promotion cleanup docs to point block-quality adoption at the completed helper promotion and keep target-post metrics on the open tracker.
- Mark the WooCommerce deterministic shipping fixture support as landed instead of pending in the matrix report generator and docs.

## Validation
- `node woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Audited tracker state, drafted the small wording cleanup, and ran targeted validation; Chris remains responsible for review.