### PR TITLE
Add deferred initialization webperf pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A **rig** is a declarative spec for a reproducible local dev environment: compon
   rigs/<id>/rig.json
   stacks/    # homeboy stack specs
   bench/     # portable bench workloads used by those rigs
+shared/      # reusable rig helper patterns that are not tied to one owner/repo
 ```
 
 Examples:
@@ -23,6 +24,12 @@ WordPress/wordpress-playground/stacks/playground-combined.json
 ```
 
 This keeps bench workloads beside the rig that uses them and makes ownership obvious when this repo becomes a shared rig package.
+
+Reusable helper patterns live under `shared/`. The first shared web performance
+pattern is `shared/webperf/deferred-init-webperf.mjs`, which lets trace workloads
+mark feature-not-needed and feature-needed phases, count feature/third-party
+requests before and after the trigger, and emit assertions proving no early
+initialization plus post-trigger success.
 
 ## Install
 

--- a/shared/webperf/README.md
+++ b/shared/webperf/README.md
@@ -1,0 +1,116 @@
+# Deferred-Initialization Webperf Pattern
+
+This package is a reusable Homeboy Rigs pattern for proving that browser work is
+deferred until a feature is needed. It is intentionally generic: rig authors
+provide feature selectors, URL matchers, and interaction scripts; the helper only
+normalizes phase markers, request counts, metrics, assertions, and metadata.
+
+## Goal
+
+Use this pattern when load-only parity is not enough. The proof shape is:
+
+1. Start a **feature-not-needed** phase before page scripts initialize.
+2. Load the page and mark the page state where the feature should still be idle.
+3. Trigger the user action or viewport condition that makes the feature needed.
+4. Mark post-trigger readiness and success.
+5. Count feature and third-party requests before and after the trigger.
+6. Assert no early feature initialization while proving post-trigger success.
+
+## Helper
+
+Import from `shared/webperf/deferred-init-webperf.mjs`:
+
+```js
+import {
+  deferredInitBrowserMarkerScript,
+  deferredInitMarkers,
+  summarizeDeferredInitWebperf,
+} from '../../shared/webperf/deferred-init-webperf.mjs';
+```
+
+`deferredInitBrowserMarkerScript(featureId)` returns a small pre-page script that
+installs `window.__homeboyDeferredInit[featureId]`. The installed channel exposes
+stable marker names and a `mark(name, data)` function. Rig-specific browser probe
+scripts can use it like this:
+
+```js
+const deferred = window.__homeboyDeferredInit['checkout-widget'];
+deferred.mark(deferred.markers.featureNotNeededReady, {
+  visible: document.querySelector('#checkout-widget') !== null,
+});
+
+document.querySelector('#show-checkout-widget').click();
+deferred.mark(deferred.markers.featureNeededTrigger, { trigger: 'button-click' });
+
+await pageWaitForWidgetReady();
+deferred.mark(deferred.markers.featureNeededReady);
+deferred.mark(deferred.markers.featureNeededSuccess, { buttonVisible: true });
+```
+
+After the browser probe finishes, pass the marker events and captured network log
+to `summarizeDeferredInitWebperf()`:
+
+```js
+const summary = summarizeDeferredInitWebperf({
+  featureId: 'checkout-widget',
+  markerEvents: scriptResult.deferredInitEvents,
+  networkEntries: browserNetworkResponses,
+  featureRequestMatchers: [/checkout-widget/, /api\.example\.com\/widget/],
+  thirdPartyRequestMatchers: [/third-party\.example/],
+  maxEarlyFeatureRequests: 0,
+  maxEarlyThirdPartyRequests: 0,
+  minPostTriggerFeatureRequests: 1,
+});
+
+for (const assertion of summary.assertions) {
+  trace.assertion(assertion);
+}
+```
+
+## Example Metrics
+
+For `featureId: 'checkout-widget'`, the helper emits metrics like:
+
+```json
+{
+  "checkout-widget_deferred_init_feature_not_needed_ready_ms": 500,
+  "checkout-widget_deferred_init_feature_needed_trigger_ms": 1500,
+  "checkout-widget_deferred_init_feature_needed_ready_ms": 2200,
+  "checkout-widget_deferred_init_feature_request_count": 3,
+  "checkout-widget_deferred_init_feature_request_count_before_trigger": 0,
+  "checkout-widget_deferred_init_feature_request_count_after_trigger": 3,
+  "checkout-widget_deferred_init_third_party_request_count_before_trigger": 0,
+  "checkout-widget_deferred_init_no_early_feature_init": true,
+  "checkout-widget_deferred_init_post_trigger_feature_requests": true,
+  "checkout-widget_deferred_init_post_trigger_success": true
+}
+```
+
+The metadata includes sampled early and post-trigger feature/third-party URLs so
+PR evidence can show what initialized too early without dumping full network logs
+into the summary.
+
+## Phase Markers
+
+The default marker namespace is `deferred_init.<featureId>.*`:
+
+- `feature_not_needed.start`
+- `feature_not_needed.ready`
+- `feature_needed.trigger`
+- `feature_needed.ready`
+- `feature_needed.success`
+
+## Current Dependencies
+
+This helper can land before Homeboy or WP Codebox adds a higher-level declarative
+deferred-init phase primitive. Current rigs still need to provide:
+
+- A browser probe or trace workload that can inject the pre-page marker script.
+- A post-load interaction script that returns the marker events.
+- A browser network artifact with request timing fields such as `t_ms`,
+  `startTime`, or `request.startTime`.
+- Rig-specific selectors and URL matchers that define what counts as feature or
+  third-party initialization.
+
+Future upstream Homeboy/WP Codebox work can wrap those pieces in declarative
+phase syntax. The metric and assertion contract here should remain reusable.

--- a/shared/webperf/deferred-init-webperf.mjs
+++ b/shared/webperf/deferred-init-webperf.mjs
@@ -1,0 +1,219 @@
+export const DEFERRED_INIT_PHASES = Object.freeze({
+  FEATURE_NOT_NEEDED: 'feature-not-needed',
+  FEATURE_NEEDED: 'feature-needed',
+});
+
+const DEFAULT_MARKER_PREFIX = 'deferred_init';
+
+function markerName(prefix, featureId, name) {
+  return `${prefix}.${featureId}.${name}`;
+}
+
+export function deferredInitMarkers(featureId, { prefix = DEFAULT_MARKER_PREFIX } = {}) {
+  if (!featureId || typeof featureId !== 'string') {
+    throw new Error('deferredInitMarkers requires a non-empty string featureId.');
+  }
+
+  return Object.freeze({
+    featureNotNeededStart: markerName(prefix, featureId, 'feature_not_needed.start'),
+    featureNotNeededReady: markerName(prefix, featureId, 'feature_not_needed.ready'),
+    featureNeededTrigger: markerName(prefix, featureId, 'feature_needed.trigger'),
+    featureNeededReady: markerName(prefix, featureId, 'feature_needed.ready'),
+    featureNeededSuccess: markerName(prefix, featureId, 'feature_needed.success'),
+  });
+}
+
+export function deferredInitBrowserMarkerScript(featureId, options = {}) {
+  const markers = deferredInitMarkers(featureId, options);
+  return `(() => {
+  const startedAt = performance.now();
+  const events = [];
+  const elapsed = () => Math.round(performance.now() - startedAt);
+  const mark = (name, data = {}) => {
+    const event = { name, t_ms: elapsed(), data };
+    events.push(event);
+    try { performance.mark(name); } catch {}
+    return event;
+  };
+  window.__homeboyDeferredInit = window.__homeboyDeferredInit || {};
+  window.__homeboyDeferredInit[${JSON.stringify(featureId)}] = {
+    featureId: ${JSON.stringify(featureId)},
+    markers: ${JSON.stringify(markers)},
+    events,
+    mark,
+  };
+  mark(${JSON.stringify(markers.featureNotNeededStart)});
+})();`;
+}
+
+function toFiniteNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function eventTime(event) {
+  return toFiniteNumber(event?.t_ms ?? event?.time_ms ?? event?.timestamp_ms ?? event?.startTime ?? event?.start_time_ms);
+}
+
+function requestTime(entry) {
+  return toFiniteNumber(
+    entry?.t_ms ??
+      entry?.time_ms ??
+      entry?.timestamp_ms ??
+      entry?.startTime ??
+      entry?.start_time_ms ??
+      entry?.request?.startTime ??
+      entry?.request?.start_time_ms
+  );
+}
+
+function requestUrl(entry) {
+  return entry?.url || entry?.request?.url || entry?.response?.url || '';
+}
+
+function compileMatcher(matcher) {
+  if (typeof matcher === 'function') {
+    return matcher;
+  }
+  if (matcher instanceof RegExp) {
+    return (entry) => matcher.test(requestUrl(entry));
+  }
+  if (typeof matcher === 'string') {
+    return (entry) => requestUrl(entry).includes(matcher);
+  }
+  throw new Error(`Unsupported deferred-init request matcher: ${String(matcher)}`);
+}
+
+function matchesAny(entry, matchers) {
+  return matchers.some((matcher) => matcher(entry));
+}
+
+function findMarkerTime(markerEvents, marker) {
+  const event = markerEvents.find((candidate) => candidate?.name === marker);
+  return eventTime(event);
+}
+
+function countRequests(entries, matchers, predicate = () => true) {
+  return entries.filter((entry) => predicate(entry) && matchesAny(entry, matchers)).length;
+}
+
+function sampleUrls(entries, matchers, predicate = () => true, limit = 20) {
+  return entries
+    .filter((entry) => predicate(entry) && matchesAny(entry, matchers))
+    .map(requestUrl)
+    .filter(Boolean)
+    .slice(0, limit);
+}
+
+function assertion(id, status, message) {
+  return { id, status, message };
+}
+
+export function summarizeDeferredInitWebperf(options) {
+  const {
+    featureId,
+    markerEvents = [],
+    networkEntries = [],
+    featureRequestMatchers = [],
+    thirdPartyRequestMatchers = [],
+    success = false,
+    maxEarlyFeatureRequests = 0,
+    maxEarlyThirdPartyRequests = null,
+    minPostTriggerFeatureRequests = 1,
+    metricsPrefix = featureId ? `${featureId}_deferred_init` : 'deferred_init',
+    markerPrefix = DEFAULT_MARKER_PREFIX,
+  } = options || {};
+
+  if (!featureId || typeof featureId !== 'string') {
+    throw new Error('summarizeDeferredInitWebperf requires a non-empty string featureId.');
+  }
+  if (featureRequestMatchers.length === 0) {
+    throw new Error('summarizeDeferredInitWebperf requires at least one featureRequestMatcher.');
+  }
+
+  const markers = deferredInitMarkers(featureId, { prefix: markerPrefix });
+  const featureMatchers = featureRequestMatchers.map(compileMatcher);
+  const thirdPartyMatchers = thirdPartyRequestMatchers.map(compileMatcher);
+  const notNeededReadyMs = findMarkerTime(markerEvents, markers.featureNotNeededReady);
+  const triggerMs = findMarkerTime(markerEvents, markers.featureNeededTrigger);
+  const neededReadyMs = findMarkerTime(markerEvents, markers.featureNeededReady);
+  const successMs = findMarkerTime(markerEvents, markers.featureNeededSuccess);
+  const hasRequestTiming = networkEntries.some((entry) => requestTime(entry) !== null);
+  const beforeTrigger = (entry) => {
+    const time = requestTime(entry);
+    return triggerMs === null || time === null ? false : time < triggerMs;
+  };
+  const afterTrigger = (entry) => {
+    const time = requestTime(entry);
+    return triggerMs === null || time === null ? false : time >= triggerMs;
+  };
+  const earlyFeatureRequests = countRequests(networkEntries, featureMatchers, beforeTrigger);
+  const postTriggerFeatureRequests = countRequests(networkEntries, featureMatchers, afterTrigger);
+  const earlyThirdPartyRequests = thirdPartyMatchers.length > 0 ? countRequests(networkEntries, thirdPartyMatchers, beforeTrigger) : null;
+  const postTriggerThirdPartyRequests = thirdPartyMatchers.length > 0 ? countRequests(networkEntries, thirdPartyMatchers, afterTrigger) : null;
+  const featureRequestCount = countRequests(networkEntries, featureMatchers);
+  const thirdPartyRequestCount = thirdPartyMatchers.length > 0 ? countRequests(networkEntries, thirdPartyMatchers) : null;
+  const earlyFeaturePass = hasRequestTiming && triggerMs !== null && earlyFeatureRequests <= maxEarlyFeatureRequests;
+  const postTriggerFeaturePass = hasRequestTiming && triggerMs !== null && postTriggerFeatureRequests >= minPostTriggerFeatureRequests;
+  const thirdPartyEarlyPass =
+    maxEarlyThirdPartyRequests === null ||
+    (hasRequestTiming && triggerMs !== null && earlyThirdPartyRequests <= maxEarlyThirdPartyRequests);
+  const successPass = success === true || successMs !== null;
+
+  const metrics = {
+    [`${metricsPrefix}_feature_not_needed_ready_ms`]: notNeededReadyMs,
+    [`${metricsPrefix}_feature_needed_trigger_ms`]: triggerMs,
+    [`${metricsPrefix}_feature_needed_ready_ms`]: neededReadyMs,
+    [`${metricsPrefix}_feature_needed_success_ms`]: successMs,
+    [`${metricsPrefix}_request_timing_available`]: hasRequestTiming,
+    [`${metricsPrefix}_feature_request_count`]: featureRequestCount,
+    [`${metricsPrefix}_feature_request_count_before_trigger`]: earlyFeatureRequests,
+    [`${metricsPrefix}_feature_request_count_after_trigger`]: postTriggerFeatureRequests,
+    [`${metricsPrefix}_third_party_request_count`]: thirdPartyRequestCount,
+    [`${metricsPrefix}_third_party_request_count_before_trigger`]: earlyThirdPartyRequests,
+    [`${metricsPrefix}_third_party_request_count_after_trigger`]: postTriggerThirdPartyRequests,
+    [`${metricsPrefix}_no_early_feature_init`]: earlyFeaturePass,
+    [`${metricsPrefix}_post_trigger_feature_requests`]: postTriggerFeaturePass,
+    [`${metricsPrefix}_post_trigger_success`]: successPass,
+  };
+
+  return {
+    featureId,
+    phases: DEFERRED_INIT_PHASES,
+    markers,
+    metrics,
+    assertions: [
+      assertion(
+        `${featureId}-no-early-feature-init`,
+        earlyFeaturePass ? 'pass' : 'fail',
+        `Observed ${earlyFeatureRequests} feature request(s) before trigger; expected <= ${maxEarlyFeatureRequests}.`
+      ),
+      assertion(
+        `${featureId}-post-trigger-feature-requests`,
+        postTriggerFeaturePass ? 'pass' : 'fail',
+        `Observed ${postTriggerFeatureRequests} feature request(s) after trigger; expected >= ${minPostTriggerFeatureRequests}.`
+      ),
+      assertion(
+        `${featureId}-post-trigger-success`,
+        successPass ? 'pass' : 'fail',
+        successPass ? 'Feature reported post-trigger success.' : 'Feature did not report post-trigger success.'
+      ),
+      ...(maxEarlyThirdPartyRequests === null
+        ? []
+        : [
+            assertion(
+              `${featureId}-no-early-third-party-init`,
+              thirdPartyEarlyPass ? 'pass' : 'fail',
+              `Observed ${earlyThirdPartyRequests} third-party request(s) before trigger; expected <= ${maxEarlyThirdPartyRequests}.`
+            ),
+          ]),
+    ],
+    metadata: {
+      marker_events: markerEvents,
+      early_feature_urls_sample: sampleUrls(networkEntries, featureMatchers, beforeTrigger),
+      post_trigger_feature_urls_sample: sampleUrls(networkEntries, featureMatchers, afterTrigger),
+      early_third_party_urls_sample: thirdPartyMatchers.length > 0 ? sampleUrls(networkEntries, thirdPartyMatchers, beforeTrigger) : [],
+      post_trigger_third_party_urls_sample: thirdPartyMatchers.length > 0 ? sampleUrls(networkEntries, thirdPartyMatchers, afterTrigger) : [],
+    },
+  };
+}

--- a/shared/webperf/deferred-init-webperf.test.mjs
+++ b/shared/webperf/deferred-init-webperf.test.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  deferredInitBrowserMarkerScript,
+  deferredInitMarkers,
+  summarizeDeferredInitWebperf,
+} from './deferred-init-webperf.mjs';
+
+test('deferred init markers are stable and namespaced by feature id', () => {
+  assert.deepEqual(deferredInitMarkers('checkout-widget'), {
+    featureNotNeededStart: 'deferred_init.checkout-widget.feature_not_needed.start',
+    featureNotNeededReady: 'deferred_init.checkout-widget.feature_not_needed.ready',
+    featureNeededTrigger: 'deferred_init.checkout-widget.feature_needed.trigger',
+    featureNeededReady: 'deferred_init.checkout-widget.feature_needed.ready',
+    featureNeededSuccess: 'deferred_init.checkout-widget.feature_needed.success',
+  });
+});
+
+test('deferred init browser script installs a feature marker channel', () => {
+  const script = deferredInitBrowserMarkerScript('checkout-widget');
+
+  assert.match(script, /__homeboyDeferredInit/);
+  assert.match(script, /checkout-widget/);
+  assert.match(script, /feature_not_needed\.start/);
+});
+
+test('summarizeDeferredInitWebperf passes when feature requests wait until trigger', () => {
+  const markers = deferredInitMarkers('checkout-widget');
+  const summary = summarizeDeferredInitWebperf({
+    featureId: 'checkout-widget',
+    markerEvents: [
+      { name: markers.featureNotNeededReady, t_ms: 500 },
+      { name: markers.featureNeededTrigger, t_ms: 1500 },
+      { name: markers.featureNeededReady, t_ms: 2200 },
+      { name: markers.featureNeededSuccess, t_ms: 2300 },
+    ],
+    networkEntries: [
+      { url: 'https://example.test/style.css', t_ms: 200 },
+      { url: 'https://cdn.example.test/feature.js', t_ms: 1600 },
+      { url: 'https://api.example.test/feature/session', t_ms: 1700 },
+      { url: 'https://third-party.example/feature-frame', t_ms: 1800 },
+    ],
+    featureRequestMatchers: [/feature/],
+    thirdPartyRequestMatchers: ['third-party.example'],
+    maxEarlyThirdPartyRequests: 0,
+  });
+
+  assert.equal(summary.metrics['checkout-widget_deferred_init_feature_request_count_before_trigger'], 0);
+  assert.equal(summary.metrics['checkout-widget_deferred_init_feature_request_count_after_trigger'], 3);
+  assert.equal(summary.metrics['checkout-widget_deferred_init_third_party_request_count_before_trigger'], 0);
+  assert.equal(summary.metrics['checkout-widget_deferred_init_post_trigger_success'], true);
+  assert.deepEqual(summary.assertions.map((entry) => entry.status), ['pass', 'pass', 'pass', 'pass']);
+  assert.deepEqual(summary.metadata.post_trigger_feature_urls_sample, [
+    'https://cdn.example.test/feature.js',
+    'https://api.example.test/feature/session',
+    'https://third-party.example/feature-frame',
+  ]);
+});
+
+test('summarizeDeferredInitWebperf fails for early feature initialization', () => {
+  const markers = deferredInitMarkers('checkout-widget');
+  const summary = summarizeDeferredInitWebperf({
+    featureId: 'checkout-widget',
+    markerEvents: [
+      { name: markers.featureNotNeededReady, t_ms: 500 },
+      { name: markers.featureNeededTrigger, t_ms: 1500 },
+    ],
+    networkEntries: [
+      { url: 'https://cdn.example.test/feature.js', t_ms: 200 },
+      { url: 'https://api.example.test/feature/session', t_ms: 1700 },
+    ],
+    featureRequestMatchers: [/feature/],
+    success: true,
+  });
+
+  assert.equal(summary.metrics['checkout-widget_deferred_init_feature_request_count_before_trigger'], 1);
+  assert.equal(summary.assertions.find((entry) => entry.id === 'checkout-widget-no-early-feature-init').status, 'fail');
+});
+
+test('summarizeDeferredInitWebperf fails when timing data cannot prove phase boundaries', () => {
+  const markers = deferredInitMarkers('checkout-widget');
+  const summary = summarizeDeferredInitWebperf({
+    featureId: 'checkout-widget',
+    markerEvents: [{ name: markers.featureNeededTrigger, t_ms: 1500 }],
+    networkEntries: [{ url: 'https://api.example.test/feature/session' }],
+    featureRequestMatchers: [/feature/],
+    success: true,
+  });
+
+  assert.equal(summary.metrics['checkout-widget_deferred_init_request_timing_available'], false);
+  assert.equal(summary.assertions.find((entry) => entry.id === 'checkout-widget-post-trigger-feature-requests').status, 'fail');
+});


### PR DESCRIPTION
## Summary
- Adds a reusable `shared/webperf/deferred-init-webperf.mjs` helper for deferred-initialization rig evidence.
- Documents the feature-not-needed / feature-needed phase pattern, marker contract, request-count metrics, and current Homeboy/WP Codebox dependencies.
- Adds focused `node:test` coverage for markers, generated browser marker script, request phase counting, and failure cases.

Fixes #221.

## Tests
- `node --test shared/webperf/deferred-init-webperf.test.mjs`
- `node scripts/lint-rig-packages.mjs`
- `node --test shared/webperf/deferred-init-webperf.test.mjs woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs Automattic/studio/bench/studio-agent-site-build.test.mjs` partially ran: 69 pass, 8 fail because Studio site-build tests require `HOMEBOY_WORDPRESS_HELPER_MANIFEST` / Homeboy Extensions materialized site quality helper in this environment.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the reusable deferred-init helper, documentation, tests, and PR description; Chris remains responsible for review and merge decisions.