### PR TITLE
Adopt target block quality helper

### DIFF
--- a/Automattic/studio/bench/lib/wordpress-quality.mjs
+++ b/Automattic/studio/bench/lib/wordpress-quality.mjs
@@ -1,10 +1,8 @@
-import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
-import path from 'node:path';
 
 import { runCli as defaultRunCli } from './studio-bench.mjs';
 import { collectLatestGeneratedTheme } from './design-gates.mjs';
-import { loadWordPressHelperManifest, loadWordPressLibHelper } from './wordpress-helper-discovery.mjs';
+import { loadWordPressLibHelper } from './wordpress-helper-discovery.mjs';
 
 export {
   collectGeneratedThemeUxGates,
@@ -14,46 +12,31 @@ export {
   structuralSelectorDriftDiagnostics,
 } from './design-gates.mjs';
 
-function blockThemeQualityProbePath(options = {}) {
-  const explicit = options.blockThemeQualityProbePath || process.env.HOMEBOY_WORDPRESS_BLOCK_THEME_QUALITY_PROBE;
-  if (explicit) {
-    return explicit;
-  }
-
-  const { manifest } = loadWordPressHelperManifest(options);
-  return manifest?.extensionRoot
-    ? path.join(manifest.extensionRoot, 'scripts', 'bench', 'lib', 'block-theme-quality-probe.php')
-    : '';
-}
-
-function blockThemeQualityProbeCode(probePath) {
-  const encodedPath = Buffer.from(probePath).toString('base64');
-  return String.raw`
-$homeboy_probe_path = base64_decode( '${encodedPath}', true );
-if ( ! is_string( $homeboy_probe_path ) || ! is_readable( $homeboy_probe_path ) ) {
-    fwrite( STDERR, 'Homeboy WordPress block theme quality probe is unavailable: ' . (string) $homeboy_probe_path );
-    exit( 1 );
-}
-require_once $homeboy_probe_path;
-$counts = homeboy_wordpress_collect_block_theme_quality( array(
-    'target_post_titles' => array( 'Studio Code' ),
-    'post_types'         => array( 'page', 'wp_template', 'wp_template_part' ),
-) );
-$counts['bfb_fallback_count'] = (int) get_option( 'studio_bfb_unsupported_fallback_count', 0 );
-$counts['core_html_without_bfb_fallback'] = max( 0, $counts['core_html_blocks'] - $counts['bfb_fallback_count'] );
-$counts['target_core_html_without_bfb_fallback'] = max( 0, $counts['target_core_html_blocks'] - $counts['bfb_fallback_count'] );
-echo wp_json_encode( $counts, JSON_PRETTY_PRINT ) . PHP_EOL;
-`;
-}
-
 export async function probeQuality(sitePath, options = {}) {
   const runCli = options.runCli || defaultRunCli;
-  const probePath = blockThemeQualityProbePath(options);
-  if (!probePath || !existsSync(probePath)) {
-    throw new Error('Homeboy WordPress block theme quality helper is unavailable. Update homeboy-extensions or set HOMEBOY_WORDPRESS_HELPER_MANIFEST.');
+  const { module: blockQuality } = loadWordPressLibHelper('block-quality.js', options);
+  if (!blockQuality?.wordpressBlockQualityProbeCode || !blockQuality?.parseWordPressBlockQualityProbeOutput) {
+    throw new Error('Homeboy WordPress block quality helper is unavailable. Update homeboy-extensions or set HOMEBOY_WORDPRESS_HELPER_MANIFEST.');
   }
-  const { stdout } = await runCli(['wp', '--path', sitePath, '--php-version', '8.3', 'eval', blockThemeQualityProbeCode(probePath)]);
-  return parseQualityProbeOutput(stdout);
+  const { stdout } = await runCli([
+    'wp',
+    '--path',
+    sitePath,
+    '--php-version',
+    '8.3',
+    'eval',
+    blockQuality.wordpressBlockQualityProbeCode({
+      fallbackOptionNames: ['studio_bfb_unsupported_fallback_count'],
+      postTypes: ['page', 'wp_template', 'wp_template_part'],
+      targetPostTitles: ['Studio Code'],
+    }),
+  ]);
+  const quality = blockQuality.parseWordPressBlockQualityProbeOutput(stdout);
+  return {
+    ...quality,
+    bfb_fallback_count: quality.fallback_count || 0,
+    core_html_without_bfb_fallback: quality.core_html_without_fallback || 0,
+  };
 }
 
 export async function probePageQuality(sitePath, pageId, options = {}) {
@@ -79,14 +62,6 @@ export async function probePageQuality(sitePath, pageId, options = {}) {
     bfb_fallback_count: quality.fallback_count || 0,
     core_html_without_bfb_fallback: quality.core_html_without_fallback || 0,
   };
-}
-
-function parseQualityProbeOutput(stdout) {
-  const jsonStart = stdout.indexOf('{');
-  if (jsonStart === -1) {
-    throw new Error(`quality probe did not emit JSON: ${stdout.slice(0, 1000)}`);
-  }
-  return JSON.parse(stdout.slice(jsonStart));
 }
 
 export async function collectLatestImportReport(sitePath) {

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -112,9 +112,7 @@ async function writeFakeWordPressManifest() {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'homeboy-wordpress-manifest-'));
   const extensionRoot = path.join(tempDir, 'wordpress');
   const libDir = path.join(extensionRoot, 'lib');
-  const benchLibDir = path.join(extensionRoot, 'scripts', 'bench', 'lib');
   await import('node:fs/promises').then(({ mkdir }) => mkdir(libDir, { recursive: true }));
-  await import('node:fs/promises').then(({ mkdir }) => mkdir(benchLibDir, { recursive: true }));
   const requestProfiler = path.join(libDir, 'request-profiler.js');
   const timingCorrelator = path.join(libDir, 'timing-correlator.js');
   const bootstrapTimeline = path.join(libDir, 'wordpress-bootstrap-timeline.js');
@@ -123,7 +121,6 @@ async function writeFakeWordPressManifest() {
   const blockQuality = path.join(libDir, 'block-quality.js');
   const fixtureSetup = path.join(libDir, 'fixture-setup.js');
   const fixtureSetupRestoreLog = path.join(tempDir, 'fixture-restore.json');
-  const blockThemeQualityProbe = path.join(benchLibDir, 'block-theme-quality-probe.php');
   const manifestPath = path.join(libDir, 'helper-manifest.js');
 
   await writeFile(requestProfiler, "module.exports = { installWordPressRequestProfiler() {} };\n");
@@ -132,8 +129,9 @@ async function writeFakeWordPressManifest() {
   await writeFile(adminPageScenarios, "module.exports = { normalizeWordPressAdminPageScenarioInput: (spec) => spec, profileWordPressAdminPageScenario: async () => ({ status: 200 }) };\n");
   await writeFile(blockQuality, `
 module.exports = {
+  wordpressBlockQualityProbeCode: (options) => 'fake site probe for ' + JSON.stringify(options),
   wordpressPostBlockQualityProbeCode: (postId) => 'fake probe for ' + postId,
-  parseWordPressBlockQualityProbeOutput: () => ({ fallback_count: 2, core_html_without_fallback: 3, stored_content_hash: 'abc' }),
+  parseWordPressBlockQualityProbeOutput: () => ({ fallback_count: 2, core_html_without_fallback: 3, target_pages_seen: 1, target_posts_with_blocks: 1, stored_content_hash: 'abc' }),
 };
 `);
   await writeFile(fixtureSetup, `
@@ -154,7 +152,6 @@ module.exports = {
   },
 };
 `);
-  await writeFile(blockThemeQualityProbe, "<?php // fake block theme quality probe\n");
   await writeFile(bootstrapTimeline, `
 module.exports = {
   instrumentIndexPhp(source) {
@@ -207,7 +204,7 @@ module.exports = {
 };
 `);
 
-  return { tempDir, manifestPath, requestProfiler, timingCorrelator, bootstrapTimeline, pageProfiler, adminPageScenarios, blockQuality, fixtureSetup, fixtureSetupRestoreLog, blockThemeQualityProbe };
+  return { tempDir, manifestPath, requestProfiler, timingCorrelator, bootstrapTimeline, pageProfiler, adminPageScenarios, blockQuality, fixtureSetup, fixtureSetupRestoreLog };
 }
 
 // --- path resolution -------------------------------------------------------
@@ -786,13 +783,12 @@ test('probePageQuality delegates post-scoped block probing to the WordPress help
   }
 });
 
-test('probeQuality delegates site block probing to the promoted block theme helper', async () => {
+test('probeQuality delegates site block probing to the promoted block quality helper', async () => {
   const fixture = await writeFakeWordPressManifest();
   try {
     await withEnvAsync(
       {
         HOMEBOY_WORDPRESS_HELPER_MANIFEST: fixture.manifestPath,
-        HOMEBOY_WORDPRESS_BLOCK_THEME_QUALITY_PROBE: undefined,
       },
       async () => {
         const calls = [];
@@ -800,24 +796,20 @@ test('probeQuality delegates site block probing to the promoted block theme help
           runCli: async (args) => {
             calls.push(args);
             return {
-              stdout: JSON.stringify({
-                target_pages_seen: 1,
-                target_posts_with_blocks: 1,
-                bfb_fallback_count: 0,
-                core_html_without_bfb_fallback: 0,
-              }),
+              stdout: JSON.stringify({ ignored: true }),
             };
           },
         });
 
         assert.equal(calls.length, 1);
         assert.deepEqual(calls[0].slice(0, 5), ['wp', '--path', '/tmp/site', '--php-version', '8.3']);
-        const encodedPath = /base64_decode\( '([^']+)'/.exec(calls[0].at(-1))?.[1] || '';
-        assert.equal(Buffer.from(encodedPath, 'base64').toString(), fixture.blockThemeQualityProbe);
-        assert.match(calls[0].at(-1), /homeboy_wordpress_collect_block_theme_quality/);
+        assert.match(calls[0].at(-1), /fake site probe/);
+        assert.match(calls[0].at(-1), /studio_bfb_unsupported_fallback_count/);
         assert.match(calls[0].at(-1), /Studio Code/);
         assert.equal(quality.target_pages_seen, 1);
         assert.equal(quality.target_posts_with_blocks, 1);
+        assert.equal(quality.bfb_fallback_count, 2);
+        assert.equal(quality.core_html_without_bfb_fallback, 3);
       }
     );
   } finally {


### PR DESCRIPTION
## Summary
- Replace Studio's local block-theme quality PHP probe wrapper with the promoted Homeboy Extensions `block-quality.js` helper.
- Keep Studio-specific target selection and fallback alias mapping in the rig while moving reusable target block counting upstream.
- Update diagnostics tests to assert the promoted helper options instead of the old `block-theme-quality-probe.php` path.

Depends on Extra-Chill/homeboy-extensions#1145.
Follow-up for #158.

## Verification
- `node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `node --check Automattic/studio/bench/lib/wordpress-quality.mjs && node --check Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `git diff --check`
- `node scripts/lint-rig-packages.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the downstream Studio rig adoption and targeted verification; Chris remains responsible for review and merge.