### PR TITLE
Fix Woo Stripe synthetic ECE fanout proof startup

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.mjs
@@ -55,6 +55,8 @@ const PROFILE_METADATA = {
   },
 };
 
+const SYNTHETIC_FANOUT_PUBLISHABLE_KEY = 'pk_test_homeboy_ece_wallet_fanout';
+
 function profileMetadata(profile) {
   return PROFILE_METADATA[profile] || PROFILE_METADATA[DEFAULT_PROFILE];
 }
@@ -89,6 +91,16 @@ export function previewPublicUrl() {
   return setting('woocommerce_stripe_ece_preview_public_url', process.env.HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL || process.env.HOMEBOY_PREVIEW_PUBLIC_URL || '');
 }
 
+function requireSyntheticFanoutProof() {
+  return ['1', 'true', 'yes'].includes(
+    String(setting('woocommerce_stripe_ece_require_fanout_proof', process.env.HOMEBOY_WC_STRIPE_REQUIRE_FANOUT_PROOF || '')).toLowerCase()
+  );
+}
+
+function syntheticFanoutPublishableKey() {
+  return process.env.HOMEBOY_WC_STRIPE_SYNTHETIC_PUBLISHABLE_KEY || SYNTHETIC_FANOUT_PUBLISHABLE_KEY;
+}
+
 function validateHttpsPublicUrl(value) {
   try {
     const url = new URL(value);
@@ -118,6 +130,8 @@ export function buildEceProfileOptions(profile = eceBrowserProfile()) {
   const metadata = profileMetadata(profile);
 
   if (profile === WEBPERF_DESKTOP_LOAD_PROFILE) {
+    const fanoutProof = requireSyntheticFanoutProof();
+
     return {
       profile,
       profileLabel: metadata.label,
@@ -126,7 +140,7 @@ export function buildEceProfileOptions(profile = eceBrowserProfile()) {
       throttleProfile: null,
       realWalletCapable: false,
       syntheticOnly: true,
-      stripePublishableKey: null,
+      stripePublishableKey: fanoutProof ? syntheticFanoutPublishableKey() : null,
       stripeSecretKey: null,
       runtimePreview: null,
       recipeRunArgs: [],
@@ -137,6 +151,8 @@ export function buildEceProfileOptions(profile = eceBrowserProfile()) {
   }
 
   if (profile === WEBPERF_DESKTOP_SLOW_4G_PROFILE) {
+    const fanoutProof = requireSyntheticFanoutProof();
+
     return {
       profile,
       profileLabel: metadata.label,
@@ -145,7 +161,7 @@ export function buildEceProfileOptions(profile = eceBrowserProfile()) {
       throttleProfile: 'low-end-mobile-slow-4g',
       realWalletCapable: false,
       syntheticOnly: true,
-      stripePublishableKey: null,
+      stripePublishableKey: fanoutProof ? syntheticFanoutPublishableKey() : null,
       stripeSecretKey: null,
       runtimePreview: null,
       recipeRunArgs: [],

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
@@ -111,6 +111,35 @@ test('webperf desktop slow 4g profile keeps desktop context while applying Codeb
   assert.ok(!options.browserProbeArgs.includes('profile=low-end-mobile-slow-4g'));
 });
 
+test('webperf wallet fanout profile supplies a non-secret synthetic publishable key', () => {
+  const previous = {
+    HOMEBOY_SETTINGS_WOOCOMMERCE_STRIPE_ECE_REQUIRE_FANOUT_PROOF: process.env.HOMEBOY_SETTINGS_WOOCOMMERCE_STRIPE_ECE_REQUIRE_FANOUT_PROOF,
+    HOMEBOY_WC_STRIPE_REQUIRE_FANOUT_PROOF: process.env.HOMEBOY_WC_STRIPE_REQUIRE_FANOUT_PROOF,
+    HOMEBOY_WC_STRIPE_SYNTHETIC_PUBLISHABLE_KEY: process.env.HOMEBOY_WC_STRIPE_SYNTHETIC_PUBLISHABLE_KEY,
+  };
+
+  process.env.HOMEBOY_SETTINGS_WOOCOMMERCE_STRIPE_ECE_REQUIRE_FANOUT_PROOF = '1';
+  process.env.HOMEBOY_WC_STRIPE_SYNTHETIC_PUBLISHABLE_KEY = 'pk_test_custom_synthetic_fixture';
+
+  try {
+    const options = buildEceProfileOptions('webperf-desktop-slow-4g');
+
+    assert.equal(options.syntheticOnly, true);
+    assert.equal(options.realWalletCapable, false);
+    assert.equal(options.stripePublishableKey, 'pk_test_custom_synthetic_fixture');
+    assert.equal(options.stripeSecretKey, null);
+    assert.deepEqual(options.recipeRunArgs, []);
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+});
+
 test('rig manifest exposes the ECE webperf profile matrix', () => {
   const manifestPath = path.join(__dirname, '../rigs/woocommerce-stripe-ece-product-page/rig.json');
   const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
@@ -536,6 +565,8 @@ test('waterfall recipe passes structural assertions to browser-probe', () => {
   assert.match(traceSource, /#wc-stripe-express-checkout-element-apple_pay/);
   assert.match(traceSource, /#wc-stripe-express-checkout-element-google_pay/);
   assert.match(traceSource, /#wc-stripe-express-checkout-element-wallets-link/);
+  assert.match(traceSource, /homeboy-stripe-ece-fanout-proof-style/);
+  assert.match(traceSource, /display: block !important; width: 100% !important/);
   assert.match(traceSource, /ece-wallet-fanout-proof/);
   assert.match(traceSource, /installStripeEceInstrumentation/);
   assert.match(traceSource, /express_checkout_create_calls/);

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -561,6 +561,15 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     window.__homeboyStripeEceFanoutProofInstalled = true;
     root.setAttribute('data-homeboy-wallet-fanout-proof', '1');
 
+    const style = document.createElement('style');
+    style.id = 'homeboy-stripe-ece-fanout-proof-style';
+    style.textContent = [
+      '#wc-stripe-express-checkout-element { display: block !important; width: 100% !important; }',
+      '#wc-stripe-express-checkout-element-wallets-link { display: block !important; width: 100% !important; }',
+      '#wc-stripe-express-checkout-element-wallets-link > div { display: block !important; width: 100% !important; margin: 0 0 8px; }',
+    ].join('\n');
+    document.head.appendChild(style);
+
     let grouped = document.querySelector('#wc-stripe-express-checkout-element-wallets-link');
     if (!grouped) {
       grouped = document.createElement('div');

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -495,23 +495,31 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
       }
       return elements;
     };
+    const wrapStripeInstance = (stripe) => {
+      if (stripe && !stripe.__homeboyEceInstrumented && typeof stripe.elements === 'function') {
+        Object.defineProperty(stripe, '__homeboyEceInstrumented', { value: true, configurable: true });
+        const originalElements = stripe.elements;
+        stripe.elements = function homeboyInstrumentedStripeElements(...elementsArgs) {
+          instrumentation.elements_calls.push({ t_ms: elapsed(), args: jsonSafe(elementsArgs) });
+          return wrapElements(originalElements.apply(this, elementsArgs));
+        };
+      }
+      return stripe;
+    };
     const wrapStripeFactory = (StripeFactory) => {
       if (typeof StripeFactory !== 'function' || StripeFactory.__homeboyEceInstrumented) {
         return StripeFactory;
       }
-      const wrappedFactory = function homeboyInstrumentedStripeFactory(...stripeArgs) {
-        instrumentation.stripe_factory_calls.push({ t_ms: elapsed(), args: jsonSafe(stripeArgs) });
-        const stripe = StripeFactory.apply(this, stripeArgs);
-        if (stripe && !stripe.__homeboyEceInstrumented && typeof stripe.elements === 'function') {
-          Object.defineProperty(stripe, '__homeboyEceInstrumented', { value: true, configurable: true });
-          const originalElements = stripe.elements;
-          stripe.elements = function homeboyInstrumentedStripeElements(...elementsArgs) {
-            instrumentation.elements_calls.push({ t_ms: elapsed(), args: jsonSafe(elementsArgs) });
-            return wrapElements(originalElements.apply(this, elementsArgs));
-          };
-        }
-        return stripe;
-      };
+      const wrappedFactory = new Proxy(StripeFactory, {
+        apply(target, thisArg, stripeArgs) {
+          instrumentation.stripe_factory_calls.push({ mode: 'call', t_ms: elapsed(), args: jsonSafe(stripeArgs) });
+          return wrapStripeInstance(Reflect.apply(target, thisArg, stripeArgs));
+        },
+        construct(target, stripeArgs, newTarget) {
+          instrumentation.stripe_factory_calls.push({ mode: 'construct', t_ms: elapsed(), args: jsonSafe(stripeArgs) });
+          return wrapStripeInstance(Reflect.construct(target, stripeArgs, newTarget));
+        },
+      });
       Object.defineProperty(wrappedFactory, '__homeboyEceInstrumented', { value: true, configurable: true });
       for (const key of Reflect.ownKeys(StripeFactory)) {
         if (['length', 'name', 'prototype'].includes(key)) {


### PR DESCRIPTION
## Summary
- Adds a non-secret synthetic Stripe publishable key when the Woo Stripe ECE fanout proof profile is requested, so Woo Stripe executes its real Express Checkout startup path instead of exiting before construction.
- Forces the synthetic fanout proof containers visible so grouped layout assertions can measure non-zero DOM rects while keeping real wallet eligibility out of the canonical proof.
- Covers the profile key behavior and trace fixture style in the targeted Node test suite.

## Verification
- `node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`
- `node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.mjs && node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs`

## Trace evidence status
A 1x `homeboy-lab` compare could not complete after the branch was pushed because Homeboy failed before trace execution/import completed:

```text
SQLite observation store error: upsert imported run record: database is locked
```

This blocks reviewer-ready 1x/repeat-3 trace evidence until the Homeboy runner observation-store lock is cleared or fixed. No Woo Stripe PR comments/edits were made.

## Issue
- Closes #262 once lab compare evidence is green and attached.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosing the Homeboy Rigs ECE proof gap, drafting the rig fix and targeted tests, and running local verification/lab compare attempts for Chris to review.