### PR TITLE
Sample Studio many-sites benchmark memory phases

### DIFF
--- a/Automattic/studio/bench/studio-many-sites-memory-scroll.bench.mjs
+++ b/Automattic/studio/bench/studio-many-sites-memory-scroll.bench.mjs
@@ -1,6 +1,6 @@
 import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { spawn } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 
 import {
   STUDIO_PATH,
@@ -14,6 +14,87 @@ import {
 
 const RUNNING_MODES = new Set(['all-stopped', 'half-running', 'all-running']);
 const RUNTIMES = new Set(['playground', 'native-php']);
+
+function processRows() {
+  if (process.platform === 'win32') {
+    return [];
+  }
+
+  try {
+    return execFileSync('ps', ['-axo', 'pid=,ppid=,rss=,comm='], { encoding: 'utf8' })
+      .trim()
+      .split('\n')
+      .map((line) => {
+        const match = line.trim().match(/^(\d+)\s+(\d+)\s+(\d+)\s+(.+)$/);
+        if (!match) {
+          return null;
+        }
+        return {
+          pid: Number.parseInt(match[1], 10),
+          ppid: Number.parseInt(match[2], 10),
+          rssKb: Number.parseInt(match[3], 10),
+          command: match[4],
+        };
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function summarizeProcessTree(rootPid) {
+  const rows = processRows();
+  if (!rows.length) {
+    return { process_count: 0, total_rss_mb: 0, groups: {} };
+  }
+
+  const children = new Map();
+  for (const row of rows) {
+    const list = children.get(row.ppid) || [];
+    list.push(row.pid);
+    children.set(row.ppid, list);
+  }
+
+  const seen = new Set([rootPid]);
+  const queue = [rootPid];
+  while (queue.length) {
+    const pid = queue.shift();
+    for (const childPid of children.get(pid) || []) {
+      if (!seen.has(childPid)) {
+        seen.add(childPid);
+        queue.push(childPid);
+      }
+    }
+  }
+
+  const groups = {};
+  let totalRssKb = 0;
+  for (const row of rows) {
+    if (!seen.has(row.pid)) {
+      continue;
+    }
+    totalRssKb += row.rssKb;
+    const command = path.basename(row.command).toLowerCase();
+    const group = command.includes('electron') || command.includes('studio') ? 'electron' : command || 'unknown';
+    groups[group] = (groups[group] || 0) + row.rssKb;
+  }
+
+  return {
+    process_count: seen.size,
+    total_rss_mb: Math.round(totalRssKb / 1024),
+    groups: Object.fromEntries(
+      Object.entries(groups)
+        .sort(([, a], [, b]) => b - a)
+        .map(([group, rssKb]) => [group, Math.round(rssKb / 1024)])
+    ),
+  };
+}
+
+function peakRss(samples, phase) {
+  return samples
+    .filter((sample) => !phase || sample.phase === phase)
+    .reduce((peak, sample) => Math.max(peak, sample.total_rss_mb || 0), 0);
+}
 
 function boolSetting(name, defaultValue) {
   const value = String(setting(name) || '').trim().toLowerCase();
@@ -47,6 +128,23 @@ function runCommand(command, args, options = {}) {
       env: { ...process.env, ...(options.env || {}) },
     });
 
+    const sampleMemory = () => {
+      if (!options.memorySamples || !options.memoryLabel) {
+        return;
+      }
+      options.memorySamples.push({
+        elapsed_ms: Date.now() - options.startedAt,
+        phase: options.memoryLabel,
+        root_pid: child.pid,
+        ...summarizeProcessTree(child.pid),
+      });
+    };
+
+    sampleMemory();
+    const memoryTimer = options.memorySamples
+      ? setInterval(sampleMemory, intSetting('many_sites_memory_sample_interval_ms', 1000))
+      : undefined;
+
     const timer = options.timeoutMs
       ? setTimeout(() => {
           if (settled) {
@@ -54,6 +152,9 @@ function runCommand(command, args, options = {}) {
           }
           settled = true;
           child.kill('SIGKILL');
+          if (memoryTimer) {
+            clearInterval(memoryTimer);
+          }
           reject(
             new Error(
               `${command} ${args.join(' ')} timed out after ${options.timeoutMs}ms; stdout=${redact(stdout).slice(
@@ -74,6 +175,9 @@ function runCommand(command, args, options = {}) {
       if (timer) {
         clearTimeout(timer);
       }
+      if (memoryTimer) {
+        clearInterval(memoryTimer);
+      }
       reject(error);
     });
     child.on('close', (code) => {
@@ -83,6 +187,10 @@ function runCommand(command, args, options = {}) {
       settled = true;
       if (timer) {
         clearTimeout(timer);
+      }
+      sampleMemory();
+      if (memoryTimer) {
+        clearInterval(memoryTimer);
       }
       resolve({ code, stdout, stderr, elapsedMs: Date.now() - started });
     });
@@ -124,16 +232,24 @@ export default async function studioManySitesMemoryScrollBench() {
   const artifactDir = path.join(studioArtifactDir('studio-many-sites-memory-scroll-artifacts'), runId);
   const resultFile = path.join(artifactDir, 'many-sites.results.json');
   const rawResultFile = path.join(artifactDir, `result-${runId}.json`);
+  const memoryTimelineFile = path.join(artifactDir, `memory-timeline-${runId}.json`);
   await mkdir(artifactDir, { recursive: true });
 
   await assertManySitesHarnessExists();
 
   const started = Date.now();
+  const memorySamples = [];
+  const phaseEvents = [{ phase: 'start', elapsed_ms: 0 }];
   let installResult = null;
   if (shouldInstall) {
+    phaseEvents.push({ phase: 'before_install', elapsed_ms: Date.now() - started });
     installResult = await runCommand('npm', ['install'], {
       timeoutMs: intSetting('many_sites_install_timeout_ms', 1200000),
+      memoryLabel: 'install',
+      memorySamples,
+      startedAt: started,
     });
+    phaseEvents.push({ phase: 'after_install', elapsed_ms: Date.now() - started });
     if (installResult.code !== 0) {
       await writeFile(
         rawResultFile,
@@ -145,9 +261,14 @@ export default async function studioManySitesMemoryScrollBench() {
 
   let packageResult = null;
   if (shouldPackage) {
+    phaseEvents.push({ phase: 'before_package', elapsed_ms: Date.now() - started });
     packageResult = await runCommand('npm', ['run', 'package'], {
       timeoutMs: intSetting('many_sites_package_timeout_ms', 1200000),
+      memoryLabel: 'package',
+      memorySamples,
+      startedAt: started,
     });
+    phaseEvents.push({ phase: 'after_package', elapsed_ms: Date.now() - started });
     if (packageResult.code !== 0) {
       await writeFile(
         rawResultFile,
@@ -157,11 +278,15 @@ export default async function studioManySitesMemoryScrollBench() {
     }
   }
 
+  phaseEvents.push({ phase: 'before_playwright_test', elapsed_ms: Date.now() - started });
   const testResult = await runCommand(
     'npx',
     ['playwright', 'test', '--config=./tools/metrics/playwright.metrics.config.ts', 'tools/metrics/tests/many-sites.test.ts'],
     {
       timeoutMs: intSetting('many_sites_test_timeout_ms', 600000),
+      memoryLabel: 'playwright_test',
+      memorySamples,
+      startedAt: started,
       env: {
         ARTIFACTS_PATH: artifactDir,
         RESULTS_ID: 'many-sites',
@@ -173,9 +298,31 @@ export default async function studioManySitesMemoryScrollBench() {
       },
     }
   );
+  phaseEvents.push({ phase: 'after_playwright_test', elapsed_ms: Date.now() - started });
   const totalElapsedMs = Date.now() - started;
   const results = await readJsonIfPresent(resultFile);
   const passed = testResult.code === 0 && Boolean(results);
+
+  await writeFile(
+    memoryTimelineFile,
+    JSON.stringify(
+      {
+        variant: currentVariant,
+        studioPath: STUDIO_PATH,
+        matrix: {
+          site_count: siteCount,
+          icon_size_kb: iconSizeKb,
+          running_mode: runningMode,
+          runtime,
+        },
+        sample_interval_ms: intSetting('many_sites_memory_sample_interval_ms', 1000),
+        phases: phaseEvents,
+        samples: memorySamples,
+      },
+      null,
+      2
+    )
+  );
 
   await writeFile(
     rawResultFile,
@@ -194,6 +341,14 @@ export default async function studioManySitesMemoryScrollBench() {
           package_ms: metric(packageResult?.elapsedMs),
           test_ms: metric(testResult.elapsedMs),
           total_elapsed_ms: totalElapsedMs,
+        },
+        memory_timeline: {
+          file: memoryTimelineFile,
+          peak_install_rss_mb: peakRss(memorySamples, 'install'),
+          peak_package_rss_mb: peakRss(memorySamples, 'package'),
+          peak_playwright_test_rss_mb: peakRss(memorySamples, 'playwright_test'),
+          peak_total_rss_mb: peakRss(memorySamples),
+          sample_count: memorySamples.length,
         },
         commands: {
           install: installResult ? safeResult(installResult) : null,
@@ -229,9 +384,14 @@ export default async function studioManySitesMemoryScrollBench() {
       package_ms: metric(packageResult?.elapsedMs),
       test_ms: metric(testResult.elapsedMs),
       total_elapsed_ms: totalElapsedMs,
+      peak_install_rss_mb: peakRss(memorySamples, 'install'),
+      peak_package_rss_mb: peakRss(memorySamples, 'package'),
+      peak_playwright_test_rss_mb: peakRss(memorySamples, 'playwright_test'),
+      peak_workload_rss_mb: peakRss(memorySamples),
     },
     artifacts: {
       raw_result: rawResultFile,
+      memory_timeline: memoryTimelineFile,
       metrics_result: resultFile,
       screenshot_top: path.join(artifactDir, 'many-sites-top.png'),
       screenshot_bottom: path.join(artifactDir, 'many-sites-bottom.png'),

--- a/Automattic/studio/rigs/studio-many-sites-memory-scroll/rig.json
+++ b/Automattic/studio/rigs/studio-many-sites-memory-scroll/rig.json
@@ -12,7 +12,8 @@
             "many_sites_count": "1000",
             "many_sites_icon_kb": "64",
             "many_sites_running_mode": "all-stopped",
-            "many_sites_runtime": "playground"
+            "many_sites_runtime": "playground",
+            "many_sites_memory_sample_interval_ms": "1000"
           }
         }
       }

--- a/README.md
+++ b/README.md
@@ -100,7 +100,30 @@ homeboy bench --rig studio-many-sites-memory-scroll \
   --shared-state /tmp/studio-many-sites
 ```
 
-Useful settings include `many_sites_count`, `many_sites_icon_kb`, `many_sites_running_mode` (`all-stopped`, `half-running`, or `all-running`), `many_sites_runtime` (`playground` or `native-php`), `many_sites_install=0`, and `many_sites_package=0`.
+Useful settings include `many_sites_count`, `many_sites_icon_kb`, `many_sites_running_mode` (`all-stopped`, `half-running`, or `all-running`), `many_sites_runtime` (`playground` or `native-php`), `many_sites_install=0`, `many_sites_package=0`, and `many_sites_memory_sample_interval_ms`.
+
+This rig intentionally incubates memory attribution before promoting anything upstream: the workload writes a `memory_timeline` artifact with phase markers for install, package, and Playwright execution plus process-tree RSS samples grouped by command. The Studio Playwright harness still owns app-specific phase metrics such as launch, bottom-scroll, and stress-scroll RSS; the rig-level timeline helps decide whether future generic process-memory helpers belong in Homeboy Extensions.
+
+Suggested comparison matrix for a suspected many-sites regression:
+
+```bash
+# Fast runtime-only default proof after the app has already been packaged.
+homeboy bench --rig studio-many-sites-memory-scroll \
+  --scenario studio-many-sites-memory-scroll \
+  --setting many_sites_install=0 \
+  --setting many_sites_package=0 \
+  --iterations 1 \
+  --shared-state /tmp/studio-many-sites
+
+# Heavier running-site metadata control without actually starting 1000 servers.
+homeboy bench --rig studio-many-sites-memory-scroll \
+  --scenario studio-many-sites-memory-scroll \
+  --setting many_sites_running_mode=half-running \
+  --setting many_sites_install=0 \
+  --setting many_sites_package=0 \
+  --iterations 1 \
+  --shared-state /tmp/studio-many-sites
+```
 
 `studio-site-editor-preload-diagnostics` injects a focused set of Site Editor REST preloads into a fresh Studio site's `site-editor.php`, loads the Site Editor once, and reports whether watched routes were satisfied from preload/cache or still reached the network. The artifact includes the page profiler's `restWaterfall.preloadDiagnostics` rows so remaining network requests are classified by likely cause, such as `_locale` query mismatches, fetch-all `per_page` rewrites, duplicate/single-use cache consumption, or no matching preload. Set `HOMEBOY_SITE_EDITOR_PRELOAD_DIAGNOSTICS_EXACT_VISIBLE=1` to add exact visible `_locale=user` route variants alongside the default probe preloads.
 


### PR DESCRIPTION
## Summary
- Add rig-level process-tree RSS sampling for the `studio-many-sites-memory-scroll` workload.
- Write a `memory_timeline` artifact with install/package/Playwright phase markers and grouped RSS samples.
- Document the rig-as-incubator memory attribution path before promoting generic helpers to Homeboy Extensions.

## Related PRs
- Builds on the durable rig added in https://github.com/chubes4/homeboy-rigs/pull/207
- Supports the Studio many-sites fix and evidence path in https://github.com/Automattic/studio/pull/3736

## Verification
- `node --check Automattic/studio/bench/studio-many-sites-memory-scroll.bench.mjs`
- `node -e 'JSON.parse(require("fs").readFileSync("Automattic/studio/rigs/studio-many-sites-memory-scroll/rig.json", "utf8")); console.log("rig json ok")'`
- `node scripts/lint-rig-packages.mjs`
- `HOMEBOY_COMPONENT_PATH=/Users/chubes/Developer/studio HOMEBOY_BENCH_SHARED_STATE=/tmp node -e 'import("./Automattic/studio/bench/studio-many-sites-memory-scroll.bench.mjs").then(() => console.log("bench import ok"))'`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Adding rig-level phase memory sampling, documenting the incubation path, and running local validation. Chris remains responsible for review and merge.