### PR TITLE
Rely on upstream rig helper primitives

### DIFF
--- a/Automattic/studio/bench/lib/visual-fidelity.mjs
+++ b/Automattic/studio/bench/lib/visual-fidelity.mjs
@@ -1,42 +1,36 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { createRequire } from 'node:module';
-import zlib from 'node:zlib';
 
 import { STUDIO_PATH } from './studio-bench.mjs';
-import { asArray, comparisonTargets, safeSlug, stringArray, surfaceUrl } from './fidelity-targets.mjs';
 import { loadWordPressLibHelper } from './wordpress-helper-discovery.mjs';
 
 const requireFromBench = createRequire(import.meta.url);
 export const VISUAL_VIEWPORT = { width: 1440, height: 1100 };
 const VISUAL_SCREENSHOT_DIAGNOSTIC_LIMIT = 5;
 const VISUAL_PIXELMATCH_THRESHOLD = 0.1;
-const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+function loadFidelityComparisonHelper() {
+  const { module } = loadWordPressLibHelper('fidelity-comparison.js');
+  if (!module) {
+    throw new Error('Homeboy WordPress fidelity comparison helper is unavailable. Update homeboy-extensions or set HOMEBOY_WORDPRESS_HELPER_MANIFEST.');
+  }
+  return module;
+}
+
+function comparisonTargets(importReport) {
+  return loadFidelityComparisonHelper().comparisonTargets(importReport);
+}
+
+function safeSlug(value, fallback) {
+  return loadFidelityComparisonHelper().safeSlug(value, fallback);
+}
+
+function surfaceUrl(target, surface, reportPath, sitePath) {
+  return loadFidelityComparisonHelper().surfaceUrl(target, surface, reportPath, sitePath);
+}
 
 function visualProbeGroups(target) {
-  const hooks = target?.comparison_hooks || {};
-  const layoutProbes = hooks.layout_probes && typeof hooks.layout_probes === 'object' ? hooks.layout_probes : {};
-  const groups = [];
-  const seen = new Set();
-
-  function add(name, selectors) {
-    const normalizedSelectors = stringArray(selectors);
-    if (!normalizedSelectors.length || seen.has(name)) {
-      return;
-    }
-    seen.add(name);
-    groups.push({ name, selectors: normalizedSelectors });
-  }
-
-  for (const [name, probe] of Object.entries(layoutProbes)) {
-    add(name, probe?.selectors);
-  }
-
-  add('hero_probe', hooks.hero);
-  add('visible_chrome', hooks.visible_chrome);
-  add('footer_chrome', ['footer', '.site-footer', '[class*=footer]']);
-
-  return groups;
+  return loadFidelityComparisonHelper().visualProbeGroups(target);
 }
 
 export async function loadVisualSurface(page, url) {
@@ -68,157 +62,11 @@ async function evaluateVisualSurface(page, groups) {
 }
 
 function visualSurfaceTotals(groups) {
-  return groups.reduce(
-    (totals, group) => {
-      totals.selector_count += group.selector_count;
-      totals.missing_selector_count += group.missing_selector_count;
-      totals.errored_selector_count += group.errored_selector_count;
-      totals.matched_selector_count += group.matched_selector_count;
-      totals.visible_selector_count += group.visible_selector_count;
-      totals.nonzero_bounding_box_selector_count += group.nonzero_bounding_box_selector_count;
-      return totals;
-    },
-    {
-      selector_count: 0,
-      missing_selector_count: 0,
-      errored_selector_count: 0,
-      matched_selector_count: 0,
-      visible_selector_count: 0,
-      nonzero_bounding_box_selector_count: 0,
-    }
-  );
-}
-
-function visualSelectorSummary(selector) {
-  const firstMatch = selector?.first_match || null;
-  return {
-    count: Number(selector?.count || 0),
-    visible_count: Number(selector?.visible_count || 0),
-    nonzero_bounding_box_count: Number(selector?.nonzero_bounding_box_count || 0),
-    first_bounding_box: firstMatch?.boundingBox || null,
-    first_visible: firstMatch?.visible === true,
-    first_visible_text: firstMatch?.text || '',
-    error: selector?.error || '',
-  };
-}
-
-function visualMismatchReason(sourceSelector, frontendSelector) {
-  if (sourceSelector?.error || frontendSelector?.error) {
-    return 'selector_error';
-  }
-  if (sourceSelector.visible_count === 0 && frontendSelector.visible_count === 0) {
-    return 'missing_on_both_surfaces';
-  }
-  if (sourceSelector.count === 0 && frontendSelector.count === 0) {
-    return 'missing_on_both_surfaces';
-  }
-  if (sourceSelector.count === 0) {
-    return 'missing_from_source_static';
-  }
-  if (frontendSelector.count === 0) {
-    return 'missing_from_wordpress_frontend';
-  }
-
-  const sourceVisible = sourceSelector.visible_count > 0;
-  const frontendVisible = frontendSelector.visible_count > 0;
-  if (sourceVisible !== frontendVisible) {
-    return sourceVisible ? 'hidden_on_wordpress_frontend' : 'hidden_on_source_static';
-  }
-
-  const sourceNonzero = sourceSelector.nonzero_bounding_box_count > 0;
-  const frontendNonzero = frontendSelector.nonzero_bounding_box_count > 0;
-  if (sourceNonzero !== frontendNonzero) {
-    return sourceNonzero ? 'zero_sized_on_wordpress_frontend' : 'zero_sized_on_source_static';
-  }
-
-  return '';
-}
-
-function visualMismatchSeverity(reason) {
-  const severities = {
-    selector_error: 100,
-    missing_from_wordpress_frontend: 90,
-    missing_from_source_static: 80,
-    hidden_on_wordpress_frontend: 60,
-    hidden_on_source_static: 50,
-    zero_sized_on_wordpress_frontend: 40,
-    zero_sized_on_source_static: 30,
-  };
-  return severities[reason] || 0;
-}
-
-function visualGroupMismatchSummary(groupName, mismatches) {
-  const reasons = {};
-  for (const mismatch of mismatches) {
-    reasons[mismatch.reason] = (reasons[mismatch.reason] || 0) + 1;
-  }
-  return {
-    group: groupName,
-    mismatch_count: mismatches.length,
-    reasons,
-    top_selectors: mismatches.slice(0, 5).map((mismatch) => ({
-      selector: mismatch.selector,
-      reason: mismatch.reason,
-      source_count: mismatch.source.count,
-      frontend_count: mismatch.frontend.count,
-      source_visible_count: mismatch.source.visible_count,
-      frontend_visible_count: mismatch.frontend.visible_count,
-    })),
-  };
-}
-
-function visualSelectorComparisonDetail(sourceGroup, sourceSelector, frontendSelector, reason) {
-  return {
-    group: sourceGroup.name,
-    selector: sourceSelector.selector,
-    reason,
-    severity: visualMismatchSeverity(reason),
-    source: visualSelectorSummary(sourceSelector),
-    frontend: visualSelectorSummary(frontendSelector),
-    screenshots: {},
-  };
+  return loadFidelityComparisonHelper().visualSurfaceTotals(groups);
 }
 
 function visualSelectorComparisonDetails(result) {
-  const sourceGroups = result.surfaces.source_static?.probes || [];
-  const frontendGroups = result.surfaces.wordpress_frontend?.probes || [];
-  const frontendGroupsByName = new Map(frontendGroups.map((group) => [group.name, group]));
-  const mismatches = [];
-  const optionalProbeAbsences = [];
-
-  for (const sourceGroup of sourceGroups) {
-    const frontendGroup = frontendGroupsByName.get(sourceGroup.name);
-    if (!frontendGroup) {
-      continue;
-    }
-
-    const frontendSelectors = new Map(frontendGroup.selectors.map((selector) => [selector.selector, selector]));
-    for (const sourceSelector of sourceGroup.selectors) {
-      const frontendSelector = frontendSelectors.get(sourceSelector.selector);
-      if (!frontendSelector) {
-        continue;
-      }
-
-      const reason = visualMismatchReason(sourceSelector, frontendSelector);
-      if (!reason) {
-        continue;
-      }
-
-      const detail = visualSelectorComparisonDetail(sourceGroup, sourceSelector, frontendSelector, reason);
-      if (reason === 'missing_on_both_surfaces') {
-        optionalProbeAbsences.push(detail);
-        continue;
-      }
-
-      mismatches.push(detail);
-    }
-  }
-
-  mismatches.sort(
-    (a, b) => b.severity - a.severity || a.group.localeCompare(b.group) || a.selector.localeCompare(b.selector)
-  );
-  optionalProbeAbsences.sort((a, b) => a.group.localeCompare(b.group) || a.selector.localeCompare(b.selector));
-  return { mismatches, optionalProbeAbsences };
+  return loadFidelityComparisonHelper().visualSelectorComparisonDetails(result);
 }
 
 async function captureSelectorScreenshot(page, selector, screenshotPath) {
@@ -234,227 +82,8 @@ async function captureSelectorScreenshot(page, selector, screenshotPath) {
   }
 }
 
-function crc32(buffer) {
-  if (!crc32.table) {
-    crc32.table = Array.from({ length: 256 }, (_, index) => {
-      let value = index;
-      for (let bit = 0; bit < 8; bit++) {
-        value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
-      }
-      return value >>> 0;
-    });
-  }
-
-  let crc = 0xffffffff;
-  for (const byte of buffer) {
-    crc = crc32.table[(crc ^ byte) & 0xff] ^ (crc >>> 8);
-  }
-  return (crc ^ 0xffffffff) >>> 0;
-}
-
-function pngChunk(type, data = Buffer.alloc(0)) {
-  const typeBuffer = Buffer.from(type, 'ascii');
-  const chunk = Buffer.concat([typeBuffer, data]);
-  const output = Buffer.alloc(12 + data.length);
-  output.writeUInt32BE(data.length, 0);
-  typeBuffer.copy(output, 4);
-  data.copy(output, 8);
-  output.writeUInt32BE(crc32(chunk), 8 + data.length);
-  return output;
-}
-
-function decodePng(buffer) {
-  if (!buffer.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)) {
-    throw new Error('Unsupported PNG signature.');
-  }
-
-  let offset = PNG_SIGNATURE.length;
-  let width = 0;
-  let height = 0;
-  let bitDepth = 0;
-  let colorType = 0;
-  const idat = [];
-
-  while (offset < buffer.length) {
-    const length = buffer.readUInt32BE(offset);
-    const type = buffer.toString('ascii', offset + 4, offset + 8);
-    const data = buffer.subarray(offset + 8, offset + 8 + length);
-    offset += 12 + length;
-
-    if (type === 'IHDR') {
-      width = data.readUInt32BE(0);
-      height = data.readUInt32BE(4);
-      bitDepth = data[8];
-      colorType = data[9];
-    } else if (type === 'IDAT') {
-      idat.push(data);
-    } else if (type === 'IEND') {
-      break;
-    }
-  }
-
-  if (bitDepth !== 8 || ![0, 2, 4, 6].includes(colorType)) {
-    throw new Error(`Unsupported PNG format: bitDepth=${bitDepth} colorType=${colorType}.`);
-  }
-
-  const channels = { 0: 1, 2: 3, 4: 2, 6: 4 }[colorType];
-  const bytesPerPixel = channels;
-  const stride = width * channels;
-  const inflated = zlib.inflateSync(Buffer.concat(idat));
-  const data = new Uint8ClampedArray(width * height * 4);
-  let inputOffset = 0;
-  let previous = Buffer.alloc(stride);
-
-  for (let y = 0; y < height; y++) {
-    const filter = inflated[inputOffset++];
-    const row = Buffer.from(inflated.subarray(inputOffset, inputOffset + stride));
-    inputOffset += stride;
-
-    for (let x = 0; x < stride; x++) {
-      const left = x >= bytesPerPixel ? row[x - bytesPerPixel] : 0;
-      const up = previous[x] || 0;
-      const upperLeft = x >= bytesPerPixel ? previous[x - bytesPerPixel] || 0 : 0;
-      let value = row[x];
-
-      if (filter === 1) {
-        value += left;
-      } else if (filter === 2) {
-        value += up;
-      } else if (filter === 3) {
-        value += Math.floor((left + up) / 2);
-      } else if (filter === 4) {
-        const p = left + up - upperLeft;
-        const pa = Math.abs(p - left);
-        const pb = Math.abs(p - up);
-        const pc = Math.abs(p - upperLeft);
-        value += pa <= pb && pa <= pc ? left : pb <= pc ? up : upperLeft;
-      } else if (filter !== 0) {
-        throw new Error(`Unsupported PNG row filter: ${filter}.`);
-      }
-
-      row[x] = value & 0xff;
-    }
-
-    for (let x = 0; x < width; x++) {
-      const source = x * channels;
-      const target = (y * width + x) * 4;
-      if (colorType === 0) {
-        data[target] = row[source];
-        data[target + 1] = row[source];
-        data[target + 2] = row[source];
-        data[target + 3] = 255;
-      } else if (colorType === 2) {
-        data[target] = row[source];
-        data[target + 1] = row[source + 1];
-        data[target + 2] = row[source + 2];
-        data[target + 3] = 255;
-      } else if (colorType === 4) {
-        data[target] = row[source];
-        data[target + 1] = row[source];
-        data[target + 2] = row[source];
-        data[target + 3] = row[source + 1];
-      } else {
-        data[target] = row[source];
-        data[target + 1] = row[source + 1];
-        data[target + 2] = row[source + 2];
-        data[target + 3] = row[source + 3];
-      }
-    }
-
-    previous = row;
-  }
-
-  return { width, height, data };
-}
-
-function encodePng({ width, height, data }) {
-  const header = Buffer.alloc(13);
-  header.writeUInt32BE(width, 0);
-  header.writeUInt32BE(height, 4);
-  header[8] = 8;
-  header[9] = 6;
-
-  const rows = Buffer.alloc((width * 4 + 1) * height);
-  for (let y = 0; y < height; y++) {
-    const rowOffset = y * (width * 4 + 1);
-    rows[rowOffset] = 0;
-    Buffer.from(data.buffer, data.byteOffset + y * width * 4, width * 4).copy(rows, rowOffset + 1);
-  }
-
-  return Buffer.concat([
-    PNG_SIGNATURE,
-    pngChunk('IHDR', header),
-    pngChunk('IDAT', zlib.deflateSync(rows)),
-    pngChunk('IEND'),
-  ]);
-}
-
-function normalizePng(image, width, height) {
-  if (image.width === width && image.height === height) {
-    return image.data;
-  }
-
-  const normalized = new Uint8ClampedArray(width * height * 4);
-  normalized.fill(255);
-  for (let y = 0; y < image.height; y++) {
-    for (let x = 0; x < image.width; x++) {
-      const source = (y * image.width + x) * 4;
-      const target = (y * width + x) * 4;
-      normalized[target] = image.data[source];
-      normalized[target + 1] = image.data[source + 1];
-      normalized[target + 2] = image.data[source + 2];
-      normalized[target + 3] = image.data[source + 3];
-    }
-  }
-  return normalized;
-}
-
-function comparePixels(sourceData, targetData, diffData) {
-  let mismatched = 0;
-  for (let index = 0; index < sourceData.length; index += 4) {
-    const delta = Math.max(
-      Math.abs(sourceData[index] - targetData[index]),
-      Math.abs(sourceData[index + 1] - targetData[index + 1]),
-      Math.abs(sourceData[index + 2] - targetData[index + 2]),
-      Math.abs(sourceData[index + 3] - targetData[index + 3])
-    );
-
-    if (delta > 26) {
-      mismatched++;
-      diffData[index] = 255;
-      diffData[index + 1] = 0;
-      diffData[index + 2] = 0;
-      diffData[index + 3] = 255;
-    } else {
-      const gray = Math.round((sourceData[index] + sourceData[index + 1] + sourceData[index + 2]) / 3);
-      diffData[index] = gray;
-      diffData[index + 1] = gray;
-      diffData[index + 2] = gray;
-      diffData[index + 3] = 80;
-    }
-  }
-  return mismatched;
-}
-
 async function comparePngScreenshots(sourcePath, targetPath, diffPath) {
-  const sourceImage = decodePng(await readFile(sourcePath));
-  const targetImage = decodePng(await readFile(targetPath));
-  const width = Math.max(sourceImage.width, targetImage.width);
-  const height = Math.max(sourceImage.height, targetImage.height);
-  const sourceData = normalizePng(sourceImage, width, height);
-  const targetData = normalizePng(targetImage, width, height);
-  const diffData = new Uint8ClampedArray(width * height * 4);
-  const mismatchedPixels = comparePixels(sourceData, targetData, diffData);
-
-  await writeFile(diffPath, encodePng({ width, height, data: diffData }));
-  return {
-    diff_path: diffPath,
-    height,
-    mismatched_pixels: mismatchedPixels,
-    pixel_count: width * height,
-    ratio: width > 0 && height > 0 ? mismatchedPixels / (width * height) : 1,
-    width,
-  };
+  return loadFidelityComparisonHelper().comparePngScreenshots(sourcePath, targetPath, diffPath);
 }
 
 async function captureVisualMismatchScreenshots(browser, result, mismatches, visualDir, targetSlug) {
@@ -555,157 +184,11 @@ async function compareVisualScreenshots(sourcePath, frontendPath, diffPath) {
 }
 
 function buildVisualDiagnostics(results, artifactPath) {
-  const targetSummaries = [];
-  const allMismatches = [];
-  const allOptionalProbeAbsences = [];
-
-  for (const result of results) {
-    const mismatches = asArray(result.diagnostics?.mismatches);
-    const optionalProbeAbsences = asArray(result.diagnostics?.optional_probe_absences);
-    const byGroup = new Map();
-
-    for (const mismatch of mismatches) {
-      if (!byGroup.has(mismatch.group)) {
-        byGroup.set(mismatch.group, []);
-      }
-      byGroup.get(mismatch.group).push(mismatch);
-      allMismatches.push({
-        target: result.source_filename || String(result.wordpress_page_id || ''),
-        ...mismatch,
-      });
-    }
-
-    for (const absence of optionalProbeAbsences) {
-      allOptionalProbeAbsences.push({
-        target: result.source_filename || String(result.wordpress_page_id || ''),
-        ...absence,
-      });
-    }
-
-    targetSummaries.push({
-      source_filename: result.source_filename || '',
-      wordpress_page_id: result.wordpress_page_id || null,
-      mismatch_count: mismatches.length,
-      optional_probe_absent_count: optionalProbeAbsences.length,
-      top_failing_groups: [...byGroup.entries()]
-        .map(([groupName, groupMismatches]) => visualGroupMismatchSummary(groupName, groupMismatches))
-        .sort((a, b) => b.mismatch_count - a.mismatch_count || a.group.localeCompare(b.group))
-        .slice(0, 5),
-      top_failing_selectors: mismatches.slice(0, 10).map((mismatch) => ({
-        group: mismatch.group,
-        selector: mismatch.selector,
-        reason: mismatch.reason,
-        source_count: mismatch.source.count,
-        frontend_count: mismatch.frontend.count,
-        source_first_bounding_box: mismatch.source.first_bounding_box,
-        frontend_first_bounding_box: mismatch.frontend.first_bounding_box,
-        source_first_visible_text: mismatch.source.first_visible_text,
-        frontend_first_visible_text: mismatch.frontend.first_visible_text,
-        screenshots: mismatch.screenshots,
-      })),
-    });
-  }
-
-  const topFailingGroups = new Map();
-  for (const mismatch of allMismatches) {
-    const key = `${mismatch.target || 'target'}:${mismatch.group}`;
-    if (!topFailingGroups.has(key)) {
-      topFailingGroups.set(key, []);
-    }
-    topFailingGroups.get(key).push(mismatch);
-  }
-
-  return {
-    artifact: artifactPath,
-    mismatch_count: allMismatches.length,
-    optional_probe_absent_count: allOptionalProbeAbsences.length,
-    top_failing_groups: [...topFailingGroups.entries()]
-      .map(([, mismatches]) => ({
-        target: mismatches[0]?.target || '',
-        ...visualGroupMismatchSummary(mismatches[0]?.group || '', mismatches),
-      }))
-      .sort((a, b) => b.mismatch_count - a.mismatch_count || a.group.localeCompare(b.group))
-      .slice(0, 10),
-    targets: targetSummaries,
-    mismatches: allMismatches,
-    optional_probe_absences: allOptionalProbeAbsences,
-  };
+  return loadFidelityComparisonHelper().buildVisualDiagnostics(results, artifactPath);
 }
 
 function visualParity(sourceGroups, frontendGroups) {
-  const frontendByName = new Map(frontendGroups.map((group) => [group.name, group]));
-  const groupComparisons = [];
-  let missingSelectorCount = 0;
-  let visibilityMismatchCount = 0;
-  let nonzeroBoundingBoxMismatchCount = 0;
-  let simpleProbeParityMismatchCount = 0;
-  const simpleProbeFamilies = {
-    nav: new Set(['nav_chrome']),
-    footer: new Set(['footer_chrome']),
-    hero: new Set(['hero_region', 'hero_probe']),
-  };
-  const simpleProbeNames = new Set(Object.values(simpleProbeFamilies).flatMap((names) => [...names]));
-  const simpleProbeMismatches = { nav: 0, footer: 0, hero: 0 };
-
-  for (const sourceGroup of sourceGroups) {
-    const frontendGroup = frontendByName.get(sourceGroup.name);
-    if (!frontendGroup) {
-      continue;
-    }
-
-    const frontendSelectors = new Map(frontendGroup.selectors.map((selector) => [selector.selector, selector]));
-    for (const sourceSelector of sourceGroup.selectors) {
-      const frontendSelector = frontendSelectors.get(sourceSelector.selector);
-      if (!frontendSelector) {
-        continue;
-      }
-
-      const sourceVisible = sourceSelector.visible_count > 0;
-      const frontendVisible = frontendSelector.visible_count > 0;
-      const sourceNonzero = sourceSelector.nonzero_bounding_box_count > 0;
-      const frontendNonzero = frontendSelector.nonzero_bounding_box_count > 0;
-
-      if (sourceSelector.count === 0 || frontendSelector.count === 0) {
-        missingSelectorCount++;
-      }
-      if (sourceVisible !== frontendVisible) {
-        visibilityMismatchCount++;
-      }
-      if (sourceNonzero !== frontendNonzero) {
-        nonzeroBoundingBoxMismatchCount++;
-      }
-    }
-
-    const sourceGroupVisible = sourceGroup.visible_selector_count > 0;
-    const frontendGroupVisible = frontendGroup.visible_selector_count > 0;
-    const simpleProbeMismatch = simpleProbeNames.has(sourceGroup.name) && sourceGroupVisible !== frontendGroupVisible;
-    if (simpleProbeMismatch) {
-      simpleProbeParityMismatchCount++;
-      for (const [family, names] of Object.entries(simpleProbeFamilies)) {
-        if (names.has(sourceGroup.name)) {
-          simpleProbeMismatches[family]++;
-        }
-      }
-    }
-
-    groupComparisons.push({
-      name: sourceGroup.name,
-      source_visible: sourceGroupVisible,
-      frontend_visible: frontendGroupVisible,
-      source_nonzero_bounding_box: sourceGroup.nonzero_bounding_box_selector_count > 0,
-      frontend_nonzero_bounding_box: frontendGroup.nonzero_bounding_box_selector_count > 0,
-      simple_probe_parity: simpleProbeNames.has(sourceGroup.name) ? !simpleProbeMismatch : null,
-    });
-  }
-
-  return {
-    missing_selector_count: missingSelectorCount,
-    visibility_mismatch_count: visibilityMismatchCount,
-    nonzero_bounding_box_mismatch_count: nonzeroBoundingBoxMismatchCount,
-    simple_probe_parity_mismatch_count: simpleProbeParityMismatchCount,
-    simple_probe_mismatches: simpleProbeMismatches,
-    groups: groupComparisons,
-  };
+  return loadFidelityComparisonHelper().visualParity(sourceGroups, frontendGroups);
 }
 
 async function emptyVisualComparison(artifactDir, error = '') {

--- a/Automattic/studio/bench/lib/wordpress-helper-discovery.mjs
+++ b/Automattic/studio/bench/lib/wordpress-helper-discovery.mjs
@@ -8,6 +8,7 @@ const WORDPRESS_HELPER_CONSUMER_FILENAME = 'wordpress-helper-consumer.js';
 const WORDPRESS_LIB_HELPER_KEYS = new Map([
   ['block-quality.js', 'blockQuality'],
   ['editor-canvas-probes.js', 'editorCanvasProbes'],
+  ['fidelity-comparison.js', 'fidelityComparison'],
   ['fixture-setup.js', 'fixtureSetup'],
   ['materialized-site-quality.js', 'materializedSiteQuality'],
   ['request-profiler.js', 'requestProfiler'],

--- a/README.md
+++ b/README.md
@@ -32,25 +32,23 @@ Install a package subpath with Homeboy's rig package lifecycle:
 homeboy rig install --all https://github.com/chubes4/homeboy-rigs.git//Automattic/studio
 ```
 
-Stack specs currently need to be copied into `~/.config/homeboy/stacks/` until stack package installation lands:
-
-```bash
-mkdir -p ~/.config/homeboy/stacks
-cp Automattic/studio/stacks/*.json ~/.config/homeboy/stacks/
-cp WordPress/wordpress-playground/stacks/*.json ~/.config/homeboy/stacks/
-```
+Homeboy installs sibling `stacks/*.json` specs from the selected package subpath together with the rig specs. Re-run the same install command after pulling this repo to refresh both rigs and stacks.
 
 ## Lint
 
-Run the repo-local package lint before opening rig package PRs:
+Run Homeboy's package checks through the installed rig before opening rig package PRs:
+
+```bash
+homeboy rig check studio-combined
+```
+
+`homeboy rig check` reports generic package lint failures such as unresolved conflict markers and invalid JSON before running the rig's own check pipeline. This repo also keeps a PHP-specific syntax pass for PHP bench workloads:
 
 ```bash
 node scripts/lint-rig-packages.mjs
 ```
 
-The lint path scans for unresolved conflict markers, validates JSON specs, and
-runs `php -l` against PHP bench workloads when PHP is available. GitHub Actions
-runs the same script with PHP installed.
+GitHub Actions runs the PHP syntax pass with PHP installed.
 
 ## Automattic/studio
 

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -1,120 +1,67 @@
 #!/usr/bin/env node
 
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readdirSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
 const root = process.argv[2] ? join(process.cwd(), process.argv[2]) : process.cwd();
-const ignoredDirectories = new Set([
-	'.git',
-	'.claude',
-	'.datamachine',
-	'.opencode',
-	'node_modules',
-	'vendor',
-]);
-const conflictMarkerPattern = /^(<<<<<<<|=======|>>>>>>>)($|\s)/;
-const jsonFiles = [];
+const ignoredDirectories = new Set(['.git', '.claude', '.datamachine', '.opencode', 'node_modules', 'vendor']);
 const phpFiles = [];
 const failures = [];
 
 if (!existsSync(root)) {
-	console.error(`Lint root does not exist: ${root}`);
-	process.exit(1);
+  console.error(`Lint root does not exist: ${root}`);
+  process.exit(1);
 }
 
 function walk(directory) {
-	for (const entry of readdirSync(directory, { withFileTypes: true })) {
-		if (entry.isDirectory()) {
-			if (!ignoredDirectories.has(entry.name)) {
-				walk(join(directory, entry.name));
-			}
-			continue;
-		}
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (!ignoredDirectories.has(entry.name)) {
+        walk(join(directory, entry.name));
+      }
+      continue;
+    }
 
-		if (!entry.isFile()) {
-			continue;
-		}
-
-		const file = join(directory, entry.name);
-		const relativePath = relative(root, file);
-		checkConflictMarkers(file, relativePath);
-
-		if (entry.name.endsWith('.json')) {
-			jsonFiles.push(file);
-		}
-		if (entry.name.endsWith('.php')) {
-			phpFiles.push(file);
-		}
-	}
-}
-
-function checkConflictMarkers(file, relativePath) {
-	const lines = readFileSync(file, 'utf8').split(/\r?\n/);
-	lines.forEach((line, index) => {
-		if (conflictMarkerPattern.test(line)) {
-			failures.push(`${relativePath}:${index + 1}: unresolved conflict marker: ${line}`);
-		}
-	});
-}
-
-function validateJson(file) {
-	try {
-		JSON.parse(readFileSync(file, 'utf8'));
-	} catch (error) {
-		failures.push(`${relative(root, file)}: invalid JSON: ${error.message}`);
-	}
+    if (entry.isFile() && entry.name.endsWith('.php')) {
+      phpFiles.push(join(directory, entry.name));
+    }
+  }
 }
 
 function lintPhp(file) {
-	const result = spawnSync('php', ['-l', file], { encoding: 'utf8' });
-	if (result.status !== 0) {
-		const output = `${result.stdout || ''}${result.stderr || ''}`.trim();
-		failures.push(`${relative(root, file)}: PHP syntax check failed${output ? `: ${output}` : ''}`);
-	}
+  const result = spawnSync('php', ['-l', file], { encoding: 'utf8' });
+  if (result.status !== 0) {
+    const output = `${result.stdout || ''}${result.stderr || ''}`.trim();
+    failures.push(`${relative(root, file)}: PHP syntax check failed${output ? `: ${output}` : ''}`);
+  }
+}
+
+function hasPhp() {
+  try {
+    execFileSync('php', ['-v'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 walk(root);
-jsonFiles.forEach(validateJson);
 
-const hasPhp = (() => {
-	try {
-		execFileSync('php', ['-v'], { stdio: 'ignore' });
-		return true;
-	} catch {
-		return false;
-	}
-})();
-
-if (hasPhp) {
-	phpFiles.forEach(lintPhp);
-} else {
-	console.warn(`PHP not found; skipped syntax checks for ${phpFiles.length} PHP file(s).`);
+if (!hasPhp()) {
+  console.warn(`PHP not found; skipped syntax checks for ${phpFiles.length} PHP file(s).`);
+  process.exit(0);
 }
+
+phpFiles.forEach(lintPhp);
 
 if (failures.length > 0) {
-	console.error('Rig package lint failed:');
-	for (const failure of failures) {
-		console.error(`- ${failure}`);
-	}
-	process.exit(1);
+  console.error('Rig package PHP syntax lint failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
 }
 
-console.log('Rig package lint passed.');
-console.log(`- Conflict marker scan: ${countFiles(root)} file(s)`);
-console.log(`- JSON validation: ${jsonFiles.length} file(s)`);
-console.log(`- PHP syntax: ${hasPhp ? phpFiles.length : 0} file(s)${hasPhp ? '' : ' (skipped; php unavailable)'}`);
-
-function countFiles(directory) {
-	let count = 0;
-	for (const entry of readdirSync(directory, { withFileTypes: true })) {
-		if (entry.isDirectory()) {
-			if (!ignoredDirectories.has(entry.name)) {
-				count += countFiles(join(directory, entry.name));
-			}
-		} else if (entry.isFile() && statSync(join(directory, entry.name)).isFile()) {
-			count++;
-		}
-	}
-	return count;
-}
+console.log('Rig package PHP syntax lint passed.');
+console.log(`- PHP syntax: ${phpFiles.length} file(s)`);


### PR DESCRIPTION
## Summary
- Updates package install/lint docs now that Homeboy owns sibling stack installation and generic rig package lint through `homeboy rig check`.
- Narrows the repo-local lint script to the PHP syntax pass that stays product/package-specific.
- Thins Studio visual fidelity helpers by delegating selector grouping, diagnostics, parity, and PNG comparison to the promoted Homeboy Extensions WordPress helper.

Refs chubes4/homeboy-rigs#210.
Refs chubes4/homeboy-rigs#211.
Refs chubes4/homeboy-rigs#212.
Depends on Extra-Chill/homeboy#3863 for the documented generic `homeboy rig check` package lint path.

## Testing
- `node scripts/lint-rig-packages.mjs`
- `node --check Automattic/studio/bench/lib/visual-fidelity.mjs && node --check Automattic/studio/bench/lib/wordpress-helper-discovery.mjs && node --check scripts/lint-rig-packages.mjs`
- `node Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `HOMEBOY_WORDPRESS_HELPER_MANIFEST=/Users/chubes/Developer/homeboy-extensions/wordpress/lib/helper-manifest.js node Automattic/studio/bench/studio-agent-site-build.test.mjs`
- `HOMEBOY_COMPONENT_PATH=/Users/chubes/Developer/studio HOMEBOY_WORDPRESS_HELPER_MANIFEST=/Users/chubes/Developer/homeboy-extensions/wordpress/lib/helper-manifest.js node -e "import('./Automattic/studio/bench/lib/visual-fidelity.mjs').then(() => console.log('visual-fidelity import ok'))"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the refactor, docs updates, and verification pass; Chris remains responsible for review and validation.