### PR TITLE
Fix gateway matrix Lab mounts

### DIFF
--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -46,7 +46,8 @@ This path mirrors the WooCommerce monorepo layout after cloning
 https://github.com/woocommerce/woocommerce into `~/Developer/woocommerce`.
 
 The checkout gateway compatibility matrix also mounts the local WooCommerce
-Stripe Gateway checkout as a first-class WP Codebox extra plugin when available:
+Stripe Gateway checkout as a first-class WordPress validation dependency, which
+the WP Codebox bench runner mounts as an extra plugin when available:
 
 ```text
 ~/Developer/woocommerce-gateway-stripe

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -4,14 +4,16 @@
   "components": {
     "woocommerce": {
       "path": "~/Developer/woocommerce/plugins/woocommerce",
-      "checkout_root": "~/Developer/woocommerce",
       "branch": "trunk",
       "extensions": {
         "wordpress": {
           "wp_codebox_wordpress_version": "7.0",
+          "validation_dependencies": [
+            "~/Developer/woocommerce-gateway-stripe"
+          ],
           "bench_env": {
             "WC_CHECKOUT_GATEWAY_MATRIX_PROFILES": "core_bacs,core_cheque,core_cod,plugin_stripe,plugin_paypal_payments,plugin_woopayments",
-            "WC_CHECKOUT_GATEWAY_MATRIX_STRIPE_PATH": "${components.woocommerce-gateway-stripe.path}",
+            "WC_CHECKOUT_GATEWAY_MATRIX_STRIPE_PATH": "~/Developer/woocommerce-gateway-stripe",
             "WC_CHECKOUT_GATEWAY_MATRIX_PAYPAL_PAYMENTS_PATH": "",
             "WC_CHECKOUT_GATEWAY_MATRIX_WOOPAYMENTS_PATH": "",
             "WC_SHIPPING_CACHE_CART_ITEMS": "40",
@@ -41,29 +43,13 @@
             "WC_ADMIN_DASHBOARD_PRODUCTS": "500",
             "WC_ADMIN_DASHBOARD_TERMS": "20",
             "WC_ADMIN_DASHBOARD_PHYSICAL_PERCENT": "100"
-          },
-          "wp_codebox_extra_plugins": [
-            {
-              "source": "${components.woocommerce-gateway-stripe.path}",
-              "slug": "woocommerce-gateway-stripe",
-              "pluginFile": "woocommerce-gateway-stripe/woocommerce-gateway-stripe.php",
-              "activate": false
-            }
-          ]
+          }
         }
       }
     },
     "woocommerce-gateway-stripe": {
       "path": "~/Developer/woocommerce-gateway-stripe",
       "branch": "develop"
-    },
-    "woocommerce-paypal-payments": {
-      "path": "",
-      "branch": "trunk"
-    },
-    "woocommerce-payments": {
-      "path": "",
-      "branch": "trunk"
     }
   },
   "resources": {


### PR DESCRIPTION
## Summary
- Fixes the post-merge Lab dispatch path for the gateway matrix follow-up from PR #261.
- Mounts WooCommerce Stripe Gateway through the WordPress bench runner's `validation_dependencies` plugin path instead of a nested unexpanded `wp_codebox_extra_plugins` setting.
- Removes the stale WooCommerce `checkout_root` and empty optional gateway components that poisoned Lab dependency materialization.

## Context
- Follow-up to merged PR #261: https://github.com/chubes4/homeboy-rigs/pull/261
- Homeboy Rigs issue 255: https://github.com/chubes4/homeboy-rigs/issues/255
- Issue follow-up comment: https://github.com/chubes4/homeboy-rigs/issues/255#issuecomment-4696662378
- WooCommerce PR 65588: https://github.com/woocommerce/woocommerce/pull/65588
- Jorge review: https://github.com/woocommerce/woocommerce/pull/65588#pullrequestreview-4488383929

## Why this follow-up exists
- PR #261 merged with `04c985c` only; the later dispatch fix commit was pushed after merge and never landed on `main`.
- The merged rig made Stripe first-class, but still left Lab dispatch blockers for the targeted matrix run.

## Verification
- `php -l woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php` passed.
- `php -r 'json_decode(file_get_contents("woocommerce/woocommerce/rigs/woocommerce-performance/rig.json"), true, 512, JSON_THROW_ON_ERROR);'` passed.
- `git diff --check origin/main..HEAD` passed.
- `homeboy rig install --id woocommerce-performance /Users/chubes/Developer/homeboy-rigs@fix-issue-255-gateway-mount-dispatch/woocommerce/woocommerce` passed.
- `homeboy rig check woocommerce-performance` passed on `homeboy-lab`; run ID `d536a26f-4e91-42d2-bd22-38b9c7cda227`.

## Targeted matrix status
- Command attempted: `HOMEBOY_SETTINGS_WOOCOMMERCE_PERFORMANCE_NAMESPACE=issue255-gateway-mount-dispatch-pr homeboy bench --rig woocommerce-performance --path /Users/chubes/Developer/woocommerce@fix-checkout-create-order-idempotency/plugins/woocommerce --scenario checkout-gateway-compatibility-matrix --iterations 1 --shared-state /tmp/woocommerce-gateway-matrix-issue-255-gateway-mount-dispatch-pr`.
- Result: dispatch reached `homeboy-lab`, ran WooCommerce prep, then failed in runner-side dependency provider install for Stripe with `npm error code EBADENGINE`.
- This is past the previous Lab path/materialization blockers; next fix is the Stripe dependency provider/runtime engine mismatch on the runner.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the missed post-merge commit, preparing the fresh branch, running verification, and drafting this PR; Chris remains responsible for review and merge.