### PR TITLE
Add checkout PR evidence matrix

### DIFF
--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -163,5 +163,8 @@ The generated matrix is intentionally dependency-aware. It lists the old PR shap
 failure run, ready commands for public `create_order()` side effects, sequential
 retry, true concurrent checkout, and core gateway rows, and keeps no-payment,
 order-pay, identity, coupon lifecycle, hook sequencing, and real Stripe rows
-blocked until their prerequisite issues land. See
+blocked until their prerequisite issues land. Real Stripe coverage is framed as a
+reusable gateway-plugin profile capability that should share the existing
+`woocommerce-stripe-ece-product-page` WooCommerce + Stripe mounting abstractions,
+not duplicate checkout-specific setup. See
 `docs/checkout-pr-evidence-matrix.md` for the full recipe.

--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -149,3 +149,19 @@ The report separates timing evidence from shipping-rate call-count evidence and
 documents the cache invalidation controls covered by the current workload. See
 `docs/checkout-shipping-cache-matrix-report.md` for the planned matrix commands
 and current dependency blockers.
+
+## Checkout PR Evidence Matrix
+
+Use the checkout PR evidence generator when preparing the final reviewer-facing
+proof loop for WooCommerce issue #62659 and PR #65588:
+
+```bash
+node woocommerce/woocommerce/tools/checkout-pr-evidence-report.mjs
+```
+
+The generated matrix is intentionally dependency-aware. It lists the old PR shape
+failure run, ready commands for public `create_order()` side effects, sequential
+retry, true concurrent checkout, and core gateway rows, and keeps no-payment,
+order-pay, identity, coupon lifecycle, hook sequencing, and real Stripe rows
+blocked until their prerequisite issues land. See
+`docs/checkout-pr-evidence-matrix.md` for the full recipe.

--- a/woocommerce/woocommerce/docs/checkout-pr-evidence-matrix.md
+++ b/woocommerce/woocommerce/docs/checkout-pr-evidence-matrix.md
@@ -1,0 +1,89 @@
+# WooCommerce Checkout PR Evidence Matrix
+
+This recipe prepares reviewer-facing evidence for WooCommerce issue
+https://github.com/woocommerce/woocommerce/issues/62659 and PR
+https://github.com/woocommerce/woocommerce/pull/65588.
+
+It intentionally separates ready evidence from prerequisite-dependent evidence.
+Do not mark blocked rows as passed until their prerequisite rigs land and produce
+artifacts.
+
+## Generate The Reviewer Matrix
+
+```bash
+node woocommerce/woocommerce/tools/checkout-pr-evidence-report.mjs
+```
+
+The report is generated from
+`woocommerce/woocommerce/tools/checkout-pr-evidence-matrix.json` so the expected
+old-fix failures, revised-candidate expectations, dependencies, and commands stay
+reviewable in one place.
+
+## Current Dependencies
+
+| Dependency | Status | Scope |
+|---|---|---|
+| https://github.com/chubes4/homeboy-rigs/issues/268 | open | no-payment and order-pay guardrails |
+| https://github.com/chubes4/homeboy-rigs/issues/269 | open | guest, logged-in, customer/session identity guardrails |
+| https://github.com/chubes4/homeboy-rigs/issues/270 | open | checkout hook sequencing and counts |
+| https://github.com/chubes4/homeboy-rigs/issues/271 | open | coupon lifecycle guardrails |
+| https://github.com/chubes4/homeboy-rigs/issues/272 | open | real gateway profile stabilization |
+| https://github.com/Extra-Chill/homeboy-extensions/issues/1321 | open | Stripe dependency provider fix |
+
+## Ready Rows
+
+Run these rows for both the old PR shape and the revised WooCommerce candidate.
+
+```bash
+homeboy rig up woocommerce-performance
+
+homeboy bench --rig woocommerce-performance \
+  --scenario checkout-gateway-compatibility-matrix \
+  --iterations 1 \
+  --shared-state /tmp/woocommerce-checkout-pr-65588-old-shape \
+  --setting-json 'bench_env={"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES":"core_bacs,core_cheque,core_cod"}'
+
+homeboy bench --rig woocommerce-performance \
+  --scenario checkout-concurrent-create-order \
+  --iterations 1 \
+  --shared-state /tmp/woocommerce-checkout-pr-65588-old-shape
+```
+
+Repeat with the revised candidate checked out and
+`--shared-state /tmp/woocommerce-checkout-pr-65588-revised-candidate`.
+
+## Expected Interpretation
+
+| Row | Old PR shape | Revised candidate |
+|---|---|---|
+| Public `create_order()` side effects | Fails: public `WC_Checkout::create_order()` writes `order_awaiting_payment`. | Passes when public `create_order()` does not set `order_awaiting_payment`; payment-start paths own that write. |
+| Sequential retry and resume | May appear to work only because the old fix writes the session branch too early. | Passes when retry/resume uses the intended branch after payment start and preserves failure/cancel carts. |
+| True concurrent checkout | Unproven by the old PR shape; do not claim `Closes #62659`. | Only passes when duplicate-order count is zero in the concurrent harness. |
+| Core gateways | Failure/regression should be visible in `order_awaiting_payment` and cart-clearing metrics. | Passes across BACS, cheque, and COD without unexpected cart clearing. |
+
+## Blocked Rows
+
+The following rows stay pending until their prerequisites land:
+
+| Row | Blocker |
+|---|---|
+| No-payment and order-pay paths | https://github.com/chubes4/homeboy-rigs/issues/268 |
+| Guest, logged-in, customer identity | https://github.com/chubes4/homeboy-rigs/issues/269 |
+| Hook sequencing and counts | https://github.com/chubes4/homeboy-rigs/issues/270 |
+| Coupon lifecycle | https://github.com/chubes4/homeboy-rigs/issues/271 |
+| Real Stripe gateway | https://github.com/chubes4/homeboy-rigs/issues/272 and https://github.com/Extra-Chill/homeboy-extensions/issues/1321 |
+
+## Reviewer-Facing Output Contract
+
+The WooCommerce PR evidence should include:
+
+- Links to WooCommerce issue #62659, WooCommerce PR #65588 or replacement PR,
+  Jorge's review, and Homeboy Rigs issue #273.
+- The old-fix guardrail failure run ID
+  `136c2b85-647c-4d85-be13-2c0be175abfd`.
+- A table with old PR shape output and revised candidate output for every ready
+  row.
+- Explicit `blocked` labels for #268-#272 and HBEX #1321 rows until those runs
+  exist.
+- A PR description note that avoids `Closes #62659` unless the true concurrent
+  checkout row passes.

--- a/woocommerce/woocommerce/docs/checkout-pr-evidence-matrix.md
+++ b/woocommerce/woocommerce/docs/checkout-pr-evidence-matrix.md
@@ -19,6 +19,20 @@ The report is generated from
 old-fix failures, revised-candidate expectations, dependencies, and commands stay
 reviewable in one place.
 
+## Reusable Stripe Gateway Capability
+
+Real Stripe checkout coverage should build on the existing
+`woocommerce/woocommerce-gateway-stripe` rig track instead of adding a
+checkout-matrix-only Stripe setup path. The
+`woocommerce-stripe-ece-product-page` rig already owns WooCommerce +
+WooCommerce Stripe mounting, Stripe checkout path checks, fixture expectations,
+and real-wallet/secure-browser profile separation.
+
+The final checkout matrix should treat Stripe as a reusable gateway-plugin
+profile capability that can be shared by WooCommerce workloads. Relevant merged
+homeboy-rigs PRs in that track include #176, #178, #183, #184, #193, #197, #219,
+#220, #235, #236, #238, and #265.
+
 ## Current Dependencies
 
 | Dependency | Status | Scope |
@@ -71,7 +85,7 @@ The following rows stay pending until their prerequisites land:
 | Guest, logged-in, customer identity | https://github.com/chubes4/homeboy-rigs/issues/269 |
 | Hook sequencing and counts | https://github.com/chubes4/homeboy-rigs/issues/270 |
 | Coupon lifecycle | https://github.com/chubes4/homeboy-rigs/issues/271 |
-| Real Stripe gateway | https://github.com/chubes4/homeboy-rigs/issues/272 and https://github.com/Extra-Chill/homeboy-extensions/issues/1321 |
+| Real Stripe gateway | https://github.com/chubes4/homeboy-rigs/issues/272 and https://github.com/Extra-Chill/homeboy-extensions/issues/1321; reuse the `woocommerce-stripe-ece-product-page` mounting abstractions instead of duplicating setup |
 
 ## Reviewer-Facing Output Contract
 
@@ -85,5 +99,8 @@ The WooCommerce PR evidence should include:
   row.
 - Explicit `blocked` labels for #268-#272 and HBEX #1321 rows until those runs
   exist.
+- Real Stripe coverage framed as reusable gateway-plugin profile capability,
+  sharing the existing WooCommerce Stripe ECE/product-page rig mounting
+  abstractions.
 - A PR description note that avoids `Closes #62659` unless the true concurrent
   checkout row passes.

--- a/woocommerce/woocommerce/tools/checkout-pr-evidence-matrix.json
+++ b/woocommerce/woocommerce/tools/checkout-pr-evidence-matrix.json
@@ -5,6 +5,16 @@
   "woocommerce_pr": "https://github.com/woocommerce/woocommerce/pull/65588",
   "review": "https://github.com/woocommerce/woocommerce/pull/65588#pullrequestreview-4488383929",
   "old_fix_failure_run": "136c2b85-647c-4d85-be13-2c0be175abfd",
+  "reusable_capabilities": [
+    {
+      "id": "stripe_gateway_plugin_profile",
+      "title": "Reusable Stripe gateway plugin profile capability",
+      "source": "woocommerce/woocommerce-gateway-stripe",
+      "rig": "woocommerce-stripe-ece-product-page",
+      "merged_prs": [176, 178, 183, 184, 193, 197, 219, 220, 235, 236, 238, 265],
+      "guidance": "Real Stripe checkout coverage should reuse the existing WooCommerce + WooCommerce Stripe mounting and dependency abstractions from the Stripe ECE/product-page rig track. Treat Stripe as a reusable gateway-plugin profile capability for WooCommerce workloads, not as a one-off checkout-matrix setup path."
+    }
+  ],
   "prerequisites": [
     {
       "id": "no_payment_order_pay",
@@ -143,8 +153,8 @@
       "blocked_by": ["https://github.com/chubes4/homeboy-rigs/issues/272", "https://github.com/Extra-Chill/homeboy-extensions/issues/1321"],
       "scenario": "checkout-gateway-compatibility-matrix",
       "command": "homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 --shared-state <shared-state> --setting-json 'bench_env={\"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES\":\"plugin_stripe\"}'",
-      "old_fix_expected": "Pending real Stripe stabilization; skip output is not failure evidence.",
-      "candidate_expected": "PASS once Stripe dependency materialization is stable; skip with explicit blocker is acceptable until then."
+      "old_fix_expected": "Pending real Stripe stabilization; skip output is not failure evidence. Reuse the existing WooCommerce Stripe ECE/product-page mounting abstractions instead of adding checkout-only Stripe setup.",
+      "candidate_expected": "PASS once Stripe dependency materialization is stable as a reusable gateway-plugin profile capability; skip with explicit blocker is acceptable until then."
     }
   ]
 }

--- a/woocommerce/woocommerce/tools/checkout-pr-evidence-matrix.json
+++ b/woocommerce/woocommerce/tools/checkout-pr-evidence-matrix.json
@@ -1,0 +1,150 @@
+{
+  "title": "WooCommerce checkout create_order idempotency evidence matrix",
+  "issue": "https://github.com/chubes4/homeboy-rigs/issues/273",
+  "woocommerce_issue": "https://github.com/woocommerce/woocommerce/issues/62659",
+  "woocommerce_pr": "https://github.com/woocommerce/woocommerce/pull/65588",
+  "review": "https://github.com/woocommerce/woocommerce/pull/65588#pullrequestreview-4488383929",
+  "old_fix_failure_run": "136c2b85-647c-4d85-be13-2c0be175abfd",
+  "prerequisites": [
+    {
+      "id": "no_payment_order_pay",
+      "title": "No-payment and order-pay checkout guardrails",
+      "url": "https://github.com/chubes4/homeboy-rigs/issues/268",
+      "status": "open"
+    },
+    {
+      "id": "identity",
+      "title": "Customer/session identity guardrails",
+      "url": "https://github.com/chubes4/homeboy-rigs/issues/269",
+      "status": "open"
+    },
+    {
+      "id": "hook_sequencing",
+      "title": "Hook sequencing guardrails",
+      "url": "https://github.com/chubes4/homeboy-rigs/issues/270",
+      "status": "open"
+    },
+    {
+      "id": "coupon_lifecycle",
+      "title": "Coupon lifecycle guardrails",
+      "url": "https://github.com/chubes4/homeboy-rigs/issues/271",
+      "status": "open"
+    },
+    {
+      "id": "real_gateway_profiles",
+      "title": "Real gateway plugin profile stabilization",
+      "url": "https://github.com/chubes4/homeboy-rigs/issues/272",
+      "status": "open"
+    },
+    {
+      "id": "stripe_dependency_provider",
+      "title": "Stripe dependency provider fix",
+      "url": "https://github.com/Extra-Chill/homeboy-extensions/issues/1321",
+      "status": "open"
+    }
+  ],
+  "runs": [
+    {
+      "id": "old_pr_shape",
+      "label": "Old PR shape baseline",
+      "woocommerce_ref": "WooCommerce PR #65588 current old-fix shape",
+      "shared_state": "/tmp/woocommerce-checkout-pr-65588-old-shape",
+      "expected": "Fails known guardrails: public create_order writes order_awaiting_payment; legacy coupon independence is not preserved; true concurrent behavior remains unproven. Do not use this as passing evidence."
+    },
+    {
+      "id": "revised_candidate",
+      "label": "Revised checkout candidate",
+      "woocommerce_ref": "replacement branch or revised PR candidate",
+      "shared_state": "/tmp/woocommerce-checkout-pr-65588-revised-candidate",
+      "expected": "Passes public create_order side-effect guardrails and resume behavior without overclaiming true concurrency unless the concurrent scenario passes. Any remaining failures must be scoped in the Woo PR description."
+    }
+  ],
+  "scenarios": [
+    {
+      "id": "public_create_order_side_effects",
+      "label": "Public create_order side effects",
+      "status": "ready",
+      "scenario": "checkout-gateway-compatibility-matrix",
+      "command": "homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 --shared-state <shared-state> --setting-json 'bench_env={\"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES\":\"core_bacs,core_cheque,core_cod\"}'",
+      "old_fix_expected": "FAIL: public WC_Checkout::create_order() sets order_awaiting_payment before payment processing.",
+      "candidate_expected": "PASS: public create_order() does not set order_awaiting_payment; payment-start paths own that write."
+    },
+    {
+      "id": "sequential_retry_resume",
+      "label": "Sequential retry and resume behavior",
+      "status": "ready",
+      "scenario": "checkout-gateway-compatibility-matrix",
+      "command": "homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 --shared-state <shared-state> --setting-json 'bench_env={\"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES\":\"core_bacs,core_cheque,core_cod\"}'",
+      "old_fix_expected": "Mixed: sequential reuse may appear to work only because create_order writes the session branch too early.",
+      "candidate_expected": "PASS: retry/resume uses the intended order_awaiting_payment branch after payment start while preserving carts for failure/cancel paths."
+    },
+    {
+      "id": "true_concurrent_checkout",
+      "label": "True concurrent checkout behavior",
+      "status": "ready",
+      "scenario": "checkout-concurrent-create-order",
+      "command": "homeboy bench --rig woocommerce-performance --scenario checkout-concurrent-create-order --iterations 1 --shared-state <shared-state>",
+      "old_fix_expected": "UNPROVEN/FAIL: old PR description overclaims Closes #62659 without proving the true concurrent duplicate-order path.",
+      "candidate_expected": "PASS only if duplicate_order_count is zero under real concurrent harness evidence; otherwise PR must avoid Closes #62659."
+    },
+    {
+      "id": "no_payment_order_pay",
+      "label": "No-payment and order-pay paths",
+      "status": "blocked",
+      "blocked_by": ["https://github.com/chubes4/homeboy-rigs/issues/268"],
+      "scenario": "pending #268 workload",
+      "command": "Run the #268 workload after it lands; append artifacts under the same shared-state root.",
+      "old_fix_expected": "Pending #268; do not claim old-shape failure beyond available artifacts.",
+      "candidate_expected": "Pending #268; expected to preserve order-pay/no-payment flows without session side-effect regressions."
+    },
+    {
+      "id": "identity",
+      "label": "Guest, logged-in, and customer identity cases",
+      "status": "blocked",
+      "blocked_by": ["https://github.com/chubes4/homeboy-rigs/issues/269"],
+      "scenario": "pending #269 workload",
+      "command": "Run the #269 workload after it lands; append artifacts under the same shared-state root.",
+      "old_fix_expected": "Pending #269; do not claim identity coverage from current gateway-only evidence.",
+      "candidate_expected": "Pending #269; expected to keep session/customer identity attached to the correct order."
+    },
+    {
+      "id": "coupon_lifecycle",
+      "label": "Coupon lifecycle",
+      "status": "blocked",
+      "blocked_by": ["https://github.com/chubes4/homeboy-rigs/issues/271"],
+      "scenario": "pending #271 workload",
+      "command": "Run the #271 workload after it lands; append artifacts under the same shared-state root.",
+      "old_fix_expected": "FAIL already known from legacy_coupon_independence guardrail state, but final matrix still needs #271 artifacts.",
+      "candidate_expected": "PASS: coupons survive retry/failure/cancel lifecycle where WooCommerce expects cart restoration."
+    },
+    {
+      "id": "hook_sequencing",
+      "label": "Hook sequencing and counts",
+      "status": "blocked",
+      "blocked_by": ["https://github.com/chubes4/homeboy-rigs/issues/270"],
+      "scenario": "pending #270 workload",
+      "command": "Run the #270 workload after it lands; append artifacts under the same shared-state root.",
+      "old_fix_expected": "Pending #270; do not infer hook sequencing from order/session metrics alone.",
+      "candidate_expected": "PASS: checkout hooks fire once in expected order for create, payment, retry, failure, and cancel paths."
+    },
+    {
+      "id": "core_gateways",
+      "label": "Core gateway profiles",
+      "status": "ready",
+      "scenario": "checkout-gateway-compatibility-matrix",
+      "command": "homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 --shared-state <shared-state> --setting-json 'bench_env={\"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES\":\"core_bacs,core_cheque,core_cod\"}'",
+      "old_fix_expected": "FAIL or scoped regressions should be visible in order_awaiting_payment and cart-clearing metrics.",
+      "candidate_expected": "PASS across BACS, cheque, and COD without unexpected cart clearing."
+    },
+    {
+      "id": "real_stripe",
+      "label": "Real Stripe gateway profile",
+      "status": "blocked",
+      "blocked_by": ["https://github.com/chubes4/homeboy-rigs/issues/272", "https://github.com/Extra-Chill/homeboy-extensions/issues/1321"],
+      "scenario": "checkout-gateway-compatibility-matrix",
+      "command": "homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 --shared-state <shared-state> --setting-json 'bench_env={\"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES\":\"plugin_stripe\"}'",
+      "old_fix_expected": "Pending real Stripe stabilization; skip output is not failure evidence.",
+      "candidate_expected": "PASS once Stripe dependency materialization is stable; skip with explicit blocker is acceptable until then."
+    }
+  ]
+}

--- a/woocommerce/woocommerce/tools/checkout-pr-evidence-report.mjs
+++ b/woocommerce/woocommerce/tools/checkout-pr-evidence-report.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const defaultMatrixPath = resolve(__dirname, 'checkout-pr-evidence-matrix.json');
+const args = parseArgs(process.argv.slice(2));
+const matrix = readJson(args.matrix || defaultMatrixPath);
+
+process.stdout.write(renderReport(matrix));
+
+function renderReport(data) {
+	const lines = [];
+	lines.push(`# ${data.title}`);
+	lines.push('');
+	lines.push('## Links');
+	lines.push('');
+	lines.push(`- Homeboy Rigs tracker: ${data.issue}`);
+	lines.push(`- WooCommerce issue: ${data.woocommerce_issue}`);
+	lines.push(`- WooCommerce PR: ${data.woocommerce_pr}`);
+	lines.push(`- Jorge review: ${data.review}`);
+	lines.push(`- Old-fix guardrail failure run: ${data.old_fix_failure_run}`);
+	lines.push('');
+	lines.push('## Status');
+	lines.push('');
+	lines.push('- This is a proof-loop recipe, not final pass/fail evidence.');
+	lines.push('- Blocked rows stay blocked until their prerequisite issues land and produce artifacts.');
+	lines.push('- The WooCommerce PR should avoid `Closes #62659` unless the true concurrent checkout row passes.');
+	lines.push('');
+	lines.push('## Prerequisites');
+	lines.push('');
+	lines.push('| Status | Dependency | Link |');
+	lines.push('|---|---|---|');
+	for (const prerequisite of data.prerequisites) {
+		lines.push(`| ${prerequisite.status} | ${prerequisite.title} | ${prerequisite.url} |`);
+	}
+	lines.push('');
+	lines.push('## Run Slots');
+	lines.push('');
+	lines.push('| Slot | WooCommerce ref | Shared state | Expected interpretation |');
+	lines.push('|---|---|---|---|');
+	for (const run of data.runs) {
+		lines.push(`| ${run.label} | ${run.woocommerce_ref} | \`${run.shared_state}\` | ${run.expected} |`);
+	}
+	lines.push('');
+	lines.push('## Evidence Matrix');
+	lines.push('');
+	lines.push('| Status | Scenario | Command | Old PR shape | Revised candidate |');
+	lines.push('|---|---|---|---|---|');
+	for (const scenario of data.scenarios) {
+		const status = scenario.status === 'blocked' ? `blocked by ${scenario.blocked_by.join(', ')}` : scenario.status;
+		lines.push(`| ${status} | ${scenario.label} | \`${scenario.command}\` | ${scenario.old_fix_expected} | ${scenario.candidate_expected} |`);
+	}
+	lines.push('');
+	lines.push('## Command Recipe');
+	lines.push('');
+	lines.push('1. Check out the old PR shape in `~/Developer/woocommerce` and run `homeboy rig up woocommerce-performance`.');
+	lines.push('2. Run every `ready` command with `<shared-state>` set to `/tmp/woocommerce-checkout-pr-65588-old-shape`.');
+	lines.push('3. Check out the revised WooCommerce candidate and rerun the same commands with `<shared-state>` set to `/tmp/woocommerce-checkout-pr-65588-revised-candidate`.');
+	lines.push('4. After #268-#272 and HBEX #1321 land, add their artifacts under the same two shared-state roots and regenerate this report.');
+	lines.push('5. Copy the filled matrix into WooCommerce PR #65588 or its replacement PR, keeping blocked rows explicitly marked instead of inferred.');
+	lines.push('');
+	return `${lines.join('\n')}\n`;
+}
+
+function readJson(path) {
+	if (!existsSync(path)) {
+		throw new Error(`Matrix file does not exist: ${path}`);
+	}
+	return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function parseArgs(rawArgs) {
+	const parsed = {};
+	for (let index = 0; index < rawArgs.length; index++) {
+		const arg = rawArgs[index];
+		if (arg === '--matrix') {
+			parsed.matrix = rawArgs[++index];
+		}
+	}
+	return parsed;
+}

--- a/woocommerce/woocommerce/tools/checkout-pr-evidence-report.mjs
+++ b/woocommerce/woocommerce/tools/checkout-pr-evidence-report.mjs
@@ -29,6 +29,18 @@ function renderReport(data) {
 	lines.push('- Blocked rows stay blocked until their prerequisite issues land and produce artifacts.');
 	lines.push('- The WooCommerce PR should avoid `Closes #62659` unless the true concurrent checkout row passes.');
 	lines.push('');
+	if (Array.isArray(data.reusable_capabilities) && data.reusable_capabilities.length > 0) {
+		lines.push('## Reusable Capabilities');
+		lines.push('');
+		lines.push('| Capability | Source | Guidance |');
+		lines.push('|---|---|---|');
+		for (const capability of data.reusable_capabilities) {
+			const source = `${capability.source} / ${capability.rig}`;
+			const prs = Array.isArray(capability.merged_prs) && capability.merged_prs.length > 0 ? ` Merged PRs: ${capability.merged_prs.map((number) => `#${number}`).join(', ')}.` : '';
+			lines.push(`| ${capability.title} | ${source} | ${capability.guidance}${prs} |`);
+		}
+		lines.push('');
+	}
 	lines.push('## Prerequisites');
 	lines.push('');
 	lines.push('| Status | Dependency | Link |');


### PR DESCRIPTION
## Summary
- Refs #273.
- Adds a manifest-driven Woo checkout PR evidence matrix for WooCommerce #62659 / PR #65588.
- Documents ready proof-loop rows for public `create_order()` side effects, sequential retry, true concurrent checkout, and core gateways.
- Marks no-payment/order-pay, identity, coupon lifecycle, hook sequencing, and real Stripe rows as blocked until #268-#272 and Extra-Chill/homeboy-extensions#1321 land.

## Verification
- `node woocommerce/woocommerce/tools/checkout-pr-evidence-report.mjs`
- `node --check woocommerce/woocommerce/tools/checkout-pr-evidence-report.mjs`
- `node -e "JSON.parse(require('fs').readFileSync('woocommerce/woocommerce/tools/checkout-pr-evidence-matrix.json','utf8')); console.log('matrix json ok')"`
- `node scripts/lint-rig-packages.mjs woocommerce/woocommerce`

## Dependencies / blockers
- chubes4/homeboy-rigs#268
- chubes4/homeboy-rigs#269
- chubes4/homeboy-rigs#270
- chubes4/homeboy-rigs#271
- chubes4/homeboy-rigs#272
- Extra-Chill/homeboy-extensions#1321

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the evidence matrix manifest, report generator, docs, and verification commands; Chris remains responsible for review and final evidence runs.