### PR TITLE
Stabilize gateway matrix profiles

### DIFF
--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -61,9 +61,21 @@ materialization, mounts the prepared plugin into WP Codebox, and attaches
 artifact reports the runtime side of that same contract: configured dependency,
 source path when explicitly provided, git revision when visible, prepared artifact
 path when exported, mounted plugin directory, plugin version, and status. If the
-dependency provider reports `WC_CHECKOUT_GATEWAY_MATRIX_<PLUGIN>_BUILD_STATUS=build_failed`,
-the workload records `build_failed` inside the matrix artifact instead of hiding
-the failure behind a generic skipped profile.
+dependency provider exports a prepared artifact path that is unavailable in the
+runtime, the workload records `build_failed` inside the matrix artifact instead
+of hiding the failure behind a generic skipped profile.
+
+This deliberately reuses the mounting shape proven by the WooCommerce Stripe ECE
+product-page rig without duplicating its browser fixture. That rig owns direct WP
+Codebox recipe mounting for Stripe product-page traces:
+
+```json
+{"source":"/path/to/woocommerce-gateway-stripe","slug":"woocommerce-gateway-stripe","pluginFile":"woocommerce-gateway-stripe/woocommerce-gateway-stripe.php","activate":true}
+```
+
+The gateway matrix is a WordPress bench workload, so it consumes the same
+slug/entrypoint/runtime metadata through Homeboy Extensions' WordPress dependency
+contract instead of building a second Stripe-specific mount path in this rig.
 
 PayPal Payments and WooPayments stay optional. Mount them for focused coverage by
 adding them to `validation_dependencies` or by overriding `wp_codebox_extra_plugins`

--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -39,12 +39,20 @@ The rig mounts the selected WooCommerce checkout into the disposable WP Codebox
 WordPress runtime. Pass `homeboy bench --path /absolute/path/to/plugins/woocommerce`
 when validating a specific WooCommerce worktree.
 
-The checkout gateway compatibility matrix declares WooCommerce Stripe Gateway as
-a first-class WordPress validation dependency by slug:
+The checkout gateway compatibility matrix defaults to the `core_only` profile
+set so BACS, Cheque, and COD controls can run even when real gateway plugin
+materialization is unavailable. Select the focused Stripe profile set when the
+runner can prepare WooCommerce Stripe Gateway:
 
-```json
-"validation_dependencies": ["woocommerce-gateway-stripe"]
+```bash
+homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 \
+  --setting-json 'bench_env={"WC_CHECKOUT_GATEWAY_MATRIX_PROFILE_SET":"stripe"}' \
+  --setting-json 'validation_dependencies=["woocommerce-gateway-stripe"]'
 ```
+
+Supported gateway matrix profile sets are `core_only`, `stripe`, and
+`all_configured_gateways`. `WC_CHECKOUT_GATEWAY_MATRIX_PROFILES` remains the
+lowest-level escape hatch for comma-separated profile ids or gateway ids.
 
 Homeboy Extensions resolves that dependency through the runner dependency
 contract, prepares a runnable artifact when the source checkout needs Composer
@@ -52,7 +60,10 @@ materialization, mounts the prepared plugin into WP Codebox, and attaches
 `prepared_dependencies` provenance to the final bench results. The workload
 artifact reports the runtime side of that same contract: configured dependency,
 source path when explicitly provided, git revision when visible, prepared artifact
-path when exported, mounted plugin directory, plugin version, and status.
+path when exported, mounted plugin directory, plugin version, and status. If the
+dependency provider reports `WC_CHECKOUT_GATEWAY_MATRIX_<PLUGIN>_BUILD_STATUS=build_failed`,
+the workload records `build_failed` inside the matrix artifact instead of hiding
+the failure behind a generic skipped profile.
 
 PayPal Payments and WooPayments stay optional. Mount them for focused coverage by
 adding them to `validation_dependencies` or by overriding `wp_codebox_extra_plugins`
@@ -132,9 +143,12 @@ into `tests/bench/`, and returns the normalized Homeboy `BenchResults` envelope.
   without secrets, and links evidence to WooCommerce issue #62659, WooCommerce PR
   #65588, Jorge's PR review, and Homeboy Rigs issue #255.
   Limit the matrix during focused smokes with
+  `WC_CHECKOUT_GATEWAY_MATRIX_PROFILE_SET=stripe` or
   `WC_CHECKOUT_GATEWAY_MATRIX_PROFILES=core_bacs,plugin_stripe`. Plugin profiles
-  report explicit skip details when their entrypoint is unavailable or activation
-  fails, so the core controls remain runnable without gateway secrets.
+  report explicit `not_configured`, `entrypoint_missing`, `activation_failed`, or
+  `build_failed` details when their entrypoint is unavailable, activation fails,
+  or dependency materialization fails, so the core controls remain runnable
+  without gateway secrets.
 - `checkout-shipping-cache` seeds simple physical products, configures a flat-rate
   US shipping zone, builds a cart, splits cart contents into configurable shipping
   packages, and measures cold, warm, totals-only churn, and address-rehashed

--- a/woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php
+++ b/woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php
@@ -186,21 +186,12 @@ return function (): array {
 		return '' !== $env_name ? (string) getenv( $env_name ) : '';
 	};
 
-	$get_profile_env_value = static function ( string $plugin, string $suffix ): string {
-		$slug     = strtoupper( str_replace( '-', '_', $plugin ) );
-		$env_name = 'WC_CHECKOUT_GATEWAY_MATRIX_' . $slug . '_' . $suffix;
-
-		return (string) getenv( $env_name );
-	};
-
-	$ensure_gateway_profile = static function ( array $profile ) use ( $get_git_revision, $get_env_value, $get_profile_env_value ): array {
+	$ensure_gateway_profile = static function ( array $profile ) use ( $get_git_revision, $get_env_value ): array {
 		$entrypoint_path    = $profile['entrypoint'] ? WP_PLUGIN_DIR . '/' . $profile['entrypoint'] : '';
 		$mounted_plugin_dir = $profile['entrypoint'] ? WP_PLUGIN_DIR . '/' . dirname( $profile['entrypoint'] ) : '';
 		$dependency         = $get_env_value( $profile, 'dependency_env' );
 		$source_path        = $get_env_value( $profile, 'source_path_env' );
 		$prepared_path      = $get_env_value( $profile, 'prepared_path_env' );
-		$build_status       = $get_profile_env_value( $profile['plugin'], 'BUILD_STATUS' );
-		$build_reason       = $get_profile_env_value( $profile['plugin'], 'BUILD_REASON' );
 		$configured         = '' !== $dependency || '' !== $source_path || '' !== $prepared_path;
 		$install            = array(
 			'plugin'                 => $profile['plugin'],
@@ -219,13 +210,6 @@ return function (): array {
 		);
 
 		if ( $profile['entrypoint'] ) {
-			if ( 'build_failed' === $build_status ) {
-				$install['available']   = false;
-				$install['status']      = 'build_failed';
-				$install['skip_reason'] = $build_reason ?: 'Dependency provider reported a plugin artifact build failure.';
-				return $install;
-			}
-
 			if ( ! file_exists( $entrypoint_path ) ) {
 				$install['available'] = false;
 				if ( '' !== $prepared_path && ! is_dir( $prepared_path ) ) {

--- a/woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php
+++ b/woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php
@@ -7,6 +7,7 @@
  * - https://github.com/woocommerce/woocommerce/pull/65588
  * - https://github.com/woocommerce/woocommerce/pull/65588#pullrequestreview-4488383929
  * - https://github.com/chubes4/homeboy-rigs/issues/255
+ * - https://github.com/chubes4/homeboy-rigs/issues/272
  */
 return function (): array {
 	if ( ! class_exists( 'WooCommerce' ) ) {
@@ -42,6 +43,7 @@ return function (): array {
 		'https://github.com/woocommerce/woocommerce/pull/65588',
 		'https://github.com/woocommerce/woocommerce/pull/65588#pullrequestreview-4488383929',
 		'https://github.com/chubes4/homeboy-rigs/issues/255',
+		'https://github.com/chubes4/homeboy-rigs/issues/272',
 	);
 
 	wp_set_current_user( 0 );
@@ -142,7 +144,19 @@ return function (): array {
 		),
 	);
 
+	$profile_sets  = array(
+		'core_only'               => array( 'core_bacs', 'core_cheque', 'core_cod' ),
+		'stripe'                  => array( 'core_bacs', 'core_cheque', 'core_cod', 'plugin_stripe' ),
+		'all_configured_gateways' => array( 'core_bacs', 'core_cheque', 'core_cod', 'plugin_stripe', 'plugin_paypal_payments', 'plugin_woopayments' ),
+	);
+	$profile_set   = getenv( 'WC_CHECKOUT_GATEWAY_MATRIX_PROFILE_SET' ) ?: 'core_only';
 	$profile_filter = getenv( 'WC_CHECKOUT_GATEWAY_MATRIX_PROFILES' );
+	if ( ! $profile_filter && ! isset( $profile_sets[ $profile_set ] ) ) {
+		$profile_set = 'core_only';
+	}
+	if ( ! $profile_filter ) {
+		$profile_filter = implode( ',', $profile_sets[ $profile_set ] );
+	}
 	if ( $profile_filter ) {
 		$allowed  = array_filter( array_map( 'trim', explode( ',', $profile_filter ) ) );
 		$profiles = array_values(
@@ -172,12 +186,21 @@ return function (): array {
 		return '' !== $env_name ? (string) getenv( $env_name ) : '';
 	};
 
-	$ensure_gateway_profile = static function ( array $profile ) use ( $get_git_revision, $get_env_value ): array {
+	$get_profile_env_value = static function ( string $plugin, string $suffix ): string {
+		$slug     = strtoupper( str_replace( '-', '_', $plugin ) );
+		$env_name = 'WC_CHECKOUT_GATEWAY_MATRIX_' . $slug . '_' . $suffix;
+
+		return (string) getenv( $env_name );
+	};
+
+	$ensure_gateway_profile = static function ( array $profile ) use ( $get_git_revision, $get_env_value, $get_profile_env_value ): array {
 		$entrypoint_path    = $profile['entrypoint'] ? WP_PLUGIN_DIR . '/' . $profile['entrypoint'] : '';
 		$mounted_plugin_dir = $profile['entrypoint'] ? WP_PLUGIN_DIR . '/' . dirname( $profile['entrypoint'] ) : '';
 		$dependency         = $get_env_value( $profile, 'dependency_env' );
 		$source_path        = $get_env_value( $profile, 'source_path_env' );
 		$prepared_path      = $get_env_value( $profile, 'prepared_path_env' );
+		$build_status       = $get_profile_env_value( $profile['plugin'], 'BUILD_STATUS' );
+		$build_reason       = $get_profile_env_value( $profile['plugin'], 'BUILD_REASON' );
 		$configured         = '' !== $dependency || '' !== $source_path || '' !== $prepared_path;
 		$install            = array(
 			'plugin'                 => $profile['plugin'],
@@ -196,6 +219,13 @@ return function (): array {
 		);
 
 		if ( $profile['entrypoint'] ) {
+			if ( 'build_failed' === $build_status ) {
+				$install['available']   = false;
+				$install['status']      = 'build_failed';
+				$install['skip_reason'] = $build_reason ?: 'Dependency provider reported a plugin artifact build failure.';
+				return $install;
+			}
+
 			if ( ! file_exists( $entrypoint_path ) ) {
 				$install['available'] = false;
 				if ( '' !== $prepared_path && ! is_dir( $prepared_path ) ) {
@@ -548,6 +578,9 @@ return function (): array {
 	$artifact = array(
 		'run_id'   => $run_id,
 		'issues'   => $issues,
+		'selected_profile_set' => $profile_set,
+		'available_profile_sets' => array_keys( $profile_sets ),
+		'install_statuses' => array( 'available', 'not_configured', 'entrypoint_missing', 'activation_failed', 'build_failed' ),
 		'profiles' => $results,
 		'metrics'  => $summary,
 	);
@@ -567,6 +600,7 @@ return function (): array {
 			'runner'   => 'wp-codebox',
 			'workload' => 'checkout-gateway-compatibility-matrix',
 			'issues'   => $issues,
+			'profile_set' => $profile_set,
 			'profiles' => array_map( static fn ( array $result ): string => $result['profile'], $results ),
 		),
 		'artifacts' => $artifact_path ? array( 'gateway_matrix' => array( 'path' => $artifact_path, 'kind' => 'json' ) ) : array(),

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -8,11 +8,9 @@
       "extensions": {
         "wordpress": {
           "wp_codebox_wordpress_version": "7.0",
-          "validation_dependencies": [
-            "woocommerce-gateway-stripe"
-          ],
           "bench_env": {
-            "WC_CHECKOUT_GATEWAY_MATRIX_PROFILES": "core_bacs,core_cheque,core_cod,plugin_stripe,plugin_paypal_payments,plugin_woopayments",
+            "WC_CHECKOUT_GATEWAY_MATRIX_PROFILE_SET": "core_only",
+            "WC_CHECKOUT_GATEWAY_MATRIX_PROFILES": "",
             "WC_CHECKOUT_GATEWAY_MATRIX_STRIPE_DEPENDENCY": "woocommerce-gateway-stripe",
             "WC_CHECKOUT_GATEWAY_MATRIX_PAYPAL_PAYMENTS_PATH": "",
             "WC_CHECKOUT_GATEWAY_MATRIX_WOOPAYMENTS_PATH": "",


### PR DESCRIPTION
## Summary
- Defaults `checkout-gateway-compatibility-matrix` to the `core_only` profile set so core BACS/Cheque/COD evidence runs without Stripe dependency preparation.
- Adds explicit `core_only`, `stripe`, and `all_configured_gateways` workload profile sets while keeping the low-level profile filter override.
- Records profile-set/status metadata in the matrix artifact, including structured `build_failed` support for dependency-provider failures surfaced by Homeboy Extensions.

## Verification
- `php -l woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php`
- `node scripts/lint-rig-packages.mjs`
- `homeboy rig check woocommerce-performance`
  - Run: `779e33ef-fb26-45f1-bfa6-e26df43049a8`
  - Artifacts: `homeboy runs artifacts 779e33ef-fb26-45f1-bfa6-e26df43049a8`
- `homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 --json-summary`
  - Run: `f44b8845-4a8f-4c5b-81e1-087c5ec31741`
  - Gateway matrix artifact: https://dfc3ef047aa33a2dc745-62965-tunnel.kimaki.dev/runs/f44b8845-4a8f-4c5b-81e1-087c5ec31741/artifacts/92539108-80da-479c-ab5c-e56bcb6f4d05
  - Result: passed with `profile_set=core_only`, profiles `core_bacs`, `core_cheque`, `core_cod`, and no plugin dependency dispatch.

## Blockers / Follow-up
- Stripe dependency materialization remains blocked by Extra-Chill/homeboy-extensions#1321. This PR intentionally does not patch around that HBEX dependency-provider bug.
- After HBEX returns dependency build failures as workload-visible metadata/env, the matrix can report `plugin_stripe` as `available` or structured `build_failed` inside the artifact rather than failing before dispatch.

Closes #272.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented and verified the focused rig/profile stabilization changes; Chris remains responsible for review and merge.