### PR TITLE
Fail invalid Woo Stripe ECE fixtures

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/README.md
+++ b/woocommerce/woocommerce-gateway-stripe/README.md
@@ -176,6 +176,18 @@ Real-wallet evidence records:
 - Browser wallet capability flags such as Payment Request and Apple Pay support.
 - Whether a visible ECE button rendered by the end of the probe.
 
+## Fixture Health
+
+Before treating waterfall metrics as reviewer-facing evidence, the rig writes an
+`ece-fixture-health.json` artifact and fails the trace when the benchmark product
+page is structurally invalid. The health gate checks that the benchmark product
+resolved, `form.cart` rendered as the selected product-page insertion point,
+`wc_stripe_express_checkout_params` is present, the ECE mount exists, captured
+HTML is not a tiny `fetch failed` page, fatal/parse-error markers are absent,
+and Woo add-to-cart/template warnings did not break rendering. Failures include
+pointers to the browser summary, captured HTML, console, and page-error artifacts
+so reviewers can inspect the broken fixture directly.
+
 ## Interpretation
 
 Use request-count and browser-object metrics as the primary signal. The browser
@@ -191,9 +203,11 @@ surfaces to appear after the browser starts loading the product page.
 The metadata artifact records requested and effective browser context, including
 requested viewport, effective viewport, browser profile, preview settings, final
 URL, user agent, and whether the page ran in `window.isSecureContext`. Treat the
-default local HTTP/headless profile as request/lifecycle evidence only. It can
-show Stripe requests, ECE containers, iframes, buttons, console output, and page
-errors, but it is not wallet-eligibility proof. Use the `secure-browser` profile
-for secure-context browser plumbing checks, and use the `real-wallet` profile
-with Stripe test keys plus an HTTPS public preview URL when collecting
-real-wallet-capable evidence.
+default local HTTP/headless profile as synthetic layout proof: it can show Stripe
+requests, ECE containers, iframes, buttons, console output, page errors, and
+deterministic CLS behavior, but it is not wallet-eligibility proof. Structural
+ECE proof means the fixture-health gate passed and the product page actually
+rendered the ECE insertion point, params, and mount needed for those metrics to
+be meaningful. Use the `secure-browser` profile for secure-context browser
+plumbing checks, and use the `real-wallet` profile with Stripe test keys plus an
+HTTPS public preview URL when collecting real-wallet-capable evidence.

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-fixture-health.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-fixture-health.mjs
@@ -1,0 +1,99 @@
+const FATAL_HTML_PATTERN = /(?:fatal error|parse error|syntax error|critical error|there has been a critical error)/i;
+const FETCH_FAILED_PATTERN = /fetch failed/i;
+const ADD_TO_CART_WARNING_PATTERN = /(?:warning|notice|deprecated|recoverable fatal error).*?(?:add-to-cart|add to cart|single-product|product-template|template|form\.cart|woocommerce_template_single_add_to_cart)/i;
+
+function artifactPointer(label, pathname) {
+  return pathname ? `${label}: ${pathname}` : null;
+}
+
+function messageText(entries) {
+  return entries.map((entry) => JSON.stringify(entry)).join('\n');
+}
+
+export function evaluateEceFixtureHealth({
+  html = '',
+  htmlPath = '',
+  summaryPath = '',
+  consolePath = '',
+  errorsPath = '',
+  summary = null,
+  consoleMessages = [],
+  pageErrors = [],
+  scriptResult = {},
+  scenario = {},
+  profileOptions = {},
+} = {}) {
+  const failures = [];
+  const pointers = [
+    artifactPointer('Browser summary', summaryPath),
+    artifactPointer('Captured HTML', htmlPath),
+    artifactPointer('Browser console', consolePath),
+    artifactPointer('Browser page errors', errorsPath),
+  ].filter(Boolean);
+  const fixture = scriptResult?.fixtureHealth || {};
+  const finalUrl = summary?.summary?.finalUrl || summary?.finalUrl || scriptResult?.locationHref || '';
+  const title = scriptResult?.title || '';
+  const combinedMessages = messageText([...consoleMessages, ...pageErrors]);
+
+  if (!fixture.productTitleMatches && !/stripe benchmark product/i.test(`${title}\n${html}`)) {
+    failures.push('Product page did not resolve to the benchmark product "Stripe Benchmark Product".');
+  }
+
+  if (finalUrl && !/stripe-benchmark-product|post_type=product/.test(finalUrl)) {
+    failures.push(`Product page resolved to unexpected URL: ${finalUrl}.`);
+  }
+
+  if (html && html.length < 1024 && FETCH_FAILED_PATTERN.test(html)) {
+    failures.push(`Captured HTML is a tiny fetch-failed page (${html.length} bytes).`);
+  }
+
+  if (FATAL_HTML_PATTERN.test(html)) {
+    failures.push('Captured HTML contains a fatal/parse/critical-error marker.');
+  }
+
+  if (ADD_TO_CART_WARNING_PATTERN.test(`${html}\n${combinedMessages}`)) {
+    failures.push('Product render emitted Woo add-to-cart/template warnings that can break ECE placement.');
+  }
+
+  if (fixture.hasCartForm === false) {
+    failures.push('Selected product-page insertion point is missing: expected form.cart to render.');
+  }
+
+  if (profileOptions.requiresEceMount !== false && scriptResult?.eceContainer !== true) {
+    failures.push('Required ECE mount #wc-stripe-express-checkout-element is missing.');
+  }
+
+  if (profileOptions.requiresStripeParams !== false && fixture.hasStripeParams !== true) {
+    failures.push('Stripe Express Checkout params are missing: expected window.wc_stripe_express_checkout_params.');
+  }
+
+  if (scenario.layout === 'below-fold' && fixture.hasBelowFoldLayout !== true) {
+    failures.push('Selected below-fold layout insertion point did not render: expected #homeboy-ece-below-fold-layout.');
+  }
+
+  return {
+    ok: failures.length === 0,
+    failures,
+    artifact_pointers: pointers,
+    details: {
+      final_url: finalUrl || null,
+      title: title || null,
+      html_bytes: html ? html.length : null,
+      has_cart_form: fixture.hasCartForm === true,
+      has_summary: fixture.hasSummary === true,
+      has_ece_container: scriptResult?.eceContainer === true,
+      has_stripe_params: fixture.hasStripeParams === true,
+      product_title_matches: fixture.productTitleMatches === true,
+      has_below_fold_layout: fixture.hasBelowFoldLayout === true,
+    },
+  };
+}
+
+export function fixtureHealthSummary(health) {
+  if (health.ok) {
+    return 'Woo Stripe ECE fixture health passed.';
+  }
+
+  const artifactText = health.artifact_pointers.length > 0 ? ` Artifacts: ${health.artifact_pointers.join('; ')}.` : '';
+  return `Woo Stripe ECE fixture health failed: ${health.failures.join(' ')}${artifactText}`;
+}

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
+import { evaluateEceFixtureHealth, fixtureHealthSummary } from './ece-product-page-fixture-health.mjs';
 import { buildEceProfileOptions } from './ece-product-page-profile.mjs';
 import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceProductPageScenario, eceProductPageScenarioIds, eceSimulatedClsScript } from './ece-product-page-scenarios.mjs';
 
@@ -263,4 +264,66 @@ test('ECE simulated CLS scripts track root and grouped ECE containers', () => {
   assert.ok(!unreservedScript.includes("].join('\n');"));
   assert.doesNotMatch(unreservedScript, /min-height: 48px/);
   assert.match(reservedScript, /min-height: 48px/);
+});
+
+test('fixture health passes for a structurally valid ECE product page', () => {
+  const health = evaluateEceFixtureHealth({
+    html: '<html><body><h1 class="product_title">Stripe Benchmark Product</h1><form class="cart"><div id="wc-stripe-express-checkout-element"></div></form></body></html>',
+    htmlPath: '/tmp/browser/page.html',
+    summaryPath: '/tmp/browser/summary.json',
+    scriptResult: {
+      title: 'Stripe Benchmark Product',
+      locationHref: 'https://example.test/stripe-benchmark-product/',
+      eceContainer: true,
+      fixtureHealth: {
+        hasCartForm: true,
+        hasSummary: true,
+        hasStripeParams: true,
+        productTitleMatches: true,
+      },
+    },
+    summary: { summary: { finalUrl: 'https://example.test/stripe-benchmark-product/' } },
+  });
+
+  assert.equal(health.ok, true);
+  assert.deepEqual(health.failures, []);
+});
+
+test('fixture health fails loudly with artifact pointers for invalid product pages', () => {
+  const health = evaluateEceFixtureHealth({
+    html: 'fetch failed\nFatal error: broken fixture',
+    htmlPath: '/tmp/browser/page.html',
+    summaryPath: '/tmp/browser/summary.json',
+    consolePath: '/tmp/browser/console.jsonl',
+    errorsPath: '/tmp/browser/errors.jsonl',
+    pageErrors: [{ text: 'PHP Warning: add-to-cart template missing' }],
+    scriptResult: {
+      title: 'Error',
+      locationHref: 'https://example.test/?post_type=product&name=stripe-benchmark-product',
+      eceContainer: false,
+      fixtureHealth: {
+        hasCartForm: false,
+        hasStripeParams: false,
+        productTitleMatches: false,
+      },
+    },
+  });
+
+  assert.equal(health.ok, false);
+  assert.ok(health.failures.some((failure) => /benchmark product/.test(failure)));
+  assert.ok(health.failures.some((failure) => /tiny fetch-failed page/.test(failure)));
+  assert.ok(health.failures.some((failure) => /fatal\/parse\/critical-error/.test(failure)));
+  assert.ok(health.failures.some((failure) => /add-to-cart\/template warnings/.test(failure)));
+  assert.ok(health.failures.some((failure) => /form\.cart/.test(failure)));
+  assert.ok(health.failures.some((failure) => /ECE mount/.test(failure)));
+  assert.ok(health.failures.some((failure) => /Stripe Express Checkout params/.test(failure)));
+  assert.ok(fixtureHealthSummary(health).includes('Captured HTML: /tmp/browser/page.html'));
+});
+
+test('waterfall recipe passes structural assertions to browser-probe', () => {
+  const tracePath = path.join(__dirname, 'ece-product-page-waterfall.trace.mjs');
+  const traceSource = readFileSync(tracePath, 'utf8');
+
+  assert.match(traceSource, /\.\.\.profileOptions\.browserProbeAssertions/);
+  assert.match(traceSource, /id: 'fixture-health'/);
 });

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -1,11 +1,12 @@
 import { execFile } from 'node:child_process';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 import { buildEceProfileOptions } from './ece-product-page-profile.mjs';
+import { evaluateEceFixtureHealth, fixtureHealthSummary } from './ece-product-page-fixture-health.mjs';
 import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceLayoutScript, eceProductPageScenario, eceSimulatedClsScript } from './ece-product-page-scenarios.mjs';
 
 const execFileAsync = promisify(execFile);
@@ -68,6 +69,7 @@ const outputFile = path.join(artifactDir, 'wp-codebox-output.json');
 const codeboxArtifacts = path.join(artifactDir, 'wp-codebox-artifacts');
 const metricsPath = path.join(artifactDir, 'ece-waterfall-metrics.json');
 const metadataPath = path.join(artifactDir, 'ece-waterfall-metadata.json');
+const fixtureHealthPath = path.join(artifactDir, 'ece-fixture-health.json');
 
 function event(source, name, data = {}) {
   return trace.mark(name, data, source);
@@ -95,6 +97,43 @@ async function readJsonl(pathname) {
     .split('\n')
     .filter(Boolean)
     .map((line) => JSON.parse(line));
+}
+
+async function findBrowserHtmlPath(directory) {
+  if (!directory || !existsSync(directory)) {
+    return '';
+  }
+
+  const entries = await readdir(directory, { withFileTypes: true });
+  for (const entry of entries) {
+    const pathname = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      const nested = await findBrowserHtmlPath(pathname);
+      if (nested) {
+        return nested;
+      }
+      continue;
+    }
+
+    if (/\.html?$/i.test(entry.name)) {
+      return pathname;
+    }
+  }
+
+  return '';
+}
+
+async function readTextIfSmall(pathname, maxBytes = 1024 * 1024 * 5) {
+  if (!pathname || !existsSync(pathname)) {
+    return '';
+  }
+
+  const fileStat = await stat(pathname);
+  if (fileStat.size > maxBytes) {
+    return '';
+  }
+
+  return readFile(pathname, 'utf8');
 }
 
 function relativeTimingMs(cdpMetrics, metricName) {
@@ -494,6 +533,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     });
     return {
       title: document.title,
+      locationHref: window.location.href,
       scenario: ${JSON.stringify(scenario.id)},
       interaction: ${JSON.stringify(scenario.interaction)},
       interactionEvents,
@@ -505,6 +545,15 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
       iframes: document.querySelectorAll('iframe').length,
       finalSnapshot,
       stripeAvailability,
+      fixtureHealth: {
+        hasCartForm: !!document.querySelector('form.cart'),
+        hasSummary: !!document.querySelector('.summary'),
+        hasAddToCartButton: !!document.querySelector('form.cart button[type="submit"], form.cart .single_add_to_cart_button'),
+        hasStripeParams: typeof window.wc_stripe_express_checkout_params === 'object' && window.wc_stripe_express_checkout_params !== null,
+        productTitle: document.querySelector('h1.product_title, .product_title, h1')?.textContent?.trim() || '',
+        productTitleMatches: /stripe benchmark product/i.test(document.querySelector('h1.product_title, .product_title, h1')?.textContent || ''),
+        hasBelowFoldLayout: !!document.querySelector('#homeboy-ece-below-fold-layout'),
+      },
       renderProbe: probe,
     };
   `;
@@ -537,6 +586,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
             `duration=${probeDuration}`,
             `viewport=${viewport}`,
             ...profileOptions.browserProbeArgs,
+            ...profileOptions.browserProbeAssertions,
             'capture=console,errors,html,network,performance,memory,screenshot',
             `pre-page-script=${prePageScript}`,
             `script=${browserProbeScript}`,
@@ -565,6 +615,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   const performancePath = browserDir ? path.join(browserDir, 'performance.json') : '';
   const consolePath = browserDir ? path.join(browserDir, 'console.jsonl') : '';
   const errorsPath = browserDir ? path.join(browserDir, 'errors.jsonl') : '';
+  const htmlPath = await findBrowserHtmlPath(browserDir);
   const network = await readJsonl(networkPath);
   const consoleMessages = await readJsonl(consolePath);
   const pageErrors = await readJsonl(errorsPath);
@@ -576,6 +627,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   const googleUrls = urls.filter((url) => /(^|\.)google\.com|(^|\.)gstatic\.com|googleapis\.com/.test(url));
   const iframeResponses = responses.filter((entry) => (entry.resourceType || entry.request?.resourceType) === 'iframe');
   const summary = await readJsonAsync(summaryPath);
+  const html = await readTextIfSmall(htmlPath);
   const performanceSummary = await readJsonAsync(performancePath);
   const browserMetrics = summary?.summary?.metrics ?? {};
   const cdpMetrics = performanceSummary?.final?.cdpMetrics ?? {};
@@ -604,6 +656,19 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   const stripeLoadPageErrors = stripeLoadMessages(pageErrors);
   const finalVisibleButtonCount = scriptResult?.finalSnapshot?.ece_visible_button_count ?? renderLatest.visible_button_count ?? 0;
   const eceRenderedVisibleButton = finalVisibleButtonCount > 0 || peakSampleValue(renderSamples, 'visible_button_count') > 0;
+  const fixtureHealth = evaluateEceFixtureHealth({
+    html,
+    htmlPath,
+    summaryPath,
+    consolePath,
+    errorsPath,
+    summary,
+    consoleMessages,
+    pageErrors,
+    scriptResult,
+    scenario,
+    profileOptions,
+  });
 
   event('browser', 'probe.ready', {
     total_responses: responses.length,
@@ -682,7 +747,12 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     ece_render_final_wallets_link_height: numberOrNull(renderLatest.ece_wallets_link_height),
     ece_interaction_event_count: interactionEvents.length,
     ece_interaction_succeeded: interactionSucceeded,
+    ece_fixture_health_passed: fixtureHealth.ok,
+    ece_fixture_health_failure_count: fixtureHealth.failures.length,
   };
+
+  await writeFile(fixtureHealthPath, `${JSON.stringify(fixtureHealth, null, 2)}\n`);
+  trace.artifact({ label: 'Fixture health', path: fixtureHealthPath });
 
   await writeFile(metricsPath, `${JSON.stringify(metrics, null, 2)}\n`);
   trace.artifact({ label: 'Waterfall metrics', path: metricsPath });
@@ -729,6 +799,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
         google_urls_sample: googleUrls.slice(0, 20),
         console_messages_sample: consoleMessages.slice(0, 20),
         page_errors_sample: pageErrors.slice(0, 20),
+        fixture_health: fixtureHealth,
         browser_script_result: scriptResult,
         pass_conditions: {
           network_path_exists: existsSync(networkPath),
@@ -756,13 +827,20 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
         : true;
   const stripeLoadPass = stripeLoadPageErrors.length === 0;
   const browserProbeCompleted = responses.length > 0 && existsSync(networkPath) && existsSync(performancePath);
-  const pass = browserProbeCompleted && stripeUrls.length > 0 && simulatedClsPass && stripeLoadPass;
+  const pass = fixtureHealth.ok && browserProbeCompleted && stripeUrls.length > 0 && simulatedClsPass && stripeLoadPass;
   const summaryText = pass
     ? `Captured Stripe ECE product-page browser waterfall: ${stripeUrls.length} Stripe responses across ${responses.length} total responses.`
-    : stripeLoadPass
+    : !fixtureHealth.ok
+      ? fixtureHealthSummary(fixtureHealth)
+      : stripeLoadPass
       ? 'Browser waterfall capture did not observe Stripe network responses.'
       : `Browser waterfall capture recorded ${stripeLoadPageErrors.length} Stripe-related page error(s).`;
 
+  trace.assertion({
+    id: 'fixture-health',
+    status: fixtureHealth.ok ? 'pass' : 'fail',
+    message: fixtureHealthSummary(fixtureHealth),
+  });
   trace.assertion({
     id: 'stripe-network-observed',
     status: stripeUrls.length > 0 ? 'pass' : 'fail',
@@ -809,6 +887,9 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   trace.artifact({ label: 'WP Codebox output', path: outputFile });
   if (summaryPath && existsSync(summaryPath)) {
     trace.artifact({ label: 'Browser summary', path: summaryPath });
+  }
+  if (htmlPath && existsSync(htmlPath)) {
+    trace.artifact({ label: 'Captured HTML', path: htmlPath });
   }
   if (networkPath && existsSync(networkPath)) {
     trace.artifact({ label: 'Browser network log', path: networkPath });


### PR DESCRIPTION
## Summary
- Adds a Woo Stripe product-page ECE fixture-health artifact that fails traces when the benchmark product page is structurally invalid before reviewer-facing evidence is accepted.
- Captures actionable diagnostics for missing ECE mount, missing Stripe params, tiny fetch-failed HTML, fatal/parse-error HTML, add-to-cart/template warnings, and missing insertion points.
- Documents synthetic layout proof, structural ECE proof, and real-wallet proof boundaries.

Fixes https://github.com/chubes4/homeboy-rigs/issues/234

## Verification
- `node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`
- `node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the fixture-health gate, targeted tests, and documentation updates; Chris remains responsible for review and merge.