### PR TITLE
Mark checkout guardrail matrix rows ready

### DIFF
--- a/woocommerce/woocommerce/docs/checkout-pr-evidence-matrix.md
+++ b/woocommerce/woocommerce/docs/checkout-pr-evidence-matrix.md
@@ -37,10 +37,10 @@ homeboy-rigs PRs in that track include #176, #178, #183, #184, #193, #197, #219,
 
 | Dependency | Status | Scope |
 |---|---|---|
-| https://github.com/chubes4/homeboy-rigs/issues/268 | open | no-payment and order-pay guardrails |
-| https://github.com/chubes4/homeboy-rigs/issues/269 | open | guest, logged-in, customer/session identity guardrails |
-| https://github.com/chubes4/homeboy-rigs/issues/270 | open | checkout hook sequencing and counts |
-| https://github.com/chubes4/homeboy-rigs/issues/271 | open | coupon lifecycle guardrails |
+| https://github.com/chubes4/homeboy-rigs/issues/268 | landed | no-payment and order-pay guardrails |
+| https://github.com/chubes4/homeboy-rigs/issues/269 | landed | guest, logged-in, customer/session identity guardrails |
+| https://github.com/chubes4/homeboy-rigs/issues/270 | landed | checkout hook sequencing and counts |
+| https://github.com/chubes4/homeboy-rigs/issues/271 | landed | coupon lifecycle guardrails |
 | https://github.com/chubes4/homeboy-rigs/issues/272 | open | real gateway profile stabilization |
 | https://github.com/Extra-Chill/homeboy-extensions/issues/1321 | open | Stripe dependency provider fix |
 
@@ -75,16 +75,12 @@ Repeat with the revised candidate checked out and
 | True concurrent checkout | Unproven by the old PR shape; do not claim `Closes #62659`. | Only passes when duplicate-order count is zero in the concurrent harness. |
 | Core gateways | Failure/regression should be visible in `order_awaiting_payment` and cart-clearing metrics. | Passes across BACS, cheque, and COD without unexpected cart clearing. |
 
-## Blocked Rows
+## Remaining Blocked Rows
 
-The following rows stay pending until their prerequisites land:
+The following row stays pending until its prerequisite real-gateway profile work lands:
 
 | Row | Blocker |
 |---|---|
-| No-payment and order-pay paths | https://github.com/chubes4/homeboy-rigs/issues/268 |
-| Guest, logged-in, customer identity | https://github.com/chubes4/homeboy-rigs/issues/269 |
-| Hook sequencing and counts | https://github.com/chubes4/homeboy-rigs/issues/270 |
-| Coupon lifecycle | https://github.com/chubes4/homeboy-rigs/issues/271 |
 | Real Stripe gateway | https://github.com/chubes4/homeboy-rigs/issues/272 and https://github.com/Extra-Chill/homeboy-extensions/issues/1321; reuse the `woocommerce-stripe-ece-product-page` mounting abstractions instead of duplicating setup |
 
 ## Reviewer-Facing Output Contract
@@ -97,8 +93,8 @@ The WooCommerce PR evidence should include:
   `136c2b85-647c-4d85-be13-2c0be175abfd`.
 - A table with old PR shape output and revised candidate output for every ready
   row.
-- Explicit `blocked` labels for #268-#272 and HBEX #1321 rows until those runs
-  exist.
+- Explicit `blocked` labels for real Stripe coverage until #272 and HBEX #1321
+  produce stable reusable gateway artifacts.
 - Real Stripe coverage framed as reusable gateway-plugin profile capability,
   sharing the existing WooCommerce Stripe ECE/product-page rig mounting
   abstractions.

--- a/woocommerce/woocommerce/tools/checkout-pr-evidence-matrix.json
+++ b/woocommerce/woocommerce/tools/checkout-pr-evidence-matrix.json
@@ -20,25 +20,25 @@
       "id": "no_payment_order_pay",
       "title": "No-payment and order-pay checkout guardrails",
       "url": "https://github.com/chubes4/homeboy-rigs/issues/268",
-      "status": "open"
+      "status": "landed"
     },
     {
       "id": "identity",
       "title": "Customer/session identity guardrails",
       "url": "https://github.com/chubes4/homeboy-rigs/issues/269",
-      "status": "open"
+      "status": "landed"
     },
     {
       "id": "hook_sequencing",
       "title": "Hook sequencing guardrails",
       "url": "https://github.com/chubes4/homeboy-rigs/issues/270",
-      "status": "open"
+      "status": "landed"
     },
     {
       "id": "coupon_lifecycle",
       "title": "Coupon lifecycle guardrails",
       "url": "https://github.com/chubes4/homeboy-rigs/issues/271",
-      "status": "open"
+      "status": "landed"
     },
     {
       "id": "real_gateway_profiles",
@@ -100,41 +100,37 @@
     {
       "id": "no_payment_order_pay",
       "label": "No-payment and order-pay paths",
-      "status": "blocked",
-      "blocked_by": ["https://github.com/chubes4/homeboy-rigs/issues/268"],
-      "scenario": "pending #268 workload",
-      "command": "Run the #268 workload after it lands; append artifacts under the same shared-state root.",
-      "old_fix_expected": "Pending #268; do not claim old-shape failure beyond available artifacts.",
-      "candidate_expected": "Pending #268; expected to preserve order-pay/no-payment flows without session side-effect regressions."
+      "status": "ready",
+      "scenario": "checkout-concurrent-create-order",
+      "command": "homeboy bench --rig woocommerce-performance --scenario checkout-concurrent-create-order --iterations 1 --shared-state <shared-state>",
+      "old_fix_expected": "FAIL: old shape should expose no-payment/order-pay session or cart side-effect regressions if present.",
+      "candidate_expected": "PASS: no-payment and order-pay flows complete without unintended session side-effect regressions."
     },
     {
       "id": "identity",
       "label": "Guest, logged-in, and customer identity cases",
-      "status": "blocked",
-      "blocked_by": ["https://github.com/chubes4/homeboy-rigs/issues/269"],
-      "scenario": "pending #269 workload",
-      "command": "Run the #269 workload after it lands; append artifacts under the same shared-state root.",
-      "old_fix_expected": "Pending #269; do not claim identity coverage from current gateway-only evidence.",
-      "candidate_expected": "Pending #269; expected to keep session/customer identity attached to the correct order."
+      "status": "ready",
+      "scenario": "checkout-concurrent-create-order",
+      "command": "homeboy bench --rig woocommerce-performance --scenario checkout-concurrent-create-order --iterations 1 --shared-state <shared-state>",
+      "old_fix_expected": "FAIL if pending-order reuse crosses billing email, customer ID, or session identity boundaries.",
+      "candidate_expected": "PASS: same-identity retries reuse safely while different billing/customer/session identities do not mutate or reuse the wrong order."
     },
     {
       "id": "coupon_lifecycle",
       "label": "Coupon lifecycle",
-      "status": "blocked",
-      "blocked_by": ["https://github.com/chubes4/homeboy-rigs/issues/271"],
-      "scenario": "pending #271 workload",
-      "command": "Run the #271 workload after it lands; append artifacts under the same shared-state root.",
-      "old_fix_expected": "FAIL already known from legacy_coupon_independence guardrail state, but final matrix still needs #271 artifacts.",
-      "candidate_expected": "PASS: coupons survive retry/failure/cancel lifecycle where WooCommerce expects cart restoration."
+      "status": "ready",
+      "scenario": "checkout-concurrent-create-order",
+      "command": "homeboy bench --rig woocommerce-performance --scenario checkout-concurrent-create-order --iterations 1 --shared-state <shared-state>",
+      "old_fix_expected": "FAIL when coupon reservation/usage state is consumed or leaked across retry, failed, completed, changed-cart, or public create_order paths.",
+      "candidate_expected": "PASS: coupons survive retry/failure/cancel lifecycle where WooCommerce expects cart restoration and independent public create_order calls remain independent."
     },
     {
       "id": "hook_sequencing",
       "label": "Hook sequencing and counts",
-      "status": "blocked",
-      "blocked_by": ["https://github.com/chubes4/homeboy-rigs/issues/270"],
-      "scenario": "pending #270 workload",
-      "command": "Run the #270 workload after it lands; append artifacts under the same shared-state root.",
-      "old_fix_expected": "Pending #270; do not infer hook sequencing from order/session metrics alone.",
+      "status": "ready",
+      "scenario": "checkout-concurrent-create-order",
+      "command": "homeboy bench --rig woocommerce-performance --scenario checkout-concurrent-create-order --iterations 1 --shared-state <shared-state>",
+      "old_fix_expected": "FAIL or scoped regression when hook counts show suppressed, duplicated, or misplaced checkout/resume/payment hooks.",
       "candidate_expected": "PASS: checkout hooks fire once in expected order for create, payment, retry, failure, and cancel paths."
     },
     {

--- a/woocommerce/woocommerce/tools/checkout-pr-evidence-report.mjs
+++ b/woocommerce/woocommerce/tools/checkout-pr-evidence-report.mjs
@@ -13,6 +13,7 @@ process.stdout.write(renderReport(matrix));
 
 function renderReport(data) {
 	const lines = [];
+	const blockedScenarios = Array.isArray(data.scenarios) ? data.scenarios.filter((scenario) => scenario.status === 'blocked') : [];
 	lines.push(`# ${data.title}`);
 	lines.push('');
 	lines.push('## Links');
@@ -26,7 +27,11 @@ function renderReport(data) {
 	lines.push('## Status');
 	lines.push('');
 	lines.push('- This is a proof-loop recipe, not final pass/fail evidence.');
-	lines.push('- Blocked rows stay blocked until their prerequisite issues land and produce artifacts.');
+	if (blockedScenarios.length > 0) {
+		lines.push('- Blocked rows stay blocked until their prerequisite issues land and produce artifacts.');
+	} else {
+		lines.push('- All matrix rows are ready to run.');
+	}
 	lines.push('- The WooCommerce PR should avoid `Closes #62659` unless the true concurrent checkout row passes.');
 	lines.push('');
 	if (Array.isArray(data.reusable_capabilities) && data.reusable_capabilities.length > 0) {
@@ -71,8 +76,11 @@ function renderReport(data) {
 	lines.push('1. Check out the old PR shape in `~/Developer/woocommerce` and run `homeboy rig up woocommerce-performance`.');
 	lines.push('2. Run every `ready` command with `<shared-state>` set to `/tmp/woocommerce-checkout-pr-65588-old-shape`.');
 	lines.push('3. Check out the revised WooCommerce candidate and rerun the same commands with `<shared-state>` set to `/tmp/woocommerce-checkout-pr-65588-revised-candidate`.');
-	lines.push('4. After #268-#272 and HBEX #1321 land, add their artifacts under the same two shared-state roots and regenerate this report.');
-	lines.push('5. Copy the filled matrix into WooCommerce PR #65588 or its replacement PR, keeping blocked rows explicitly marked instead of inferred.');
+	if (blockedScenarios.length > 0) {
+		lines.push('4. Keep blocked rows explicitly marked until their prerequisite artifacts exist, then add those artifacts under the same two shared-state roots and regenerate this report.');
+	} else {
+		lines.push('4. Regenerate this report from the two shared-state roots and copy the filled matrix into WooCommerce PR #65588 or its replacement PR.');
+	}
 	lines.push('');
 	return `${lines.join('\n')}\n`;
 }


### PR DESCRIPTION
## Summary
- Marks #268-#271 checkout guardrails as landed/ready in the evidence matrix after #276 and #289 merged.
- Updates the generated report wording so only the real Stripe gateway row remains blocked.
- Keeps the loop command recipe aligned with the current issue branch before running evidence.

## Verification
- `node woocommerce/woocommerce/tools/checkout-pr-evidence-report.mjs`
- `git diff --check`
- `node scripts/lint-rig-packages.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Updating stale evidence matrix metadata and validating the generated runbook.