### PR TITLE
Harden WooCommerce checkout duplicate order proof

### DIFF
--- a/woocommerce/woocommerce/bench/checkout-concurrent-create-order.php
+++ b/woocommerce/woocommerce/bench/checkout-concurrent-create-order.php
@@ -143,8 +143,14 @@ return function (): array {
 
 	$checkout = WC()->checkout();
 	$before   = microtime( true );
-	$order_id_1 = $checkout->create_order( $data );
-	$order_id_2 = $checkout->create_order( $data );
+	$unexpected_output = '';
+	ob_start();
+	try {
+		$order_id_1 = $checkout->create_order( $data );
+		$order_id_2 = $checkout->create_order( $data );
+	} finally {
+		$unexpected_output = (string) ob_get_clean();
+	}
 	$elapsed_ms = ( microtime( true ) - $before ) * 1000;
 
 	if ( is_wp_error( $order_id_1 ) ) {
@@ -157,7 +163,11 @@ return function (): array {
 	$order_ids = array_map( 'absint', array( $order_id_1, $order_id_2 ) );
 	$orders    = array_filter( array_map( 'wc_get_order', $order_ids ) );
 	$unique_order_ids = array_values( array_unique( $order_ids ) );
+	$unique_orders    = array_filter( array_map( 'wc_get_order', $unique_order_ids ) );
+	$main_order       = wc_get_order( $order_ids[0] );
 	$duplicate_created = count( $unique_order_ids ) > 1 ? 1 : 0;
+	$main_order_item_count = $main_order instanceof WC_Order ? count( $main_order->get_items() ) : 0;
+	$main_order_total      = $main_order instanceof WC_Order ? (float) $main_order->get_total() : 0;
 
 	$artifact = array(
 		'run_id'             => $run_id,
@@ -169,6 +179,7 @@ return function (): array {
 		'order_ids'          => $order_ids,
 		'unique_order_ids'   => $unique_order_ids,
 		'duplicate_created'  => (bool) $duplicate_created,
+		'unexpected_output'  => $unexpected_output,
 		'orders'             => array_map(
 			static function ( WC_Order $order ): array {
 				return array(
@@ -189,9 +200,23 @@ return function (): array {
 		'order_create_attempts'      => 2,
 		'unique_order_count'         => count( $unique_order_ids ),
 		'duplicate_order_count'      => max( 0, count( $unique_order_ids ) - 1 ),
+		'second_attempt_reused_first_order' => $order_ids[0] === $order_ids[1] ? 1 : 0,
+		'main_order_succeeded'       => $main_order instanceof WC_Order ? 1 : 0,
+		'main_order_item_count'      => $main_order_item_count,
+		'main_order_total'           => $main_order_total,
+		'unexpected_output_detected' => '' === $unexpected_output ? 0 : 1,
+		'unexpected_output_bytes'    => strlen( $unexpected_output ),
 		'elapsed_ms'                 => $elapsed_ms,
 		'cart_items'                 => WC()->cart->get_cart_contents_count(),
 		'cart_total'                 => (float) WC()->cart->get_total( 'edit' ),
+		'unique_same_cart_hash_order_count' => count(
+			array_filter(
+				$unique_orders,
+				static function ( WC_Order $order ) use ( $cart_hash ): bool {
+					return $order->get_cart_hash() === $cart_hash;
+				}
+			)
+		),
 		'same_cart_hash_order_count' => count(
 			array_filter(
 				$orders,


### PR DESCRIPTION
## Summary
- Buffers unexpected non-fatal output during the duplicate-order create attempts so the bench result stays parseable.
- Adds explicit proof metrics for main order success, item count, total, same-cart unique order count, and whether the second attempt reused the first order.
- Preserves the existing duplicate repro metrics for before/after comparisons.

## Evidence
Using this hardened workload:

| Run | WooCommerce branch | Result |
| --- | --- | --- |
| `d86e2656-6153-4cac-b189-5de42e5035f6` | trunk baseline | `duplicate_reproduced=1`, `unique_order_count=2`, `main_order_succeeded=1`, `main_order_item_count=1`, `main_order_total=19.99` |
| `b307bc94-8f5b-4a71-b90e-312c4cdebc1e` | checkout idempotency candidate | `duplicate_reproduced=0`, `unique_order_count=1`, `second_attempt_reused_first_order=1`, `main_order_succeeded=1`, `main_order_item_count=1`, `main_order_total=19.99` |

## Verification
- `php -l woocommerce/woocommerce/bench/checkout-concurrent-create-order.php`
- Baseline and candidate Homeboy Lab bench runs above both completed with `status=passed`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Hardened the checkout duplicate-order workload metrics and captured before/after evidence; Chris remains responsible for review and submission.