### PR TITLE
Add Stripe ECE web performance profile

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.mjs
@@ -1,5 +1,6 @@
 export const DEFAULT_PROFILE = 'smoke';
 export const REAL_WALLET_PROFILE = 'real-wallet';
+export const WEBPERF_DESKTOP_SLOW_4G_PROFILE = 'webperf-desktop-slow-4g';
 
 export function setting(name, defaultValue = '') {
   const envName = `HOMEBOY_SETTINGS_${name.toUpperCase()}`;
@@ -57,6 +58,28 @@ function requireRealWalletProfileEnv(publicUrl) {
 }
 
 export function buildEceProfileOptions(profile = eceBrowserProfile()) {
+  if (profile === WEBPERF_DESKTOP_SLOW_4G_PROFILE) {
+    return {
+      profile,
+      realWalletCapable: false,
+      syntheticOnly: true,
+      stripePublishableKey: null,
+      stripeSecretKey: null,
+      runtimePreview: null,
+      recipeRunArgs: [],
+      browserProbeArgs: [
+        'browser=chromium',
+        'device=Desktop Chrome',
+        'locale=en-US',
+        'timezone=America/New_York',
+        'mobile=0',
+        'touch=0',
+        'throttle=low-end-mobile-slow-4g',
+      ],
+      waitFor: 'load',
+    };
+  }
+
   if (!['secure-browser', REAL_WALLET_PROFILE].includes(profile)) {
     return {
       profile,
@@ -67,6 +90,7 @@ export function buildEceProfileOptions(profile = eceBrowserProfile()) {
       runtimePreview: null,
       recipeRunArgs: [],
       browserProbeArgs: [],
+      waitFor: null,
     };
   }
 
@@ -104,5 +128,6 @@ export function buildEceProfileOptions(profile = eceBrowserProfile()) {
       'mobile=0',
       'touch=0',
     ],
+    waitFor: null,
   };
 }

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
@@ -55,6 +55,20 @@ test('secure-browser profile uses generic preview and browser profile args', () 
   }
 });
 
+test('webperf desktop slow 4g profile keeps desktop context while applying Codebox throttle', () => {
+  const options = buildEceProfileOptions('webperf-desktop-slow-4g');
+
+  assert.equal(options.profile, 'webperf-desktop-slow-4g');
+  assert.equal(options.runtimePreview, null);
+  assert.deepEqual(options.recipeRunArgs, []);
+  assert.equal(options.waitFor, 'load');
+  assert.ok(options.browserProbeArgs.includes('device=Desktop Chrome'));
+  assert.ok(options.browserProbeArgs.includes('mobile=0'));
+  assert.ok(options.browserProbeArgs.includes('touch=0'));
+  assert.ok(options.browserProbeArgs.includes('throttle=low-end-mobile-slow-4g'));
+  assert.ok(!options.browserProbeArgs.includes('profile=low-end-mobile-slow-4g'));
+});
+
 test('real-wallet profile fails fast when Stripe keys are missing', () => {
   const previous = {
     STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY,

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -199,6 +199,46 @@ if ( ${profileOptions.realWalletCapable ? 'true' : 'false'} ) {
 	update_option( 'woocommerce_stripe_settings', $stripe_settings );
 }
 
+$mu_plugin_dir = WP_CONTENT_DIR . '/mu-plugins';
+if ( ! is_dir( $mu_plugin_dir ) && ! wp_mkdir_p( $mu_plugin_dir ) ) {
+	throw new RuntimeException( 'Could not create mu-plugins directory for Stripe benchmark fixture.' );
+}
+
+file_put_contents(
+	$mu_plugin_dir . '/homeboy-stripe-ece-fixture-dependencies.php',
+	'<?php
+add_action(
+	"wp_enqueue_scripts",
+	function () {
+		if ( function_exists( "is_product" ) && is_product() ) {
+			wp_enqueue_script( "wc-settings" );
+		}
+	},
+	20
+);
+add_action(
+	"wp_head",
+	function () {
+		if ( ! function_exists( "is_product" ) || ! is_product() ) {
+			return;
+		}
+		?>
+<script id="homeboy-stripe-ece-wc-settings-shim">
+window.wc = window.wc || {};
+window.wcSettings = window.wcSettings || {};
+window.wc.wcSettings = window.wc.wcSettings || {
+	getSetting: function( name, defaultValue ) {
+		return Object.prototype.hasOwnProperty.call( window.wcSettings, name ) ? window.wcSettings[ name ] : defaultValue;
+	}
+};
+</script>
+		<?php
+	},
+	0
+);
+'
+);
+
 update_option( 'permalink_structure', '/%postname%/' );
 flush_rewrite_rules();
 
@@ -463,7 +503,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
           command: 'wordpress.browser-probe',
           args: [
             'url=/?product=stripe-benchmark-product',
-            `wait-for=${scenario.waitFor || 'networkidle'}`,
+            `wait-for=${profileOptions.waitFor || scenario.waitFor || 'networkidle'}`,
             `duration=${probeDuration}`,
             `viewport=${viewport}`,
             ...profileOptions.browserProbeArgs,
@@ -566,7 +606,13 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     stripe_payment_request_supported: scriptResult?.stripeAvailability?.paymentRequestSupported === true,
     stripe_apple_pay_session_supported: scriptResult?.stripeAvailability?.applePaySessionSupported === true,
     stripe_secure_payment_confirmation_supported: scriptResult?.stripeAvailability?.securePaymentConfirmationSupported === true,
-    browser_dom_content_loaded_ms: relativeTimingMs(cdpMetrics, 'DomContentLoaded'),
+    browser_nav_duration_ms: browserMetrics.browser_nav_duration_ms ?? performanceSummary?.final?.navigation?.durationMs ?? null,
+    browser_dom_content_loaded_ms: browserMetrics.browser_dom_content_loaded_ms ?? relativeTimingMs(cdpMetrics, 'DomContentLoaded'),
+    browser_load_event_ms: browserMetrics.browser_load_event_ms ?? performanceSummary?.final?.navigation?.loadEventMs ?? null,
+    browser_ttfb_ms: browserMetrics.browser_ttfb_ms ?? performanceSummary?.final?.navigation?.ttfbMs ?? null,
+    browser_fcp_ms: browserMetrics.browser_fcp_ms ?? performanceSummary?.final?.paint?.firstContentfulPaintMs ?? null,
+    browser_lcp_ms: browserMetrics.browser_lcp_ms ?? performanceSummary?.final?.paint?.largestContentfulPaintMs ?? null,
+    browser_lcp_size: browserMetrics.browser_lcp_size ?? performanceSummary?.final?.paint?.largestContentfulPaintSize ?? null,
     browser_first_meaningful_paint_ms: relativeTimingMs(cdpMetrics, 'FirstMeaningfulPaint'),
     browser_iframe_count: browserMetrics.browser_iframe_count ?? null,
     browser_resource_count: browserMetrics.browser_resource_count ?? performanceSummary?.summary?.resources ?? null,
@@ -661,10 +707,13 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
       : scenario.simulatedCls === 'reserved'
         ? typeof metrics.browser_cls === 'number' && metrics.browser_cls <= 0.01 && eceRenderedVisibleButton
         : true;
-  const pass = output.success === true && stripeUrls.length > 0 && simulatedClsPass;
+  const stripeLoadPass = stripeLoadPageErrors.length === 0;
+  const pass = output.success === true && stripeUrls.length > 0 && simulatedClsPass && stripeLoadPass;
   const summaryText = pass
     ? `Captured Stripe ECE product-page browser waterfall: ${stripeUrls.length} Stripe responses across ${responses.length} total responses.`
-    : 'Browser waterfall capture did not observe Stripe network responses.';
+    : stripeLoadPass
+      ? 'Browser waterfall capture did not observe Stripe network responses.'
+      : `Browser waterfall capture recorded ${stripeLoadPageErrors.length} Stripe-related page error(s).`;
 
   trace.assertion({
     id: 'stripe-network-observed',
@@ -680,6 +729,11 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     id: 'page-errors-recorded',
     status: 'pass',
     message: `Recorded ${pageErrors.length} page errors.`,
+  });
+  trace.assertion({
+    id: 'stripe-load-errors',
+    status: stripeLoadPass ? 'pass' : 'fail',
+    message: `Recorded ${stripeLoadPageErrors.length} Stripe-related page error(s).`,
   });
   trace.assertion({
     id: 'scenario-interaction',

--- a/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
+++ b/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
@@ -22,6 +22,23 @@ The default `smoke` profile preserves the existing WP Codebox browser-probe
 defaults: local Playground origin, default Chromium context, and the rig's fixed
 `1366x900` viewport.
 
+Set `woocommerce_stripe_ece_browser_profile=webperf-desktop-slow-4g` to keep
+the desktop browser context used by the synthetic ECE fixture while applying WP
+Codebox's deterministic `low-end-mobile-slow-4g` CPU/network throttle. This
+profile waits for `load` and then records the configured probe duration, rather
+than waiting for `networkidle`, because Stripe/product-page probes may keep
+third-party network activity alive long enough to make `networkidle` timeout.
+The disposable product fixture also provides the Woo settings package surface
+expected by the built Stripe assets on classic product pages, and the trace fails
+if Stripe bootstrap still emits page errors.
+
+```bash
+homeboy trace --rig woocommerce-stripe-ece-product-page \
+  --setting woocommerce_stripe_ece_browser_profile=webperf-desktop-slow-4g \
+  woocommerce-gateway-stripe ece-product-page-waterfall \
+  --output /tmp/wc-stripe-ece-webperf.json
+```
+
 Set `woocommerce_stripe_ece_browser_profile=secure-browser` to run the same
 Stripe product-page scenario through generic secure/browser-visible upstream
 knobs:
@@ -100,6 +117,8 @@ The stable signals are structural:
 - JS event listener count.
 - DOM node count.
 - Long-task count and total duration.
+- WP Codebox web performance metrics when available: `browser_ttfb_ms`,
+  `browser_fcp_ms`, `browser_lcp_ms`, and `browser_nav_duration_ms`.
 - Real-wallet evidence classification: `ece_real_wallet_capable` and
   `ece_synthetic_only`.
 - Stripe Elements session status/error counts and visible-button outcome.


### PR DESCRIPTION
## Summary
- Adds a `webperf-desktop-slow-4g` Stripe ECE browser profile that keeps the desktop fixture context while applying WP Codebox's deterministic low-end mobile slow 4G throttle.
- Records promoted WP Codebox web performance metrics from the ECE waterfall trace, including TTFB, FCP, LCP, load, and navigation duration.
- Adds a Woo settings fixture shim and a Stripe bootstrap-error assertion so the synthetic product-page trace fails when built Stripe assets crash before useful network evidence is captured.

## Evidence
- `node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`
- `git diff --check origin/main...HEAD`

## Notes
- This PR adds measurement capability only. It does not claim that Woo Stripe #5530 improves page-load timing.
- Any performance conclusion for #5530 needs repeated baseline/candidate runs with medians and variance before posting reviewer-facing evidence.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the rig/profile/doc changes and ran local validation; Chris remains responsible for review and merge.