### PR TITLE
Refactor WooCommerce rig prep commands

### DIFF
--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -118,36 +118,36 @@
       {
         "kind": "command",
         "label": "WooCommerce Composer package autoloader exists or can be prepared",
-        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; test -d \"$woocommerce_dir\" || { printf '%s\\n' \"Cannot check WooCommerce Composer dependencies because $woocommerce_dir is missing. Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path.\"; exit 1; }; test -f \"$woocommerce_dir/vendor/autoload_packages.php\" || command -v composer >/dev/null 2>&1 || { printf '%s\\n' 'Missing WooCommerce Composer dependencies: vendor/autoload_packages.php is absent and composer is not available. Install Composer on the runner, then run: homeboy rig up woocommerce-performance'; exit 1; }"
+        "command": "bash \"${package.root}/tools/woocommerce-composer-dependencies.sh\" check \"${components.woocommerce.path}\""
       },
       {
         "kind": "command",
         "label": "WooCommerce generated feature config exists or can be prepared",
-        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; test -d \"$woocommerce_dir\" || { printf '%s\\n' \"Cannot check WooCommerce generated feature config because $woocommerce_dir is missing. Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path.\"; exit 1; }; test -f \"$woocommerce_dir/includes/react-admin/feature-config.php\" || { test -f \"$woocommerce_dir/bin/generate-feature-config.php\" && command -v php >/dev/null 2>&1; } || { printf '%s\\n' 'Missing WooCommerce generated feature config: includes/react-admin/feature-config.php is absent. Ensure PHP is available, then run: homeboy rig up woocommerce-performance'; exit 1; }"
+        "command": "bash \"${package.root}/tools/woocommerce-feature-config.sh\" check \"${components.woocommerce.path}\""
       }
     ],
     "up": [
       {
         "kind": "command",
         "label": "Prepare WooCommerce Composer dependencies when missing",
-        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; cd \"$woocommerce_dir\" || { printf '%s\\n' \"Missing WooCommerce runner checkout: expected $woocommerce_dir before rig up. Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path.\"; exit 1; }; if [ -f vendor/autoload_packages.php ]; then printf '%s\\n' 'WooCommerce Composer dependencies already prepared.'; else XDEBUG_MODE=off composer install --no-interaction --no-progress; fi"
+        "command": "bash \"${package.root}/tools/woocommerce-composer-dependencies.sh\" prepare \"${components.woocommerce.path}\" \"rig up\""
       },
       {
         "kind": "command",
         "label": "Generate WooCommerce feature config when missing",
-        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; cd \"$woocommerce_dir\" || { printf '%s\\n' \"Missing WooCommerce runner checkout: expected $woocommerce_dir before rig up. Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path.\"; exit 1; }; if [ -f includes/react-admin/feature-config.php ]; then printf '%s\\n' 'WooCommerce feature config already generated.'; else php bin/generate-feature-config.php; fi"
+        "command": "bash \"${package.root}/tools/woocommerce-feature-config.sh\" prepare \"${components.woocommerce.path}\" \"rig up\""
       }
     ],
     "bench_prepare": [
       {
         "kind": "command",
         "label": "Prepare WooCommerce Composer dependencies when missing",
-        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; cd \"$woocommerce_dir\" || { printf '%s\\n' \"Missing WooCommerce runner checkout: expected $woocommerce_dir before bench_prepare. Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path.\"; exit 1; }; if [ -f vendor/autoload_packages.php ]; then printf '%s\\n' 'WooCommerce Composer dependencies already prepared.'; else XDEBUG_MODE=off composer install --no-interaction --no-progress; fi"
+        "command": "bash \"${package.root}/tools/woocommerce-composer-dependencies.sh\" prepare \"${components.woocommerce.path}\" \"bench_prepare\""
       },
       {
         "kind": "command",
         "label": "Generate WooCommerce feature config when missing",
-        "command": "woocommerce_dir=\"${components.woocommerce.path}\"; cd \"$woocommerce_dir\" || { printf '%s\\n' \"Missing WooCommerce runner checkout: expected $woocommerce_dir before bench_prepare. Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path.\"; exit 1; }; if [ -f includes/react-admin/feature-config.php ]; then printf '%s\\n' 'WooCommerce feature config already generated.'; else php bin/generate-feature-config.php; fi"
+        "command": "bash \"${package.root}/tools/woocommerce-feature-config.sh\" prepare \"${components.woocommerce.path}\" \"bench_prepare\""
       }
     ],
     "down": []

--- a/woocommerce/woocommerce/tools/woocommerce-composer-dependencies.sh
+++ b/woocommerce/woocommerce/tools/woocommerce-composer-dependencies.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -u
+
+usage() {
+	printf '%s\n' 'Usage: woocommerce-composer-dependencies.sh check|prepare <woocommerce-dir> [phase]' >&2
+	exit 2
+}
+
+mode="${1:-}"
+woocommerce_dir="${2:-}"
+phase="${3:-rig up}"
+
+if [ -z "$mode" ] || [ -z "$woocommerce_dir" ]; then
+	usage
+fi
+
+case "$mode" in
+	check)
+		test -d "$woocommerce_dir" || {
+			printf '%s\n' "Cannot check WooCommerce Composer dependencies because $woocommerce_dir is missing. Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path."
+			exit 1
+		}
+
+		test -f "$woocommerce_dir/vendor/autoload_packages.php" || command -v composer >/dev/null 2>&1 || {
+			printf '%s\n' 'Missing WooCommerce Composer dependencies: vendor/autoload_packages.php is absent and composer is not available. Install Composer on the runner, then run: homeboy rig up woocommerce-performance'
+			exit 1
+		}
+		;;
+	prepare)
+		cd "$woocommerce_dir" || {
+			printf '%s\n' "Missing WooCommerce runner checkout: expected $woocommerce_dir before $phase. Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path."
+			exit 1
+		}
+
+		if [ -f vendor/autoload_packages.php ]; then
+			printf '%s\n' 'WooCommerce Composer dependencies already prepared.'
+			exit 0
+		fi
+
+		command -v composer >/dev/null 2>&1 || {
+			printf '%s\n' 'Missing WooCommerce Composer dependencies: vendor/autoload_packages.php is absent and composer is not available. Install Composer on the runner, then run: homeboy rig up woocommerce-performance'
+			exit 1
+		}
+
+		XDEBUG_MODE=off composer install --no-interaction --no-progress
+		;;
+	*)
+		usage
+		;;
+esac

--- a/woocommerce/woocommerce/tools/woocommerce-feature-config.sh
+++ b/woocommerce/woocommerce/tools/woocommerce-feature-config.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -u
+
+usage() {
+	printf '%s\n' 'Usage: woocommerce-feature-config.sh check|prepare <woocommerce-dir> [phase]' >&2
+	exit 2
+}
+
+mode="${1:-}"
+woocommerce_dir="${2:-}"
+phase="${3:-rig up}"
+
+if [ -z "$mode" ] || [ -z "$woocommerce_dir" ]; then
+	usage
+fi
+
+case "$mode" in
+	check)
+		test -d "$woocommerce_dir" || {
+			printf '%s\n' "Cannot check WooCommerce generated feature config because $woocommerce_dir is missing. Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path."
+			exit 1
+		}
+
+		test -f "$woocommerce_dir/includes/react-admin/feature-config.php" || {
+			test -f "$woocommerce_dir/bin/generate-feature-config.php" && command -v php >/dev/null 2>&1
+		} || {
+			printf '%s\n' 'Missing WooCommerce generated feature config: includes/react-admin/feature-config.php is absent. Ensure PHP is available, then run: homeboy rig up woocommerce-performance'
+			exit 1
+		}
+		;;
+	prepare)
+		cd "$woocommerce_dir" || {
+			printf '%s\n' "Missing WooCommerce runner checkout: expected $woocommerce_dir before $phase. Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path."
+			exit 1
+		}
+
+		if [ -f includes/react-admin/feature-config.php ]; then
+			printf '%s\n' 'WooCommerce feature config already generated.'
+			exit 0
+		fi
+
+		if [ ! -f bin/generate-feature-config.php ] || ! command -v php >/dev/null 2>&1; then
+			printf '%s\n' 'Missing WooCommerce generated feature config: includes/react-admin/feature-config.php is absent. Ensure PHP is available, then run: homeboy rig up woocommerce-performance'
+			exit 1
+		fi
+
+		php bin/generate-feature-config.php
+		;;
+	*)
+		usage
+		;;
+esac


### PR DESCRIPTION
## Summary
- Moves WooCommerce Composer dependency validation/prep into a rig-owned helper script.
- Moves generated feature config validation/prep into a rig-owned helper script.
- Keeps `woocommerce-performance` pipeline entries short while preserving the existing actionable checkout/prep diagnostics.

Closes #284

## Verification
- `bash -n woocommerce/woocommerce/tools/woocommerce-composer-dependencies.sh`
- `bash -n woocommerce/woocommerce/tools/woocommerce-feature-config.sh`
- `node --check woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs`
- `node --check scripts/lint-rig-packages.mjs`
- `node scripts/lint-rig-packages.mjs`
- `node -e "JSON.parse(require('node:fs').readFileSync('woocommerce/woocommerce/rigs/woocommerce-performance/rig.json','utf8')); console.log('rig.json valid JSON');"`
- `homeboy rig check woocommerce-performance`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the helper script extraction, updated the rig pipeline references, and ran local/lab verification. Chris remains responsible for review and merge.