### PR TITLE
Add checkout create_order side-effect guardrails

### DIFF
--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -20,6 +20,10 @@ performance bugs in disposable WordPress/WooCommerce runtimes.
 - https://github.com/woocommerce/woocommerce/issues/17355
 - https://github.com/chubes4/homeboy-rigs/issues/224
 - https://wordpress.org/support/topic/wp_query-get_posts-slow-query-on-dashboard/
+- https://github.com/woocommerce/woocommerce/issues/62659
+- https://github.com/woocommerce/woocommerce/pull/65588
+- https://github.com/woocommerce/woocommerce/pull/65588#pullrequestreview-4488383929
+- https://github.com/chubes4/homeboy-rigs/issues/253
 
 ## Install
 
@@ -89,6 +93,13 @@ into `tests/bench/`, and returns the normalized Homeboy `BenchResults` envelope.
 
 ## Current Workloads
 
+- `checkout-concurrent-create-order` calls public `WC_Checkout::create_order()`
+  twice against the same cart to report duplicate-order behavior, then records
+  deterministic guardrails for session/cart side effects: public create-order
+  `order_awaiting_payment` mutation, public create-order cart clearing,
+  pending/failed retries, completed-order safety, changed-cart retries,
+  `template_redirect` cart clearing after paid extension-created orders, and
+  legacy coupon independence.
 - `checkout-shipping-cache` seeds simple physical products, configures a flat-rate
   US shipping zone, builds a cart, splits cart contents into configurable shipping
   packages, and measures cold, warm, totals-only churn, and address-rehashed
@@ -121,6 +132,16 @@ The first slice reports:
 
 - `cold_shipping_ms`, `warm_shipping_p50_ms`, `warm_shipping_p95_ms`, and
   `warm_to_cold_ratio`.
+- `duplicate_reproduced`, `public_create_order_sets_order_awaiting_payment`,
+  `public_create_order_clears_cart`, `pending_retry_reuses_order`,
+  `failed_retry_reuses_order`, `completed_order_is_not_reused`,
+  `completed_order_status_is_preserved`,
+  `changed_cart_retry_creates_new_order`,
+  `template_redirect_clears_paid_completed_extension_order`,
+  `template_redirect_does_not_clear_without_payment_signal`,
+  `template_redirect_does_not_clear_pending_retry_order`,
+  `legacy_coupon_independence`, and `guardrail_failure_count` for the checkout
+  duplicate-order side-effect guardrails.
 - `total_churn_shipping_p50_ms`, `total_churn_to_warm_ratio`, and
   `total_churn_rate_calculation_calls` for package subtotal/total-only churn.
 - `rehash_shipping_p50_ms` and `rehash_to_warm_ratio` for address/hash changes.

--- a/woocommerce/woocommerce/bench/checkout-concurrent-create-order.php
+++ b/woocommerce/woocommerce/bench/checkout-concurrent-create-order.php
@@ -1,11 +1,12 @@
 <?php
 /**
- * WP Codebox-backed WooCommerce checkout atomicity repro workload.
+ * WP Codebox-backed WooCommerce checkout atomicity and side-effect guardrail workload.
  *
- * Reproduces the race window tracked in:
- * - https://github.com/woocommerce/woocommerce/issues/14541
+ * Reproduces the duplicate public create_order window and records guardrails for:
  * - https://github.com/woocommerce/woocommerce/issues/62659
- * - https://github.com/woocommerce/woocommerce/issues/43770
+ * - https://github.com/woocommerce/woocommerce/pull/65588
+ * - https://github.com/woocommerce/woocommerce/pull/65588#pullrequestreview-4488383929
+ * - https://github.com/chubes4/homeboy-rigs/issues/253
  */
 return function (): array {
 	if ( ! class_exists( 'WooCommerce' ) ) {
@@ -31,12 +32,18 @@ return function (): array {
 	if ( ! WC()->order_factory && class_exists( 'WC_Order_Factory' ) ) {
 		WC()->order_factory = new WC_Order_Factory();
 	}
+	if ( ! WC()->payment_gateways && class_exists( 'WC_Payment_Gateways' ) ) {
+		WC()->payment_gateways = new WC_Payment_Gateways();
+	}
 
 	$run_id = 'woocommerce-checkout-concurrent-create-order-' . getmypid() . '-' . time() . '-' . wp_generate_password( 6, false );
 	$issues = array(
 		'https://github.com/woocommerce/woocommerce/issues/14541',
 		'https://github.com/woocommerce/woocommerce/issues/62659',
 		'https://github.com/woocommerce/woocommerce/issues/43770',
+		'https://github.com/woocommerce/woocommerce/pull/65588',
+		'https://github.com/woocommerce/woocommerce/pull/65588#pullrequestreview-4488383929',
+		'https://github.com/chubes4/homeboy-rigs/issues/253',
 	);
 
 	wp_set_current_user( 0 );
@@ -45,6 +52,7 @@ return function (): array {
 	update_option( 'woocommerce_prices_include_tax', 'no' );
 	update_option( 'woocommerce_calc_taxes', 'no' );
 	update_option( 'woocommerce_enable_guest_checkout', 'yes' );
+	update_option( 'woocommerce_enable_coupons', 'yes' );
 
 	if ( ! WC()->session ) {
 		if ( method_exists( WC(), 'initialize_session' ) ) {
@@ -63,7 +71,6 @@ return function (): array {
 	if ( ! WC()->cart ) {
 		throw new RuntimeException( 'WooCommerce cart failed to initialize.' );
 	}
-	WC()->cart->empty_cart();
 
 	$product = new WC_Product_Simple();
 	$product->set_name( 'Homeboy Concurrent Checkout Product ' . $run_id );
@@ -77,110 +84,309 @@ return function (): array {
 	$product->set_stock_status( 'instock' );
 	$product->save();
 
-	$cart_item_key = 'homeboy_concurrent_checkout_' . md5( $run_id );
-	WC()->cart->cart_contents = array(
-		$cart_item_key => array(
-			'key'               => $cart_item_key,
-			'product_id'        => $product->get_id(),
-			'variation_id'      => 0,
-			'variation'         => array(),
-			'quantity'          => 1,
-			'data'              => $product,
-			'line_subtotal'     => 19.99,
-			'line_subtotal_tax' => 0,
-			'line_total'        => 19.99,
-			'line_tax'          => 0,
-			'line_tax_data'     => array(
-				'subtotal' => array(),
-				'total'    => array(),
-			),
-		),
-	);
-
-	if ( WC()->customer ) {
-		WC()->customer->set_billing_first_name( 'Homeboy' );
-		WC()->customer->set_billing_last_name( 'Checkout' );
-		WC()->customer->set_billing_email( 'homeboy-' . $run_id . '@example.com' );
-		WC()->customer->set_billing_phone( '5555555555' );
-		WC()->customer->set_billing_country( 'US' );
-		WC()->customer->set_billing_state( 'CA' );
-		WC()->customer->set_billing_postcode( '94107' );
-		WC()->customer->set_billing_city( 'San Francisco' );
-		WC()->customer->set_billing_address( '123 Atomicity Way' );
-		WC()->customer->save();
-	}
-
-	WC()->cart->calculate_totals();
-	$cart_hash = WC()->cart->get_cart_hash();
-	$email     = 'homeboy-' . $run_id . '@example.com';
-	$data      = array(
-		'billing_first_name' => 'Homeboy',
-		'billing_last_name'  => 'Checkout',
-		'billing_company'    => '',
-		'billing_country'    => 'US',
-		'billing_address_1'  => '123 Atomicity Way',
-		'billing_address_2'  => '',
-		'billing_city'       => 'San Francisco',
-		'billing_state'      => 'CA',
-		'billing_postcode'   => '94107',
-		'billing_phone'      => '5555555555',
-		'billing_email'      => $email,
-		'shipping_first_name' => 'Homeboy',
-		'shipping_last_name' => 'Checkout',
-		'shipping_company'   => '',
-		'shipping_country'   => 'US',
-		'shipping_address_1' => '123 Atomicity Way',
-		'shipping_address_2' => '',
-		'shipping_city'      => 'San Francisco',
-		'shipping_state'     => 'CA',
-		'shipping_postcode'  => '94107',
-		'order_comments'     => 'Homeboy checkout atomicity repro ' . $run_id,
-		'payment_method'     => '',
-		'terms'              => 1,
-		'createaccount'      => 0,
+	$email = 'homeboy-' . $run_id . '@example.com';
+	$data  = array(
+		'billing_first_name'        => 'Homeboy',
+		'billing_last_name'         => 'Checkout',
+		'billing_company'           => '',
+		'billing_country'           => 'US',
+		'billing_address_1'         => '123 Atomicity Way',
+		'billing_address_2'         => '',
+		'billing_city'              => 'San Francisco',
+		'billing_state'             => 'CA',
+		'billing_postcode'          => '94107',
+		'billing_phone'             => '5555555555',
+		'billing_email'             => $email,
+		'shipping_first_name'       => 'Homeboy',
+		'shipping_last_name'        => 'Checkout',
+		'shipping_company'          => '',
+		'shipping_country'          => 'US',
+		'shipping_address_1'        => '123 Atomicity Way',
+		'shipping_address_2'        => '',
+		'shipping_city'             => 'San Francisco',
+		'shipping_state'            => 'CA',
+		'shipping_postcode'         => '94107',
+		'order_comments'            => 'Homeboy checkout atomicity repro ' . $run_id,
+		'payment_method'            => '',
+		'terms'                     => 1,
+		'createaccount'             => 0,
 		'ship_to_different_address' => 0,
 	);
 
-	$checkout = WC()->checkout();
-	$before   = microtime( true );
+	$set_cart = static function ( int $quantity = 1 ) use ( $product, $run_id ): array {
+		WC()->cart->empty_cart();
+		if ( WC()->session ) {
+			WC()->session->__unset( 'order_awaiting_payment' );
+		}
+
+		$cart_item_key = 'homeboy_concurrent_checkout_' . md5( $run_id . ':' . $quantity );
+		WC()->cart->cart_contents = array(
+			$cart_item_key => array(
+				'key'               => $cart_item_key,
+				'product_id'        => $product->get_id(),
+				'variation_id'      => 0,
+				'variation'         => array(),
+				'quantity'          => $quantity,
+				'data'              => $product,
+				'line_subtotal'     => 19.99 * $quantity,
+				'line_subtotal_tax' => 0,
+				'line_total'        => 19.99 * $quantity,
+				'line_tax'          => 0,
+				'line_tax_data'     => array(
+					'subtotal' => array(),
+					'total'    => array(),
+				),
+			),
+		);
+
+		if ( WC()->customer ) {
+			WC()->customer->set_billing_first_name( 'Homeboy' );
+			WC()->customer->set_billing_last_name( 'Checkout' );
+			WC()->customer->set_billing_email( 'homeboy-' . $run_id . '@example.com' );
+			WC()->customer->set_billing_phone( '5555555555' );
+			WC()->customer->set_billing_country( 'US' );
+			WC()->customer->set_billing_state( 'CA' );
+			WC()->customer->set_billing_postcode( '94107' );
+			WC()->customer->set_billing_city( 'San Francisco' );
+			WC()->customer->set_billing_address( '123 Atomicity Way' );
+			WC()->customer->save();
+		}
+
+		WC()->cart->calculate_totals();
+
+		return array(
+			'cart_item_key' => $cart_item_key,
+			'cart_hash'     => WC()->cart->get_cart_hash(),
+			'cart_count'    => WC()->cart->get_cart_contents_count(),
+			'cart_total'    => (float) WC()->cart->get_total( 'edit' ),
+		);
+	};
+
+	$session_order_awaiting_payment = static function (): int {
+		return WC()->session ? absint( WC()->session->get( 'order_awaiting_payment' ) ) : 0;
+	};
+
 	$unexpected_output = '';
-	ob_start();
-	try {
-		$order_id_1 = $checkout->create_order( $data );
-		$order_id_2 = $checkout->create_order( $data );
-	} finally {
-		$unexpected_output = (string) ob_get_clean();
-	}
-	$elapsed_ms = ( microtime( true ) - $before ) * 1000;
+	$create_order      = static function ( array $posted_data ) use ( &$unexpected_output ): int {
+		ob_start();
+		try {
+			$order_id = WC()->checkout()->create_order( $posted_data );
+		} finally {
+			$unexpected_output .= (string) ob_get_clean();
+		}
+		if ( is_wp_error( $order_id ) ) {
+			throw new RuntimeException( 'create_order failed: ' . $order_id->get_error_message() );
+		}
+		$order_id = absint( $order_id );
+		if ( ! wc_get_order( $order_id ) ) {
+			throw new RuntimeException( 'create_order returned a missing order ID: ' . $order_id );
+		}
 
-	if ( is_wp_error( $order_id_1 ) ) {
-		throw new RuntimeException( 'First create_order failed: ' . $order_id_1->get_error_message() );
-	}
-	if ( is_wp_error( $order_id_2 ) ) {
-		throw new RuntimeException( 'Second create_order failed: ' . $order_id_2->get_error_message() );
-	}
+		return $order_id;
+	};
 
-	$order_ids = array_map( 'absint', array( $order_id_1, $order_id_2 ) );
-	$orders    = array_filter( array_map( 'wc_get_order', $order_ids ) );
-	$unique_order_ids = array_values( array_unique( $order_ids ) );
-	$unique_orders    = array_filter( array_map( 'wc_get_order', $unique_order_ids ) );
-	$main_order       = wc_get_order( $order_ids[0] );
-	$duplicate_created = count( $unique_order_ids ) > 1 ? 1 : 0;
+	$run_template_redirect_clear = static function ( WC_Order $order, bool $with_session_reference = true ): array {
+		global $wp;
+
+		$previous_query_vars = isset( $wp ) && isset( $wp->query_vars ) ? $wp->query_vars : array();
+		$previous_get        = $_GET;
+
+		if ( ! isset( $wp ) || ! is_object( $wp ) ) {
+			$wp = new WP();
+		}
+		$wp->query_vars = array();
+		$_GET           = array();
+		if ( WC()->session ) {
+			if ( $with_session_reference ) {
+				WC()->session->set( 'order_awaiting_payment', $order->get_id() );
+			} else {
+				WC()->session->__unset( 'order_awaiting_payment' );
+			}
+		}
+
+		$before_count = WC()->cart->get_cart_contents_count();
+		wc_clear_cart_after_payment();
+		$after_count = WC()->cart->get_cart_contents_count();
+
+		$wp->query_vars = $previous_query_vars;
+		$_GET           = $previous_get;
+
+		return array(
+			'before_count' => $before_count,
+			'after_count'  => $after_count,
+			'cleared'      => 0 === $after_count && $before_count > 0,
+		);
+	};
+
+	$before = microtime( true );
+
+	$base_cart                             = $set_cart( 1 );
+	$order_id_1                            = $create_order( $data );
+	$session_after_first_create_order      = $session_order_awaiting_payment();
+	$cart_count_after_first_create_order   = WC()->cart->get_cart_contents_count();
+	$order_id_2                            = $create_order( $data );
+	$session_after_second_create_order     = $session_order_awaiting_payment();
+	$cart_count_after_second_create_order  = WC()->cart->get_cart_contents_count();
+	$elapsed_ms                            = ( microtime( true ) - $before ) * 1000;
+
+	$order_ids          = array_map( 'absint', array( $order_id_1, $order_id_2 ) );
+	$orders             = array_filter( array_map( 'wc_get_order', $order_ids ) );
+	$unique_order_ids   = array_values( array_unique( $order_ids ) );
+	$unique_orders      = array_filter( array_map( 'wc_get_order', $unique_order_ids ) );
+	$main_order         = wc_get_order( $order_ids[0] );
+	$duplicate_created  = count( $unique_order_ids ) > 1 ? 1 : 0;
 	$main_order_item_count = $main_order instanceof WC_Order ? count( $main_order->get_items() ) : 0;
 	$main_order_total      = $main_order instanceof WC_Order ? (float) $main_order->get_total() : 0;
+	$public_side_effect = array(
+		'order_awaiting_payment_after_first'  => $session_after_first_create_order,
+		'order_awaiting_payment_after_second' => $session_after_second_create_order,
+		'cart_count_after_first'              => $cart_count_after_first_create_order,
+		'cart_count_after_second'             => $cart_count_after_second_create_order,
+		'sets_order_awaiting_payment'         => $session_after_first_create_order > 0 || $session_after_second_create_order > 0,
+		'clears_cart'                         => 0 === $cart_count_after_first_create_order || 0 === $cart_count_after_second_create_order,
+	);
+
+	$set_cart( 1 );
+	$pending_order_id = $create_order( $data );
+	WC()->session->set( 'order_awaiting_payment', $pending_order_id );
+	$pending_retry_id = $create_order( $data );
+
+	$set_cart( 1 );
+	$failed_order_id = $create_order( $data );
+	$failed_order    = wc_get_order( $failed_order_id );
+	$failed_order->set_status( 'failed' );
+	$failed_order->save();
+	WC()->session->set( 'order_awaiting_payment', $failed_order_id );
+	$failed_retry_id = $create_order( $data );
+
+	$set_cart( 1 );
+	$completed_order_id = $create_order( $data );
+	$completed_order    = wc_get_order( $completed_order_id );
+	$completed_order->set_status( 'completed' );
+	$completed_order->save();
+	WC()->session->set( 'order_awaiting_payment', $completed_order_id );
+	$completed_retry_id    = $create_order( $data );
+	$completed_after_retry = wc_get_order( $completed_order_id );
+
+	$set_cart( 1 );
+	$changed_cart_order_id = $create_order( $data );
+	WC()->session->set( 'order_awaiting_payment', $changed_cart_order_id );
+	$changed_original_hash = wc_get_order( $changed_cart_order_id )->get_cart_hash();
+	$changed_cart          = $set_cart( 2 );
+	WC()->session->set( 'order_awaiting_payment', $changed_cart_order_id );
+	$changed_retry_id = $create_order( $data );
+
+	$set_cart( 1 );
+	$extension_order = wc_create_order(
+		array(
+			'created_via' => 'homeboy-extension',
+			'status'      => 'completed',
+		)
+	);
+	if ( is_wp_error( $extension_order ) ) {
+		throw new RuntimeException( 'Extension-created order setup failed: ' . $extension_order->get_error_message() );
+	}
+	$extension_order->set_cart_hash( WC()->cart->get_cart_hash() );
+	$extension_order->set_total( (float) WC()->cart->get_total( 'edit' ) );
+	$extension_order->save();
+	$template_redirect_completed = $run_template_redirect_clear( $extension_order, true );
+
+	$set_cart( 1 );
+	$safety_order = wc_get_order( $completed_order_id );
+	$template_redirect_completed_without_session = $run_template_redirect_clear( $safety_order, false );
+
+	$set_cart( 1 );
+	$pending_clear_order       = wc_get_order( $pending_order_id );
+	$template_redirect_pending = $run_template_redirect_clear( $pending_clear_order, true );
+
+	$coupon_metrics = array(
+		'covered'                         => false,
+		'public_create_order_sets_session' => null,
+		'public_create_order_clears_cart'  => null,
+		'order_coupon_line_count'          => null,
+	);
+	if ( class_exists( 'WC_Coupon' ) ) {
+		$set_cart( 1 );
+		$coupon_code = 'homeboy-legacy-' . strtolower( wp_generate_password( 6, false ) );
+		$coupon      = new WC_Coupon();
+		$coupon->set_code( $coupon_code );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->set_amount( 1 );
+		$coupon->save();
+		WC()->cart->apply_coupon( $coupon_code );
+		WC()->cart->calculate_totals();
+		$before_coupon_session = $session_order_awaiting_payment();
+		$coupon_order_id       = $create_order( $data );
+		$coupon_order          = wc_get_order( $coupon_order_id );
+		$coupon_metrics        = array(
+			'covered'                         => true,
+			'public_create_order_sets_session' => $session_order_awaiting_payment() !== $before_coupon_session,
+			'public_create_order_clears_cart'  => 0 === WC()->cart->get_cart_contents_count(),
+			'order_coupon_line_count'          => count( $coupon_order->get_coupon_codes() ),
+		);
+	}
+
+	$changed_retry_order = wc_get_order( $changed_retry_id );
+	$guardrails          = array(
+		'public_create_order_does_not_set_order_awaiting_payment' => ! $public_side_effect['sets_order_awaiting_payment'],
+		'public_create_order_does_not_clear_cart'                 => ! $public_side_effect['clears_cart'],
+		'pending_retry_reuses_order'                              => $pending_order_id === $pending_retry_id,
+		'failed_retry_reuses_order'                               => $failed_order_id === $failed_retry_id,
+		'completed_order_is_not_reused'                           => $completed_order_id !== $completed_retry_id,
+		'completed_order_status_is_preserved'                     => $completed_after_retry && $completed_after_retry->has_status( 'completed' ),
+		'changed_cart_retry_creates_new_order'                    => $changed_cart_order_id !== $changed_retry_id,
+		'changed_cart_retry_uses_new_cart_hash'                   => $changed_retry_order && $changed_retry_order->get_cart_hash() === $changed_cart['cart_hash'] && $changed_original_hash !== $changed_cart['cart_hash'],
+		'template_redirect_clears_paid_completed_extension_order' => $template_redirect_completed['cleared'],
+		'template_redirect_does_not_clear_without_payment_signal' => ! $template_redirect_completed_without_session['cleared'],
+		'template_redirect_does_not_clear_pending_retry_order'    => ! $template_redirect_pending['cleared'],
+		'legacy_coupon_independence'                              => ! $coupon_metrics['covered'] || ( ! $coupon_metrics['public_create_order_sets_session'] && ! $coupon_metrics['public_create_order_clears_cart'] && $coupon_metrics['order_coupon_line_count'] > 0 ),
+	);
+
+	$failed_guardrails = array_keys(
+		array_filter(
+			$guardrails,
+			static function ( bool $passed ): bool {
+				return ! $passed;
+			}
+		)
+	);
+	if ( $failed_guardrails ) {
+		throw new RuntimeException( 'Checkout side-effect guardrail failure: ' . implode( ', ', $failed_guardrails ) );
+	}
 
 	$artifact = array(
-		'run_id'             => $run_id,
-		'issues'             => $issues,
-		'cart_hash'          => $cart_hash,
-		'product_id'         => $product->get_id(),
-		'cart_item_key'      => $cart_item_key,
-		'billing_email'      => $email,
-		'order_ids'          => $order_ids,
-		'unique_order_ids'   => $unique_order_ids,
-		'duplicate_created'  => (bool) $duplicate_created,
-		'unexpected_output'  => $unexpected_output,
-		'orders'             => array_map(
+		'run_id'            => $run_id,
+		'issues'            => $issues,
+		'cart_hash'         => $base_cart['cart_hash'],
+		'product_id'        => $product->get_id(),
+		'cart_item_key'     => $base_cart['cart_item_key'],
+		'billing_email'     => $email,
+		'order_ids'         => $order_ids,
+		'unique_order_ids'  => $unique_order_ids,
+		'duplicate_created' => (bool) $duplicate_created,
+		'unexpected_output' => $unexpected_output,
+		'public_side_effects' => $public_side_effect,
+		'retry_behavior'    => array(
+			'pending_order_id'      => $pending_order_id,
+			'pending_retry_id'      => $pending_retry_id,
+			'failed_order_id'       => $failed_order_id,
+			'failed_retry_id'       => $failed_retry_id,
+			'completed_order_id'    => $completed_order_id,
+			'completed_retry_id'    => $completed_retry_id,
+			'changed_cart_order_id' => $changed_cart_order_id,
+			'changed_cart_retry_id' => $changed_retry_id,
+			'changed_original_hash' => $changed_original_hash,
+			'changed_retry_hash'    => $changed_retry_order ? $changed_retry_order->get_cart_hash() : '',
+		),
+		'template_redirect' => array(
+			'completed_extension_order' => $template_redirect_completed,
+			'completed_without_signal'  => $template_redirect_completed_without_session,
+			'pending_retry_order'       => $template_redirect_pending,
+		),
+		'legacy_coupon'     => $coupon_metrics,
+		'guardrails'        => $guardrails,
+		'failed_guardrails' => $failed_guardrails,
+		'orders'            => array_map(
 			static function ( WC_Order $order ): array {
 				return array(
 					'id'         => $order->get_id(),
@@ -195,36 +401,50 @@ return function (): array {
 	);
 
 	$summary = array(
-		'success_rate'               => 1,
-		'duplicate_reproduced'       => $duplicate_created,
-		'order_create_attempts'      => 2,
-		'unique_order_count'         => count( $unique_order_ids ),
-		'duplicate_order_count'      => max( 0, count( $unique_order_ids ) - 1 ),
-		'second_attempt_reused_first_order' => $order_ids[0] === $order_ids[1] ? 1 : 0,
-		'main_order_succeeded'       => $main_order instanceof WC_Order ? 1 : 0,
-		'main_order_item_count'      => $main_order_item_count,
-		'main_order_total'           => $main_order_total,
-		'unexpected_output_detected' => '' === $unexpected_output ? 0 : 1,
-		'unexpected_output_bytes'    => strlen( $unexpected_output ),
-		'elapsed_ms'                 => $elapsed_ms,
-		'cart_items'                 => WC()->cart->get_cart_contents_count(),
-		'cart_total'                 => (float) WC()->cart->get_total( 'edit' ),
-		'unique_same_cart_hash_order_count' => count(
+		'success_rate'                                            => 1,
+		'duplicate_reproduced'                                    => $duplicate_created,
+		'order_create_attempts'                                   => 2,
+		'unique_order_count'                                      => count( $unique_order_ids ),
+		'duplicate_order_count'                                   => max( 0, count( $unique_order_ids ) - 1 ),
+		'second_attempt_reused_first_order'                       => $order_ids[0] === $order_ids[1] ? 1 : 0,
+		'main_order_succeeded'                                    => $main_order instanceof WC_Order ? 1 : 0,
+		'main_order_item_count'                                   => $main_order_item_count,
+		'main_order_total'                                        => $main_order_total,
+		'unexpected_output_detected'                              => '' === $unexpected_output ? 0 : 1,
+		'unexpected_output_bytes'                                 => strlen( $unexpected_output ),
+		'elapsed_ms'                                              => $elapsed_ms,
+		'cart_items'                                              => WC()->cart->get_cart_contents_count(),
+		'cart_total'                                              => (float) WC()->cart->get_total( 'edit' ),
+		'unique_same_cart_hash_order_count'                       => count(
 			array_filter(
 				$unique_orders,
-				static function ( WC_Order $order ) use ( $cart_hash ): bool {
-					return $order->get_cart_hash() === $cart_hash;
+				static function ( WC_Order $order ) use ( $base_cart ): bool {
+					return $order->get_cart_hash() === $base_cart['cart_hash'];
 				}
 			)
 		),
-		'same_cart_hash_order_count' => count(
+		'same_cart_hash_order_count'                              => count(
 			array_filter(
 				$orders,
-				static function ( WC_Order $order ) use ( $cart_hash ): bool {
-					return $order->get_cart_hash() === $cart_hash;
+				static function ( WC_Order $order ) use ( $base_cart ): bool {
+					return $order->get_cart_hash() === $base_cart['cart_hash'];
 				}
 			)
 		),
+		'public_create_order_sets_order_awaiting_payment'         => (int) $public_side_effect['sets_order_awaiting_payment'],
+		'public_create_order_clears_cart'                         => (int) $public_side_effect['clears_cart'],
+		'order_awaiting_payment_after_public_create_order'        => $session_after_second_create_order,
+		'pending_retry_reuses_order'                              => (int) $guardrails['pending_retry_reuses_order'],
+		'failed_retry_reuses_order'                               => (int) $guardrails['failed_retry_reuses_order'],
+		'completed_order_is_not_reused'                           => (int) $guardrails['completed_order_is_not_reused'],
+		'completed_order_status_is_preserved'                     => (int) $guardrails['completed_order_status_is_preserved'],
+		'changed_cart_retry_creates_new_order'                    => (int) $guardrails['changed_cart_retry_creates_new_order'],
+		'changed_cart_retry_uses_new_cart_hash'                   => (int) $guardrails['changed_cart_retry_uses_new_cart_hash'],
+		'template_redirect_clears_paid_completed_extension_order' => (int) $guardrails['template_redirect_clears_paid_completed_extension_order'],
+		'template_redirect_does_not_clear_without_payment_signal' => (int) $guardrails['template_redirect_does_not_clear_without_payment_signal'],
+		'template_redirect_does_not_clear_pending_retry_order'    => (int) $guardrails['template_redirect_does_not_clear_pending_retry_order'],
+		'legacy_coupon_independence'                              => (int) $guardrails['legacy_coupon_independence'],
+		'guardrail_failure_count'                                 => count( $failed_guardrails ),
 	);
 
 	$artifact_path = '';
@@ -239,10 +459,10 @@ return function (): array {
 	return array(
 		'metrics'   => $summary,
 		'metadata'  => array(
-			'runner'   => 'wp-codebox',
-			'workload' => 'checkout-concurrent-create-order',
-			'issues'   => $issues,
-			'cart_hash' => $cart_hash,
+			'runner'    => 'wp-codebox',
+			'workload'  => 'checkout-concurrent-create-order',
+			'issues'    => $issues,
+			'cart_hash' => $base_cart['cart_hash'],
 		),
 		'artifacts' => $artifact_path ? array( 'raw_result' => array( 'path' => $artifact_path, 'kind' => 'json' ) ) : array(),
 	);


### PR DESCRIPTION
## Summary
- Extends `checkout-concurrent-create-order` with deterministic guardrails for public `WC_Checkout::create_order()` session/cart side effects.
- Records explicit metrics for `order_awaiting_payment`, cart clearing, pending/failed retries, completed-order safety, changed-cart retries, `template_redirect` clearing for paid extension-created orders, and legacy coupon independence.
- Documents the workload links back to WooCommerce issue 62659, WooCommerce PR 65588, Jorge's review, and Homeboy Rigs issue 253.

## Links
- Homeboy Rigs issue: https://github.com/chubes4/homeboy-rigs/issues/253
- WooCommerce issue: https://github.com/woocommerce/woocommerce/issues/62659
- WooCommerce PR: https://github.com/woocommerce/woocommerce/pull/65588
- Jorge review: https://github.com/woocommerce/woocommerce/pull/65588#pullrequestreview-4488383929

## Verification
- `php -l woocommerce/woocommerce/bench/checkout-concurrent-create-order.php` passed.
- `git diff --check` passed.
- `homeboy rig check woocommerce-performance` passed on `homeboy-lab`; run ID `519a6906-0647-4a15-b0cf-1801a96a9261`.
- `homeboy bench list --rig woocommerce-performance` passed and includes `checkout-concurrent-create-order`.

## Blocker
- Offloaded one-iteration checkout smoke reached `homeboy-lab` but failed before workload execution because the runner lacks a WP Codebox runtime-core recipe builder export: `buildWordPressBenchRecipe is unavailable`.
- Failed smoke run ID: `276d1c31-89e3-4823-b416-31a4abfb5ab0`.
- The failure is runner/runtime setup, not a workload guardrail failure; iterations stayed at `0`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the rig workload changes, README updates, and verification/PR preparation; Chris remains responsible for review and merge.