### PR TITLE
Adopt WordPress materialized site quality helper

### DIFF
--- a/Automattic/studio/bench/lib/site-build-gates.mjs
+++ b/Automattic/studio/bench/lib/site-build-gates.mjs
@@ -1,145 +1,62 @@
 import { semanticMismatchFailureDetails } from './semantic-fidelity.mjs';
+import { loadWordPressLibHelper } from './wordpress-helper-discovery.mjs';
 
-const VISUAL_EDITOR_PIXEL_DIFF_THRESHOLD = 0.05;
 export const VISUAL_PIXEL_DIFF_THRESHOLD = 0.05;
 
-function metric(value) {
-  const number = Number(value ?? 0);
-  return Number.isFinite(number) ? number : 0;
-}
-
-export function importerBlockQualityMetrics(importReport) {
-  const quality = importReport?.report?.quality || {};
-
-  return {
-    importerCoreHtmlBlockCount: metric(quality.core_html_block_count),
-    importerFreeformBlockCount: metric(quality.freeform_block_count),
-    importerFallbackCount: metric(quality.fallback_count),
-  };
-}
-
-export function importerBlockQualityFailureDetails(importerBlockQuality) {
-  const { importerCoreHtmlBlockCount, importerFreeformBlockCount, importerFallbackCount } = importerBlockQuality;
-
-  if (importerCoreHtmlBlockCount === 0 && importerFreeformBlockCount === 0 && importerFallbackCount === 0) {
-    return [];
+function materializedSiteQualityHelper(options = {}) {
+  const { module } = loadWordPressLibHelper('materialized-site-quality.js', {
+    ...options,
+    helperKey: 'materializedSiteQuality',
+  });
+  if (!module?.evaluateMaterializedSiteQuality) {
+    throw new Error('Homeboy WordPress materialized site quality helper is unavailable. Update homeboy-extensions or set HOMEBOY_WORDPRESS_HELPER_MANIFEST.');
   }
-
-  return [
-    `importer block quality: core/html=${importerCoreHtmlBlockCount}, freeform=${importerFreeformBlockCount}, fallback=${importerFallbackCount}`,
-  ];
+  return module;
 }
 
-function visualRatio(value) {
-  const ratio = metric(value);
-  return Number.isFinite(ratio) ? ratio : 1;
+export function importerBlockQualityMetrics(importReport, options = {}) {
+  return materializedSiteQualityHelper(options).importerBlockQualityMetrics(importReport);
 }
 
-function formatVisualRatio(value) {
-  return visualRatio(value).toFixed(2);
+export function importerBlockQualityFailureDetails(importerBlockQuality, options = {}) {
+  return materializedSiteQualityHelper(options).importerBlockQualityFailureDetails(importerBlockQuality);
 }
 
-export function visualEditorParityMetrics(visualComparison) {
-  return {
-    visualEditorVsSourcePixelDiffRatio: visualRatio(visualComparison?.visual_editor_vs_source_pixel_diff_ratio),
-    visualEditorVsFrontendPixelDiffRatio: visualRatio(visualComparison?.visual_editor_vs_frontend_pixel_diff_ratio),
-    visualSourceVsFrontendPixelDiffRatio: visualRatio(
-      visualComparison?.visual_pixel_diff_ratio ??
-        visualComparison?.pixel_diff_ratio ??
-        visualComparison?.visual_source_vs_frontend_pixel_diff_ratio_diagnostic
-    ),
-    visualEditorParityErrorCount: metric(visualComparison?.visual_editor_parity_error_count),
-  };
+export function visualEditorParityMetrics(visualComparison, options = {}) {
+  return materializedSiteQualityHelper(options).visualEditorParityMetrics(visualComparison);
 }
 
-export function visualEditorParityFailureDetails(visualEditorParity) {
-  const {
-    visualEditorVsSourcePixelDiffRatio,
-    visualEditorVsFrontendPixelDiffRatio,
-    visualSourceVsFrontendPixelDiffRatio,
-    visualEditorParityErrorCount,
-  } = visualEditorParity;
-  const editorFailedSource = visualEditorVsSourcePixelDiffRatio > VISUAL_EDITOR_PIXEL_DIFF_THRESHOLD;
-  const editorFailedFrontend = visualEditorVsFrontendPixelDiffRatio > VISUAL_EDITOR_PIXEL_DIFF_THRESHOLD;
-
-  if (visualEditorParityErrorCount > 0) {
-    return [`editor visual parity could not be measured (${visualEditorParityErrorCount} capture/diff errors)`];
-  }
-
-  if (!editorFailedSource && !editorFailedFrontend) {
-    return [];
-  }
-
-  if (editorFailedFrontend && visualSourceVsFrontendPixelDiffRatio <= VISUAL_EDITOR_PIXEL_DIFF_THRESHOLD) {
-    return [
-      `editor render diverges from frontend (editor diff: ${formatVisualRatio(
-        visualEditorVsSourcePixelDiffRatio
-      )}, frontend diff: ${formatVisualRatio(
-        visualSourceVsFrontendPixelDiffRatio
-      )}) - likely block-validation or unscoped CSS`,
-    ];
-  }
-
-  if (editorFailedSource && visualSourceVsFrontendPixelDiffRatio > VISUAL_EDITOR_PIXEL_DIFF_THRESHOLD) {
-    return [
-      `editor and frontend both diverge from source (editor: ${formatVisualRatio(
-        visualEditorVsSourcePixelDiffRatio
-      )}, frontend: ${formatVisualRatio(visualSourceVsFrontendPixelDiffRatio)}) - conversion failed before editor concern`,
-    ];
-  }
-
-  return [
-    `editor visual parity failed (editor vs source: ${formatVisualRatio(
-      visualEditorVsSourcePixelDiffRatio
-    )}, editor vs frontend: ${formatVisualRatio(visualEditorVsFrontendPixelDiffRatio)})`,
-  ];
+export function visualEditorParityFailureDetails(visualEditorParity, options = {}) {
+  return materializedSiteQualityHelper(options).visualEditorParityFailureDetails(visualEditorParity, options);
 }
 
-export function visualPixelDiffFailureDetails(visualComparison) {
-  const visualPixelDiffRatio = metric(visualComparison?.pixel_diff_ratio);
-  if (visualPixelDiffRatio <= VISUAL_PIXEL_DIFF_THRESHOLD) {
-    return [];
-  }
-
-  return [
-    `visual pixel diff: ${visualPixelDiffRatio.toFixed(3)} (threshold: ${VISUAL_PIXEL_DIFF_THRESHOLD.toFixed(3)})`,
-  ];
+export function visualPixelDiffFailureDetails(visualComparison, options = {}) {
+  return materializedSiteQualityHelper(options).visualPixelDiffFailureDetails(visualComparison, options);
 }
 
-export function agentSuccessGate(result, semanticComparison, importReport, visualComparison) {
-  const semanticMismatchCount = metric(semanticComparison?.mismatch_count);
-  const importerBlockQuality = importerBlockQualityMetrics(importReport);
-  const visualEditorParity = visualEditorParityMetrics(visualComparison);
-  const visualPixelDiffRatio = metric(visualComparison?.pixel_diff_ratio);
-  const agentTimedOut = result?.timedOut === true;
-  const agentSucceeded =
-    result?.success === true &&
-    !result?.error &&
-    !agentTimedOut &&
-    semanticMismatchCount === 0 &&
-    importerBlockQuality.importerCoreHtmlBlockCount === 0 &&
-    importerBlockQuality.importerFreeformBlockCount === 0 &&
-    importerBlockQuality.importerFallbackCount === 0 &&
-    visualEditorParity.visualEditorParityErrorCount === 0 &&
-    visualEditorParity.visualEditorVsSourcePixelDiffRatio <= VISUAL_EDITOR_PIXEL_DIFF_THRESHOLD &&
-    visualEditorParity.visualEditorVsFrontendPixelDiffRatio <= VISUAL_EDITOR_PIXEL_DIFF_THRESHOLD &&
-    visualPixelDiffRatio <= VISUAL_PIXEL_DIFF_THRESHOLD;
-
-  return {
-    agentSucceeded,
-    semanticMismatchCount,
-    semanticFailureDetails: semanticMismatchCount > 0 ? semanticMismatchFailureDetails(semanticComparison) : [],
-    importerBlockQuality,
-    importerBlockQualityFailureDetails: importerBlockQualityFailureDetails(importerBlockQuality),
-    visualEditorParity,
-    visualEditorFailureDetails: visualEditorParityFailureDetails(visualEditorParity),
-    visualPixelDiffRatio,
-    visualPixelDiffFailureDetails: visualPixelDiffFailureDetails(visualComparison),
-    metrics: {
-      success_rate: agentSucceeded ? 1 : 0,
-      agent_error_rate: agentSucceeded ? 0 : 1,
-      timed_out: agentTimedOut ? 1 : 0,
-      agent_runner_error: typeof result?.error === 'string' ? 1 : 0,
+export function agentSuccessGate(result, semanticComparison, importReport, visualComparison, options = {}) {
+  const helper = materializedSiteQualityHelper(options);
+  const gate = helper.evaluateMaterializedSiteQuality(
+    {
+      result,
+      semanticComparison,
+      importReport,
+      visualComparison,
+      semanticMismatchFailureDetails,
     },
+    options
+  );
+
+  return {
+    agentSucceeded: gate.passed,
+    semanticMismatchCount: gate.semanticMismatchCount,
+    semanticFailureDetails: gate.semanticMismatchCount > 0 ? semanticMismatchFailureDetails(semanticComparison) : [],
+    importerBlockQuality: gate.importerBlockQuality,
+    importerBlockQualityFailureDetails: helper.importerBlockQualityFailureDetails(gate.importerBlockQuality),
+    visualEditorParity: gate.visualEditorParity,
+    visualEditorFailureDetails: helper.visualEditorParityFailureDetails(gate.visualEditorParity, options),
+    visualPixelDiffRatio: gate.visualPixelDiffRatio,
+    visualPixelDiffFailureDetails: helper.visualPixelDiffFailureDetails(visualComparison, options),
+    metrics: gate.metrics,
   };
 }

--- a/Automattic/studio/bench/lib/wordpress-helper-discovery.mjs
+++ b/Automattic/studio/bench/lib/wordpress-helper-discovery.mjs
@@ -9,6 +9,7 @@ const WORDPRESS_LIB_HELPER_KEYS = new Map([
   ['block-quality.js', 'blockQuality'],
   ['editor-canvas-probes.js', 'editorCanvasProbes'],
   ['fixture-setup.js', 'fixtureSetup'],
+  ['materialized-site-quality.js', 'materializedSiteQuality'],
   ['request-profiler.js', 'requestProfiler'],
   ['timing-correlator.js', 'timingCorrelator'],
   ['wordpress-bootstrap-timeline.js', 'bootstrapTimeline'],

--- a/Automattic/studio/bench/lib/wordpress-quality.mjs
+++ b/Automattic/studio/bench/lib/wordpress-quality.mjs
@@ -150,81 +150,20 @@ export function importerTimingMetrics(importReport) {
 }
 
 export function agentAuthoredBlockMetrics(result) {
-  const toolCalls = Array.isArray(result?.toolCalls) ? result.toolCalls : [];
-  const writeCalls = toolCalls.filter((item) => item && item.name === 'Write');
-  let agentAuthoredWpHtmlOpeners = 0;
-  let agentAuthoredWpBlockComments = 0;
-  let agentAuthoredWpHtmlWriteCalls = 0;
-
-  for (const call of writeCalls) {
-    const content = typeof call?.input?.content === 'string' ? call.input.content : '';
-    const wpHtmlOpeners = countRegex(content, /<!--\s+wp:html\b/g);
-    agentAuthoredWpHtmlOpeners += wpHtmlOpeners;
-    agentAuthoredWpBlockComments += countRegex(content, /<!--\s+\/?wp:/g);
-    if (wpHtmlOpeners > 0) {
-      agentAuthoredWpHtmlWriteCalls++;
-    }
-  }
-
-  return {
-    agent_authored_wp_html_openers: agentAuthoredWpHtmlOpeners,
-    agent_authored_wp_html_write_calls: agentAuthoredWpHtmlWriteCalls,
-    agent_authored_wp_block_comments: agentAuthoredWpBlockComments,
-  };
+  return materializedSiteQualityHelper().agentAuthoredBlockMetrics(result);
 }
 
 export function nativeBlockQualityMetrics(quality, authoredBlocks, editorValidation, importReport) {
-  const reasons = [];
-  const bfbFallbackCount = metric(quality?.bfb_fallback_count);
-  const coreHtmlWithoutBfbFallback = metric(quality?.core_html_without_bfb_fallback);
-  const importerQuality = importReport?.report?.quality || {};
-  const importerCoreHtmlBlocks = metric(importerQuality.core_html_block_count);
-  const importerInvalidBlocks = metric(importerQuality.invalid_block_count);
-  const agentAuthoredWpHtmlOpeners = metric(authoredBlocks.agent_authored_wp_html_openers);
-  const invalidEditorBlocks = metric(editorValidation?.invalid_blocks);
-  const targetPagesSeen = metric(quality?.target_pages_seen);
-  const targetPostsWithBlocks = metric(quality?.target_posts_with_blocks);
-
-  if (targetPagesSeen === 0 || targetPostsWithBlocks === 0) {
-    reasons.push('missing_target_block_page');
-  }
-  if (agentAuthoredWpHtmlOpeners > 0) {
-    reasons.push('agent_authored_wp_html');
-  }
-  if (coreHtmlWithoutBfbFallback > 0) {
-    reasons.push('core_html_without_bfb_fallback');
-  }
-  if (bfbFallbackCount > 0) {
-    reasons.push('bfb_fallback');
-  }
-  if (importerCoreHtmlBlocks > 0) {
-    reasons.push('importer_core_html_blocks');
-  }
-  if (importerInvalidBlocks > 0) {
-    reasons.push('importer_invalid_blocks');
-  }
-  if (importReport?.error) {
-    reasons.push('importer_report_error');
-  }
-  if (invalidEditorBlocks > 0) {
-    reasons.push('editor_invalid_blocks');
-  }
-  if (editorValidation?.error) {
-    reasons.push('editor_validation_error');
-  }
-
-  return {
-    native_block_quality_pass: reasons.length === 0,
-    native_block_quality_failure_count: reasons.length,
-    native_block_quality_failure_reasons: reasons,
-  };
+  return materializedSiteQualityHelper().nativeBlockQualityMetrics(quality, authoredBlocks, editorValidation, importReport);
 }
 
-function countRegex(value, pattern) {
-  return typeof value === 'string' ? (value.match(pattern) || []).length : 0;
-}
-
-function metric(value) {
-  const number = Number(value ?? 0);
-  return Number.isFinite(number) ? number : 0;
+function materializedSiteQualityHelper(options = {}) {
+  const { module } = loadWordPressLibHelper('materialized-site-quality.js', {
+    ...options,
+    helperKey: 'materializedSiteQuality',
+  });
+  if (!module?.nativeBlockQualityMetrics || !module?.agentAuthoredBlockMetrics) {
+    throw new Error('Homeboy WordPress materialized site quality helper is unavailable. Update homeboy-extensions or set HOMEBOY_WORDPRESS_HELPER_MANIFEST.');
+  }
+  return module;
 }


### PR DESCRIPTION
## Summary
- Replaces Studio's local materialized-site gate implementation with thin wrappers around the promoted Homeboy WordPress helper.
- Adds `materialized-site-quality.js` to WordPress helper discovery so the rig consumes the helper manifest path.
- Keeps Studio-owned semantic mismatch detail formatting in the rig wrapper while generic WordPress quality logic lives in `homeboy-extensions/wordpress`.

## Dependency
- Depends on https://github.com/Extra-Chill/homeboy-extensions/pull/1153.

## Verification
- `HOMEBOY_WORDPRESS_HELPER_MANIFEST=/Users/chubes/Developer/homeboy-extensions@issue-1147-materialized-site-quality/wordpress/lib/helper-manifest.js node --test Automattic/studio/bench/studio-agent-site-build.test.mjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the helper-consumption refactor, dependency notes, and targeted verification for Chris to review.