### PR TITLE
fix(woocommerce): bootstrap shortcode checkout workload

### DIFF
--- a/woocommerce/woocommerce/bench/checkout-shortcode-place-order-latency.php
+++ b/woocommerce/woocommerce/bench/checkout-shortcode-place-order-latency.php
@@ -23,8 +23,20 @@ return function (): array {
 	if ( ! function_exists( 'wc_load_cart' ) ) {
 		throw new RuntimeException( 'WooCommerce cart loader is not available.' );
 	}
+	if ( ! did_action( 'woocommerce_init' ) && method_exists( WC(), 'init' ) ) {
+		WC()->init();
+	}
+	if ( ! did_action( 'woocommerce_after_register_taxonomy' ) && class_exists( 'WC_Post_Types' ) ) {
+		WC_Post_Types::register_taxonomies();
+	}
+	if ( ! did_action( 'woocommerce_after_register_post_type' ) && class_exists( 'WC_Post_Types' ) ) {
+		WC_Post_Types::register_post_types();
+	}
 	if ( ! did_action( 'before_woocommerce_init' ) ) {
 		do_action( 'before_woocommerce_init' );
+	}
+	if ( ! WC()->product_factory && class_exists( 'WC_Product_Factory' ) ) {
+		WC()->product_factory = new WC_Product_Factory();
 	}
 	if ( ! WC()->countries && class_exists( 'WC_Countries' ) ) {
 		WC()->countries = new WC_Countries();


### PR DESCRIPTION
## Summary
- Bootstraps WooCommerce init, taxonomy, and post type registration inside the shortcode checkout workload when the bench runtime loads WooCommerce after the normal WordPress init pass.
- Restores the real `WC()->cart->add_to_cart()` path for the Zendesk-linked checkout latency workload instead of failing before checkout starts.

## Verification
- `php -l woocommerce/woocommerce/bench/checkout-shortcode-place-order-latency.php`
- `jq empty woocommerce/woocommerce/rigs/woocommerce-performance/rig.json`
- `homeboy rig install /Users/chubes/Developer/homeboy-rigs@fix-checkout-latency-product-reload/woocommerce/woocommerce && homeboy bench --runner homeboy-lab --rig woocommerce-performance --path /Users/chubes/Developer/woocommerce@bench-zendesk-performance-evidence/plugins/woocommerce --scenario checkout-shortcode-place-order-latency --iterations 1 --runs 1 --json-summary`

## Evidence
- Persisted Homeboy run: `b2533432-c6ff-42b9-9c29-cbd6ffc7a58d`
- Scenario: `checkout-shortcode-place-order-latency`
- Smoke result: `success_rate=1`, `checkout_post_elapsed_ms≈238`, `order_creation_elapsed_ms≈127`, `query_count=312`, shortcode checkout, CPT orders.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Diagnosed the WP Codebox bench initialization failure, drafted the workload bootstrap fix, and ran the verification commands for Chris to review.