### PR TITLE
Add Woo Stripe ECE browser profile matrix

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.mjs
@@ -1,6 +1,48 @@
 export const DEFAULT_PROFILE = 'smoke';
 export const REAL_WALLET_PROFILE = 'real-wallet';
+export const WEBPERF_DESKTOP_LOAD_PROFILE = 'webperf-desktop-load';
 export const WEBPERF_DESKTOP_SLOW_4G_PROFILE = 'webperf-desktop-slow-4g';
+
+const DESKTOP_BROWSER_PROBE_ARGS = [
+  'browser=chromium',
+  'device=Desktop Chrome',
+  'locale=en-US',
+  'timezone=America/New_York',
+  'mobile=0',
+  'touch=0',
+];
+
+const PROFILE_METADATA = {
+  [DEFAULT_PROFILE]: {
+    label: 'Smoke',
+    caveat: 'Smoke profile uses WP Codebox browser-probe defaults; use it for rig health, not browser performance conclusions.',
+    conclusion: 'Rig health and fixture availability only.',
+  },
+  'secure-browser': {
+    label: 'Secure desktop browser',
+    caveat: 'Secure-browser profile exercises preview/browser visibility contracts; use it for secure-context plumbing evidence.',
+    conclusion: 'Secure preview routing and browser-visible integration behavior.',
+  },
+  [REAL_WALLET_PROFILE]: {
+    label: 'Real-wallet desktop browser',
+    caveat: 'Real-wallet profile depends on live Stripe keys, HTTPS preview routing, wallet eligibility, and third-party variance.',
+    conclusion: 'Wallet-capable ECE behavior under real Stripe configuration.',
+  },
+  [WEBPERF_DESKTOP_LOAD_PROFILE]: {
+    label: 'Desktop load',
+    caveat: 'Desktop load profile uses a desktop browser context without synthetic CPU/network throttle; use it for normal-ish absolute load timings, not stable synthetic fan-out deltas.',
+    conclusion: 'Non-throttled desktop LCP/FCP/TTFB/load/navigation timing shape.',
+  },
+  [WEBPERF_DESKTOP_SLOW_4G_PROFILE]: {
+    label: 'Desktop slow 4G',
+    caveat: 'Desktop slow-4g profile keeps desktop rendering while applying deterministic low-end-mobile-slow-4g throttle; use it for stable synthetic third-party fan-out deltas, not absolute desktop timings.',
+    conclusion: 'Stable synthetic third-party response fan-out and relative waterfall deltas.',
+  },
+};
+
+function profileMetadata(profile) {
+  return PROFILE_METADATA[profile] || PROFILE_METADATA[DEFAULT_PROFILE];
+}
 
 export function setting(name, defaultValue = '') {
   const envName = `HOMEBOY_SETTINGS_${name.toUpperCase()}`;
@@ -58,9 +100,33 @@ function requireRealWalletProfileEnv(publicUrl) {
 }
 
 export function buildEceProfileOptions(profile = eceBrowserProfile()) {
+  const metadata = profileMetadata(profile);
+
+  if (profile === WEBPERF_DESKTOP_LOAD_PROFILE) {
+    return {
+      profile,
+      profileLabel: metadata.label,
+      profileCaveat: metadata.caveat,
+      profileConclusion: metadata.conclusion,
+      throttleProfile: null,
+      realWalletCapable: false,
+      syntheticOnly: true,
+      stripePublishableKey: null,
+      stripeSecretKey: null,
+      runtimePreview: null,
+      recipeRunArgs: [],
+      browserProbeArgs: DESKTOP_BROWSER_PROBE_ARGS,
+      waitFor: 'load',
+    };
+  }
+
   if (profile === WEBPERF_DESKTOP_SLOW_4G_PROFILE) {
     return {
       profile,
+      profileLabel: metadata.label,
+      profileCaveat: metadata.caveat,
+      profileConclusion: metadata.conclusion,
+      throttleProfile: 'low-end-mobile-slow-4g',
       realWalletCapable: false,
       syntheticOnly: true,
       stripePublishableKey: null,
@@ -68,12 +134,7 @@ export function buildEceProfileOptions(profile = eceBrowserProfile()) {
       runtimePreview: null,
       recipeRunArgs: [],
       browserProbeArgs: [
-        'browser=chromium',
-        'device=Desktop Chrome',
-        'locale=en-US',
-        'timezone=America/New_York',
-        'mobile=0',
-        'touch=0',
+        ...DESKTOP_BROWSER_PROBE_ARGS,
         'throttle=low-end-mobile-slow-4g',
       ],
       waitFor: 'load',
@@ -83,6 +144,10 @@ export function buildEceProfileOptions(profile = eceBrowserProfile()) {
   if (!['secure-browser', REAL_WALLET_PROFILE].includes(profile)) {
     return {
       profile,
+      profileLabel: metadata.label,
+      profileCaveat: metadata.caveat,
+      profileConclusion: metadata.conclusion,
+      throttleProfile: null,
       realWalletCapable: false,
       syntheticOnly: true,
       stripePublishableKey: null,
@@ -110,6 +175,10 @@ export function buildEceProfileOptions(profile = eceBrowserProfile()) {
 
   return {
     profile,
+    profileLabel: metadata.label,
+    profileCaveat: metadata.caveat,
+    profileConclusion: metadata.conclusion,
+    throttleProfile: null,
     realWalletCapable: profile === REAL_WALLET_PROFILE,
     syntheticOnly: profile !== REAL_WALLET_PROFILE,
     stripePublishableKey: profile === REAL_WALLET_PROFILE ? process.env.STRIPE_PUBLISHABLE_KEY : null,
@@ -120,14 +189,7 @@ export function buildEceProfileOptions(profile = eceBrowserProfile()) {
       ...(bind ? ['--preview-bind', bind] : []),
       ...(publicUrl ? ['--preview-public-url', publicUrl] : []),
     ],
-    browserProbeArgs: [
-      'browser=chromium',
-      'device=Desktop Chrome',
-      'locale=en-US',
-      'timezone=America/New_York',
-      'mobile=0',
-      'touch=0',
-    ],
+    browserProbeArgs: DESKTOP_BROWSER_PROBE_ARGS,
     waitFor: null,
   };
 }

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
@@ -1,16 +1,26 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 
 import { buildEceProfileOptions } from './ece-product-page-profile.mjs';
 import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceProductPageScenario, eceProductPageScenarioIds, eceSimulatedClsScript } from './ece-product-page-scenarios.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 test('default smoke profile preserves browser probe defaults', () => {
   const options = buildEceProfileOptions('smoke');
 
   assert.equal(options.profile, 'smoke');
+  assert.equal(options.profileLabel, 'Smoke');
+  assert.match(options.profileCaveat, /rig health/);
+  assert.equal(options.profileConclusion, 'Rig health and fixture availability only.');
+  assert.equal(options.throttleProfile, null);
   assert.equal(options.runtimePreview, null);
   assert.deepEqual(options.recipeRunArgs, []);
   assert.deepEqual(options.browserProbeArgs, []);
+  assert.equal(options.waitFor, null);
 });
 
 test('secure-browser profile uses generic preview and browser profile args', () => {
@@ -28,6 +38,9 @@ test('secure-browser profile uses generic preview and browser profile args', () 
     const options = buildEceProfileOptions('secure-browser');
 
     assert.equal(options.profile, 'secure-browser');
+    assert.equal(options.profileLabel, 'Secure desktop browser');
+    assert.match(options.profileCaveat, /secure-context plumbing/);
+    assert.equal(options.throttleProfile, null);
     assert.deepEqual(options.runtimePreview, {
       port: 49800,
       bind: '127.0.0.1',
@@ -44,6 +57,7 @@ test('secure-browser profile uses generic preview and browser profile args', () 
     assert.ok(options.browserProbeArgs.includes('browser=chromium'));
     assert.ok(options.browserProbeArgs.includes('device=Desktop Chrome'));
     assert.ok(options.browserProbeArgs.includes('locale=en-US'));
+    assert.equal(options.waitFor, null);
   } finally {
     for (const [key, value] of Object.entries(previous)) {
       if (value === undefined) {
@@ -55,18 +69,58 @@ test('secure-browser profile uses generic preview and browser profile args', () 
   }
 });
 
+test('webperf desktop load profile uses load wait without synthetic throttle', () => {
+  const options = buildEceProfileOptions('webperf-desktop-load');
+
+  assert.equal(options.profile, 'webperf-desktop-load');
+  assert.equal(options.profileLabel, 'Desktop load');
+  assert.match(options.profileCaveat, /without synthetic CPU\/network throttle/);
+  assert.match(options.profileConclusion, /Non-throttled desktop/);
+  assert.equal(options.runtimePreview, null);
+  assert.deepEqual(options.recipeRunArgs, []);
+  assert.equal(options.waitFor, 'load');
+  assert.equal(options.throttleProfile, null);
+  assert.ok(options.browserProbeArgs.includes('device=Desktop Chrome'));
+  assert.ok(options.browserProbeArgs.includes('mobile=0'));
+  assert.ok(options.browserProbeArgs.includes('touch=0'));
+  assert.ok(!options.browserProbeArgs.some((arg) => arg.startsWith('throttle=')));
+  assert.ok(!options.browserProbeArgs.includes('profile=low-end-mobile-slow-4g'));
+});
+
 test('webperf desktop slow 4g profile keeps desktop context while applying Codebox throttle', () => {
   const options = buildEceProfileOptions('webperf-desktop-slow-4g');
 
   assert.equal(options.profile, 'webperf-desktop-slow-4g');
+  assert.equal(options.profileLabel, 'Desktop slow 4G');
+  assert.match(options.profileCaveat, /stable synthetic third-party fan-out deltas/);
+  assert.match(options.profileConclusion, /Stable synthetic third-party response fan-out/);
   assert.equal(options.runtimePreview, null);
   assert.deepEqual(options.recipeRunArgs, []);
   assert.equal(options.waitFor, 'load');
+  assert.equal(options.throttleProfile, 'low-end-mobile-slow-4g');
   assert.ok(options.browserProbeArgs.includes('device=Desktop Chrome'));
   assert.ok(options.browserProbeArgs.includes('mobile=0'));
   assert.ok(options.browserProbeArgs.includes('touch=0'));
   assert.ok(options.browserProbeArgs.includes('throttle=low-end-mobile-slow-4g'));
   assert.ok(!options.browserProbeArgs.includes('profile=low-end-mobile-slow-4g'));
+});
+
+test('rig manifest exposes the ECE webperf profile matrix', () => {
+  const manifestPath = path.join(__dirname, '../rigs/woocommerce-stripe-ece-product-page/rig.json');
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+
+  assert.deepEqual(manifest.trace_profiles['webperf-desktop-load'], {
+    scenario: 'ece-product-page-waterfall',
+    settings: {
+      woocommerce_stripe_ece_browser_profile: 'webperf-desktop-load',
+    },
+  });
+  assert.deepEqual(manifest.trace_profiles['webperf-desktop-slow-4g'], {
+    scenario: 'ece-product-page-waterfall',
+    settings: {
+      woocommerce_stripe_ece_browser_profile: 'webperf-desktop-slow-4g',
+    },
+  });
 });
 
 test('real-wallet profile fails fast when Stripe keys are missing', () => {
@@ -142,6 +196,9 @@ test('real-wallet profile carries real-wallet evidence settings without leaking 
     const options = buildEceProfileOptions('real-wallet');
 
     assert.equal(options.profile, 'real-wallet');
+    assert.equal(options.profileLabel, 'Real-wallet desktop browser');
+    assert.match(options.profileCaveat, /live Stripe keys/);
+    assert.equal(options.throttleProfile, null);
     assert.equal(options.realWalletCapable, true);
     assert.equal(options.syntheticOnly, false);
     assert.equal(options.stripePublishableKey, 'pk_test_real_fixture');

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -168,6 +168,10 @@ try {
     ece_scenario_profile: scenario.profile,
     ece_interaction: scenario.interaction,
     browser_profile: profileOptions.profile,
+    browser_profile_label: profileOptions.profileLabel,
+    browser_profile_caveat: profileOptions.profileCaveat,
+    browser_wait_for: profileOptions.waitFor || scenario.waitFor || 'networkidle',
+    browser_throttle_profile: profileOptions.throttleProfile,
     real_wallet_capable: profileOptions.realWalletCapable,
     synthetic_only: profileOptions.syntheticOnly,
   });
@@ -581,6 +585,12 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   });
 
   const metrics = {
+    browser_profile: profileOptions.profile,
+    browser_profile_label: profileOptions.profileLabel,
+    browser_profile_caveat: profileOptions.profileCaveat,
+    browser_profile_conclusion: profileOptions.profileConclusion,
+    browser_wait_for: profileOptions.waitFor || scenario.waitFor || 'networkidle',
+    browser_throttle_profile: profileOptions.throttleProfile,
     network_response_count: responses.length,
     stripe_response_count: stripeUrls.length,
     google_response_count: googleUrls.length,
@@ -662,9 +672,14 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
           description: scenario.description,
         },
         browser_profile: profileOptions.profile,
+        browser_profile_label: profileOptions.profileLabel,
+        browser_profile_caveat: profileOptions.profileCaveat,
+        browser_profile_conclusion: profileOptions.profileConclusion,
         requested_browser_context: {
           viewport,
           browser_profile: profileOptions.profile,
+          wait_for: profileOptions.waitFor || scenario.waitFor || 'networkidle',
+          throttle_profile: profileOptions.throttleProfile,
           runtime_preview: profileOptions.runtimePreview,
           browser_probe_args: profileOptions.browserProbeArgs,
           secure_context_profile: ['secure-browser', 'real-wallet'].includes(profileOptions.profile),

--- a/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
+++ b/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
@@ -20,7 +20,31 @@ https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1439.
 
 The default `smoke` profile preserves the existing WP Codebox browser-probe
 defaults: local Playground origin, default Chromium context, and the rig's fixed
-`1366x900` viewport.
+`1366x900` viewport. Use it for rig health only, not for browser performance
+conclusions.
+
+The product-page waterfall rig now has a small browser performance profile
+matrix. Generated `ece-waterfall-metrics.json` and `ece-waterfall-metadata.json`
+preserve the selected profile name, label, caveat, conclusion scope, wait mode,
+and throttle profile so downstream reports can carry the right labels without a
+Homeboy core reporting change.
+
+| Profile | Wait | Throttle | Supports | Caveat |
+| --- | --- | --- | --- | --- |
+| `webperf-desktop-load` | `load` | none | Normal-ish desktop LCP/FCP/TTFB/load/navigation timing shape. | Use for non-throttled absolute load context, not stable synthetic fan-out deltas. |
+| `webperf-desktop-slow-4g` | `load` | `low-end-mobile-slow-4g` | Stable synthetic third-party response fan-out and relative waterfall deltas. | Desktop rendering is intentionally paired with a slow synthetic throttle; do not present these as normal desktop absolute timings. |
+
+Set `woocommerce_stripe_ece_browser_profile=webperf-desktop-load` to keep the
+desktop browser context without synthetic CPU/network throttling. This profile
+waits for `load` and then records the configured probe duration so LCP/FCP/TTFB,
+load, and navigation metrics remain visible without relying on `networkidle`.
+
+```bash
+homeboy trace --rig woocommerce-stripe-ece-product-page \
+  --setting woocommerce_stripe_ece_browser_profile=webperf-desktop-load \
+  woocommerce-gateway-stripe ece-product-page-waterfall \
+  --output /tmp/wc-stripe-ece-desktop-load.json
+```
 
 Set `woocommerce_stripe_ece_browser_profile=webperf-desktop-slow-4g` to keep
 the desktop browser context used by the synthetic ECE fixture while applying WP
@@ -117,6 +141,10 @@ The stable signals are structural:
 - JS event listener count.
 - DOM node count.
 - Long-task count and total duration.
+- Browser profile identity and caveats: `browser_profile`,
+  `browser_profile_label`, `browser_profile_caveat`,
+  `browser_profile_conclusion`, `browser_wait_for`, and
+  `browser_throttle_profile`.
 - WP Codebox web performance metrics when available: `browser_ttfb_ms`,
   `browser_fcp_ms`, `browser_lcp_ms`, and `browser_nav_duration_ms`.
 - Real-wallet evidence classification: `ece_real_wallet_capable` and

--- a/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
+++ b/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
@@ -258,6 +258,18 @@
     "smoke": {
       "scenario": "ece-product-page-waterfall"
     },
+    "webperf-desktop-load": {
+      "scenario": "ece-product-page-waterfall",
+      "settings": {
+        "woocommerce_stripe_ece_browser_profile": "webperf-desktop-load"
+      }
+    },
+    "webperf-desktop-slow-4g": {
+      "scenario": "ece-product-page-waterfall",
+      "settings": {
+        "woocommerce_stripe_ece_browser_profile": "webperf-desktop-slow-4g"
+      }
+    },
     "secure-browser": {
       "scenario": "ece-product-page-waterfall",
       "settings": {


### PR DESCRIPTION
## Summary
- Adds a non-throttled `webperf-desktop-load` trace profile for the Woo Stripe ECE product-page waterfall rig.
- Preserves `webperf-desktop-slow-4g` as the deterministic throttled profile for stable synthetic third-party fan-out deltas.
- Carries profile name, label, caveat, conclusion scope, wait mode, and throttle profile into waterfall metrics/metadata and docs.

Closes #196.

## Verification
- `node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`
- `git diff --check`

## Dry-run caveat
- Full local browser dry-run was not practical in this session because the local Stripe checkout fixture `tests/benchmarks/fixture-bootstrap.php` was missing, and Homeboy lab offload hit the known runner daemon null-exec fallback before the local warm-machine guard. I avoided forcing a full local performance run because that would produce noisy evidence.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the rig/profile/docs/test changes and ran local verification; Chris remains responsible for review and merge.