### PR TITLE
Fix gateway matrix dependency materialization

### DIFF
--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -35,27 +35,28 @@ homeboy rig check woocommerce-performance
 
 ## Runner Prerequisites
 
-The rig mounts a local WooCommerce checkout into the disposable WP Codebox
-WordPress runtime. On local and Lab runners, the checkout must exist at:
+The rig mounts the selected WooCommerce checkout into the disposable WP Codebox
+WordPress runtime. Pass `homeboy bench --path /absolute/path/to/plugins/woocommerce`
+when validating a specific WooCommerce worktree.
 
-```text
-~/Developer/woocommerce/plugins/woocommerce
+The checkout gateway compatibility matrix declares WooCommerce Stripe Gateway as
+a first-class WordPress validation dependency by slug:
+
+```json
+"validation_dependencies": ["woocommerce-gateway-stripe"]
 ```
 
-This path mirrors the WooCommerce monorepo layout after cloning
-https://github.com/woocommerce/woocommerce into `~/Developer/woocommerce`.
+Homeboy Extensions resolves that dependency through the runner dependency
+contract, prepares a runnable artifact when the source checkout needs Composer
+materialization, mounts the prepared plugin into WP Codebox, and attaches
+`prepared_dependencies` provenance to the final bench results. The workload
+artifact reports the runtime side of that same contract: configured dependency,
+source path when explicitly provided, git revision when visible, prepared artifact
+path when exported, mounted plugin directory, plugin version, and status.
 
-The checkout gateway compatibility matrix also mounts the local WooCommerce
-Stripe Gateway checkout as a first-class WordPress validation dependency, which
-the WP Codebox bench runner mounts as an extra plugin when available:
-
-```text
-~/Developer/woocommerce-gateway-stripe
-```
-
-PayPal Payments and WooPayments stay optional. Mount them for focused local
-coverage by overriding `wp_codebox_extra_plugins` and the matching artifact path
-env values:
+PayPal Payments and WooPayments stay optional. Mount them for focused coverage by
+adding them to `validation_dependencies` or by overriding `wp_codebox_extra_plugins`
+and the matching artifact path env values:
 
 ```bash
 homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 \
@@ -65,7 +66,9 @@ homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatib
 
 Unavailable gateway plugin profiles skip explicitly as `not_configured` when no
 path is configured, `entrypoint_missing` when a configured path did not mount the
-expected plugin file, or `activation_failed` when WordPress rejects activation.
+expected plugin file, `build_failed` when a prepared artifact path is configured
+but unavailable, or `activation_failed` when WordPress rejects activation or the
+gateway does not register after activation.
 Homeboy core Lab offload provisioning gaps are tracked in:
 
 - https://github.com/Extra-Chill/homeboy/issues/3474
@@ -89,13 +92,8 @@ homeboy rig check woocommerce-performance
   `includes/react-admin/feature-config.php` is missing.
 - It does not modify WooCommerce source files or switch branches.
 
-Equivalent manual prep, when needed for debugging:
-
-```bash
-cd ~/Developer/woocommerce/plugins/woocommerce
-XDEBUG_MODE=off composer install --no-interaction --no-progress
-php bin/generate-feature-config.php
-```
+Equivalent manual prep, when needed for debugging, should run from the selected
+WooCommerce plugin directory.
 
 ## Benchmark Commands
 
@@ -129,10 +127,10 @@ into `tests/bench/`, and returns the normalized Homeboy `BenchResults` envelope.
   idempotency repro across core BACS, Cheque, and COD gateway controls plus
   first-class mounted real-plugin profiles for WooCommerce Stripe Gateway,
   WooCommerce PayPal Payments, and WooPayments when those plugin paths are
-  configured. It captures plugin activation, configured path, mounted path,
-  best-effort git revision, and version details without secrets, and links
-  evidence to WooCommerce issue #62659, WooCommerce PR #65588, Jorge's PR
-  review, and Homeboy Rigs issue #255.
+  configured. It captures configured dependency/source/prepared paths, mounted
+  plugin directory, best-effort git revision, plugin version, and status details
+  without secrets, and links evidence to WooCommerce issue #62659, WooCommerce PR
+  #65588, Jorge's PR review, and Homeboy Rigs issue #255.
   Limit the matrix during focused smokes with
   `WC_CHECKOUT_GATEWAY_MATRIX_PROFILES=core_bacs,plugin_stripe`. Plugin profiles
   report explicit skip details when their entrypoint is unavailable or activation

--- a/woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php
+++ b/woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php
@@ -102,34 +102,40 @@ return function (): array {
 			),
 		),
 		array(
-			'profile'        => 'plugin_stripe',
-			'gateway_id'     => 'stripe',
-			'label'          => 'WooCommerce Stripe Gateway',
-			'plugin'         => 'woocommerce-gateway-stripe',
-			'entrypoint'     => 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php',
-			'path_env'       => 'WC_CHECKOUT_GATEWAY_MATRIX_STRIPE_PATH',
-			'settings'       => array(
+			'profile'           => 'plugin_stripe',
+			'gateway_id'        => 'stripe',
+			'label'             => 'WooCommerce Stripe Gateway',
+			'plugin'            => 'woocommerce-gateway-stripe',
+			'entrypoint'        => 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php',
+			'dependency_env'    => 'WC_CHECKOUT_GATEWAY_MATRIX_STRIPE_DEPENDENCY',
+			'source_path_env'   => 'WC_CHECKOUT_GATEWAY_MATRIX_STRIPE_SOURCE_PATH',
+			'prepared_path_env' => 'WC_CHECKOUT_GATEWAY_MATRIX_STRIPE_PREPARED_ARTIFACT_PATH',
+			'settings'          => array(
 				'enabled'  => 'yes',
 				'testmode' => 'yes',
 			),
 		),
 		array(
-			'profile'        => 'plugin_paypal_payments',
-			'gateway_id'     => 'ppcp-gateway',
-			'label'          => 'WooCommerce PayPal Payments',
-			'plugin'         => 'woocommerce-paypal-payments',
-			'entrypoint'     => 'woocommerce-paypal-payments/woocommerce-paypal-payments.php',
-			'path_env'       => 'WC_CHECKOUT_GATEWAY_MATRIX_PAYPAL_PAYMENTS_PATH',
-			'settings'       => array( 'enabled' => 'yes' ),
+			'profile'           => 'plugin_paypal_payments',
+			'gateway_id'        => 'ppcp-gateway',
+			'label'             => 'WooCommerce PayPal Payments',
+			'plugin'            => 'woocommerce-paypal-payments',
+			'entrypoint'        => 'woocommerce-paypal-payments/woocommerce-paypal-payments.php',
+			'dependency_env'    => 'WC_CHECKOUT_GATEWAY_MATRIX_PAYPAL_PAYMENTS_DEPENDENCY',
+			'source_path_env'   => 'WC_CHECKOUT_GATEWAY_MATRIX_PAYPAL_PAYMENTS_PATH',
+			'prepared_path_env' => 'WC_CHECKOUT_GATEWAY_MATRIX_PAYPAL_PAYMENTS_PREPARED_ARTIFACT_PATH',
+			'settings'          => array( 'enabled' => 'yes' ),
 		),
 		array(
-			'profile'        => 'plugin_woopayments',
-			'gateway_id'     => 'woocommerce_payments',
-			'label'          => 'WooPayments',
-			'plugin'         => 'woocommerce-payments',
-			'entrypoint'     => 'woocommerce-payments/woocommerce-payments.php',
-			'path_env'       => 'WC_CHECKOUT_GATEWAY_MATRIX_WOOPAYMENTS_PATH',
-			'settings'       => array(
+			'profile'           => 'plugin_woopayments',
+			'gateway_id'        => 'woocommerce_payments',
+			'label'             => 'WooPayments',
+			'plugin'            => 'woocommerce-payments',
+			'entrypoint'        => 'woocommerce-payments/woocommerce-payments.php',
+			'dependency_env'    => 'WC_CHECKOUT_GATEWAY_MATRIX_WOOPAYMENTS_DEPENDENCY',
+			'source_path_env'   => 'WC_CHECKOUT_GATEWAY_MATRIX_WOOPAYMENTS_PATH',
+			'prepared_path_env' => 'WC_CHECKOUT_GATEWAY_MATRIX_WOOPAYMENTS_PREPARED_ARTIFACT_PATH',
+			'settings'          => array(
 				'enabled'  => 'yes',
 				'testmode' => 'yes',
 			),
@@ -149,7 +155,7 @@ return function (): array {
 		);
 	}
 
-	$get_mounted_plugin_revision = static function ( string $plugin_dir ): ?string {
+	$get_git_revision = static function ( string $plugin_dir ): ?string {
 		if ( '' === $plugin_dir || ! is_dir( $plugin_dir ) || ! function_exists( 'shell_exec' ) ) {
 			return null;
 		}
@@ -161,38 +167,50 @@ return function (): array {
 		return '' !== $revision ? $revision : null;
 	};
 
-	$ensure_gateway_profile = static function ( array $profile ) use ( $get_mounted_plugin_revision ): array {
-		$entrypoint_path = $profile['entrypoint'] ? WP_PLUGIN_DIR . '/' . $profile['entrypoint'] : '';
-		$mounted_path    = $profile['entrypoint'] ? WP_PLUGIN_DIR . '/' . dirname( $profile['entrypoint'] ) : '';
-		$configured_path = '';
-		if ( ! empty( $profile['path_env'] ) ) {
-			$configured_path = (string) getenv( $profile['path_env'] );
-		}
-		$install         = array(
-			'plugin'            => $profile['plugin'],
-			'entrypoint'        => $profile['entrypoint'],
-			'entrypoint_path'   => $entrypoint_path,
-			'configured_path'   => $configured_path,
-			'mounted_path'      => $mounted_path,
-			'mounted_revision'  => null,
-			'available'         => true,
-			'activated'         => false,
-			'version'           => null,
-			'status'            => 'available',
-			'skip_reason'       => '',
+	$get_env_value = static function ( array $profile, string $key ): string {
+		$env_name = (string) ( $profile[ $key ] ?? '' );
+		return '' !== $env_name ? (string) getenv( $env_name ) : '';
+	};
+
+	$ensure_gateway_profile = static function ( array $profile ) use ( $get_git_revision, $get_env_value ): array {
+		$entrypoint_path    = $profile['entrypoint'] ? WP_PLUGIN_DIR . '/' . $profile['entrypoint'] : '';
+		$mounted_plugin_dir = $profile['entrypoint'] ? WP_PLUGIN_DIR . '/' . dirname( $profile['entrypoint'] ) : '';
+		$dependency         = $get_env_value( $profile, 'dependency_env' );
+		$source_path        = $get_env_value( $profile, 'source_path_env' );
+		$prepared_path      = $get_env_value( $profile, 'prepared_path_env' );
+		$configured         = '' !== $dependency || '' !== $source_path || '' !== $prepared_path;
+		$install            = array(
+			'plugin'                 => $profile['plugin'],
+			'entrypoint'             => $profile['entrypoint'],
+			'entrypoint_path'        => $entrypoint_path,
+			'configured_dependency'  => $dependency,
+			'source_path'            => $source_path,
+			'git_revision'           => null,
+			'prepared_artifact_path' => $prepared_path,
+			'mounted_plugin_dir'     => $mounted_plugin_dir,
+			'plugin_version'         => null,
+			'available'              => true,
+			'activated'              => false,
+			'status'                 => 'available',
+			'skip_reason'            => '',
 		);
 
 		if ( $profile['entrypoint'] ) {
 			if ( ! file_exists( $entrypoint_path ) ) {
-				$install['available']   = false;
-				$install['status']      = $configured_path ? 'entrypoint_missing' : 'not_configured';
-				$install['skip_reason'] = $configured_path
-					? 'Configured plugin path did not mount the expected entrypoint in WP Codebox.'
-					: 'Plugin path is not configured for this gateway profile.';
+				$install['available'] = false;
+				if ( '' !== $prepared_path && ! is_dir( $prepared_path ) ) {
+					$install['status']      = 'build_failed';
+					$install['skip_reason'] = 'Prepared dependency artifact path is configured but is not available in the runtime.';
+				} else {
+					$install['status']      = $configured ? 'entrypoint_missing' : 'not_configured';
+					$install['skip_reason'] = $configured
+						? 'Configured dependency did not mount the expected plugin entrypoint in WP Codebox.'
+						: 'Plugin path is not configured for this gateway profile.';
+				}
 				return $install;
 			}
 
-			$install['mounted_revision'] = $get_mounted_plugin_revision( $mounted_path );
+			$install['git_revision'] = $get_git_revision( $source_path ) ?: $get_git_revision( $mounted_plugin_dir );
 
 			if ( ! function_exists( 'is_plugin_active' ) || ! function_exists( 'activate_plugin' ) ) {
 				require_once ABSPATH . 'wp-admin/includes/plugin.php';
@@ -213,8 +231,8 @@ return function (): array {
 				require_once ABSPATH . 'wp-admin/includes/plugin.php';
 			}
 			if ( function_exists( 'get_plugin_data' ) ) {
-				$plugin_data        = get_plugin_data( $entrypoint_path, false, false );
-				$install['version'] = $plugin_data['Version'] ?? null;
+				$plugin_data               = get_plugin_data( $entrypoint_path, false, false );
+				$install['plugin_version'] = $plugin_data['Version'] ?? null;
 			}
 		}
 
@@ -232,7 +250,7 @@ return function (): array {
 		$gateways = WC()->payment_gateways ? WC()->payment_gateways->payment_gateways() : array();
 		if ( ! isset( $gateways[ $profile['gateway_id'] ] ) ) {
 			$install['available']   = false;
-			$install['status']      = 'gateway_missing';
+			$install['status']      = 'activation_failed';
 			$install['skip_reason'] = 'Gateway id is not registered after activation/configuration.';
 		}
 

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -3,17 +3,17 @@
   "description": "WooCommerce large-merchant performance rig. Uses the WordPress/WP Codebox bench runtime for checkout and shipping cache workloads tied to concrete WooCommerce performance issues.",
   "components": {
     "woocommerce": {
-      "path": "~/Developer/woocommerce/plugins/woocommerce",
+      "path": "$HOME/Developer/woocommerce/plugins/woocommerce",
       "branch": "trunk",
       "extensions": {
         "wordpress": {
           "wp_codebox_wordpress_version": "7.0",
           "validation_dependencies": [
-            "~/Developer/woocommerce-gateway-stripe"
+            "woocommerce-gateway-stripe"
           ],
           "bench_env": {
             "WC_CHECKOUT_GATEWAY_MATRIX_PROFILES": "core_bacs,core_cheque,core_cod,plugin_stripe,plugin_paypal_payments,plugin_woopayments",
-            "WC_CHECKOUT_GATEWAY_MATRIX_STRIPE_PATH": "~/Developer/woocommerce-gateway-stripe",
+            "WC_CHECKOUT_GATEWAY_MATRIX_STRIPE_DEPENDENCY": "woocommerce-gateway-stripe",
             "WC_CHECKOUT_GATEWAY_MATRIX_PAYPAL_PAYMENTS_PATH": "",
             "WC_CHECKOUT_GATEWAY_MATRIX_WOOPAYMENTS_PATH": "",
             "WC_SHIPPING_CACHE_CART_ITEMS": "40",
@@ -46,10 +46,6 @@
           }
         }
       }
-    },
-    "woocommerce-gateway-stripe": {
-      "path": "~/Developer/woocommerce-gateway-stripe",
-      "branch": "develop"
     }
   },
   "resources": {
@@ -57,8 +53,7 @@
       "woocommerce-performance:${env.HOMEBOY_SETTINGS_WOOCOMMERCE_PERFORMANCE_NAMESPACE}"
     ],
     "paths": [
-      "${components.woocommerce.path}",
-      "${components.woocommerce-gateway-stripe.path}"
+      "${components.woocommerce.path}"
     ]
   },
   "bench": {
@@ -110,51 +105,51 @@
       {
         "kind": "command",
         "label": "WooCommerce runner checkout exists",
-        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; test -f \"$woocommerce_dir/woocommerce.php\" || { printf '%s\\n' \"Missing WooCommerce runner checkout: expected $woocommerce_dir/woocommerce.php (default ~/Developer/woocommerce/plugins/woocommerce/woocommerce.php). Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path before running woocommerce-performance.\"; exit 1; }"
+        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; test -f \"$woocommerce_dir/woocommerce.php\" || { printf '%s\\n' \"Missing WooCommerce runner checkout: expected $woocommerce_dir/woocommerce.php. Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path before running woocommerce-performance.\"; exit 1; }"
       },
       {
         "kind": "command",
         "label": "WooCommerce cart class exists",
-        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; test -f \"$woocommerce_dir/includes/class-wc-cart.php\" || { printf '%s\\n' \"Missing WooCommerce cart class: expected $woocommerce_dir/includes/class-wc-cart.php (default ~/Developer/woocommerce/plugins/woocommerce/includes/class-wc-cart.php). Verify the selected component path is the WooCommerce monorepo plugin directory, not an empty or partial clone.\"; exit 1; }"
+        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; test -f \"$woocommerce_dir/includes/class-wc-cart.php\" || { printf '%s\\n' \"Missing WooCommerce cart class: expected $woocommerce_dir/includes/class-wc-cart.php. Verify the selected component path is the WooCommerce monorepo plugin directory, not an empty or partial clone.\"; exit 1; }"
       },
       {
         "kind": "command",
         "label": "WooCommerce shipping class exists",
-        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; test -f \"$woocommerce_dir/includes/class-wc-shipping.php\" || { printf '%s\\n' \"Missing WooCommerce shipping class: expected $woocommerce_dir/includes/class-wc-shipping.php (default ~/Developer/woocommerce/plugins/woocommerce/includes/class-wc-shipping.php). Verify the selected component path is the WooCommerce monorepo plugin directory, not an empty or partial clone.\"; exit 1; }"
+        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; test -f \"$woocommerce_dir/includes/class-wc-shipping.php\" || { printf '%s\\n' \"Missing WooCommerce shipping class: expected $woocommerce_dir/includes/class-wc-shipping.php. Verify the selected component path is the WooCommerce monorepo plugin directory, not an empty or partial clone.\"; exit 1; }"
       },
       {
         "kind": "command",
         "label": "WooCommerce Composer package autoloader exists or can be prepared",
-        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; test -d \"$woocommerce_dir\" || { printf '%s\\n' \"Cannot check WooCommerce Composer dependencies because $woocommerce_dir is missing (default ~/Developer/woocommerce/plugins/woocommerce). Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path.\"; exit 1; }; test -f \"$woocommerce_dir/vendor/autoload_packages.php\" || command -v composer >/dev/null 2>&1 || { printf '%s\\n' 'Missing WooCommerce Composer dependencies: vendor/autoload_packages.php is absent and composer is not available. Install Composer on the runner, then run: homeboy rig up woocommerce-performance'; exit 1; }"
+        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; test -d \"$woocommerce_dir\" || { printf '%s\\n' \"Cannot check WooCommerce Composer dependencies because $woocommerce_dir is missing. Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path.\"; exit 1; }; test -f \"$woocommerce_dir/vendor/autoload_packages.php\" || command -v composer >/dev/null 2>&1 || { printf '%s\\n' 'Missing WooCommerce Composer dependencies: vendor/autoload_packages.php is absent and composer is not available. Install Composer on the runner, then run: homeboy rig up woocommerce-performance'; exit 1; }"
       },
       {
         "kind": "command",
         "label": "WooCommerce generated feature config exists or can be prepared",
-        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; test -d \"$woocommerce_dir\" || { printf '%s\\n' \"Cannot check WooCommerce generated feature config because $woocommerce_dir is missing (default ~/Developer/woocommerce/plugins/woocommerce). Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path.\"; exit 1; }; test -f \"$woocommerce_dir/includes/react-admin/feature-config.php\" || { test -f \"$woocommerce_dir/bin/generate-feature-config.php\" && command -v php >/dev/null 2>&1; } || { printf '%s\\n' 'Missing WooCommerce generated feature config: includes/react-admin/feature-config.php is absent. Ensure PHP is available, then run: homeboy rig up woocommerce-performance'; exit 1; }"
+        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; test -d \"$woocommerce_dir\" || { printf '%s\\n' \"Cannot check WooCommerce generated feature config because $woocommerce_dir is missing. Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path.\"; exit 1; }; test -f \"$woocommerce_dir/includes/react-admin/feature-config.php\" || { test -f \"$woocommerce_dir/bin/generate-feature-config.php\" && command -v php >/dev/null 2>&1; } || { printf '%s\\n' 'Missing WooCommerce generated feature config: includes/react-admin/feature-config.php is absent. Ensure PHP is available, then run: homeboy rig up woocommerce-performance'; exit 1; }"
       }
     ],
     "up": [
       {
         "kind": "command",
         "label": "Prepare WooCommerce Composer dependencies when missing",
-        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; cd \"$woocommerce_dir\" || { printf '%s\\n' \"Missing WooCommerce runner checkout: expected $woocommerce_dir before rig up (default ~/Developer/woocommerce/plugins/woocommerce). Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path.\"; exit 1; }; if [ -f vendor/autoload_packages.php ]; then printf '%s\\n' 'WooCommerce Composer dependencies already prepared.'; else XDEBUG_MODE=off composer install --no-interaction --no-progress; fi"
+        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; cd \"$woocommerce_dir\" || { printf '%s\\n' \"Missing WooCommerce runner checkout: expected $woocommerce_dir before rig up. Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path.\"; exit 1; }; if [ -f vendor/autoload_packages.php ]; then printf '%s\\n' 'WooCommerce Composer dependencies already prepared.'; else XDEBUG_MODE=off composer install --no-interaction --no-progress; fi"
       },
       {
         "kind": "command",
         "label": "Generate WooCommerce feature config when missing",
-        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; cd \"$woocommerce_dir\" || { printf '%s\\n' \"Missing WooCommerce runner checkout: expected $woocommerce_dir before rig up (default ~/Developer/woocommerce/plugins/woocommerce). Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path.\"; exit 1; }; if [ -f includes/react-admin/feature-config.php ]; then printf '%s\\n' 'WooCommerce feature config already generated.'; else php bin/generate-feature-config.php; fi"
+        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; cd \"$woocommerce_dir\" || { printf '%s\\n' \"Missing WooCommerce runner checkout: expected $woocommerce_dir before rig up. Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path.\"; exit 1; }; if [ -f includes/react-admin/feature-config.php ]; then printf '%s\\n' 'WooCommerce feature config already generated.'; else php bin/generate-feature-config.php; fi"
       }
     ],
     "bench_prepare": [
       {
         "kind": "command",
         "label": "Prepare WooCommerce Composer dependencies when missing",
-        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; cd \"$woocommerce_dir\" || { printf '%s\\n' \"Missing WooCommerce runner checkout: expected $woocommerce_dir before bench_prepare (default ~/Developer/woocommerce/plugins/woocommerce). Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path.\"; exit 1; }; if [ -f vendor/autoload_packages.php ]; then printf '%s\\n' 'WooCommerce Composer dependencies already prepared.'; else XDEBUG_MODE=off composer install --no-interaction --no-progress; fi"
+        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; cd \"$woocommerce_dir\" || { printf '%s\\n' \"Missing WooCommerce runner checkout: expected $woocommerce_dir before bench_prepare. Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path.\"; exit 1; }; if [ -f vendor/autoload_packages.php ]; then printf '%s\\n' 'WooCommerce Composer dependencies already prepared.'; else XDEBUG_MODE=off composer install --no-interaction --no-progress; fi"
       },
       {
         "kind": "command",
         "label": "Generate WooCommerce feature config when missing",
-        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; cd \"$woocommerce_dir\" || { printf '%s\\n' \"Missing WooCommerce runner checkout: expected $woocommerce_dir before bench_prepare (default ~/Developer/woocommerce/plugins/woocommerce). Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path.\"; exit 1; }; if [ -f includes/react-admin/feature-config.php ]; then printf '%s\\n' 'WooCommerce feature config already generated.'; else php bin/generate-feature-config.php; fi"
+        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; cd \"$woocommerce_dir\" || { printf '%s\\n' \"Missing WooCommerce runner checkout: expected $woocommerce_dir before bench_prepare. Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path.\"; exit 1; }; if [ -f includes/react-admin/feature-config.php ]; then printf '%s\\n' 'WooCommerce feature config already generated.'; else php bin/generate-feature-config.php; fi"
       }
     ],
     "down": []


### PR DESCRIPTION
## Summary
- Updates `woocommerce-performance` to declare WooCommerce Stripe Gateway via the Homeboy Extensions `validation_dependencies` contract instead of brittle local path assumptions.
- Updates `checkout-gateway-compatibility-matrix` artifact fields to report configured dependency/source/prepared paths, git revision, mounted plugin directory, plugin version, and normalized status.
- Keeps PayPal/WooPayments optional and explicitly skipped when absent.

## Verification
- `php -l woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php`
- `jq empty woocommerce/woocommerce/rigs/woocommerce-performance/rig.json`
- `homeboy rig install /Users/chubes/Developer/homeboy-rigs@fix-issue-255-dependency-materialization/woocommerce/woocommerce --id woocommerce-performance`
- `homeboy rig check woocommerce-performance`

## Evidence
- Rig check passed before installing the local HBEX follow-up: `0130d514-93da-4272-acf1-ce4b5bb05743`
- Targeted gateway matrix against WooCommerce old fix still blocked before workload execution by HBEX dependency provider install: `npm EBADENGINE`
- Local HBEX follow-up identified for coordination: `Extra-Chill/homeboy-extensions` commit `a3958fd7` on `fix/gateway-matrix-plugin-materialization-255`

## Blocker
The real Stripe profile proof still depends on the HBEX dependency/materialization fix being available on the Lab runner. This PR does not patch around that extension bug.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the rig dependency/materialization follow-up, drafted verification notes, and prepared this PR body for Chris review.