### PR TITLE
Add true concurrent WooCommerce checkout rig

### DIFF
--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -78,6 +78,7 @@ php bin/generate-feature-config.php
 
 ```bash
 homeboy rig up woocommerce-performance
+homeboy bench --rig woocommerce-performance --scenario checkout-concurrent-create-order --iterations 1 --shared-state /tmp/woocommerce-concurrent-checkout
 homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-bench
 homeboy bench --rig woocommerce-performance --scenario checkout-shortcode-place-order-latency --iterations 1 --shared-state /tmp/woocommerce-shortcode-checkout
 homeboy bench --rig woocommerce-performance --scenario admin-dashboard-physical-products-query --iterations 1 --shared-state /tmp/woocommerce-admin-dashboard-products --setting-json 'bench_env={"WC_ADMIN_DASHBOARD_PRODUCTS":"500","WC_ADMIN_DASHBOARD_TERMS":"20"}'
@@ -111,6 +112,11 @@ into `tests/bench/`, and returns the normalized Homeboy `BenchResults` envelope.
   synthetic successful gateway while capturing checkout POST timing, order
   creation timing, query counts, Action Scheduler deltas, and raw JSON evidence
   for the slow place-order report in homeboy-rigs issue #223.
+- `checkout-concurrent-create-order` seeds one WooCommerce cart/session, then
+  fires simultaneous `/?wc-ajax=checkout` POSTs with the same session cookie to
+  distinguish true request races from sequential `create_order()` retry fixes.
+  It links evidence to WooCommerce issue #62659, PR #65588, Jorge's review, and
+  homeboy-rigs issue #254.
 - `layered-nav-count-cache` seeds a real WooCommerce product attribute, terms,
   and simple products, then exercises `Filterer::get_filtered_term_product_counts()`
   across many unique layered-nav count query hashes to measure growth of the
@@ -151,6 +157,12 @@ The first slice reports:
   slowest query summaries when `SAVEQUERIES` is available, Action Scheduler job
   deltas, order ID/payment method rows, HPOS mode, checkout renderer, and
   WooCommerce version for shortcode place-order latency.
+- `checkout_request_count`, `successful_response_count`, `unique_order_count`,
+  `duplicate_reproduced`, `cart_item_owner_order_count`,
+  `payment_attempt_count_observed`, `safe_losing_response_count`,
+  `cart_session_integrity_after_burst_iteration_count`, and
+  `repeated_iteration_stability` for true concurrent checkout duplicate-order
+  behavior.
 - `final_transient_entry_count`, `max_transient_entry_count`,
   `final_serialized_value_bytes`, and `cache_exceeded_limit` for layered-nav
   count cache growth.
@@ -160,6 +172,20 @@ The first slice reports:
   WooCommerce version for the admin dashboard physical-products path.
 
 See `docs/checkout-shipping-cache.md` for workload details and current TODOs.
+
+For baseline/candidate duplicate-checkout comparisons, run the focused profile
+against each WooCommerce checkout and keep the shared-state artifacts attached
+to the WooCommerce tracker or PR:
+
+```bash
+homeboy bench --rig woocommerce-performance --profile checkout-concurrent --iterations 1 --shared-state /tmp/wc-checkout-baseline
+homeboy bench --rig woocommerce-performance --profile checkout-concurrent --iterations 1 --shared-state /tmp/wc-checkout-candidate
+```
+
+Use `bench_env.WC_CONCURRENT_CHECKOUT_REQUESTS`,
+`bench_env.WC_CONCURRENT_CHECKOUT_ITERATIONS`, and
+`bench_env.WC_CONCURRENT_CHECKOUT_PAYMENT_MODE` to adjust burst width,
+repetition, and COD vs no-payment-needed checkout paths.
 
 ## Matrix Report
 

--- a/woocommerce/woocommerce/bench/checkout-concurrent-create-order.php
+++ b/woocommerce/woocommerce/bench/checkout-concurrent-create-order.php
@@ -2,11 +2,13 @@
 /**
  * WP Codebox-backed WooCommerce checkout atomicity and side-effect guardrail workload.
  *
- * Reproduces the duplicate public create_order window and records guardrails for:
+ * Reproduces the duplicate public create_order window, records side-effect
+ * guardrails, and fires true concurrent checkout requests for:
  * - https://github.com/woocommerce/woocommerce/issues/62659
  * - https://github.com/woocommerce/woocommerce/pull/65588
  * - https://github.com/woocommerce/woocommerce/pull/65588#pullrequestreview-4488383929
  * - https://github.com/chubes4/homeboy-rigs/issues/253
+ * - https://github.com/chubes4/homeboy-rigs/issues/254
  */
 return function (): array {
 	if ( ! class_exists( 'WooCommerce' ) ) {
@@ -20,8 +22,11 @@ return function (): array {
 	if ( ! class_exists( 'WooCommerce' ) || ! function_exists( 'WC' ) ) {
 		throw new RuntimeException( 'WooCommerce is not loaded.' );
 	}
-	if ( ! function_exists( 'wc_load_cart' ) ) {
-		throw new RuntimeException( 'WooCommerce cart loader is not available.' );
+	if ( ! function_exists( 'wc_load_cart' ) || ! class_exists( 'WC_Session_Handler' ) || ! class_exists( 'WC_Cart' ) || ! class_exists( 'WC_Cart_Session' ) ) {
+		throw new RuntimeException( 'WooCommerce cart/session classes are not available.' );
+	}
+	if ( ! function_exists( 'curl_multi_init' ) ) {
+		throw new RuntimeException( 'PHP cURL multi support is required for true concurrent checkout requests.' );
 	}
 	if ( ! did_action( 'before_woocommerce_init' ) ) {
 		do_action( 'before_woocommerce_init' );
@@ -36,6 +41,8 @@ return function (): array {
 		WC()->payment_gateways = new WC_Payment_Gateways();
 	}
 
+	global $wpdb;
+
 	$run_id = 'woocommerce-checkout-concurrent-create-order-' . getmypid() . '-' . time() . '-' . wp_generate_password( 6, false );
 	$issues = array(
 		'https://github.com/woocommerce/woocommerce/issues/14541',
@@ -44,7 +51,12 @@ return function (): array {
 		'https://github.com/woocommerce/woocommerce/pull/65588',
 		'https://github.com/woocommerce/woocommerce/pull/65588#pullrequestreview-4488383929',
 		'https://github.com/chubes4/homeboy-rigs/issues/253',
+		'https://github.com/chubes4/homeboy-rigs/issues/254',
 	);
+	$request_count = max( 2, min( 8, absint( getenv( 'WC_CONCURRENT_CHECKOUT_REQUESTS' ) ?: 2 ) ) );
+	$iterations    = max( 1, min( 10, absint( getenv( 'WC_CONCURRENT_CHECKOUT_ITERATIONS' ) ?: 3 ) ) );
+	$payment_mode  = 'free' === strtolower( (string) getenv( 'WC_CONCURRENT_CHECKOUT_PAYMENT_MODE' ) ) ? 'free' : 'cod';
+	$checkout_url  = getenv( 'WC_CONCURRENT_CHECKOUT_URL' ) ?: home_url( '/?wc-ajax=checkout' );
 
 	wp_set_current_user( 0 );
 	update_option( 'woocommerce_default_country', 'US:CA' );
@@ -53,6 +65,18 @@ return function (): array {
 	update_option( 'woocommerce_calc_taxes', 'no' );
 	update_option( 'woocommerce_enable_guest_checkout', 'yes' );
 	update_option( 'woocommerce_enable_coupons', 'yes' );
+	update_option( 'woocommerce_enable_checkout_login_reminder', 'no' );
+	update_option(
+		'woocommerce_cod_settings',
+		array(
+			'enabled'            => 'yes',
+			'title'              => 'Cash on delivery',
+			'description'        => 'Pay with cash upon delivery.',
+			'instructions'       => 'Homeboy concurrent checkout COD probe.',
+			'enable_for_methods' => array(),
+			'enable_for_virtual' => 'yes',
+		)
+	);
 
 	if ( ! WC()->session ) {
 		if ( method_exists( WC(), 'initialize_session' ) ) {
@@ -218,6 +242,261 @@ return function (): array {
 		);
 	};
 
+	$session_probe = new WC_Session_Handler();
+	$cookie_name   = ( new ReflectionProperty( WC_Session_Handler::class, '_cookie' ) )->getValue( $session_probe );
+	$session_table = $wpdb->prefix . 'woocommerce_sessions';
+	$hash_method   = new ReflectionMethod( WC_Session_Handler::class, 'hash' );
+	$hash_method->setAccessible( true );
+
+	$make_cookie_value = static function ( string $customer_id ) use ( $session_probe, $hash_method ): string {
+		$expiration = time() + 2 * DAY_IN_SECONDS;
+		$expiring   = time() + DAY_IN_SECONDS;
+		return $customer_id . '|' . $expiration . '|' . $expiring . '|' . $hash_method->invoke( $session_probe, $customer_id . '|' . $expiration );
+	};
+
+	$get_persisted_session = static function ( string $customer_id ) use ( $wpdb, $session_table ): array {
+		$row = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT session_value FROM %i WHERE session_key = %s',
+				$session_table,
+				$customer_id
+			)
+		);
+		return $row ? (array) maybe_unserialize( $row ) : array();
+	};
+
+	$session_cart_count = static function ( array $session ): int {
+		$cart = array_key_exists( 'cart', $session ) ? maybe_unserialize( $session['cart'] ) : array();
+		return is_array( $cart ) ? count( $cart ) : 0;
+	};
+
+	$parse_response_order_id = static function ( array $decoded ): int {
+		$redirect = isset( $decoded['redirect'] ) ? (string) $decoded['redirect'] : '';
+		if ( preg_match( '#order-received/(\d+)#', $redirect, $matches ) ) {
+			return absint( $matches[1] );
+		}
+		return 0;
+	};
+
+	$create_concurrent_product = static function ( string $iteration_id, string $payment_mode ): WC_Product_Simple {
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Homeboy Concurrent Checkout Product ' . $iteration_id );
+		$product->set_slug( 'homeboy-concurrent-checkout-' . $iteration_id );
+		$product->set_status( 'publish' );
+		$product->set_sku( 'homeboy-concurrent-checkout-' . $iteration_id );
+		$product->set_regular_price( 'free' === $payment_mode ? '0' : '19.99' );
+		$product->set_price( 'free' === $payment_mode ? '0' : '19.99' );
+		$product->set_virtual( true );
+		$product->set_manage_stock( false );
+		$product->set_stock_status( 'instock' );
+		$product->save();
+		return $product;
+	};
+
+	$seed_checkout_session = static function ( string $iteration_id, string $cookie_value, WC_Product_Simple $product, string $payment_mode ) use ( $cookie_name ): array {
+		$_COOKIE[ $cookie_name ] = $cookie_value;
+		$session = new WC_Session_Handler();
+		$session->init();
+		WC()->session = $session;
+		WC()->cart    = new WC_Cart();
+
+		$cart_item_key = WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		$cart_session = new WC_Cart_Session( WC()->cart );
+		$cart_session->set_session();
+		$session->set( 'chosen_payment_method', 'free' === $payment_mode ? '' : 'cod' );
+		$session->set( 'order_awaiting_payment', null );
+		$session->set(
+			'customer',
+			array(
+				'email'      => 'homeboy-' . $iteration_id . '@example.com',
+				'first_name' => 'Homeboy',
+				'last_name'  => 'Checkout',
+				'country'    => 'US',
+				'state'      => 'CA',
+			)
+		);
+		$session->save_data();
+
+		return array(
+			'cart_item_key' => $cart_item_key,
+			'cart_hash'     => WC()->cart->get_cart_hash(),
+			'cart_total'    => (float) WC()->cart->get_total( 'edit' ),
+		);
+	};
+
+	$build_checkout_post_data = static function ( string $iteration_id, string $payment_mode ): array {
+		return array(
+			'billing_first_name'        => 'Homeboy',
+			'billing_last_name'         => 'Checkout',
+			'billing_company'           => '',
+			'billing_country'           => 'US',
+			'billing_address_1'         => '123 Atomicity Way',
+			'billing_address_2'         => '',
+			'billing_city'              => 'San Francisco',
+			'billing_state'             => 'CA',
+			'billing_postcode'          => '94107',
+			'billing_phone'             => '5555555555',
+			'billing_email'             => 'homeboy-' . $iteration_id . '@example.com',
+			'shipping_first_name'       => 'Homeboy',
+			'shipping_last_name'        => 'Checkout',
+			'shipping_company'          => '',
+			'shipping_country'          => 'US',
+			'shipping_address_1'        => '123 Atomicity Way',
+			'shipping_address_2'        => '',
+			'shipping_city'             => 'San Francisco',
+			'shipping_state'            => 'CA',
+			'shipping_postcode'         => '94107',
+			'order_comments'            => 'Homeboy true concurrent checkout repro ' . $iteration_id,
+			'payment_method'            => 'free' === $payment_mode ? '' : 'cod',
+			'terms'                     => 1,
+			'createaccount'             => 0,
+			'ship_to_different_address' => 0,
+			'security'                  => wp_create_nonce( 'woocommerce-process_checkout' ),
+		);
+	};
+
+	$fire_concurrent_checkout_requests = static function ( string $checkout_url, string $cookie_name, string $cookie_value, array $post_data, int $request_count ): array {
+		$multi_handle = curl_multi_init();
+		$handles      = array();
+		$started_at   = microtime( true );
+
+		for ( $index = 0; $index < $request_count; $index++ ) {
+			$handle = curl_init( $checkout_url );
+			curl_setopt_array(
+				$handle,
+				array(
+					CURLOPT_POST           => true,
+					CURLOPT_POSTFIELDS     => http_build_query( $post_data, '', '&' ),
+					CURLOPT_RETURNTRANSFER => true,
+					CURLOPT_HEADER         => false,
+					CURLOPT_FOLLOWLOCATION => false,
+					CURLOPT_CONNECTTIMEOUT => 10,
+					CURLOPT_TIMEOUT        => 60,
+					CURLOPT_HTTPHEADER     => array(
+						'Content-Type: application/x-www-form-urlencoded; charset=UTF-8',
+						'X-Requested-With: XMLHttpRequest',
+					),
+					CURLOPT_COOKIE         => $cookie_name . '=' . $cookie_value,
+				)
+			);
+			curl_multi_add_handle( $multi_handle, $handle );
+			$handles[ $index ] = $handle;
+		}
+
+		$running = null;
+		do {
+			$status = curl_multi_exec( $multi_handle, $running );
+			if ( CURLM_OK !== $status ) {
+				break;
+			}
+			if ( $running ) {
+				curl_multi_select( $multi_handle, 1.0 );
+			}
+		} while ( $running );
+
+		$responses = array();
+		foreach ( $handles as $index => $handle ) {
+			$body    = (string) curl_multi_getcontent( $handle );
+			$decoded = json_decode( $body, true );
+			if ( ! is_array( $decoded ) ) {
+				$decoded = array();
+			}
+			$responses[] = array(
+				'index'       => $index,
+				'http_code'   => (int) curl_getinfo( $handle, CURLINFO_HTTP_CODE ),
+				'curl_errno'  => (int) curl_errno( $handle ),
+				'curl_error'  => (string) curl_error( $handle ),
+				'elapsed_ms'  => (float) curl_getinfo( $handle, CURLINFO_TOTAL_TIME ) * 1000,
+				'body_bytes'  => strlen( $body ),
+				'json'        => $decoded,
+				'raw_excerpt' => substr( $body, 0, 1000 ),
+			);
+			curl_multi_remove_handle( $multi_handle, $handle );
+			curl_close( $handle );
+		}
+		curl_multi_close( $multi_handle );
+
+		return array(
+			'elapsed_ms' => ( microtime( true ) - $started_at ) * 1000,
+			'responses'  => $responses,
+		);
+	};
+
+	$summarize_checkout_orders = static function ( string $email, int $product_id, string $cart_hash ): array {
+		$order_rows = array();
+		$orders     = wc_get_orders(
+			array(
+				'limit'         => -1,
+				'billing_email' => $email,
+				'orderby'       => 'ID',
+				'order'         => 'ASC',
+				'return'        => 'objects',
+			)
+		);
+
+		foreach ( $orders as $order ) {
+			if ( ! $order instanceof WC_Order ) {
+				continue;
+			}
+			$product_quantity = 0;
+			foreach ( $order->get_items() as $item ) {
+				if ( (int) $item->get_product_id() === $product_id ) {
+					$product_quantity += (int) $item->get_quantity();
+				}
+			}
+			$order_rows[] = array(
+				'id'               => $order->get_id(),
+				'status'           => $order->get_status(),
+				'total'            => (float) $order->get_total(),
+				'cart_hash'        => $order->get_cart_hash(),
+				'item_count'       => count( $order->get_items() ),
+				'product_quantity' => $product_quantity,
+				'payment_method'   => $order->get_payment_method(),
+				'needs_payment'    => $order->needs_payment(),
+			);
+		}
+
+		$item_owner_ids = array_values(
+			array_map(
+				static function ( array $order ): int {
+					return (int) $order['id'];
+				},
+				array_filter(
+					$order_rows,
+					static function ( array $order ): bool {
+						return $order['product_quantity'] > 0;
+					}
+				)
+			)
+		);
+
+		return array(
+			'orders'                         => $order_rows,
+			'order_ids'                      => array_values( wp_list_pluck( $order_rows, 'id' ) ),
+			'unique_order_ids'               => array_values( array_unique( wp_list_pluck( $order_rows, 'id' ) ) ),
+			'cart_item_owner_order_ids'      => $item_owner_ids,
+			'cart_item_owner_order_count'    => count( $item_owner_ids ),
+			'unique_same_cart_hash_order_count' => count(
+				array_filter(
+					$order_rows,
+					static function ( array $order ) use ( $cart_hash ): bool {
+						return $cart_hash && $order['cart_hash'] === $cart_hash;
+					}
+				)
+			),
+			'payment_attempt_count_observed' => count(
+				array_filter(
+					$order_rows,
+					static function ( array $order ): bool {
+						return '' !== $order['payment_method'];
+					}
+				)
+			),
+		);
+	};
+
 	$before = microtime( true );
 
 	$base_cart                             = $set_cart( 1 );
@@ -354,6 +633,135 @@ return function (): array {
 		throw new RuntimeException( 'Checkout side-effect guardrail failure: ' . implode( ', ', $failed_guardrails ) );
 	}
 
+	$concurrent_iterations = array();
+	$concurrent_metrics    = array();
+	for ( $iteration = 1; $iteration <= $iterations; $iteration++ ) {
+		$iteration_id = $run_id . '-concurrent-' . $iteration;
+		$customer_id  = 't_homeboy_checkout_' . md5( $iteration_id );
+		$cookie_value = $make_cookie_value( $customer_id );
+		$checkout_email = 'homeboy-' . $iteration_id . '@example.com';
+
+		$wpdb->delete( $session_table, array( 'session_key' => $customer_id ) );
+		$concurrent_product = $create_concurrent_product( $iteration_id, $payment_mode );
+		$seed               = $seed_checkout_session( $iteration_id, $cookie_value, $concurrent_product, $payment_mode );
+		$session_before     = $get_persisted_session( $customer_id );
+		$post_data          = $build_checkout_post_data( $iteration_id, $payment_mode );
+		$burst              = $fire_concurrent_checkout_requests( $checkout_url, $cookie_name, $cookie_value, $post_data, $request_count );
+		$session_after      = $get_persisted_session( $customer_id );
+		$order_summary      = $summarize_checkout_orders( $checkout_email, $concurrent_product->get_id(), $seed['cart_hash'] );
+
+		$response_order_ids = array_values(
+			array_filter(
+				array_map(
+					static function ( array $response ) use ( $parse_response_order_id ): int {
+						return $parse_response_order_id( $response['json'] );
+					},
+					$burst['responses']
+				)
+			)
+		);
+		$successful_responses = count(
+			array_filter(
+				$burst['responses'],
+				static function ( array $response ): bool {
+					return 200 === $response['http_code'] && isset( $response['json']['result'] ) && 'success' === $response['json']['result'];
+				}
+			)
+		);
+		$failed_responses = count(
+			array_filter(
+				$burst['responses'],
+				static function ( array $response ): bool {
+					return 200 !== $response['http_code'] || ! isset( $response['json']['result'] ) || 'success' !== $response['json']['result'];
+				}
+			)
+		);
+		$safe_losing_responses = max( 0, $request_count - $successful_responses ) === $failed_responses ? $failed_responses : 0;
+		$duplicate_reproduced  = $order_summary['cart_item_owner_order_count'] > 1 || count( $order_summary['unique_order_ids'] ) > 1;
+
+		$metrics = array(
+			'checkout_request_count'             => $request_count,
+			'successful_response_count'          => $successful_responses,
+			'failed_response_count'              => $failed_responses,
+			'safe_losing_response_count'         => $safe_losing_responses,
+			'unique_order_count'                 => count( $order_summary['unique_order_ids'] ),
+			'duplicate_order_count'              => max( 0, count( $order_summary['unique_order_ids'] ) - 1 ),
+			'duplicate_reproduced'               => $duplicate_reproduced ? 1 : 0,
+			'cart_item_owner_order_count'        => $order_summary['cart_item_owner_order_count'],
+			'only_one_order_contains_cart_items' => 1 === $order_summary['cart_item_owner_order_count'] ? 1 : 0,
+			'payment_attempt_count_observed'     => $order_summary['payment_attempt_count_observed'],
+			'cart_session_exists_after_burst'    => empty( $session_after ) ? 0 : 1,
+			'cart_session_parseable_after_burst' => is_array( $session_after ) ? 1 : 0,
+			'cart_items_before_burst'            => $session_cart_count( $session_before ),
+			'cart_items_after_burst'             => $session_cart_count( $session_after ),
+			'order_awaiting_payment_after_burst' => isset( $session_after['order_awaiting_payment'] ) ? absint( maybe_unserialize( $session_after['order_awaiting_payment'] ) ) : 0,
+			'same_cart_hash_order_count'         => $order_summary['unique_same_cart_hash_order_count'],
+			'burst_elapsed_ms'                   => $burst['elapsed_ms'],
+		);
+
+		$concurrent_metrics[] = $metrics;
+		$concurrent_iterations[] = array(
+			'iteration'          => $iteration,
+			'customer_id'        => $customer_id,
+			'cookie_name'        => $cookie_name,
+			'checkout_url'       => $checkout_url,
+			'product_id'         => $concurrent_product->get_id(),
+			'cart_item_key'      => $seed['cart_item_key'],
+			'cart_hash'          => $seed['cart_hash'],
+			'billing_email'      => $checkout_email,
+			'response_order_ids' => $response_order_ids,
+			'order_summary'      => $order_summary,
+			'session_before_keys' => array_keys( $session_before ),
+			'session_after_keys' => array_keys( $session_after ),
+			'responses'          => $burst['responses'],
+			'metrics'            => $metrics,
+		);
+	}
+
+	$sum_concurrent_metric = static function ( string $key ) use ( $concurrent_metrics ): float {
+		return array_sum(
+			array_map(
+				static function ( array $metrics ) use ( $key ): float {
+					return isset( $metrics[ $key ] ) ? (float) $metrics[ $key ] : 0.0;
+				},
+				$concurrent_metrics
+			)
+		);
+	};
+	$max_concurrent_metric = static function ( string $key ) use ( $concurrent_metrics ): float {
+		$values = array_map(
+			static function ( array $metrics ) use ( $key ): float {
+				return isset( $metrics[ $key ] ) ? (float) $metrics[ $key ] : 0.0;
+			},
+			$concurrent_metrics
+		);
+		return empty( $values ) ? 0.0 : max( $values );
+	};
+	$concurrent_summary = array(
+		'concurrent_checkout_iterations'        => $iterations,
+		'checkout_request_count'                => $request_count * $iterations,
+		'checkout_request_count_per_iteration'  => $request_count,
+		'successful_response_count'             => $sum_concurrent_metric( 'successful_response_count' ),
+		'failed_response_count'                 => $sum_concurrent_metric( 'failed_response_count' ),
+		'safe_losing_response_count'            => $sum_concurrent_metric( 'safe_losing_response_count' ),
+		'unique_order_count'                    => $sum_concurrent_metric( 'unique_order_count' ),
+		'max_unique_order_count_per_iteration'  => $max_concurrent_metric( 'unique_order_count' ),
+		'duplicate_order_count'                 => $sum_concurrent_metric( 'duplicate_order_count' ),
+		'duplicate_reproduced'                  => $max_concurrent_metric( 'duplicate_reproduced' ) > 0 ? 1 : 0,
+		'duplicate_reproduced_iteration_count'  => $sum_concurrent_metric( 'duplicate_reproduced' ),
+		'cart_item_owner_order_count'           => $sum_concurrent_metric( 'cart_item_owner_order_count' ),
+		'max_cart_item_owner_order_count_per_iteration' => $max_concurrent_metric( 'cart_item_owner_order_count' ),
+		'only_one_order_contains_cart_items_iteration_count' => $sum_concurrent_metric( 'only_one_order_contains_cart_items' ),
+		'payment_attempt_count_observed'        => $sum_concurrent_metric( 'payment_attempt_count_observed' ),
+		'cart_session_integrity_after_burst_iteration_count' => $sum_concurrent_metric( 'cart_session_parseable_after_burst' ),
+		'cart_session_exists_after_burst_iteration_count' => $sum_concurrent_metric( 'cart_session_exists_after_burst' ),
+		'cart_items_before_burst'               => $sum_concurrent_metric( 'cart_items_before_burst' ),
+		'cart_items_after_burst'                => $sum_concurrent_metric( 'cart_items_after_burst' ),
+		'same_cart_hash_order_count'            => $sum_concurrent_metric( 'same_cart_hash_order_count' ),
+		'repeated_iteration_stability'          => count( array_unique( wp_list_pluck( $concurrent_metrics, 'duplicate_reproduced' ) ) ) <= 1 ? 1 : 0,
+		'max_burst_elapsed_ms'                  => $max_concurrent_metric( 'burst_elapsed_ms' ),
+	);
+
 	$artifact = array(
 		'run_id'            => $run_id,
 		'issues'            => $issues,
@@ -386,6 +794,14 @@ return function (): array {
 		'legacy_coupon'     => $coupon_metrics,
 		'guardrails'        => $guardrails,
 		'failed_guardrails' => $failed_guardrails,
+		'concurrent_checkout' => array(
+			'request_count' => $request_count,
+			'iterations'    => $iterations,
+			'payment_mode'  => $payment_mode,
+			'checkout_url'  => $checkout_url,
+			'iterations_artifact' => $concurrent_iterations,
+			'metrics'       => $concurrent_summary,
+		),
 		'orders'            => array_map(
 			static function ( WC_Order $order ): array {
 				return array(
@@ -446,6 +862,10 @@ return function (): array {
 		'legacy_coupon_independence'                              => (int) $guardrails['legacy_coupon_independence'],
 		'guardrail_failure_count'                                 => count( $failed_guardrails ),
 	);
+	foreach ( $concurrent_summary as $metric_name => $metric_value ) {
+		$summary[ 'concurrent_' . $metric_name ] = $metric_value;
+	}
+	$summary['true_concurrent_duplicate_reproduced'] = $concurrent_summary['duplicate_reproduced'];
 
 	$artifact_path = '';
 	$shared_state  = getenv( 'HOMEBOY_BENCH_SHARED_STATE' );

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -31,6 +31,9 @@
             "WC_SHORTCODE_CHECKOUT_VARIATIONS": "125",
             "WC_SHORTCODE_CHECKOUT_HISTORICAL_ORDERS": "25",
             "WC_SHORTCODE_CHECKOUT_PAYMENT_METHODS": "cod,homeboy_synthetic",
+            "WC_CONCURRENT_CHECKOUT_REQUESTS": "2",
+            "WC_CONCURRENT_CHECKOUT_ITERATIONS": "3",
+            "WC_CONCURRENT_CHECKOUT_PAYMENT_MODE": "cod",
             "WC_ADMIN_DASHBOARD_PRODUCTS": "500",
             "WC_ADMIN_DASHBOARD_TERMS": "20",
             "WC_ADMIN_DASHBOARD_PHYSICAL_PERCENT": "100"
@@ -83,6 +86,9 @@
       "layered-nav-count-cache",
       "layered-nav-catalog-crawl",
       "rest-product-batch-import"
+    ],
+    "checkout-concurrent": [
+      "checkout-concurrent-create-order"
     ]
   },
   "pipeline": {


### PR DESCRIPTION
## Summary
- Replaces the sequential duplicate checkout workload with a true concurrent `/?wc-ajax=checkout` burst using one shared WooCommerce session cookie.
- Adds repeated-iteration metrics for request counts, successful/failed responses, unique orders, duplicate reproduction, cart item ownership, observed payment attempts, safe losing responses, cart/session integrity, and stability.
- Adds a focused `checkout-concurrent` profile plus README guidance for baseline/candidate comparisons.

## Evidence links
- Homeboy Rigs issue: https://github.com/chubes4/homeboy-rigs/issues/254
- WooCommerce issue: https://github.com/woocommerce/woocommerce/issues/62659
- WooCommerce PR: https://github.com/woocommerce/woocommerce/pull/65588
- Jorge review: https://github.com/woocommerce/woocommerce/pull/65588#pullrequestreview-4488383929

## Verification
- `php -l woocommerce/woocommerce/bench/checkout-concurrent-create-order.php` passed.
- `node scripts/lint-rig-packages.mjs` passed: PHP syntax lint for 9 files.
- `python3 -m json.tool woocommerce/woocommerce/rigs/woocommerce-performance/rig.json >/dev/null` passed.
- `git diff --check` passed.
- `homeboy rig install --id woocommerce-performance /Users/chubes/Developer/homeboy-rigs@fix-issue-254-concurrent-checkout-rig/woocommerce/woocommerce && homeboy rig check woocommerce-performance` passed on Homeboy Lab, run `4b20ab67-fe3f-47ce-a24c-72dec7abbeac`.
- `homeboy bench list --rig woocommerce-performance --scenario checkout-concurrent-create-order` passed and lists the scenario.

## Blocker
- Targeted bench execution was attempted with:
  `homeboy bench --rig woocommerce-performance --path /Users/chubes/Developer/woocommerce@fix-checkout-create-order-idempotency/plugins/woocommerce --scenario checkout-concurrent-create-order --iterations 1 --shared-state /tmp/homeboy-rigs-issue-254-smoke --setting-json 'bench_env={"WC_CONCURRENT_CHECKOUT_ITERATIONS":"1","WC_CONCURRENT_CHECKOUT_REQUESTS":"2"}'`
- It failed before running the workload because the Homeboy Lab WordPress bench runtime cannot load WP Codebox runtime-core export `buildWordPressBenchRecipe`.
- Persisted failed run: `20601b60-9ec5-4408-a9fa-6718313dab93`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the concurrent checkout workload, rig profile wiring, README guidance, and verification/PR preparation for Chris to review.

Closes #254.