### PR TITLE
Add WooCommerce admin dashboard products query rig

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,15 +282,16 @@ homeboy bench --rig playground-cli-diagnostics --scenario playground-cli-runphp-
 
 ## woocommerce/woocommerce
 
-`rigs/woocommerce-performance/rig.json` runs WooCommerce checkout/shipping cache
-performance workloads against a local WooCommerce monorepo checkout mounted into
-the WP Codebox WordPress bench runtime.
+`rigs/woocommerce-performance/rig.json` runs WooCommerce checkout, shipping,
+catalog, and admin-dashboard performance workloads against a local WooCommerce
+monorepo checkout mounted into the WP Codebox WordPress bench runtime.
 
 ```bash
 homeboy rig install /Users/chubes/Developer/homeboy-rigs@<branch>/woocommerce/woocommerce
 homeboy rig check woocommerce-performance
 homeboy rig up woocommerce-performance
 homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-bench
+homeboy bench --rig woocommerce-performance --scenario admin-dashboard-physical-products-query --iterations 1 --shared-state /tmp/woocommerce-admin-dashboard-products
 ```
 
 The runner must provide `~/Developer/woocommerce/plugins/woocommerce`. The rig

--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -18,6 +18,8 @@ performance bugs in disposable WordPress/WooCommerce runtimes.
 - https://github.com/woocommerce/woocommerce/issues/32055
 - https://github.com/woocommerce/woocommerce/issues/26569
 - https://github.com/woocommerce/woocommerce/issues/17355
+- https://github.com/chubes4/homeboy-rigs/issues/224
+- https://wordpress.org/support/topic/wp_query-get_posts-slow-query-on-dashboard/
 
 ## Install
 
@@ -73,6 +75,7 @@ php bin/generate-feature-config.php
 ```bash
 homeboy rig up woocommerce-performance
 homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-bench
+homeboy bench --rig woocommerce-performance --scenario admin-dashboard-physical-products-query --iterations 1 --shared-state /tmp/woocommerce-admin-dashboard-products --setting-json 'bench_env={"WC_ADMIN_DASHBOARD_PRODUCTS":"500","WC_ADMIN_DASHBOARD_TERMS":"20"}'
 homeboy bench --rig woocommerce-performance --scenario layered-nav-count-cache --iterations 1 --shared-state /tmp/woocommerce-layered-nav-cache --setting-json 'bench_env={"WC_LAYERED_NAV_CACHE_ITERATIONS":"150","WC_LAYERED_NAV_CACHE_LIMIT":"25"}'
 homeboy bench --rig woocommerce-performance --scenario layered-nav-catalog-crawl --iterations 1 --shared-state /tmp/woocommerce-layered-nav-crawl --setting-json 'bench_env={"WC_LAYERED_NAV_CRAWL_REQUESTS":"150","WC_LAYERED_NAV_CRAWL_LIMIT":"25"}'
 homeboy bench --rig woocommerce-performance --profile hot --iterations 1 --shared-state /tmp/woocommerce-performance-hot --setting-json 'bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"120","WC_SHIPPING_CACHE_PACKAGES":"24"}' --force-hot
@@ -95,6 +98,12 @@ into `tests/bench/`, and returns the normalized Homeboy `BenchResults` envelope.
   across many unique layered-nav count query hashes to measure growth of the
   single `wc_layered_nav_counts_*` taxonomy transient reported in WooCommerce
   issue #17355.
+- `admin-dashboard-physical-products-query` seeds configurable simple products
+  and product categories with deterministic `_virtual` metadata, sets the
+  WooCommerce onboarding state, exercises
+  `Shipping::has_physical_products()` plus the dashboard setup-widget PHP path,
+  and records whether the reported physical-products SQL appears on the tested
+  WooCommerce branch.
 - `layered-nav-catalog-crawl` uses real `filter_*` request combinations and
   renders the layered-nav widget list path for each request shape, measuring
   the same transient growth through a crawler/catalog-traffic-shaped path.
@@ -112,6 +121,10 @@ The first slice reports:
 - `final_transient_entry_count`, `max_transient_entry_count`,
   `final_serialized_value_bytes`, and `cache_exceeded_limit` for layered-nav
   count cache growth.
+- `direct_has_physical_products_ms`, `dashboard_setup_widget_ms`,
+  `matching_query_elapsed_ms`, `matching_query_count`, `total_query_count`,
+  seeded product/term counts, physical/virtual split, onboarding state, and
+  WooCommerce version for the admin dashboard physical-products path.
 
 See `docs/checkout-shipping-cache.md` for workload details and current TODOs.
 

--- a/woocommerce/woocommerce/bench/admin-dashboard-physical-products-query.php
+++ b/woocommerce/woocommerce/bench/admin-dashboard-physical-products-query.php
@@ -1,0 +1,286 @@
+<?php
+/**
+ * WP Codebox-backed WooCommerce admin dashboard physical-products query workload.
+ *
+ * Reproduces the wp-admin/index.php onboarding setup widget path reported in:
+ * https://wordpress.org/support/topic/wp_query-get_posts-slow-query-on-dashboard/
+ */
+return function (): array {
+	if ( ! class_exists( 'WooCommerce' ) ) {
+		$woocommerce_entrypoint = WP_PLUGIN_DIR . '/woocommerce/woocommerce.php';
+		if ( ! file_exists( $woocommerce_entrypoint ) ) {
+			throw new RuntimeException( 'WooCommerce plugin entrypoint is not mounted.' );
+		}
+		require_once $woocommerce_entrypoint;
+	}
+
+	if ( ! class_exists( 'WooCommerce' ) || ! function_exists( 'WC' ) ) {
+		throw new RuntimeException( 'WooCommerce is not loaded.' );
+	}
+	if ( ! class_exists( Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Shipping::class ) ) {
+		throw new RuntimeException( 'WooCommerce onboarding shipping task is not available.' );
+	}
+
+	global $wpdb;
+
+	$product_count  = max( 1, min( 20000, (int) ( getenv( 'WC_ADMIN_DASHBOARD_PRODUCTS' ) ?: 500 ) ) );
+	$term_count     = max( 1, min( 1000, (int) ( getenv( 'WC_ADMIN_DASHBOARD_TERMS' ) ?: 20 ) ) );
+	$physical_ratio = max( 0, min( 100, (int) ( getenv( 'WC_ADMIN_DASHBOARD_PHYSICAL_PERCENT' ) ?: 100 ) ) );
+	$run_id         = 'woocommerce-admin-dashboard-physical-products-' . getmypid() . '-' . time() . '-' . wp_generate_password( 6, false );
+	$sources        = array(
+		'https://automattic.zendesk.com/agent/tickets/5428113',
+		'https://wordpress.org/support/topic/wp_query-get_posts-slow-query-on-dashboard/',
+		'https://github.com/chubes4/homeboy-rigs/issues/224',
+	);
+
+	wp_set_current_user( 1 );
+	update_option( 'woocommerce_store_address', '123 Performance Way' );
+	update_option( 'woocommerce_store_city', 'San Francisco' );
+	update_option( 'woocommerce_default_country', 'US:CA' );
+	update_option( 'woocommerce_currency', 'USD' );
+	update_option( 'woocommerce_task_list_hidden', 'no' );
+	update_option( 'woocommerce_task_list_complete', 'no' );
+	update_option( 'woocommerce_task_list_hidden_lists', array() );
+	update_option( 'woocommerce_task_list_completed_lists', array() );
+	update_option( 'woocommerce_admin_created_default_shipping_zones', 'no' );
+
+	if ( class_exists( Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingProfile::class ) ) {
+		update_option(
+			Automattic\WooCommerce\Internal\Admin\Onboarding\OnboardingProfile::DATA_OPTION,
+			array(
+				'product_types' => array( 'physical' ),
+				'product_count' => $product_count,
+			)
+		);
+	}
+
+	$feature_filter = static function ( array $features ): array {
+		$features = array_values( array_unique( array_merge( $features, array( 'onboarding' ) ) ) );
+		return array_values( array_diff( $features, array( 'shipping-smart-defaults' ) ) );
+	};
+	add_filter( 'woocommerce_admin_features', $feature_filter, 100 );
+
+	$term_ids = array();
+	for ( $i = 0; $i < $term_count; $i++ ) {
+		$term = wp_insert_term( 'Homeboy Dashboard Term ' . ( $i + 1 ) . ' ' . $run_id, 'product_cat', array( 'slug' => 'homeboy-dashboard-' . $run_id . '-' . ( $i + 1 ) ) );
+		if ( is_wp_error( $term ) ) {
+			throw new RuntimeException( 'Failed to create Homeboy dashboard product category: ' . $term->get_error_message() );
+		}
+		$term_ids[] = (int) $term['term_id'];
+	}
+
+	$product_ids     = array();
+	$physical_count  = 0;
+	$virtual_count   = 0;
+	$term_product_map = array_fill_keys( $term_ids, 0 );
+	for ( $i = 0; $i < $product_count; $i++ ) {
+		$is_physical = ( ( $i * 100 ) / $product_count ) < $physical_ratio;
+		$product     = new WC_Product_Simple();
+		$product->set_name( 'Homeboy Dashboard Product ' . $run_id . ' #' . ( $i + 1 ) );
+		$product->set_slug( 'homeboy-dashboard-product-' . $run_id . '-' . ( $i + 1 ) );
+		$product->set_status( 'publish' );
+		$product->set_sku( 'homeboy-dashboard-' . $run_id . '-' . ( $i + 1 ) );
+		$product->set_regular_price( '10' );
+		$product->set_price( '10' );
+		$product->set_virtual( ! $is_physical );
+		$product->set_manage_stock( false );
+		$product->set_stock_status( 'instock' );
+		$product->save();
+
+		$term_id = $term_ids[ $i % count( $term_ids ) ];
+		wp_set_object_terms( $product->get_id(), array( $term_id ), 'product_cat' );
+		update_post_meta( $product->get_id(), '_virtual', $is_physical ? 'no' : 'yes' );
+
+		$product_ids[] = $product->get_id();
+		if ( $is_physical ) {
+			++$physical_count;
+		} else {
+			++$virtual_count;
+		}
+		++$term_product_map[ $term_id ];
+	}
+
+	$captured_queries = array();
+	$query_filter     = static function ( string $query ) use ( &$captured_queries ): string {
+		$captured_queries[] = $query;
+		return $query;
+	};
+
+	$wpdb->save_queries = true;
+
+	$summarize_queries = static function ( array $queries, int $query_count, float $elapsed_ms ): array {
+		$matching = array();
+		$slowest  = array(
+			'sql'        => '',
+			'elapsed_ms' => 0,
+			'caller'     => '',
+		);
+
+		foreach ( $queries as $entry ) {
+			$sql       = is_array( $entry ) ? (string) ( $entry[0] ?? '' ) : (string) $entry;
+			$query_ms  = is_array( $entry ) ? (float) ( ( $entry[1] ?? 0 ) * 1000 ) : null;
+			$caller    = is_array( $entry ) ? (string) ( $entry[2] ?? '' ) : '';
+			$lower_sql = strtolower( $sql );
+
+			if ( null !== $query_ms && $query_ms > $slowest['elapsed_ms'] ) {
+				$slowest = array(
+					'sql'        => substr( preg_replace( '/\s+/', ' ', $sql ), 0, 1000 ),
+					'elapsed_ms' => $query_ms,
+					'caller'     => $caller,
+				);
+			}
+
+			if ( false !== strpos( $lower_sql, '_virtual' ) && false !== strpos( $lower_sql, 'product' ) ) {
+				$matching[] = array(
+					'sql'        => substr( preg_replace( '/\s+/', ' ', $sql ), 0, 2000 ),
+					'elapsed_ms' => $query_ms,
+					'caller'     => $caller,
+				);
+			}
+		}
+
+		$matching_elapsed = array_values(
+			array_filter(
+				array_map(
+					static function ( array $query ) {
+						return $query['elapsed_ms'];
+					},
+					$matching
+				),
+				static function ( $value ): bool {
+					return null !== $value;
+				}
+			)
+		);
+
+		return array(
+			'elapsed_ms'                => $elapsed_ms,
+			'query_count'               => $query_count,
+			'matching_query_count'      => count( $matching ),
+			'matching_query_elapsed_ms' => empty( $matching_elapsed ) ? 0 : max( $matching_elapsed ),
+			'slowest_query'             => $slowest,
+			'matching_queries'          => $matching,
+		);
+	};
+
+	$measure = static function ( string $label, callable $callback ) use ( $wpdb, &$captured_queries, $query_filter, $summarize_queries ): array {
+		$captured_queries = array();
+		$wpdb->queries    = array();
+		$queries_before   = (int) $wpdb->num_queries;
+		add_filter( 'query', $query_filter );
+		$started = microtime( true );
+		$result  = $callback();
+		$elapsed = ( microtime( true ) - $started ) * 1000;
+		remove_filter( 'query', $query_filter );
+
+		$queries = is_array( $wpdb->queries ) && ! empty( $wpdb->queries ) ? $wpdb->queries : $captured_queries;
+		return array(
+			'label'  => $label,
+			'result' => $result,
+			'query'  => $summarize_queries( $queries, (int) $wpdb->num_queries - $queries_before, $elapsed ),
+		);
+	};
+
+	$rows   = array();
+	$rows[] = $measure(
+		'direct_has_physical_products',
+		static function (): array {
+			$has_physical_products = Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Shipping::has_physical_products();
+			$shipping_task         = new Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Shipping();
+
+			return array(
+				'has_physical_products' => (bool) $has_physical_products,
+				'shipping_can_view'      => (bool) $shipping_task->can_view(),
+			);
+		}
+	);
+
+	$dashboard_setup_widget_available = false;
+	$rows[]                          = $measure(
+		'dashboard_setup_widget',
+		static function () use ( &$dashboard_setup_widget_available ): array {
+			$dashboard_file = WC()->plugin_path() . '/includes/admin/class-wc-admin-dashboard-setup.php';
+			if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) && file_exists( $dashboard_file ) ) {
+				include_once $dashboard_file;
+			}
+
+			if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) {
+				return array(
+					'available' => false,
+					'reason'    => 'WC_Admin_Dashboard_Setup class is unavailable.',
+				);
+			}
+
+			$dashboard_setup_widget_available = true;
+			$widget                           = new WC_Admin_Dashboard_Setup();
+			$task_list                        = $widget->get_task_list();
+			$tasks                            = $task_list ? $widget->get_tasks() : array();
+			return array(
+				'available'             => true,
+				'should_display_widget' => (bool) $widget->should_display_widget(),
+				'task_count'            => count( $tasks ),
+			);
+		}
+	);
+
+	remove_filter( 'woocommerce_admin_features', $feature_filter, 100 );
+
+	$direct_row    = $rows[0];
+	$dashboard_row = $rows[1];
+	$all_matching  = array_merge( $direct_row['query']['matching_queries'], $dashboard_row['query']['matching_queries'] );
+	$summary       = array(
+		'success_rate'                        => 1,
+		'product_count'                       => $product_count,
+		'term_count'                          => $term_count,
+		'physical_product_count'              => $physical_count,
+		'virtual_product_count'               => $virtual_count,
+		'onboarding_product_types_physical'    => 1,
+		'woocommerce_version'                  => defined( 'WC_VERSION' ) ? WC_VERSION : '',
+		'direct_has_physical_products_ms'      => (float) $direct_row['query']['elapsed_ms'],
+		'dashboard_setup_widget_ms'            => (float) $dashboard_row['query']['elapsed_ms'],
+		'dashboard_setup_widget_available'     => $dashboard_setup_widget_available ? 1 : 0,
+		'dashboard_request_available'          => 0,
+		'dashboard_request_elapsed_ms'         => 0,
+		'matching_query_elapsed_ms'            => max( (float) $direct_row['query']['matching_query_elapsed_ms'], (float) $dashboard_row['query']['matching_query_elapsed_ms'] ),
+		'matching_query_count'                 => count( $all_matching ),
+		'total_query_count'                    => (int) $direct_row['query']['query_count'] + (int) $dashboard_row['query']['query_count'],
+		'direct_has_physical_products_result'  => ! empty( $direct_row['result']['has_physical_products'] ) ? 1 : 0,
+		'dashboard_should_display_widget'      => ! empty( $dashboard_row['result']['should_display_widget'] ) ? 1 : 0,
+	);
+
+	$artifact_path = '';
+	$shared_state  = getenv( 'HOMEBOY_BENCH_SHARED_STATE' );
+	if ( $shared_state ) {
+		$artifact_dir = rtrim( $shared_state, '/' ) . '/admin-dashboard-physical-products-query';
+		wp_mkdir_p( $artifact_dir );
+		$artifact_path = $artifact_dir . '/' . $run_id . '.json';
+		file_put_contents(
+			$artifact_path,
+			wp_json_encode(
+				array(
+					'run_id'           => $run_id,
+					'sources'          => $sources,
+					'product_ids'      => $product_ids,
+					'term_ids'         => $term_ids,
+					'term_product_map' => $term_product_map,
+					'rows'             => $rows,
+					'metrics'          => $summary,
+				),
+				JSON_PRETTY_PRINT
+			) . "\n"
+		);
+	}
+
+	return array(
+		'metrics'   => $summary,
+		'metadata'  => array(
+			'runner'                  => 'wp-codebox',
+			'workload'                => 'admin-dashboard-physical-products-query',
+			'sources'                 => $sources,
+			'fixture'                 => 'simple-products-product-cat-physical-virtual-split',
+			'reported_call_stack'     => 'WC_Admin_Dashboard_Setup->should_display_widget() > TaskList->is_complete() > Shipping->can_view() > Shipping::has_physical_products()',
+			'dashboard_request_shape' => 'setup-widget PHP path; full wp-admin/index.php request unavailable in wordpress.bench PHP workload',
+		),
+		'artifacts' => $artifact_path ? array( 'raw_result' => array( 'path' => $artifact_path, 'kind' => 'json' ) ) : array(),
+	);
+};

--- a/woocommerce/woocommerce/docs/admin-dashboard-physical-products-query.md
+++ b/woocommerce/woocommerce/docs/admin-dashboard-physical-products-query.md
@@ -1,0 +1,72 @@
+# Admin Dashboard Physical Products Query
+
+`admin-dashboard-physical-products-query` captures the WooCommerce admin
+dashboard onboarding path from the forum/Zendesk report tracked in
+https://github.com/chubes4/homeboy-rigs/issues/224.
+
+## Source Reports
+
+- Zendesk: https://automattic.zendesk.com/agent/tickets/5428113
+- Public forum: https://wordpress.org/support/topic/wp_query-get_posts-slow-query-on-dashboard/
+
+## Workload Shape
+
+The workload runs inside Homeboy Extensions' `wordpress.bench` runtime with the
+WooCommerce checkout mounted as the runtime plugin. It:
+
+- Seeds configurable simple products and `product_cat` terms.
+- Writes deterministic `_virtual` metadata using `WC_ADMIN_DASHBOARD_PHYSICAL_PERCENT`.
+- Sets WooCommerce onboarding state so the shipping task can see physical products.
+- Exercises `Shipping::has_physical_products()` directly.
+- Exercises the `WC_Admin_Dashboard_Setup` setup-widget PHP path when available.
+- Records full dashboard request metrics as unavailable because the current
+  `wordpress.bench` PHP workload API does not issue a real `wp-admin/index.php`
+  HTTP request.
+- Captures query strings, query counts, slowest query summaries, and matching
+  `_virtual` product-query evidence when the tested WooCommerce branch emits it.
+
+Current WooCommerce trunk may not emit the reported SQL because
+`Shipping::has_physical_products()` now reads onboarding profile data directly.
+That is expected and is recorded as `matching_query_count: 0` in the raw artifact
+for branches where the SQL-backed path is absent.
+
+## Commands
+
+```bash
+homeboy rig up woocommerce-performance
+homeboy rig check woocommerce-performance
+homeboy bench --rig woocommerce-performance \
+  --scenario admin-dashboard-physical-products-query \
+  --iterations 1 \
+  --shared-state /tmp/woocommerce-admin-dashboard-products \
+  --setting-json 'bench_env={"WC_ADMIN_DASHBOARD_PRODUCTS":"500","WC_ADMIN_DASHBOARD_TERMS":"20"}'
+```
+
+Use larger sweeps through `bench_env` when running in an offloaded Homeboy lab:
+
+```bash
+homeboy bench --rig woocommerce-performance \
+  --scenario admin-dashboard-physical-products-query \
+  --iterations 1 \
+  --shared-state /tmp/woocommerce-admin-dashboard-products-5000x100 \
+  --setting-json 'bench_env={"WC_ADMIN_DASHBOARD_PRODUCTS":"5000","WC_ADMIN_DASHBOARD_TERMS":"100","WC_ADMIN_DASHBOARD_PHYSICAL_PERCENT":"100"}'
+```
+
+## Metrics
+
+The normalized metrics include:
+
+- `direct_has_physical_products_ms`
+- `dashboard_setup_widget_ms`
+- `dashboard_request_available`, `dashboard_request_elapsed_ms`
+- `matching_query_elapsed_ms`
+- `matching_query_count`
+- `total_query_count`
+- `product_count`, `term_count`, `physical_product_count`, `virtual_product_count`
+- `onboarding_product_types_physical`
+- `woocommerce_version`
+
+Raw JSON artifacts are written under
+`$HOMEBOY_BENCH_SHARED_STATE/admin-dashboard-physical-products-query/` and include
+the captured SQL snippets and call-site metadata where WordPress query logging
+provides it.

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -18,7 +18,10 @@
             "WC_REST_BATCH_IMPORT_ITEMS": "25",
             "WC_REST_BATCH_IMPORT_ATTRIBUTES": "3",
             "WC_REST_BATCH_IMPORT_TERMS_PER_ATTRIBUTE": "8",
-            "WC_REST_BATCH_IMPORT_CATALOG_PRODUCTS": "0"
+            "WC_REST_BATCH_IMPORT_CATALOG_PRODUCTS": "0",
+            "WC_ADMIN_DASHBOARD_PRODUCTS": "500",
+            "WC_ADMIN_DASHBOARD_TERMS": "20",
+            "WC_ADMIN_DASHBOARD_PHYSICAL_PERCENT": "100"
           }
         }
       }
@@ -40,6 +43,7 @@
     "wordpress": [
       { "path": "${package.root}/bench/checkout-concurrent-create-order.php" },
       { "path": "${package.root}/bench/checkout-shipping-cache.php" },
+      { "path": "${package.root}/bench/admin-dashboard-physical-products-query.php" },
       { "path": "${package.root}/bench/layered-nav-count-cache.php" },
       { "path": "${package.root}/bench/layered-nav-catalog-crawl.php" },
       { "path": "${package.root}/bench/rest-product-batch-import.php" }
@@ -49,6 +53,7 @@
     "smoke": [
       "checkout-concurrent-create-order",
       "checkout-shipping-cache",
+      "admin-dashboard-physical-products-query",
       "layered-nav-count-cache",
       "layered-nav-catalog-crawl",
       "rest-product-batch-import"
@@ -56,6 +61,7 @@
     "hot": [
       "checkout-concurrent-create-order",
       "checkout-shipping-cache",
+      "admin-dashboard-physical-products-query",
       "layered-nav-count-cache",
       "layered-nav-catalog-crawl",
       "rest-product-batch-import"


### PR DESCRIPTION
## Summary
- Add `admin-dashboard-physical-products-query` to the `woocommerce-performance` bench rig.
- Seed deterministic product/category fixtures with `_virtual` metadata and capture direct `Shipping::has_physical_products()` plus dashboard setup-widget query evidence.
- Document workload commands, metrics, source reports, and current trunk compatibility where the SQL-backed path may no longer appear.

Closes #224.

## Verification
- `php -l woocommerce/woocommerce/bench/admin-dashboard-physical-products-query.php`
- `php -r 'json_decode(file_get_contents("woocommerce/woocommerce/rigs/woocommerce-performance/rig.json")); if (json_last_error()) { fwrite(STDERR, json_last_error_msg() . PHP_EOL); exit(1); }'`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the workload implementation, rig registration, and docs updates; Chris remains responsible for review and validation.