### PR TITLE
Use extension admin scale sweep normalization

### DIFF
--- a/Automattic/studio/bench/lib/wordpress-admin-scale-sweep.mjs
+++ b/Automattic/studio/bench/lib/wordpress-admin-scale-sweep.mjs
@@ -1,80 +1,17 @@
-import { readFile } from 'node:fs/promises';
+import { loadWordPressAdminPageScenarios } from './wordpress-page-profiler.mjs';
 
-import { wordpressResourceInclude } from './wordpress-page-profiler.mjs';
-
-const DEFAULT_ADMIN_READY = { selector: '#wpbody-content, body.wp-admin', timeout: 120000 };
-
-function pageIdFromPath(pagePath) {
-  return String(pagePath || '')
-    .replace(/^https?:\/\/[^/]+/i, '')
-    .replace(/^\/+/, '')
-    .replace(/[^A-Za-z0-9_.:-]+/g, '-')
-    .replace(/^-|-$/g, '') || 'wordpress-admin-page';
-}
-
-function metricId(id) {
-  return String(id || 'page')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '') || 'page';
+function loadAdminScaleSweepModule(options = {}) {
+  const module = options.adminPageScenarios || loadWordPressAdminPageScenarios(options).module;
+  if (!module?.normalizeWordPressAdminScaleSweepManifest || !module?.loadWordPressAdminScaleSweepManifest) {
+    throw new Error('WordPress admin scale sweep helpers are unavailable. Update homeboy-extensions or set HOMEBOY_WORDPRESS_ADMIN_PAGE_SCENARIOS_PATH.');
+  }
+  return module;
 }
 
 export function normalizeWordPressAdminScaleSweepManifest(manifest, options = {}) {
-  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
-    throw new Error('WordPress admin scale sweep manifest must be an object');
-  }
-  if (!Array.isArray(manifest.pages) || manifest.pages.length === 0) {
-    throw new Error('WordPress admin scale sweep manifest requires a non-empty pages array');
-  }
-
-  const resourceInclude = options.resourceInclude || wordpressResourceInclude(options);
-
-  return {
-    ...manifest,
-    pages: manifest.pages.map((page, index) => {
-      if (!page || typeof page !== 'object' || Array.isArray(page)) {
-        throw new Error(`WordPress admin scale sweep page ${index + 1} must be an object`);
-      }
-      if (!page.path || typeof page.path !== 'string') {
-        throw new Error(`WordPress admin scale sweep page ${index + 1} requires a path`);
-      }
-
-      const id = page.id || pageIdFromPath(page.path);
-      const ready = page.ready || DEFAULT_ADMIN_READY;
-      return {
-        ...page,
-        id,
-        metricId: metricId(id),
-        label: page.label || id,
-        ready,
-        resources: {
-          includeResourceSubstrings: resourceInclude,
-          ...(page.resources || {}),
-        },
-        timeout: Number(page.timeout || ready.timeout || 120000),
-        interactions: Array.isArray(page.interactions) ? page.interactions : [],
-      };
-    }),
-  };
+  return loadAdminScaleSweepModule(options).normalizeWordPressAdminScaleSweepManifest(manifest, options);
 }
 
 export async function loadWordPressAdminScaleSweepManifest(options = {}) {
-  const rawJson = options.json || process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_MANIFEST_JSON;
-  const manifestPath = options.path || process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_MANIFEST;
-  if (rawJson) {
-    return normalizeWordPressAdminScaleSweepManifest(JSON.parse(rawJson), options);
-  }
-  if (manifestPath) {
-    return normalizeWordPressAdminScaleSweepManifest(JSON.parse(await readFile(manifestPath, 'utf8')), options);
-  }
-
-  return normalizeWordPressAdminScaleSweepManifest({
-    pages: [
-      { id: 'dashboard', path: '/wp-admin/index.php' },
-      { id: 'plugins', path: '/wp-admin/plugins.php' },
-      { id: 'themes', path: '/wp-admin/themes.php', ready: { selector: '.theme-browser, #wpbody-content', timeout: 120000 } },
-      { id: 'posts', path: '/wp-admin/edit.php' },
-      { id: 'add-post', path: '/wp-admin/post-new.php', ready: { selector: '.edit-post-layout, #editor, body.wp-admin', timeout: 120000 } },
-    ],
-  }, options);
+  return loadAdminScaleSweepModule(options).loadWordPressAdminScaleSweepManifest(options);
 }

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -861,6 +861,24 @@ test('probeQuality delegates site block probing to the promoted block theme help
 // --- WordPress admin scale sweep ------------------------------------------
 
 test('normalizeWordPressAdminScaleSweepManifest accepts page manifests and adds defaults', () => {
+  const calls = [];
+  const adminPageScenarios = {
+    normalizeWordPressAdminScaleSweepManifest(manifest, options) {
+      calls.push({ manifest, options });
+      return {
+        ...manifest,
+        pages: manifest.pages.map((page, index) => ({
+          ...page,
+          id: page.id || 'wp-admin-admin.php-page-datamachine-jobs',
+          metricId: page.id || `page_${index + 1}`,
+          ready: page.ready || { selector: '#wpbody-content, body.wp-admin' },
+          resources: { includeResourceSubstrings: DEFAULT_RESOURCE_INCLUDE },
+          interactions: Array.isArray(page.interactions) ? page.interactions : [],
+        })),
+      };
+    },
+    async loadWordPressAdminScaleSweepManifest() {},
+  };
   const manifest = normalizeWordPressAdminScaleSweepManifest({
     pages: [
       {
@@ -873,8 +891,10 @@ test('normalizeWordPressAdminScaleSweepManifest accepts page manifests and adds 
         interactions: [{ type: 'click', selector: '.jobs-row:first-child button' }],
       },
     ],
-  }, { pageProfiler: pageProfilerApi });
+  }, { adminPageScenarios, pageProfiler: pageProfilerApi });
 
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].options.pageProfiler, pageProfilerApi);
   assert.equal(manifest.pages.length, 2);
   assert.equal(manifest.pages[0].metricId, 'pipelines');
   assert.equal(manifest.pages[0].resources.includeResourceSubstrings.includes('/wp-json/'), true);


### PR DESCRIPTION
## Summary
- Replaces rig-local WordPress admin scale sweep normalization with a thin shim that delegates to `homeboy-extensions` admin page scenarios.
- Keeps the existing rig import path stable while moving the reusable primitive upstream.
- Updates the rig unit test to verify delegation instead of duplicating normalization behavior locally.

Depends on https://github.com/Extra-Chill/homeboy-extensions/pull/1152
Related to https://github.com/Extra-Chill/homeboy-extensions/issues/1149

## Verification
- `node Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `HOMEBOY_COMPONENT_PATH="/tmp/homeboy-rigs-test-component" HOMEBOY_WORDPRESS_ADMIN_PAGE_SCENARIOS_PATH="/Users/chubes/Developer/homeboy-extensions@fix-1149-admin-scale-sweep-normalization/wordpress/lib/admin-page-scenarios.js" node --input-type=module -e "import { loadWordPressAdminScaleSweepManifest } from './Automattic/studio/bench/lib/wordpress-admin-scale-sweep.mjs'; const manifest = await loadWordPressAdminScaleSweepManifest({ pageProfiler: { DEFAULT_RESOURCE_INCLUDE: ['/custom/'] } }); if (manifest.pages.map((page) => page.id).join(',') !== 'dashboard,plugins,themes,posts,add-post') throw new Error('unexpected default pages'); if (manifest.pages[0].resources.includeResourceSubstrings[0] !== '/custom/') throw new Error('resource include not delegated');"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the downstream delegation shim, test adjustment, and verification steps; Chris remains responsible for review and merge.