### PR TITLE
Fix Woo Stripe ECE asset false passes

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-asset-health.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-asset-health.mjs
@@ -1,0 +1,102 @@
+function entryUrl(entry) {
+  return entry?.url || entry?.request?.url || entry?.response?.url || '';
+}
+
+function entryStatus(entry) {
+  return entry?.status ?? entry?.response?.status ?? entry?.responseStatus ?? null;
+}
+
+function entryFailureText(entry) {
+  return [entry?.errorText, entry?.failure?.errorText, entry?.response?.errorText, entry?.message, entry?.text]
+    .filter(Boolean)
+    .join(' ');
+}
+
+function isCriticalAssetUrl(url) {
+  if (!/\.(?:js|css)(?:\?|$)/i.test(url)) {
+    return false;
+  }
+
+  return /\/wp-content\/plugins\/(?:woocommerce-gateway-stripe|woocommerce)\//.test(url);
+}
+
+function assetLabel(url) {
+  const match = /\/wp-content\/plugins\/([^?#]+)/.exec(url);
+  return match ? `/wp-content/plugins/${match[1]}` : url;
+}
+
+function assetFailure(entry) {
+  const status = entryStatus(entry);
+  const failureText = entryFailureText(entry);
+
+  if (typeof status === 'number' && status >= 400) {
+    return `HTTP ${status}`;
+  }
+
+  if (/net::ERR_|ERR_ABORTED|failed|aborted|blocked/i.test(failureText)) {
+    return failureText || 'request failed';
+  }
+
+  return '';
+}
+
+function metricNumber(metrics, key) {
+  const value = metrics?.[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+export function evaluateEceRealWalletAssetHealth({ networkEntries = [], metrics = {}, profileOptions = {} } = {}) {
+  const failures = [];
+
+  if (profileOptions.realWalletCapable !== true) {
+    return {
+      ok: true,
+      failures,
+      details: {
+        checked: false,
+      },
+    };
+  }
+
+  const failedAssets = networkEntries
+    .map((entry) => ({ entry, url: entryUrl(entry), reason: assetFailure(entry) }))
+    .filter(({ url, reason }) => url && reason && isCriticalAssetUrl(url));
+  const failedAssetLabels = failedAssets.map(({ url, reason }) => `${assetLabel(url)} (${reason})`);
+
+  if (failedAssetLabels.length > 0) {
+    failures.push(`Critical Woo/ECE frontend assets failed to load: ${failedAssetLabels.slice(0, 8).join('; ')}.`);
+  }
+
+  if (metricNumber(metrics, 'stripe_elements_session_response_count') < 1) {
+    failures.push('Real-wallet ECE did not start a Stripe Elements session request.');
+  }
+
+  const peakChildCount = metricNumber(metrics, 'ece_render_peak_child_count');
+  const peakIframeCount = metricNumber(metrics, 'ece_render_peak_iframe_count');
+  const peakVisibleButtonCount = metricNumber(metrics, 'ece_render_peak_visible_button_count');
+  if (peakChildCount < 1 && peakIframeCount < 1 && peakVisibleButtonCount < 1) {
+    failures.push('Real-wallet ECE render probe never observed ECE children, iframes, or visible buttons.');
+  }
+
+  return {
+    ok: failures.length === 0,
+    failures,
+    details: {
+      checked: true,
+      failed_asset_count: failedAssets.length,
+      failed_assets: failedAssetLabels.slice(0, 20),
+      stripe_elements_session_response_count: metricNumber(metrics, 'stripe_elements_session_response_count'),
+      ece_render_peak_child_count: peakChildCount,
+      ece_render_peak_iframe_count: peakIframeCount,
+      ece_render_peak_visible_button_count: peakVisibleButtonCount,
+    },
+  };
+}
+
+export function realWalletAssetHealthSummary(health) {
+  if (health.ok) {
+    return health.details?.checked === false ? 'Real-wallet asset health was not required for this profile.' : 'Real-wallet Woo Stripe ECE asset health passed.';
+  }
+
+  return `Real-wallet Woo Stripe ECE asset health failed: ${health.failures.join(' ')}`;
+}

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
+import { evaluateEceRealWalletAssetHealth, realWalletAssetHealthSummary } from './ece-product-page-asset-health.mjs';
 import { evaluateEceFixtureHealth, fixtureHealthSummary } from './ece-product-page-fixture-health.mjs';
 import { buildEceProfileOptions } from './ece-product-page-profile.mjs';
 import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceProductPageScenario, eceProductPageScenarioIds, eceSimulatedClsScript } from './ece-product-page-scenarios.mjs';
@@ -289,6 +290,61 @@ test('fixture health passes for a structurally valid ECE product page', () => {
   assert.deepEqual(health.failures, []);
 });
 
+test('real-wallet asset health fails on critical Woo Stripe asset failures and missing ECE startup', () => {
+  const health = evaluateEceRealWalletAssetHealth({
+    profileOptions: { realWalletCapable: true },
+    networkEntries: [
+      {
+        type: 'response',
+        url: 'https://example.test/wp-content/plugins/woocommerce-gateway-stripe/build/express-checkout.js?ver=10.8.0',
+        status: 502,
+      },
+      {
+        type: 'requestfailed',
+        url: 'https://example.test/wp-content/plugins/woocommerce/assets/client/blocks/wc-blocks.css?ver=1',
+        errorText: 'net::ERR_ABORTED',
+      },
+    ],
+    metrics: {
+      stripe_elements_session_response_count: 0,
+      ece_render_peak_child_count: 0,
+      ece_render_peak_iframe_count: 0,
+      ece_render_peak_visible_button_count: 0,
+    },
+  });
+
+  assert.equal(health.ok, false);
+  assert.equal(health.details.failed_asset_count, 2);
+  assert.ok(health.failures.some((failure) => /Critical Woo\/ECE frontend assets failed/.test(failure)));
+  assert.ok(health.failures.some((failure) => /Stripe Elements session/.test(failure)));
+  assert.ok(health.failures.some((failure) => /never observed ECE children/.test(failure)));
+  assert.match(realWalletAssetHealthSummary(health), /asset health failed/);
+});
+
+test('real-wallet asset health is profile-scoped and passes when assets and ECE startup are healthy', () => {
+  assert.equal(evaluateEceRealWalletAssetHealth({ profileOptions: { realWalletCapable: false } }).ok, true);
+
+  const health = evaluateEceRealWalletAssetHealth({
+    profileOptions: { realWalletCapable: true },
+    networkEntries: [
+      {
+        type: 'response',
+        url: 'https://example.test/wp-content/plugins/woocommerce-gateway-stripe/build/express-checkout.js?ver=10.8.0',
+        status: 200,
+      },
+    ],
+    metrics: {
+      stripe_elements_session_response_count: 1,
+      ece_render_peak_child_count: 1,
+      ece_render_peak_iframe_count: 1,
+      ece_render_peak_visible_button_count: 0,
+    },
+  });
+
+  assert.equal(health.ok, true);
+  assert.equal(health.details.failed_asset_count, 0);
+});
+
 test('fixture health fails loudly with artifact pointers for invalid product pages', () => {
   const health = evaluateEceFixtureHealth({
     html: 'fetch failed\nFatal error: broken fixture',
@@ -326,4 +382,14 @@ test('waterfall recipe passes structural assertions to browser-probe', () => {
 
   assert.match(traceSource, /\.\.\.profileOptions\.browserProbeAssertions/);
   assert.match(traceSource, /id: 'fixture-health'/);
+  assert.match(traceSource, /id: 'real-wallet-asset-health'/);
+});
+
+test('fixture bootstrap forces a tiny Woo-compatible classic theme', () => {
+  const fixtureBootstrapPath = path.join(__dirname, 'fixture-bootstrap.php');
+  const fixtureBootstrapSource = readFileSync(fixtureBootstrapPath, 'utf8');
+
+  assert.match(fixtureBootstrapSource, /ensure_classic_woocommerce_theme/);
+  assert.match(fixtureBootstrapSource, /add_theme_support\( 'woocommerce' \)/);
+  assert.match(fixtureBootstrapSource, /switch_theme\( 'homeboy-stripe-ece-classic' \)/);
 });

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
+import { evaluateEceRealWalletAssetHealth, realWalletAssetHealthSummary } from './ece-product-page-asset-health.mjs';
 import { buildEceProfileOptions } from './ece-product-page-profile.mjs';
 import { evaluateEceFixtureHealth, fixtureHealthSummary } from './ece-product-page-fixture-health.mjs';
 import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceLayoutScript, eceProductPageScenario, eceSimulatedClsScript } from './ece-product-page-scenarios.mjs';
@@ -70,6 +71,7 @@ const codeboxArtifacts = path.join(artifactDir, 'wp-codebox-artifacts');
 const metricsPath = path.join(artifactDir, 'ece-waterfall-metrics.json');
 const metadataPath = path.join(artifactDir, 'ece-waterfall-metadata.json');
 const fixtureHealthPath = path.join(artifactDir, 'ece-fixture-health.json');
+const realWalletAssetHealthPath = path.join(artifactDir, 'ece-real-wallet-asset-health.json');
 
 function event(source, name, data = {}) {
   return trace.mark(name, data, source);
@@ -750,9 +752,18 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     ece_fixture_health_passed: fixtureHealth.ok,
     ece_fixture_health_failure_count: fixtureHealth.failures.length,
   };
+  const realWalletAssetHealth = evaluateEceRealWalletAssetHealth({
+    networkEntries: network,
+    metrics,
+    profileOptions,
+  });
+  metrics.ece_real_wallet_asset_health_passed = realWalletAssetHealth.ok;
+  metrics.ece_real_wallet_asset_health_failure_count = realWalletAssetHealth.failures.length;
 
   await writeFile(fixtureHealthPath, `${JSON.stringify(fixtureHealth, null, 2)}\n`);
   trace.artifact({ label: 'Fixture health', path: fixtureHealthPath });
+  await writeFile(realWalletAssetHealthPath, `${JSON.stringify(realWalletAssetHealth, null, 2)}\n`);
+  trace.artifact({ label: 'Real-wallet asset health', path: realWalletAssetHealthPath });
 
   await writeFile(metricsPath, `${JSON.stringify(metrics, null, 2)}\n`);
   trace.artifact({ label: 'Waterfall metrics', path: metricsPath });
@@ -800,6 +811,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
         console_messages_sample: consoleMessages.slice(0, 20),
         page_errors_sample: pageErrors.slice(0, 20),
         fixture_health: fixtureHealth,
+        real_wallet_asset_health: realWalletAssetHealth,
         browser_script_result: scriptResult,
         pass_conditions: {
           network_path_exists: existsSync(networkPath),
@@ -827,11 +839,13 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
         : true;
   const stripeLoadPass = stripeLoadPageErrors.length === 0;
   const browserProbeCompleted = responses.length > 0 && existsSync(networkPath) && existsSync(performancePath);
-  const pass = fixtureHealth.ok && browserProbeCompleted && stripeUrls.length > 0 && simulatedClsPass && stripeLoadPass;
+  const pass = fixtureHealth.ok && realWalletAssetHealth.ok && browserProbeCompleted && stripeUrls.length > 0 && simulatedClsPass && stripeLoadPass;
   const summaryText = pass
     ? `Captured Stripe ECE product-page browser waterfall: ${stripeUrls.length} Stripe responses across ${responses.length} total responses.`
     : !fixtureHealth.ok
       ? fixtureHealthSummary(fixtureHealth)
+      : !realWalletAssetHealth.ok
+      ? realWalletAssetHealthSummary(realWalletAssetHealth)
       : stripeLoadPass
       ? 'Browser waterfall capture did not observe Stripe network responses.'
       : `Browser waterfall capture recorded ${stripeLoadPageErrors.length} Stripe-related page error(s).`;
@@ -860,6 +874,11 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     id: 'stripe-load-errors',
     status: stripeLoadPass ? 'pass' : 'fail',
     message: `Recorded ${stripeLoadPageErrors.length} Stripe-related page error(s).`,
+  });
+  trace.assertion({
+    id: 'real-wallet-asset-health',
+    status: realWalletAssetHealth.ok ? 'pass' : 'fail',
+    message: realWalletAssetHealthSummary(realWalletAssetHealth),
   });
   trace.assertion({
     id: 'scenario-interaction',

--- a/woocommerce/woocommerce-gateway-stripe/bench/fixture-bootstrap.php
+++ b/woocommerce/woocommerce-gateway-stripe/bench/fixture-bootstrap.php
@@ -50,6 +50,7 @@ if ( ! class_exists( 'Homeboy_WC_Stripe_Benchmark_Fixture_Bootstrap' ) ) {
 			$args = array_merge( self::DEFAULT_ARGS, self::env_args(), $args );
 
 			self::assert_runtime_loaded();
+			self::ensure_classic_woocommerce_theme();
 			self::ensure_woocommerce_install_state();
 			self::ensure_store_settings( (string) $args['currency'] );
 
@@ -177,6 +178,44 @@ if ( ! class_exists( 'Homeboy_WC_Stripe_Benchmark_Fixture_Bootstrap' ) ) {
 
 			if ( function_exists( 'wc_update_product_lookup_tables_is_running' ) && ! wc_update_product_lookup_tables_is_running() ) {
 				delete_transient( 'wc_product_loop' );
+			}
+		}
+
+		/**
+		 * Force a tiny classic theme so product pages render Woo's form.cart template.
+		 *
+		 * @return void
+		 */
+		private static function ensure_classic_woocommerce_theme(): void {
+			$theme_slug = 'homeboy-stripe-ece-classic';
+			$theme_dir  = WP_CONTENT_DIR . '/themes/' . $theme_slug;
+
+			if ( ! is_dir( $theme_dir ) && ! wp_mkdir_p( $theme_dir ) ) {
+				throw new RuntimeException( 'Benchmark fixture setup failed: could not create classic WooCommerce theme directory.' );
+			}
+
+			file_put_contents(
+				$theme_dir . '/style.css',
+				"/*\nTheme Name: Homeboy Stripe ECE Classic\nVersion: 1.0.0\n*/\n"
+			);
+
+			file_put_contents(
+				$theme_dir . '/functions.php',
+				"<?php\nadd_action( 'after_setup_theme', static function () {\n\tadd_theme_support( 'woocommerce' );\n} );\n"
+			);
+
+			file_put_contents(
+				$theme_dir . '/index.php',
+				"<?php\nget_header();\nif ( have_posts() ) {\n\twhile ( have_posts() ) {\n\t\tthe_post();\n\t\tthe_content();\n\t}\n}\nget_footer();\n"
+			);
+
+			file_put_contents(
+				$theme_dir . '/single-product.php',
+				"<?php\nget_header();\nif ( function_exists( 'woocommerce_content' ) ) {\n\twoocommerce_content();\n}\nget_footer();\n"
+			);
+
+			if ( get_stylesheet() !== $theme_slug ) {
+				switch_theme( 'homeboy-stripe-ece-classic' );
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Adds a real-wallet-only Woo Stripe ECE asset/runtime health gate that fails when critical Woo/Woo Stripe frontend assets return errors or abort before ECE can start.
- Fails real-wallet proof when no Stripe Elements session request starts and the render probe never observes ECE children, iframes, or visible buttons.
- Forces the disposable fixture onto a tiny Woo-compatible classic theme so block themes do not omit the product `form.cart` insertion point.

Fixes #237.

## Verification
- `node --test "woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs"`
- `node --check "woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafting the rig health gate, fixture bootstrap update, tests, and PR text; Chris remains responsible for review and merge.