### PR TITLE
Report structured Stripe gateway skips

### DIFF
--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -43,20 +43,24 @@ The rig mounts the selected WooCommerce checkout into the disposable WP Codebox
 WordPress runtime. Pass `homeboy bench --path /absolute/path/to/plugins/woocommerce`
 when validating a specific WooCommerce worktree.
 
-The checkout gateway compatibility matrix declares WooCommerce Stripe Gateway as
-a first-class WordPress validation dependency by slug:
+The checkout gateway compatibility matrix treats WooCommerce Stripe Gateway as a
+first-class WordPress validation dependency when the selected bench run provides
+that dependency by slug:
 
 ```json
 "validation_dependencies": ["woocommerce-gateway-stripe"]
 ```
 
-Homeboy Extensions resolves that dependency through the runner dependency
-contract, prepares a runnable artifact when the source checkout needs Composer
-materialization, mounts the prepared plugin into WP Codebox, and attaches
-`prepared_dependencies` provenance to the final bench results. The workload
-artifact reports the runtime side of that same contract: configured dependency,
-source path when explicitly provided, git revision when visible, prepared artifact
-path when exported, mounted plugin directory, plugin version, and status.
+Homeboy Extensions is expected to resolve that dependency through the runner
+dependency contract, prepare a runnable artifact when the source checkout needs
+Composer materialization, mount the prepared plugin into WP Codebox, and attach
+`prepared_dependencies` provenance to the final bench results. Until
+https://github.com/Extra-Chill/homeboy-extensions/issues/1336 lands, the rig keeps
+Stripe dependency setup opt-in so core gateway profiles remain runnable without
+Stripe materialization. The workload artifact reports the runtime side of that
+same contract: configured dependency, source path when explicitly provided, git
+revision when visible, prepared artifact path when exported, mounted plugin
+directory, plugin version, activation status, and skip/build failure status.
 
 PayPal Payments and WooPayments stay optional. Mount them for focused coverage by
 adding them to `validation_dependencies` or by overriding `wp_codebox_extra_plugins`
@@ -71,8 +75,9 @@ homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatib
 Unavailable gateway plugin profiles skip explicitly as `not_configured` when no
 path is configured, `entrypoint_missing` when a configured path did not mount the
 expected plugin file, `build_failed` when a prepared artifact path is configured
-but unavailable, or `activation_failed` when WordPress rejects activation or the
-gateway does not register after activation.
+but unavailable, `activation_failed` when WordPress rejects activation, or
+`gateway_missing` when the plugin activates but does not register the expected
+gateway.
 Homeboy core Lab offload provisioning gaps are tracked in:
 
 - https://github.com/Extra-Chill/homeboy/issues/3474

--- a/woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php
+++ b/woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php
@@ -103,7 +103,10 @@ return function (): array {
 			'gateway_id'     => 'stripe',
 			'label'          => 'WooCommerce Stripe Gateway',
 			'plugin'         => 'woocommerce-gateway-stripe',
+			'dependency'     => 'woocommerce-gateway-stripe',
 			'entrypoint'     => 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php',
+			'source_env'     => array( 'WC_CHECKOUT_GATEWAY_MATRIX_STRIPE_PATH', 'HOMEBOY_WC_STRIPE_COMPONENT_PATH' ),
+			'prepared_env'   => array( 'WC_CHECKOUT_GATEWAY_MATRIX_STRIPE_PREPARED_PATH' ),
 			'settings'       => array(
 				'enabled'  => 'yes',
 				'testmode' => 'yes',
@@ -114,7 +117,10 @@ return function (): array {
 			'gateway_id'     => 'ppcp-gateway',
 			'label'          => 'WooCommerce PayPal Payments',
 			'plugin'         => 'woocommerce-paypal-payments',
+			'dependency'     => 'woocommerce-paypal-payments',
 			'entrypoint'     => 'woocommerce-paypal-payments/woocommerce-paypal-payments.php',
+			'source_env'     => array( 'WC_CHECKOUT_GATEWAY_MATRIX_PAYPAL_PAYMENTS_PATH' ),
+			'prepared_env'   => array( 'WC_CHECKOUT_GATEWAY_MATRIX_PAYPAL_PAYMENTS_PREPARED_PATH' ),
 			'settings'       => array( 'enabled' => 'yes' ),
 		),
 		array(
@@ -122,7 +128,10 @@ return function (): array {
 			'gateway_id'     => 'woocommerce_payments',
 			'label'          => 'WooPayments',
 			'plugin'         => 'woocommerce-payments',
+			'dependency'     => 'woocommerce-payments',
 			'entrypoint'     => 'woocommerce-payments/woocommerce-payments.php',
+			'source_env'     => array( 'WC_CHECKOUT_GATEWAY_MATRIX_WOOPAYMENTS_PATH' ),
+			'prepared_env'   => array( 'WC_CHECKOUT_GATEWAY_MATRIX_WOOPAYMENTS_PREPARED_PATH' ),
 			'settings'       => array(
 				'enabled'  => 'yes',
 				'testmode' => 'yes',
@@ -143,22 +152,66 @@ return function (): array {
 		);
 	}
 
-	$ensure_gateway_profile = static function ( array $profile ): array {
+	$get_first_env = static function ( array $names ): string {
+		foreach ( $names as $name ) {
+			$value = getenv( $name );
+			if ( false !== $value && '' !== trim( (string) $value ) ) {
+				return (string) $value;
+			}
+		}
+		return '';
+	};
+
+	$get_git_revision = static function ( string $path ): ?string {
+		if ( '' === $path || ! is_dir( $path ) || ! function_exists( 'shell_exec' ) ) {
+			return null;
+		}
+
+		$revision = shell_exec( 'git -C ' . escapeshellarg( $path ) . ' rev-parse HEAD 2>/dev/null' );
+		$revision = is_string( $revision ) ? trim( $revision ) : '';
+		return '' !== $revision ? $revision : null;
+	};
+
+	$ensure_gateway_profile = static function ( array $profile ) use ( $get_first_env, $get_git_revision ): array {
 		$entrypoint_path = $profile['entrypoint'] ? WP_PLUGIN_DIR . '/' . $profile['entrypoint'] : '';
+		$source_path     = $profile['entrypoint'] ? $get_first_env( $profile['source_env'] ?? array() ) : '';
+		$prepared_path   = $profile['entrypoint'] ? $get_first_env( $profile['prepared_env'] ?? array() ) : '';
+		$mounted_dir     = $profile['entrypoint'] ? WP_PLUGIN_DIR . '/' . $profile['plugin'] : '';
 		$install         = array(
-			'plugin'          => $profile['plugin'],
-			'entrypoint'      => $profile['entrypoint'],
-			'entrypoint_path' => $entrypoint_path,
-			'available'       => true,
-			'activated'       => false,
-			'version'         => null,
-			'skip_reason'     => '',
+			'plugin'                 => $profile['plugin'],
+			'dependency'             => $profile['dependency'] ?? $profile['plugin'],
+			'entrypoint'             => $profile['entrypoint'],
+			'entrypoint_path'        => $entrypoint_path,
+			'source_path'            => $source_path,
+			'source_git_revision'    => $get_git_revision( $source_path ),
+			'prepared_artifact_path' => $prepared_path,
+			'mounted_plugin_dir'     => $mounted_dir,
+			'available'              => true,
+			'activated'              => false,
+			'activation_status'      => $profile['entrypoint'] ? 'not_attempted' : 'core',
+			'version'                => null,
+			'status'                 => 'available',
+			'status_reason'          => '',
+			'skip_reason'            => '',
+			'build_failure_reason'   => '',
 		);
 
 		if ( $profile['entrypoint'] ) {
 			if ( ! file_exists( $entrypoint_path ) ) {
-				$install['available']   = false;
-				$install['skip_reason'] = 'Plugin entrypoint is not mounted in WP Codebox.';
+				$install['available'] = false;
+				if ( '' !== $prepared_path && ! file_exists( $prepared_path ) ) {
+					$install['status']               = 'build_failed';
+					$install['build_failure_reason'] = 'Prepared artifact path is configured but unavailable in the runtime.';
+					$install['skip_reason']          = $install['build_failure_reason'];
+				} elseif ( '' === $source_path && '' === $prepared_path ) {
+					$install['status']      = 'not_configured';
+					$install['skip_reason'] = 'Plugin dependency was not configured or mounted for this run.';
+				} else {
+					$install['status']      = 'entrypoint_missing';
+					$install['skip_reason'] = 'Configured plugin dependency did not mount the expected WordPress entrypoint.';
+				}
+				$install['status_reason']     = $install['skip_reason'];
+				$install['activation_status'] = 'skipped';
 				return $install;
 			}
 
@@ -169,12 +222,16 @@ return function (): array {
 			if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( $profile['entrypoint'] ) ) {
 				$result = activate_plugin( $profile['entrypoint'], '', false, true );
 				if ( is_wp_error( $result ) ) {
-					$install['available']   = false;
-					$install['skip_reason'] = 'Plugin activation failed: ' . $result->get_error_message();
+					$install['available']         = false;
+					$install['activation_status'] = 'failed';
+					$install['status']            = 'activation_failed';
+					$install['skip_reason']       = 'Plugin activation failed: ' . $result->get_error_message();
+					$install['status_reason']     = $install['skip_reason'];
 					return $install;
 				}
 				$install['activated'] = true;
 			}
+			$install['activation_status'] = function_exists( 'is_plugin_active' ) && is_plugin_active( $profile['entrypoint'] ) ? 'active' : 'loaded';
 
 			if ( ! function_exists( 'get_plugin_data' ) ) {
 				require_once ABSPATH . 'wp-admin/includes/plugin.php';
@@ -198,8 +255,10 @@ return function (): array {
 
 		$gateways = WC()->payment_gateways ? WC()->payment_gateways->payment_gateways() : array();
 		if ( ! isset( $gateways[ $profile['gateway_id'] ] ) ) {
-			$install['available']   = false;
-			$install['skip_reason'] = 'Gateway id is not registered after activation/configuration.';
+			$install['available']     = false;
+			$install['status']        = 'gateway_missing';
+			$install['skip_reason']   = 'Gateway id is not registered after activation/configuration.';
+			$install['status_reason'] = $install['skip_reason'];
 		}
 
 		return $install;

--- a/woocommerce/woocommerce/docs/checkout-pr-evidence-matrix.md
+++ b/woocommerce/woocommerce/docs/checkout-pr-evidence-matrix.md
@@ -41,8 +41,8 @@ homeboy-rigs PRs in that track include #176, #178, #183, #184, #193, #197, #219,
 | https://github.com/chubes4/homeboy-rigs/issues/269 | landed | guest, logged-in, customer/session identity guardrails |
 | https://github.com/chubes4/homeboy-rigs/issues/270 | landed | checkout hook sequencing and counts |
 | https://github.com/chubes4/homeboy-rigs/issues/271 | landed | coupon lifecycle guardrails |
-| https://github.com/chubes4/homeboy-rigs/issues/272 | open | real gateway profile stabilization |
-| https://github.com/Extra-Chill/homeboy-extensions/issues/1321 | open | Stripe dependency provider fix |
+| https://github.com/chubes4/homeboy-rigs/issues/272 | closed | previous real gateway profile blocker |
+| https://github.com/Extra-Chill/homeboy-extensions/issues/1336 | open | Stripe dependency provider fix |
 
 ## Ready Rows
 
@@ -77,11 +77,11 @@ Repeat with the revised candidate checked out and
 
 ## Remaining Blocked Rows
 
-The following row stays pending until its prerequisite real-gateway profile work lands:
+The following row stays pending until its reusable Stripe dependency provider work lands. The rig-side workload should still reach execution and emit a structured `not_configured`, `build_failed`, `entrypoint_missing`, `activation_failed`, or `gateway_missing` artifact row instead of failing before dispatch.
 
 | Row | Blocker |
 |---|---|
-| Real Stripe gateway | https://github.com/chubes4/homeboy-rigs/issues/272 and https://github.com/Extra-Chill/homeboy-extensions/issues/1321; reuse the `woocommerce-stripe-ece-product-page` mounting abstractions instead of duplicating setup |
+| Real Stripe gateway | https://github.com/Extra-Chill/homeboy-extensions/issues/1336; reuse the `woocommerce-stripe-ece-product-page` mounting abstractions instead of duplicating setup |
 
 ## Reviewer-Facing Output Contract
 
@@ -93,8 +93,8 @@ The WooCommerce PR evidence should include:
   `136c2b85-647c-4d85-be13-2c0be175abfd`.
 - A table with old PR shape output and revised candidate output for every ready
   row.
-- Explicit `blocked` labels for real Stripe coverage until #272 and HBEX #1321
-  produce stable reusable gateway artifacts.
+- Explicit `blocked` labels for real Stripe coverage until HBEX #1336 produces
+  stable reusable gateway artifacts or structured dependency build failures.
 - Real Stripe coverage framed as reusable gateway-plugin profile capability,
   sharing the existing WooCommerce Stripe ECE/product-page rig mounting
   abstractions.

--- a/woocommerce/woocommerce/tools/checkout-pr-evidence-matrix.json
+++ b/woocommerce/woocommerce/tools/checkout-pr-evidence-matrix.json
@@ -49,7 +49,7 @@
     {
       "id": "stripe_dependency_provider",
       "title": "Stripe dependency provider fix",
-      "url": "https://github.com/Extra-Chill/homeboy-extensions/issues/1321",
+      "url": "https://github.com/Extra-Chill/homeboy-extensions/issues/1336",
       "status": "open"
     }
   ],
@@ -146,11 +146,11 @@
       "id": "real_stripe",
       "label": "Real Stripe gateway profile",
       "status": "blocked",
-      "blocked_by": ["https://github.com/chubes4/homeboy-rigs/issues/272", "https://github.com/Extra-Chill/homeboy-extensions/issues/1321"],
+      "blocked_by": ["https://github.com/Extra-Chill/homeboy-extensions/issues/1336"],
       "scenario": "checkout-gateway-compatibility-matrix",
       "command": "homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 --shared-state <shared-state> --setting-json 'bench_env={\"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES\":\"plugin_stripe\"}'",
-      "old_fix_expected": "Pending real Stripe stabilization; skip output is not failure evidence. Reuse the existing WooCommerce Stripe ECE/product-page mounting abstractions instead of adding checkout-only Stripe setup.",
-      "candidate_expected": "PASS once Stripe dependency materialization is stable as a reusable gateway-plugin profile capability; skip with explicit blocker is acceptable until then."
+      "old_fix_expected": "Pending real Stripe dependency-provider stabilization; structured not_configured/build_failed/entrypoint_missing output is blocker evidence, not checkout pass/fail evidence. Reuse the existing WooCommerce Stripe ECE/product-page mounting abstractions instead of adding checkout-only Stripe setup.",
+      "candidate_expected": "PASS once Stripe dependency materialization is stable as a reusable gateway-plugin profile capability; structured build_failed or explicit skip with blocker #1336 is acceptable until then."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Enrich the checkout gateway matrix plugin-profile artifact with dependency slug, source path, source git revision, prepared artifact path, mounted plugin dir, plugin version, activation status, and structured status/reason fields.
- Keep Stripe dependency setup opt-in while Homeboy Extensions issue #1336 remains open, so core gateway profiles continue running without Stripe materialization.
- Update the checkout evidence matrix/docs from the closed #272/#1321 blockers to the current #1336 blocker and structured skip/build-failure interpretation.

## Verification
- `php -l woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php` passed.
- `node -e "JSON.parse(require('node:fs').readFileSync('woocommerce/woocommerce/tools/checkout-pr-evidence-matrix.json','utf8'));"` passed.
- `node woocommerce/woocommerce/tools/checkout-pr-evidence-report.mjs >/tmp/homeboy-rigs-issue-292-evidence-report.md` passed.
- `homeboy rig check woocommerce-performance` passed on Lab runner. Run ID: `7018b301-4fc3-4653-a442-d4e94bb2e106`.
- Core gateway matrix passed on Lab runner: `homeboy bench --rig woocommerce-performance --path /Users/chubes/Developer/woocommerce/plugins/woocommerce --scenario checkout-gateway-compatibility-matrix --iterations 1 --shared-state /tmp/homeboy-rigs-issue-292-core --setting-json 'bench_env={"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES":"core_bacs,core_cheque,core_cod"}'`. Run ID: `adcdc1ce-f1c4-478a-974d-d262e57b57f5`.
- Stripe profile reached workload execution and reported a structured `not_configured` skip instead of pre-dispatch failure: `homeboy bench --rig woocommerce-performance --path /Users/chubes/Developer/woocommerce/plugins/woocommerce --scenario checkout-gateway-compatibility-matrix --iterations 1 --shared-state /tmp/homeboy-rigs-issue-292-stripe --setting-json 'bench_env={"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES":"plugin_stripe"}'`. Run ID: `96416840-6c39-4083-baf4-03025d79093b`; gateway artifact URL: https://homeboy-artifacts-tunnel.dev.chubes.net/runs/96416840-6c39-4083-baf4-03025d79093b/artifacts/f237fd4f-17b5-4903-baa9-28fc1852fe68.

## Remaining blocker
- Real Stripe execution remains blocked by https://github.com/Extra-Chill/homeboy-extensions/issues/1336. This PR avoids a workaround; it makes the rig-side artifact accurately record unavailable/build-failed dependency states until the upstream provider supplies a mounted Stripe artifact or structured provider failure.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Implemented the rig-side artifact/status handling, updated evidence docs, and ran verification under Chris's review workflow.