### PR TITLE
Route Woo Stripe ECE trace through Codebox helper

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
@@ -9,8 +9,24 @@ import { evaluateEceFixtureHealth, fixtureHealthSummary } from './ece-product-pa
 import { buildEceProfileOptions } from './ece-product-page-profile.mjs';
 import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceProductPageScenario, eceProductPageScenarioIds, eceSimulatedClsScript } from './ece-product-page-scenarios.mjs';
 import { classifyEceWalletFanoutEvidence, ECE_FANOUT_REVIEWER_READY, ECE_FANOUT_SUPPLEMENTAL, groupedWalletLayoutSummary } from './ece-product-page-wallet-classification.mjs';
+import { wpCodeboxBin, wpCodeboxCommand } from './ece-product-page-wp-codebox.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+test('WP Codebox helper centralizes binary resolution', () => {
+  assert.equal(wpCodeboxBin({}), 'wp-codebox');
+  assert.equal(wpCodeboxBin({ HOMEBOY_SETTINGS_WP_CODEBOX_BIN: '/tmp/wp-codebox-settings.js' }), '/tmp/wp-codebox-settings.js');
+  assert.equal(
+    wpCodeboxBin({
+      HOMEBOY_WP_CODEBOX_BIN: '/tmp/wp-codebox-env.mjs',
+      HOMEBOY_SETTINGS_WP_CODEBOX_BIN: '/tmp/wp-codebox-settings.js',
+    }),
+    '/tmp/wp-codebox-env.mjs'
+  );
+
+  assert.deepEqual(wpCodeboxCommand('/tmp/wp-codebox.mjs'), { command: 'node', args: ['/tmp/wp-codebox.mjs'] });
+  assert.deepEqual(wpCodeboxCommand('wp-codebox'), { command: 'wp-codebox', args: [] });
+});
 
 test('default smoke profile preserves browser probe defaults', () => {
   const options = buildEceProfileOptions('smoke');

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -10,6 +10,7 @@ import { buildEceProfileOptions, setting } from './ece-product-page-profile.mjs'
 import { evaluateEceFixtureHealth, fixtureHealthSummary } from './ece-product-page-fixture-health.mjs';
 import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceLayoutScript, eceProductPageScenario, eceSimulatedClsScript } from './ece-product-page-scenarios.mjs';
 import { classifyEceWalletFanoutEvidence, groupedWalletLayoutSummary } from './ece-product-page-wallet-classification.mjs';
+import { runWpCodeboxRecipe } from './ece-product-page-wp-codebox.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -19,7 +20,6 @@ const scenarioId = process.env.HOMEBOY_TRACE_SCENARIO || DEFAULT_ECE_SCENARIO_ID
 const scenario = eceProductPageScenario(scenarioId);
 const resultsFile = process.env.HOMEBOY_TRACE_RESULTS_FILE;
 const artifactDir = process.env.HOMEBOY_TRACE_ARTIFACT_DIR || path.join(tmpdir(), 'wc-stripe-ece-waterfall-artifacts');
-const wpCodeboxBin = process.env.HOMEBOY_WP_CODEBOX_BIN || 'wp-codebox';
 const woocommercePath = process.env.HOMEBOY_WC_STRIPE_WOOCOMMERCE_PATH || path.join(process.env.HOME || '', 'Developer/woocommerce/plugins/woocommerce');
 const wpVersion = process.env.HOMEBOY_WC_STRIPE_WP_VERSION || '7.0';
 const eceLocations = process.env.HOMEBOY_WC_STRIPE_ECE_LOCATIONS || 'product';
@@ -155,14 +155,6 @@ function relativeTimingMs(cdpMetrics, metricName) {
   }
 
   return Math.round((value - navigationStart) * 1000);
-}
-
-function wpCodeboxCommand() {
-  if (wpCodeboxBin.endsWith('.js') || wpCodeboxBin.endsWith('.cjs') || wpCodeboxBin.endsWith('.mjs')) {
-    return { command: 'node', args: [wpCodeboxBin] };
-  }
-
-  return { command: wpCodeboxBin, args: [] };
 }
 
 async function prepareStripePlugin(pathname) {
@@ -900,12 +892,13 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
 
   await writeFile(recipeFile, `${JSON.stringify(recipe, null, 2)}\n`);
 
-  event('wp_codebox', 'recipe.start', { recipe_file: recipeFile });
-  const { command, args } = wpCodeboxCommand();
-  const result = await execFileAsync(command, [...args, 'recipe-run', '--recipe', recipeFile, '--artifacts', codeboxArtifacts, ...profileOptions.recipeRunArgs, '--json'], {
-    maxBuffer: 1024 * 1024 * 50,
+  const result = await runWpCodeboxRecipe({
+    recipeFile,
+    artifactsDir: codeboxArtifacts,
+    outputFile,
+    recipeRunArgs: profileOptions.recipeRunArgs,
+    event,
   });
-  await writeFile(outputFile, result.stdout);
   event('wordpress', 'fixture.ready');
 
   const output = JSON.parse(result.stdout);

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-wp-codebox.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-wp-codebox.mjs
@@ -1,0 +1,58 @@
+import { execFile } from 'node:child_process';
+import { writeFile } from 'node:fs/promises';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export function wpCodeboxBin(env = process.env) {
+  return env.HOMEBOY_WP_CODEBOX_BIN || env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN || 'wp-codebox';
+}
+
+export function wpCodeboxCommand(bin = wpCodeboxBin()) {
+  if (/\.(?:js|cjs|mjs)$/.test(bin)) {
+    return { command: 'node', args: [bin] };
+  }
+
+  return { command: bin, args: [] };
+}
+
+export async function runWpCodeboxRecipe({
+  recipeFile,
+  artifactsDir,
+  outputFile,
+  recipeRunArgs = [],
+  event,
+  maxBuffer = 1024 * 1024 * 50,
+}) {
+  const { command, args } = wpCodeboxCommand();
+  const commandArgs = [
+    ...args,
+    'recipe-run',
+    '--recipe',
+    recipeFile,
+    '--artifacts',
+    artifactsDir,
+    ...recipeRunArgs,
+    '--json',
+  ];
+
+  event?.('wp_codebox', 'recipe.start', { recipe_file: recipeFile, artifacts_dir: artifactsDir });
+
+  try {
+    const result = await execFileAsync(command, commandArgs, { maxBuffer });
+    await writeFile(outputFile, result.stdout);
+    event?.('wp_codebox', 'recipe.done', { output_file: outputFile, artifacts_dir: artifactsDir });
+    return result;
+  } catch (error) {
+    if (typeof error?.stdout === 'string' && error.stdout) {
+      await writeFile(outputFile, error.stdout);
+    }
+
+    event?.('wp_codebox', 'recipe.failed', {
+      output_file: outputFile,
+      artifacts_dir: artifactsDir,
+      exit_code: error?.code ?? null,
+    });
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- Extract the Woo Stripe ECE trace's WP Codebox binary resolution and `recipe-run` invocation into a small shared bench helper.
- Keep the trace-owned recipe shape and profile-provided preview args intact, including secure-browser and real-wallet behavior.
- Add focused coverage for the helper's binary precedence and JS entrypoint wrapping.

Fixes #282
Related: Extra-Chill/homeboy-extensions#1328

## Verification
- `node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs && node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-wp-codebox.mjs && node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`
- `for file in woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-*.trace.mjs; do node --check "$file" || exit 1; done`
- `node scripts/lint-rig-packages.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the helper extraction, updated focused tests, and ran local verification. Chris remains responsible for review and merge.