### PR TITLE
Expand checkout gateway evidence matrix

### DIFF
--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -43,12 +43,19 @@ The rig mounts the selected WooCommerce checkout into the disposable WP Codebox
 WordPress runtime. Pass `homeboy bench --path /absolute/path/to/plugins/woocommerce`
 when validating a specific WooCommerce worktree.
 
-The checkout gateway compatibility matrix treats WooCommerce Stripe Gateway as a
-first-class WordPress validation dependency when the selected bench run provides
-that dependency by slug:
+The checkout gateway compatibility matrix declares popular real gateway plugins
+as first-class profile metadata by slug:
 
 ```json
-"validation_dependencies": ["woocommerce-gateway-stripe"]
+[
+  "woocommerce-gateway-stripe",
+  "woocommerce-payments",
+  "woocommerce-paypal-payments",
+  "woocommerce-square",
+  "razorpay",
+  "mollie-payments-for-woocommerce",
+  "klarna-payments-for-woocommerce"
+]
 ```
 
 Homeboy Extensions is expected to resolve that dependency through the runner
@@ -62,22 +69,49 @@ same contract: configured dependency, source path when explicitly provided, git
 revision when visible, prepared artifact path when exported, mounted plugin
 directory, plugin version, activation status, and skip/build failure status.
 
-PayPal Payments and WooPayments stay optional. Mount them for focused coverage by
-adding them to `validation_dependencies` or by overriding `wp_codebox_extra_plugins`
-and the matching artifact path env values:
+Core gateway profiles stay independent of third-party plugin preparation. Run the
+core controls with:
 
 ```bash
 homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 \
-  --setting-json 'wp_codebox_extra_plugins=[{"source":"/path/to/woocommerce-paypal-payments","slug":"woocommerce-paypal-payments","pluginFile":"woocommerce-paypal-payments/woocommerce-paypal-payments.php","activate":false},{"source":"/path/to/woocommerce-payments","slug":"woocommerce-payments","pluginFile":"woocommerce-payments/woocommerce-payments.php","activate":false}]' \
-  --setting-json 'bench_env={"WC_CHECKOUT_GATEWAY_MATRIX_PAYPAL_PAYMENTS_PATH":"/path/to/woocommerce-paypal-payments","WC_CHECKOUT_GATEWAY_MATRIX_WOOPAYMENTS_PATH":"/path/to/woocommerce-payments"}'
+  --setting-json 'bench_env={"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES":"core_bacs,core_cheque,core_cod"}'
 ```
+
+Mount gateway plugins for focused coverage by adding them to
+`validation_dependencies` once Homeboy Extensions supports the selected provider,
+or by overriding `wp_codebox_extra_plugins` and matching source/prepared artifact
+path env values:
+
+```bash
+homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 \
+  --setting-json 'wp_codebox_extra_plugins=[{"source":"/path/to/woocommerce-paypal-payments","slug":"woocommerce-paypal-payments","pluginFile":"woocommerce-paypal-payments/woocommerce-paypal-payments.php","activate":false}]' \
+  --setting-json 'bench_env={"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES":"plugin_paypal_payments","WC_CHECKOUT_GATEWAY_MATRIX_PAYPAL_PAYMENTS_PATH":"/path/to/woocommerce-paypal-payments"}'
+```
+
+Profile-specific env keys use this shape:
+
+| Profile | Source path env | Prepared artifact env |
+|---|---|---|
+| `plugin_stripe` | `WC_CHECKOUT_GATEWAY_MATRIX_STRIPE_PATH` | `WC_CHECKOUT_GATEWAY_MATRIX_STRIPE_PREPARED_PATH` |
+| `plugin_woopayments` | `WC_CHECKOUT_GATEWAY_MATRIX_WOOPAYMENTS_PATH` | `WC_CHECKOUT_GATEWAY_MATRIX_WOOPAYMENTS_PREPARED_PATH` |
+| `plugin_paypal_payments` | `WC_CHECKOUT_GATEWAY_MATRIX_PAYPAL_PAYMENTS_PATH` | `WC_CHECKOUT_GATEWAY_MATRIX_PAYPAL_PAYMENTS_PREPARED_PATH` |
+| `plugin_square` | `WC_CHECKOUT_GATEWAY_MATRIX_SQUARE_PATH` | `WC_CHECKOUT_GATEWAY_MATRIX_SQUARE_PREPARED_PATH` |
+| `plugin_razorpay` | `WC_CHECKOUT_GATEWAY_MATRIX_RAZORPAY_PATH` | `WC_CHECKOUT_GATEWAY_MATRIX_RAZORPAY_PREPARED_PATH` |
+| `plugin_mollie` | `WC_CHECKOUT_GATEWAY_MATRIX_MOLLIE_PATH` | `WC_CHECKOUT_GATEWAY_MATRIX_MOLLIE_PREPARED_PATH` |
+| `plugin_klarna` | `WC_CHECKOUT_GATEWAY_MATRIX_KLARNA_PATH` | `WC_CHECKOUT_GATEWAY_MATRIX_KLARNA_PREPARED_PATH` |
 
 Unavailable gateway plugin profiles skip explicitly as `not_configured` when no
 path is configured, `entrypoint_missing` when a configured path did not mount the
 expected plugin file, `build_failed` when a prepared artifact path is configured
 but unavailable, `activation_failed` when WordPress rejects activation, or
 `gateway_missing` when the plugin activates but does not register the expected
-gateway.
+gateway. Each profile row reports structured `available`, `build_failed`,
+`skipped`, and `blocked` fields.
+Gateway dependency-provider blockers are tracked in:
+
+- https://github.com/chubes4/homeboy-rigs/issues/292
+- https://github.com/Extra-Chill/homeboy-extensions/issues/1336
+
 Homeboy core Lab offload provisioning gaps are tracked in:
 
 - https://github.com/Extra-Chill/homeboy/issues/3474
@@ -146,15 +180,18 @@ into `tests/bench/`, and returns the normalized Homeboy `BenchResults` envelope.
 - `checkout-gateway-compatibility-matrix` runs the duplicate-checkout/order
   idempotency repro across core BACS, Cheque, and COD gateway controls plus
   first-class mounted real-plugin profiles for WooCommerce Stripe Gateway,
-  WooCommerce PayPal Payments, and WooPayments when those plugin paths are
-  configured. It captures configured dependency/source/prepared paths, mounted
-  plugin directory, best-effort git revision, plugin version, and status details
-  without secrets, and links evidence to WooCommerce issue #62659, WooCommerce PR
-  #65588, Jorge's PR review, and Homeboy Rigs issue #255.
+  WooPayments, WooCommerce PayPal Payments, WooCommerce Square, Razorpay for
+  WooCommerce, Mollie Payments for WooCommerce, and Klarna for WooCommerce when
+  those plugin paths are configured. It captures configured dependency/source/
+  prepared paths, mounted plugin directory, expected and registered gateway IDs,
+  plugin version, and status details without secrets, and links evidence to
+  WooCommerce issue #62659, WooCommerce PR #65588, Jorge's PR review, and
+  Homeboy Rigs issue #255.
   Limit the matrix during focused smokes with
   `WC_CHECKOUT_GATEWAY_MATRIX_PROFILES=core_bacs,plugin_stripe`. Plugin profiles
-  report explicit skip details when their entrypoint is unavailable or activation
-  fails, so the core controls remain runnable without gateway secrets.
+  report explicit `available`, `build_failed`, `skipped`, and `blocked` details
+  when their entrypoint is unavailable or activation fails, so the core controls
+  remain runnable without gateway secrets or third-party materialization.
 - `checkout-shipping-cache` seeds simple physical products, configures a flat-rate
   US shipping zone, builds a cart, splits cart contents into configurable shipping
   packages, and measures cold, warm, totals-only churn, and address-rehashed
@@ -285,10 +322,10 @@ node woocommerce/woocommerce/tools/checkout-pr-evidence-report.mjs
 
 The generated matrix is intentionally dependency-aware. It lists the old PR shape
 failure run, ready commands for public `create_order()` side effects, sequential
-retry, true concurrent checkout, and core gateway rows, and keeps no-payment,
-order-pay, identity, coupon lifecycle, hook sequencing, and real Stripe rows
-blocked until their prerequisite issues land. Real Stripe coverage is framed as a
-reusable gateway-plugin profile capability that should share the existing
+retry, true concurrent checkout, and core gateway rows, and keeps real plugin
+gateway rows blocked until their prerequisite dependency-provider work lands or
+returns structured build-failure artifacts. Real gateway coverage is framed as a
+reusable gateway-plugin profile capability. Stripe should share the existing
 `woocommerce-stripe-ece-product-page` WooCommerce + Stripe mounting abstractions,
 not duplicate checkout-specific setup. See
 `docs/checkout-pr-evidence-matrix.md` for the full recipe.

--- a/woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php
+++ b/woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php
@@ -73,24 +73,30 @@ return function (): array {
 		array(
 			'profile'        => 'core_bacs',
 			'gateway_id'     => 'bacs',
+			'expected_gateway_ids' => array( 'bacs' ),
 			'label'          => 'Direct bank transfer (BACS)',
 			'plugin'         => 'woocommerce-core',
+			'dependency_slug' => 'woocommerce-core',
 			'entrypoint'     => '',
 			'settings'       => array( 'enabled' => 'yes' ),
 		),
 		array(
 			'profile'        => 'core_cheque',
 			'gateway_id'     => 'cheque',
+			'expected_gateway_ids' => array( 'cheque' ),
 			'label'          => 'Check payments',
 			'plugin'         => 'woocommerce-core',
+			'dependency_slug' => 'woocommerce-core',
 			'entrypoint'     => '',
 			'settings'       => array( 'enabled' => 'yes' ),
 		),
 		array(
 			'profile'        => 'core_cod',
 			'gateway_id'     => 'cod',
+			'expected_gateway_ids' => array( 'cod' ),
 			'label'          => 'Cash on delivery',
 			'plugin'         => 'woocommerce-core',
+			'dependency_slug' => 'woocommerce-core',
 			'entrypoint'     => '',
 			'settings'       => array(
 				'enabled'            => 'yes',
@@ -101,12 +107,17 @@ return function (): array {
 		array(
 			'profile'        => 'plugin_stripe',
 			'gateway_id'     => 'stripe',
+			'expected_gateway_ids' => array( 'stripe' ),
 			'label'          => 'WooCommerce Stripe Gateway',
 			'plugin'         => 'woocommerce-gateway-stripe',
 			'dependency'     => 'woocommerce-gateway-stripe',
 			'entrypoint'     => 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php',
 			'source_env'     => array( 'WC_CHECKOUT_GATEWAY_MATRIX_STRIPE_PATH', 'HOMEBOY_WC_STRIPE_COMPONENT_PATH' ),
 			'prepared_env'   => array( 'WC_CHECKOUT_GATEWAY_MATRIX_STRIPE_PREPARED_PATH' ),
+			'blocked_by'     => array(
+				'https://github.com/chubes4/homeboy-rigs/issues/292',
+				'https://github.com/Extra-Chill/homeboy-extensions/issues/1336',
+			),
 			'settings'       => array(
 				'enabled'  => 'yes',
 				'testmode' => 'yes',
@@ -115,6 +126,7 @@ return function (): array {
 		array(
 			'profile'        => 'plugin_paypal_payments',
 			'gateway_id'     => 'ppcp-gateway',
+			'expected_gateway_ids' => array( 'ppcp-gateway' ),
 			'label'          => 'WooCommerce PayPal Payments',
 			'plugin'         => 'woocommerce-paypal-payments',
 			'dependency'     => 'woocommerce-paypal-payments',
@@ -126,6 +138,7 @@ return function (): array {
 		array(
 			'profile'        => 'plugin_woopayments',
 			'gateway_id'     => 'woocommerce_payments',
+			'expected_gateway_ids' => array( 'woocommerce_payments' ),
 			'label'          => 'WooPayments',
 			'plugin'         => 'woocommerce-payments',
 			'dependency'     => 'woocommerce-payments',
@@ -135,6 +148,64 @@ return function (): array {
 			'settings'       => array(
 				'enabled'  => 'yes',
 				'testmode' => 'yes',
+			),
+		),
+		array(
+			'profile'        => 'plugin_square',
+			'gateway_id'     => 'square_credit_card',
+			'expected_gateway_ids' => array( 'square_credit_card' ),
+			'label'          => 'WooCommerce Square',
+			'plugin'         => 'woocommerce-square',
+			'dependency'     => 'woocommerce-square',
+			'entrypoint'     => 'woocommerce-square/woocommerce-square.php',
+			'source_env'     => array( 'WC_CHECKOUT_GATEWAY_MATRIX_SQUARE_PATH' ),
+			'prepared_env'   => array( 'WC_CHECKOUT_GATEWAY_MATRIX_SQUARE_PREPARED_PATH' ),
+			'settings'       => array(
+				'enabled'          => 'yes',
+				'environment'      => 'sandbox',
+				'create_customer'  => 'no',
+			),
+		),
+		array(
+			'profile'        => 'plugin_razorpay',
+			'gateway_id'     => 'razorpay',
+			'expected_gateway_ids' => array( 'razorpay' ),
+			'label'          => 'Razorpay for WooCommerce',
+			'plugin'         => 'razorpay',
+			'dependency'     => 'razorpay',
+			'entrypoint'     => 'razorpay/razorpay.php',
+			'source_env'     => array( 'WC_CHECKOUT_GATEWAY_MATRIX_RAZORPAY_PATH' ),
+			'prepared_env'   => array( 'WC_CHECKOUT_GATEWAY_MATRIX_RAZORPAY_PREPARED_PATH' ),
+			'settings'       => array(
+				'enabled' => 'yes',
+			),
+		),
+		array(
+			'profile'        => 'plugin_mollie',
+			'gateway_id'     => 'mollie_wc_gateway_creditcard',
+			'expected_gateway_ids' => array( 'mollie_wc_gateway_creditcard', 'mollie_wc_gateway_ideal', 'mollie_wc_gateway_paypal' ),
+			'label'          => 'Mollie Payments for WooCommerce',
+			'plugin'         => 'mollie-payments-for-woocommerce',
+			'dependency'     => 'mollie-payments-for-woocommerce',
+			'entrypoint'     => 'mollie-payments-for-woocommerce/mollie-payments-for-woocommerce.php',
+			'source_env'     => array( 'WC_CHECKOUT_GATEWAY_MATRIX_MOLLIE_PATH' ),
+			'prepared_env'   => array( 'WC_CHECKOUT_GATEWAY_MATRIX_MOLLIE_PREPARED_PATH' ),
+			'settings'       => array(
+				'enabled' => 'yes',
+			),
+		),
+		array(
+			'profile'        => 'plugin_klarna',
+			'gateway_id'     => 'klarna_payments',
+			'expected_gateway_ids' => array( 'klarna_payments', 'kco' ),
+			'label'          => 'Klarna for WooCommerce',
+			'plugin'         => 'klarna-payments-for-woocommerce',
+			'dependency'     => 'klarna-payments-for-woocommerce',
+			'entrypoint'     => 'klarna-payments-for-woocommerce/klarna-payments-for-woocommerce.php',
+			'source_env'     => array( 'WC_CHECKOUT_GATEWAY_MATRIX_KLARNA_PATH' ),
+			'prepared_env'   => array( 'WC_CHECKOUT_GATEWAY_MATRIX_KLARNA_PREPARED_PATH' ),
+			'settings'       => array(
+				'enabled' => 'yes',
 			),
 		),
 	);
@@ -180,13 +251,23 @@ return function (): array {
 		$install         = array(
 			'plugin'                 => $profile['plugin'],
 			'dependency'             => $profile['dependency'] ?? $profile['plugin'],
+			'dependency_slug'        => $profile['dependency'] ?? $profile['plugin'],
 			'entrypoint'             => $profile['entrypoint'],
 			'entrypoint_path'        => $entrypoint_path,
+			'source_env'             => $profile['source_env'] ?? array(),
 			'source_path'            => $source_path,
 			'source_git_revision'    => $get_git_revision( $source_path ),
+			'prepared_env'           => $profile['prepared_env'] ?? array(),
 			'prepared_artifact_path' => $prepared_path,
+			'prepared_path'          => $prepared_path,
 			'mounted_plugin_dir'     => $mounted_dir,
+			'expected_gateway_ids'   => $profile['expected_gateway_ids'] ?? array( $profile['gateway_id'] ),
+			'registered_gateway_ids' => array(),
+			'blocked_by'             => $profile['blocked_by'] ?? array(),
 			'available'              => true,
+			'build_failed'           => false,
+			'skipped'                => false,
+			'blocked'                => false,
 			'activated'              => false,
 			'activation_status'      => $profile['entrypoint'] ? 'not_attempted' : 'core',
 			'version'                => null,
@@ -199,9 +280,11 @@ return function (): array {
 		if ( $profile['entrypoint'] ) {
 			if ( ! file_exists( $entrypoint_path ) ) {
 				$install['available'] = false;
+				$install['skipped']   = true;
 				if ( '' !== $prepared_path && ! file_exists( $prepared_path ) ) {
 					$install['status']               = 'build_failed';
 					$install['build_failure_reason'] = 'Prepared artifact path is configured but unavailable in the runtime.';
+					$install['build_failed']         = true;
 					$install['skip_reason']          = $install['build_failure_reason'];
 				} elseif ( '' === $source_path && '' === $prepared_path ) {
 					$install['status']      = 'not_configured';
@@ -212,6 +295,7 @@ return function (): array {
 				}
 				$install['status_reason']     = $install['skip_reason'];
 				$install['activation_status'] = 'skipped';
+				$install['blocked'] = ! empty( $install['blocked_by'] );
 				return $install;
 			}
 
@@ -223,6 +307,7 @@ return function (): array {
 				$result = activate_plugin( $profile['entrypoint'], '', false, true );
 				if ( is_wp_error( $result ) ) {
 					$install['available']         = false;
+					$install['skipped']           = true;
 					$install['activation_status'] = 'failed';
 					$install['status']            = 'activation_failed';
 					$install['skip_reason']       = 'Plugin activation failed: ' . $result->get_error_message();
@@ -253,9 +338,20 @@ return function (): array {
 			WC()->payment_gateways->init();
 		}
 
-		$gateways = WC()->payment_gateways ? WC()->payment_gateways->payment_gateways() : array();
+		$gateways              = WC()->payment_gateways ? WC()->payment_gateways->payment_gateways() : array();
+		$expected_gateway_ids  = $profile['expected_gateway_ids'] ?? array( $profile['gateway_id'] );
+		$registered_gateway_ids = array_values(
+			array_filter(
+				$expected_gateway_ids,
+				static function ( string $gateway_id ) use ( $gateways ): bool {
+					return isset( $gateways[ $gateway_id ] );
+				}
+			)
+		);
+		$install['registered_gateway_ids'] = $registered_gateway_ids;
 		if ( ! isset( $gateways[ $profile['gateway_id'] ] ) ) {
 			$install['available']     = false;
+			$install['skipped']       = true;
 			$install['status']        = 'gateway_missing';
 			$install['skip_reason']   = 'Gateway id is not registered after activation/configuration.';
 			$install['status_reason'] = $install['skip_reason'];
@@ -369,9 +465,17 @@ return function (): array {
 		$result                             = array(
 			'profile'        => $profile['profile'],
 			'gateway_id'     => $profile['gateway_id'],
+			'expected_gateway_ids' => $profile['expected_gateway_ids'] ?? array( $profile['gateway_id'] ),
 			'label'          => $profile['label'],
+			'dependency_slug' => $profile['dependency'] ?? $profile['plugin'],
 			'install'        => $install,
-			'skipped'        => ! $install['available'],
+			'status'         => $install['status'],
+			'status_reason'  => $install['status_reason'],
+			'available'      => (bool) $install['available'],
+			'build_failed'   => (bool) $install['build_failed'],
+			'skipped'        => (bool) $install['skipped'],
+			'blocked'        => (bool) $install['blocked'],
+			'blocked_by'     => $install['blocked_by'],
 			'skip_reason'    => $install['skip_reason'],
 		);
 
@@ -531,6 +635,22 @@ return function (): array {
 			}
 		)
 	);
+	$build_failed_count = count(
+		array_filter(
+			$results,
+			static function ( array $result ): bool {
+				return ! empty( $result['build_failed'] );
+			}
+		)
+	);
+	$blocked_count = count(
+		array_filter(
+			$results,
+			static function ( array $result ): bool {
+				return ! empty( $result['blocked'] );
+			}
+		)
+	);
 
 	$summary = array(
 		'success_rate'                       => 1,
@@ -538,6 +658,8 @@ return function (): array {
 		'gateway_profiles_available'         => $available_count,
 		'gateway_plugin_profiles_available'  => $plugin_available_count,
 		'gateway_profiles_skipped'           => count( $results ) - $available_count,
+		'gateway_profiles_build_failed'      => $build_failed_count,
+		'gateway_profiles_blocked'           => $blocked_count,
 		'duplicate_checkout_attempts'         => array_sum( array_map( static fn ( array $result ): int => (int) ( $result['metrics']['duplicate_checkout_attempts'] ?? 0 ), $results ) ),
 		'duplicate_order_count'               => array_sum( array_map( static fn ( array $result ): int => (int) ( $result['metrics']['duplicate_order_count'] ?? 0 ), $results ) ),
 		'order_awaiting_payment_writes'       => array_sum( array_map( static fn ( array $result ): int => (int) ( $result['metrics']['order_awaiting_payment_writes'] ?? 0 ), $results ) ),
@@ -567,7 +689,24 @@ return function (): array {
 			'runner'   => 'wp-codebox',
 			'workload' => 'checkout-gateway-compatibility-matrix',
 			'issues'   => $issues,
-			'profiles' => array_map( static fn ( array $result ): string => $result['profile'], $results ),
+			'profiles' => array_map(
+				static function ( array $result ): array {
+					return array(
+						'profile'              => $result['profile'],
+						'gateway_id'           => $result['gateway_id'],
+						'expected_gateway_ids' => $result['expected_gateway_ids'],
+						'dependency_slug'      => $result['dependency_slug'],
+						'status'               => $result['status'],
+						'status_reason'        => $result['status_reason'],
+						'available'            => $result['available'],
+						'build_failed'         => $result['build_failed'],
+						'skipped'              => $result['skipped'],
+						'blocked'              => $result['blocked'],
+						'blocked_by'           => $result['blocked_by'],
+					);
+				},
+				$results
+			),
 		),
 		'artifacts' => $artifact_path ? array( 'gateway_matrix' => array( 'path' => $artifact_path, 'kind' => 'json' ) ) : array(),
 	);

--- a/woocommerce/woocommerce/docs/checkout-pr-evidence-matrix.md
+++ b/woocommerce/woocommerce/docs/checkout-pr-evidence-matrix.md
@@ -19,7 +19,7 @@ The report is generated from
 old-fix failures, revised-candidate expectations, dependencies, and commands stay
 reviewable in one place.
 
-## Reusable Stripe Gateway Capability
+## Reusable Gateway Profile Capability
 
 Real Stripe checkout coverage should build on the existing
 `woocommerce/woocommerce-gateway-stripe` rig track instead of adding a
@@ -33,6 +33,23 @@ profile capability that can be shared by WooCommerce workloads. Relevant merged
 homeboy-rigs PRs in that track include #176, #178, #183, #184, #193, #197, #219,
 #220, #235, #236, #238, and #265.
 
+The expanded gateway profile matrix now declares explicit rows for these popular
+gateway plugins:
+
+| Profile | Dependency slug | Expected gateway IDs |
+|---|---|---|
+| `plugin_stripe` | `woocommerce-gateway-stripe` | `stripe` |
+| `plugin_woopayments` | `woocommerce-payments` | `woocommerce_payments` |
+| `plugin_paypal_payments` | `woocommerce-paypal-payments` | `ppcp-gateway` |
+| `plugin_square` | `woocommerce-square` | `square_credit_card` |
+| `plugin_razorpay` | `razorpay` | `razorpay` |
+| `plugin_mollie` | `mollie-payments-for-woocommerce` | `mollie_wc_gateway_creditcard`, `mollie_wc_gateway_ideal`, `mollie_wc_gateway_paypal` |
+| `plugin_klarna` | `klarna-payments-for-woocommerce` | `klarna_payments`, `kco` |
+
+Each runtime profile reports structured `available`, `build_failed`, `skipped`,
+and `blocked` fields plus source/prepared path env metadata. Core profiles do
+not require any third-party plugin preparation.
+
 ## Current Dependencies
 
 | Dependency | Status | Scope |
@@ -41,8 +58,8 @@ homeboy-rigs PRs in that track include #176, #178, #183, #184, #193, #197, #219,
 | https://github.com/chubes4/homeboy-rigs/issues/269 | landed | guest, logged-in, customer/session identity guardrails |
 | https://github.com/chubes4/homeboy-rigs/issues/270 | landed | checkout hook sequencing and counts |
 | https://github.com/chubes4/homeboy-rigs/issues/271 | landed | coupon lifecycle guardrails |
-| https://github.com/chubes4/homeboy-rigs/issues/272 | closed | previous real gateway profile blocker |
-| https://github.com/Extra-Chill/homeboy-extensions/issues/1336 | open | Stripe dependency provider fix |
+| https://github.com/chubes4/homeboy-rigs/issues/292 | open | real Stripe gateway evidence row |
+| https://github.com/Extra-Chill/homeboy-extensions/issues/1336 | open | reusable gateway dependency provider materialization |
 
 ## Ready Rows
 
@@ -77,11 +94,19 @@ Repeat with the revised candidate checked out and
 
 ## Remaining Blocked Rows
 
-The following row stays pending until its reusable Stripe dependency provider work lands. The rig-side workload should still reach execution and emit a structured `not_configured`, `build_failed`, `entrypoint_missing`, `activation_failed`, or `gateway_missing` artifact row instead of failing before dispatch.
+The following rows stay pending until reusable gateway dependency materialization
+can either mount each plugin or return structured `build_failed` artifacts without
+aborting unrelated/core rows:
 
 | Row | Blocker |
 |---|---|
-| Real Stripe gateway | https://github.com/Extra-Chill/homeboy-extensions/issues/1336; reuse the `woocommerce-stripe-ece-product-page` mounting abstractions instead of duplicating setup |
+| Real Stripe gateway | https://github.com/chubes4/homeboy-rigs/issues/292 and https://github.com/Extra-Chill/homeboy-extensions/issues/1336; reuse the `woocommerce-stripe-ece-product-page` mounting abstractions instead of duplicating setup |
+| Real WooPayments gateway | https://github.com/Extra-Chill/homeboy-extensions/issues/1336 |
+| Real WooCommerce PayPal Payments gateway | https://github.com/Extra-Chill/homeboy-extensions/issues/1336 |
+| Real WooCommerce Square gateway | https://github.com/Extra-Chill/homeboy-extensions/issues/1336 |
+| Real Razorpay for WooCommerce gateway | https://github.com/Extra-Chill/homeboy-extensions/issues/1336 |
+| Real Mollie Payments for WooCommerce gateway | https://github.com/Extra-Chill/homeboy-extensions/issues/1336 |
+| Real Klarna for WooCommerce gateway | https://github.com/Extra-Chill/homeboy-extensions/issues/1336 |
 
 ## Reviewer-Facing Output Contract
 
@@ -93,10 +118,10 @@ The WooCommerce PR evidence should include:
   `136c2b85-647c-4d85-be13-2c0be175abfd`.
 - A table with old PR shape output and revised candidate output for every ready
   row.
-- Explicit `blocked` labels for real Stripe coverage until HBEX #1336 produces
-  stable reusable gateway artifacts or structured dependency build failures.
-- Real Stripe coverage framed as reusable gateway-plugin profile capability,
-  sharing the existing WooCommerce Stripe ECE/product-page rig mounting
-  abstractions.
+- Explicit `blocked` labels for real gateway coverage until #292 and HBEX #1336
+  produce stable reusable gateway artifacts or structured build-failure rows.
+- Real gateway coverage framed as reusable gateway-plugin profile capability.
+  Stripe should share the existing WooCommerce Stripe ECE/product-page rig
+  mounting abstractions.
 - A PR description note that avoids `Closes #62659` unless the true concurrent
   checkout row passes.

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -10,7 +10,7 @@
         "wordpress": {
           "wp_codebox_wordpress_version": "7.0",
           "bench_env": {
-            "WC_CHECKOUT_GATEWAY_MATRIX_PROFILES": "core_bacs,core_cheque,core_cod,plugin_stripe,plugin_paypal_payments,plugin_woopayments",
+            "WC_CHECKOUT_GATEWAY_MATRIX_PROFILES": "core_bacs,core_cheque,core_cod,plugin_stripe,plugin_woopayments,plugin_paypal_payments,plugin_square,plugin_razorpay,plugin_mollie,plugin_klarna",
             "WC_SHIPPING_CACHE_CART_ITEMS": "40",
             "WC_SHIPPING_CACHE_PACKAGES": "8",
             "WC_SHIPPING_CACHE_WARM_RUNS": "5",

--- a/woocommerce/woocommerce/tools/checkout-pr-evidence-matrix.json
+++ b/woocommerce/woocommerce/tools/checkout-pr-evidence-matrix.json
@@ -43,12 +43,12 @@
     {
       "id": "real_gateway_profiles",
       "title": "Real gateway plugin profile stabilization",
-      "url": "https://github.com/chubes4/homeboy-rigs/issues/272",
+      "url": "https://github.com/chubes4/homeboy-rigs/issues/292",
       "status": "open"
     },
     {
-      "id": "stripe_dependency_provider",
-      "title": "Stripe dependency provider fix",
+      "id": "gateway_dependency_provider",
+      "title": "Gateway dependency provider materialization fix",
       "url": "https://github.com/Extra-Chill/homeboy-extensions/issues/1336",
       "status": "open"
     }
@@ -67,6 +67,119 @@
       "woocommerce_ref": "replacement branch or revised PR candidate",
       "shared_state": "/tmp/woocommerce-checkout-pr-65588-revised-candidate",
       "expected": "Passes public create_order side-effect guardrails and resume behavior without overclaiming true concurrency unless the concurrent scenario passes. Any remaining failures must be scoped in the Woo PR description."
+    }
+  ],
+  "gateway_profiles": [
+    {
+      "profile": "core_bacs",
+      "label": "Direct bank transfer (BACS)",
+      "dependency_slug": "woocommerce-core",
+      "entrypoint": "",
+      "expected_gateway_ids": ["bacs"],
+      "status_fields": { "available": true, "build_failed": false, "skipped": false, "blocked": false },
+      "command_profiles": "core_bacs"
+    },
+    {
+      "profile": "core_cheque",
+      "label": "Check payments",
+      "dependency_slug": "woocommerce-core",
+      "entrypoint": "",
+      "expected_gateway_ids": ["cheque"],
+      "status_fields": { "available": true, "build_failed": false, "skipped": false, "blocked": false },
+      "command_profiles": "core_cheque"
+    },
+    {
+      "profile": "core_cod",
+      "label": "Cash on delivery",
+      "dependency_slug": "woocommerce-core",
+      "entrypoint": "",
+      "expected_gateway_ids": ["cod"],
+      "status_fields": { "available": true, "build_failed": false, "skipped": false, "blocked": false },
+      "command_profiles": "core_cod"
+    },
+    {
+      "profile": "plugin_stripe",
+      "label": "WooCommerce Stripe Gateway",
+      "dependency_slug": "woocommerce-gateway-stripe",
+      "entrypoint": "woocommerce-gateway-stripe/woocommerce-gateway-stripe.php",
+      "source_path_env": "WC_CHECKOUT_GATEWAY_MATRIX_STRIPE_PATH",
+      "prepared_path_env": "WC_CHECKOUT_GATEWAY_MATRIX_STRIPE_PREPARED_PATH",
+      "expected_gateway_ids": ["stripe"],
+      "status_fields": { "available": "artifact-dependent", "build_failed": "artifact-dependent", "skipped": "artifact-dependent", "blocked": true },
+      "blocked_by": ["https://github.com/chubes4/homeboy-rigs/issues/292", "https://github.com/Extra-Chill/homeboy-extensions/issues/1336"],
+      "command_profiles": "plugin_stripe"
+    },
+    {
+      "profile": "plugin_woopayments",
+      "label": "WooPayments",
+      "dependency_slug": "woocommerce-payments",
+      "entrypoint": "woocommerce-payments/woocommerce-payments.php",
+      "source_path_env": "WC_CHECKOUT_GATEWAY_MATRIX_WOOPAYMENTS_PATH",
+      "prepared_path_env": "WC_CHECKOUT_GATEWAY_MATRIX_WOOPAYMENTS_PREPARED_PATH",
+      "expected_gateway_ids": ["woocommerce_payments"],
+      "status_fields": { "available": "artifact-dependent", "build_failed": "artifact-dependent", "skipped": "artifact-dependent", "blocked": true },
+      "blocked_by": ["https://github.com/Extra-Chill/homeboy-extensions/issues/1336"],
+      "command_profiles": "plugin_woopayments"
+    },
+    {
+      "profile": "plugin_paypal_payments",
+      "label": "WooCommerce PayPal Payments",
+      "dependency_slug": "woocommerce-paypal-payments",
+      "entrypoint": "woocommerce-paypal-payments/woocommerce-paypal-payments.php",
+      "source_path_env": "WC_CHECKOUT_GATEWAY_MATRIX_PAYPAL_PAYMENTS_PATH",
+      "prepared_path_env": "WC_CHECKOUT_GATEWAY_MATRIX_PAYPAL_PAYMENTS_PREPARED_PATH",
+      "expected_gateway_ids": ["ppcp-gateway"],
+      "status_fields": { "available": "artifact-dependent", "build_failed": "artifact-dependent", "skipped": "artifact-dependent", "blocked": true },
+      "blocked_by": ["https://github.com/Extra-Chill/homeboy-extensions/issues/1336"],
+      "command_profiles": "plugin_paypal_payments"
+    },
+    {
+      "profile": "plugin_square",
+      "label": "WooCommerce Square",
+      "dependency_slug": "woocommerce-square",
+      "entrypoint": "woocommerce-square/woocommerce-square.php",
+      "source_path_env": "WC_CHECKOUT_GATEWAY_MATRIX_SQUARE_PATH",
+      "prepared_path_env": "WC_CHECKOUT_GATEWAY_MATRIX_SQUARE_PREPARED_PATH",
+      "expected_gateway_ids": ["square_credit_card"],
+      "status_fields": { "available": "artifact-dependent", "build_failed": "artifact-dependent", "skipped": "artifact-dependent", "blocked": true },
+      "blocked_by": ["https://github.com/Extra-Chill/homeboy-extensions/issues/1336"],
+      "command_profiles": "plugin_square"
+    },
+    {
+      "profile": "plugin_razorpay",
+      "label": "Razorpay for WooCommerce",
+      "dependency_slug": "razorpay",
+      "entrypoint": "razorpay/razorpay.php",
+      "source_path_env": "WC_CHECKOUT_GATEWAY_MATRIX_RAZORPAY_PATH",
+      "prepared_path_env": "WC_CHECKOUT_GATEWAY_MATRIX_RAZORPAY_PREPARED_PATH",
+      "expected_gateway_ids": ["razorpay"],
+      "status_fields": { "available": "artifact-dependent", "build_failed": "artifact-dependent", "skipped": "artifact-dependent", "blocked": true },
+      "blocked_by": ["https://github.com/Extra-Chill/homeboy-extensions/issues/1336"],
+      "command_profiles": "plugin_razorpay"
+    },
+    {
+      "profile": "plugin_mollie",
+      "label": "Mollie Payments for WooCommerce",
+      "dependency_slug": "mollie-payments-for-woocommerce",
+      "entrypoint": "mollie-payments-for-woocommerce/mollie-payments-for-woocommerce.php",
+      "source_path_env": "WC_CHECKOUT_GATEWAY_MATRIX_MOLLIE_PATH",
+      "prepared_path_env": "WC_CHECKOUT_GATEWAY_MATRIX_MOLLIE_PREPARED_PATH",
+      "expected_gateway_ids": ["mollie_wc_gateway_creditcard", "mollie_wc_gateway_ideal", "mollie_wc_gateway_paypal"],
+      "status_fields": { "available": "artifact-dependent", "build_failed": "artifact-dependent", "skipped": "artifact-dependent", "blocked": true },
+      "blocked_by": ["https://github.com/Extra-Chill/homeboy-extensions/issues/1336"],
+      "command_profiles": "plugin_mollie"
+    },
+    {
+      "profile": "plugin_klarna",
+      "label": "Klarna for WooCommerce",
+      "dependency_slug": "klarna-payments-for-woocommerce",
+      "entrypoint": "klarna-payments-for-woocommerce/klarna-payments-for-woocommerce.php",
+      "source_path_env": "WC_CHECKOUT_GATEWAY_MATRIX_KLARNA_PATH",
+      "prepared_path_env": "WC_CHECKOUT_GATEWAY_MATRIX_KLARNA_PREPARED_PATH",
+      "expected_gateway_ids": ["klarna_payments", "kco"],
+      "status_fields": { "available": "artifact-dependent", "build_failed": "artifact-dependent", "skipped": "artifact-dependent", "blocked": true },
+      "blocked_by": ["https://github.com/Extra-Chill/homeboy-extensions/issues/1336"],
+      "command_profiles": "plugin_klarna"
     }
   ],
   "scenarios": [
@@ -146,11 +259,71 @@
       "id": "real_stripe",
       "label": "Real Stripe gateway profile",
       "status": "blocked",
-      "blocked_by": ["https://github.com/Extra-Chill/homeboy-extensions/issues/1336"],
+      "blocked_by": ["https://github.com/chubes4/homeboy-rigs/issues/292", "https://github.com/Extra-Chill/homeboy-extensions/issues/1336"],
       "scenario": "checkout-gateway-compatibility-matrix",
       "command": "homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 --shared-state <shared-state> --setting-json 'bench_env={\"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES\":\"plugin_stripe\"}'",
       "old_fix_expected": "Pending real Stripe dependency-provider stabilization; structured not_configured/build_failed/entrypoint_missing output is blocker evidence, not checkout pass/fail evidence. Reuse the existing WooCommerce Stripe ECE/product-page mounting abstractions instead of adding checkout-only Stripe setup.",
-      "candidate_expected": "PASS once Stripe dependency materialization is stable as a reusable gateway-plugin profile capability; structured build_failed or explicit skip with blocker #1336 is acceptable until then."
+      "candidate_expected": "PASS once Stripe dependency materialization is stable as a reusable gateway-plugin profile capability; structured build_failed or explicit skip with blockers #292 and #1336 is acceptable until then."
+    },
+    {
+      "id": "real_woopayments",
+      "label": "Real WooPayments gateway profile",
+      "status": "blocked",
+      "blocked_by": ["https://github.com/Extra-Chill/homeboy-extensions/issues/1336"],
+      "scenario": "checkout-gateway-compatibility-matrix",
+      "command": "homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 --shared-state <shared-state> --setting-json 'bench_env={\"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES\":\"plugin_woopayments\"}'",
+      "old_fix_expected": "Pending reusable gateway dependency materialization; skip/build_failed output is not payment compatibility evidence.",
+      "candidate_expected": "PASS once WooPayments materializes and registers gateway id woocommerce_payments, or remain explicitly blocked/skipped with structured status fields."
+    },
+    {
+      "id": "real_paypal_payments",
+      "label": "Real WooCommerce PayPal Payments gateway profile",
+      "status": "blocked",
+      "blocked_by": ["https://github.com/Extra-Chill/homeboy-extensions/issues/1336"],
+      "scenario": "checkout-gateway-compatibility-matrix",
+      "command": "homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 --shared-state <shared-state> --setting-json 'bench_env={\"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES\":\"plugin_paypal_payments\"}'",
+      "old_fix_expected": "Pending reusable gateway dependency materialization; skip/build_failed output is not payment compatibility evidence.",
+      "candidate_expected": "PASS once PayPal Payments materializes and registers gateway id ppcp-gateway, or remain explicitly blocked/skipped with structured status fields."
+    },
+    {
+      "id": "real_square",
+      "label": "Real WooCommerce Square gateway profile",
+      "status": "blocked",
+      "blocked_by": ["https://github.com/Extra-Chill/homeboy-extensions/issues/1336"],
+      "scenario": "checkout-gateway-compatibility-matrix",
+      "command": "homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 --shared-state <shared-state> --setting-json 'bench_env={\"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES\":\"plugin_square\"}'",
+      "old_fix_expected": "Pending reusable gateway dependency materialization; skip/build_failed output is not payment compatibility evidence.",
+      "candidate_expected": "PASS once Square materializes and registers gateway id square_credit_card, or remain explicitly blocked/skipped with structured status fields."
+    },
+    {
+      "id": "real_razorpay",
+      "label": "Real Razorpay for WooCommerce gateway profile",
+      "status": "blocked",
+      "blocked_by": ["https://github.com/Extra-Chill/homeboy-extensions/issues/1336"],
+      "scenario": "checkout-gateway-compatibility-matrix",
+      "command": "homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 --shared-state <shared-state> --setting-json 'bench_env={\"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES\":\"plugin_razorpay\"}'",
+      "old_fix_expected": "Pending reusable gateway dependency materialization; skip/build_failed output is not payment compatibility evidence.",
+      "candidate_expected": "PASS once Razorpay materializes and registers gateway id razorpay, or remain explicitly blocked/skipped with structured status fields."
+    },
+    {
+      "id": "real_mollie",
+      "label": "Real Mollie Payments for WooCommerce gateway profile",
+      "status": "blocked",
+      "blocked_by": ["https://github.com/Extra-Chill/homeboy-extensions/issues/1336"],
+      "scenario": "checkout-gateway-compatibility-matrix",
+      "command": "homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 --shared-state <shared-state> --setting-json 'bench_env={\"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES\":\"plugin_mollie\"}'",
+      "old_fix_expected": "Pending reusable gateway dependency materialization; skip/build_failed output is not payment compatibility evidence.",
+      "candidate_expected": "PASS once Mollie materializes and registers one of mollie_wc_gateway_creditcard, mollie_wc_gateway_ideal, or mollie_wc_gateway_paypal, or remain explicitly blocked/skipped with structured status fields."
+    },
+    {
+      "id": "real_klarna",
+      "label": "Real Klarna for WooCommerce gateway profile",
+      "status": "blocked",
+      "blocked_by": ["https://github.com/Extra-Chill/homeboy-extensions/issues/1336"],
+      "scenario": "checkout-gateway-compatibility-matrix",
+      "command": "homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 --shared-state <shared-state> --setting-json 'bench_env={\"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES\":\"plugin_klarna\"}'",
+      "old_fix_expected": "Pending reusable gateway dependency materialization; skip/build_failed output is not payment compatibility evidence.",
+      "candidate_expected": "PASS once Klarna materializes and registers gateway id klarna_payments or kco, or remain explicitly blocked/skipped with structured status fields."
     }
   ]
 }

--- a/woocommerce/woocommerce/tools/checkout-pr-evidence-report.mjs
+++ b/woocommerce/woocommerce/tools/checkout-pr-evidence-report.mjs
@@ -62,12 +62,26 @@ function renderReport(data) {
 		lines.push(`| ${run.label} | ${run.woocommerce_ref} | \`${run.shared_state}\` | ${run.expected} |`);
 	}
 	lines.push('');
+	if (Array.isArray(data.gateway_profiles) && data.gateway_profiles.length > 0) {
+		lines.push('## Gateway Profiles');
+		lines.push('');
+		lines.push('| Profile | Dependency | Expected gateway IDs | Entrypoint | Status fields | Blockers |');
+		lines.push('|---|---|---|---|---|---|');
+		for (const profile of data.gateway_profiles) {
+			const expectedGatewayIds = Array.isArray(profile.expected_gateway_ids) ? profile.expected_gateway_ids.join(', ') : '';
+			const statusFields = profile.status_fields ? Object.entries(profile.status_fields).map(([key, value]) => `${key}=${value}`).join(', ') : '';
+			const blockers = Array.isArray(profile.blocked_by) && profile.blocked_by.length > 0 ? profile.blocked_by.join(', ') : '';
+			lines.push(`| ${profile.profile} | ${profile.dependency_slug} | ${expectedGatewayIds} | ${profile.entrypoint || 'WooCommerce core'} | ${statusFields} | ${blockers} |`);
+		}
+		lines.push('');
+	}
 	lines.push('## Evidence Matrix');
 	lines.push('');
 	lines.push('| Status | Scenario | Command | Old PR shape | Revised candidate |');
 	lines.push('|---|---|---|---|---|');
 	for (const scenario of data.scenarios) {
-		const status = scenario.status === 'blocked' ? `blocked by ${scenario.blocked_by.join(', ')}` : scenario.status;
+		const blockers = Array.isArray(scenario.blocked_by) ? scenario.blocked_by.join(', ') : '';
+		const status = scenario.status === 'blocked' ? `blocked by ${blockers}` : scenario.status;
 		lines.push(`| ${status} | ${scenario.label} | \`${scenario.command}\` | ${scenario.old_fix_expected} | ${scenario.candidate_expected} |`);
 	}
 	lines.push('');


### PR DESCRIPTION
## Summary
- Expand `checkout-gateway-compatibility-matrix` from core controls plus Stripe/PayPal/WooPayments stubs to explicit popular gateway profiles for Stripe, WooPayments, WooCommerce PayPal Payments, WooCommerce Square, Razorpay, Mollie, and Klarna.
- Add dependency metadata, expected gateway IDs, source/prepared path env fields, and structured `available`, `build_failed`, `skipped`, and `blocked` status fields to runtime artifacts and metadata.
- Update the reviewer-facing evidence matrix/report generator and docs so core gateway controls remain ready while real plugin rows stay blocked on dependency-provider materialization.

## Blockers
- Homeboy Rigs real Stripe blocker: https://github.com/chubes4/homeboy-rigs/issues/292
- Homeboy Extensions dependency-provider blocker: https://github.com/Extra-Chill/homeboy-extensions/issues/1336
- Updated blocker comments:
  - https://github.com/chubes4/homeboy-rigs/issues/292#issuecomment-4698742069
  - https://github.com/Extra-Chill/homeboy-extensions/issues/1336#issuecomment-4698741581

## Verification
- `php -l woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php`
- `node -e "JSON.parse(require('node:fs').readFileSync('woocommerce/woocommerce/tools/checkout-pr-evidence-matrix.json','utf8')); console.log('checkout-pr-evidence-matrix.json ok')"`
- `node woocommerce/woocommerce/tools/checkout-pr-evidence-report.mjs >/tmp/checkout-pr-evidence-report.md`
- `git diff --check`

Local `homeboy bench` was not run because this Studio site forbids local benchmark execution; the core/no-network command is documented and preserved for offloaded/Homeboy-runner execution.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the gateway profile matrix expansion, docs/report updates, blocker comments, and verification commands; Chris remains responsible for review and acceptance.