### PR TITLE
Add checkout gateway profile readiness scenario

### DIFF
--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -77,6 +77,22 @@ homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatib
   --setting-json 'bench_env={"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES":"core_bacs,core_cheque,core_cod"}'
 ```
 
+Classify real gateway plugin readiness independently with:
+
+```bash
+homeboy bench --rig woocommerce-performance --scenario checkout-gateway-profile-readiness --iterations 1 \
+  --shared-state /tmp/woocommerce-gateway-profile-readiness
+```
+
+The readiness workload writes structured JSON artifacts under
+`checkout-gateway-profile-readiness/` with plugin source path/revision, prepared
+artifact path, activation result, registered gateway IDs, checkout surface,
+status, reason, and per-profile log tail. Missing dependency-provider output is
+reported per profile as `blocked_dependency_provider` with links to
+https://github.com/chubes4/homeboy-rigs/issues/296 and
+https://github.com/Extra-Chill/homeboy-extensions/issues/1339, so one gateway
+plugin failure does not abort unrelated profiles.
+
 Mount gateway plugins for focused coverage by adding them to
 `validation_dependencies` once Homeboy Extensions supports the selected provider,
 or by overriding `wp_codebox_extra_plugins` and matching source/prepared artifact
@@ -192,6 +208,12 @@ into `tests/bench/`, and returns the normalized Homeboy `BenchResults` envelope.
   report explicit `available`, `build_failed`, `skipped`, and `blocked` details
   when their entrypoint is unavailable or activation fails, so the core controls
   remain runnable without gateway secrets or third-party materialization.
+- `checkout-gateway-profile-readiness` classifies real gateway plugin profile
+  readiness for WooPayments, Stripe, PayPal, Square, Razorpay, Mollie, and
+  Klarna without running checkout payment flows. Each profile is isolated and
+  writes source/revision/artifact/activation/gateway/surface/status/reason/log
+  evidence; dependency-provider gaps are classified as
+  `blocked_dependency_provider` rather than failing the full scenario.
 - `checkout-shipping-cache` seeds simple physical products, configures a flat-rate
   US shipping zone, builds a cart, splits cart contents into configurable shipping
   packages, and measures cold, warm, totals-only churn, and address-rehashed

--- a/woocommerce/woocommerce/bench/checkout-gateway-profile-readiness.php
+++ b/woocommerce/woocommerce/bench/checkout-gateway-profile-readiness.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Classify WooCommerce checkout gateway plugin profile readiness.
+ *
+ * Evidence links:
+ * - https://github.com/chubes4/homeboy-rigs/issues/295
+ * - https://github.com/chubes4/homeboy-rigs/issues/296
+ * - https://github.com/Extra-Chill/homeboy-extensions/issues/1339
+ */
+return function (): array {
+	if ( ! class_exists( 'WooCommerce' ) ) {
+		$woocommerce_entrypoint = WP_PLUGIN_DIR . '/woocommerce/woocommerce.php';
+		if ( ! file_exists( $woocommerce_entrypoint ) ) {
+			throw new RuntimeException( 'WooCommerce plugin entrypoint is not mounted.' );
+		}
+		require_once $woocommerce_entrypoint;
+	}
+
+	if ( ! class_exists( 'WooCommerce' ) || ! function_exists( 'WC' ) ) {
+		throw new RuntimeException( 'WooCommerce is not loaded.' );
+	}
+	if ( ! did_action( 'before_woocommerce_init' ) ) {
+		do_action( 'before_woocommerce_init' );
+	}
+	if ( ! WC()->payment_gateways && class_exists( 'WC_Payment_Gateways' ) ) {
+		WC()->payment_gateways = new WC_Payment_Gateways();
+	}
+
+	$run_id = 'woocommerce-checkout-gateway-profile-readiness-' . getmypid() . '-' . time() . '-' . wp_generate_password( 6, false );
+	$issues = array(
+		'https://github.com/chubes4/homeboy-rigs/issues/295',
+		'https://github.com/chubes4/homeboy-rigs/issues/296',
+		'https://github.com/Extra-Chill/homeboy-extensions/issues/1339',
+	);
+
+	$profiles = array(
+		array(
+			'profile'              => 'plugin_woopayments',
+			'label'                => 'WooPayments',
+			'plugin'               => 'woocommerce-payments',
+			'dependency_slug'      => 'woocommerce-payments',
+			'entrypoint'           => 'woocommerce-payments/woocommerce-payments.php',
+			'source_env'           => array( 'WC_CHECKOUT_GATEWAY_MATRIX_WOOPAYMENTS_PATH' ),
+			'prepared_env'         => array( 'WC_CHECKOUT_GATEWAY_MATRIX_WOOPAYMENTS_PREPARED_PATH' ),
+			'expected_gateway_ids' => array( 'woocommerce_payments' ),
+		),
+		array(
+			'profile'              => 'plugin_stripe',
+			'label'                => 'WooCommerce Stripe Gateway',
+			'plugin'               => 'woocommerce-gateway-stripe',
+			'dependency_slug'      => 'woocommerce-gateway-stripe',
+			'entrypoint'           => 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php',
+			'source_env'           => array( 'WC_CHECKOUT_GATEWAY_MATRIX_STRIPE_PATH', 'HOMEBOY_WC_STRIPE_COMPONENT_PATH' ),
+			'prepared_env'         => array( 'WC_CHECKOUT_GATEWAY_MATRIX_STRIPE_PREPARED_PATH' ),
+			'expected_gateway_ids' => array( 'stripe' ),
+		),
+		array(
+			'profile'              => 'plugin_paypal',
+			'label'                => 'WooCommerce PayPal Payments',
+			'plugin'               => 'woocommerce-paypal-payments',
+			'dependency_slug'      => 'woocommerce-paypal-payments',
+			'entrypoint'           => 'woocommerce-paypal-payments/woocommerce-paypal-payments.php',
+			'source_env'           => array( 'WC_CHECKOUT_GATEWAY_MATRIX_PAYPAL_PAYMENTS_PATH' ),
+			'prepared_env'         => array( 'WC_CHECKOUT_GATEWAY_MATRIX_PAYPAL_PAYMENTS_PREPARED_PATH' ),
+			'expected_gateway_ids' => array( 'ppcp-gateway' ),
+		),
+		array(
+			'profile'              => 'plugin_square',
+			'label'                => 'WooCommerce Square',
+			'plugin'               => 'woocommerce-square',
+			'dependency_slug'      => 'woocommerce-square',
+			'entrypoint'           => 'woocommerce-square/woocommerce-square.php',
+			'source_env'           => array( 'WC_CHECKOUT_GATEWAY_MATRIX_SQUARE_PATH' ),
+			'prepared_env'         => array( 'WC_CHECKOUT_GATEWAY_MATRIX_SQUARE_PREPARED_PATH' ),
+			'expected_gateway_ids' => array( 'square_credit_card' ),
+		),
+		array(
+			'profile'              => 'plugin_razorpay',
+			'label'                => 'Razorpay for WooCommerce',
+			'plugin'               => 'razorpay',
+			'dependency_slug'      => 'razorpay',
+			'entrypoint'           => 'razorpay/razorpay.php',
+			'source_env'           => array( 'WC_CHECKOUT_GATEWAY_MATRIX_RAZORPAY_PATH' ),
+			'prepared_env'         => array( 'WC_CHECKOUT_GATEWAY_MATRIX_RAZORPAY_PREPARED_PATH' ),
+			'expected_gateway_ids' => array( 'razorpay' ),
+		),
+		array(
+			'profile'              => 'plugin_mollie',
+			'label'                => 'Mollie Payments for WooCommerce',
+			'plugin'               => 'mollie-payments-for-woocommerce',
+			'dependency_slug'      => 'mollie-payments-for-woocommerce',
+			'entrypoint'           => 'mollie-payments-for-woocommerce/mollie-payments-for-woocommerce.php',
+			'source_env'           => array( 'WC_CHECKOUT_GATEWAY_MATRIX_MOLLIE_PATH' ),
+			'prepared_env'         => array( 'WC_CHECKOUT_GATEWAY_MATRIX_MOLLIE_PREPARED_PATH' ),
+			'expected_gateway_ids' => array( 'mollie_wc_gateway_creditcard', 'mollie_wc_gateway_ideal', 'mollie_wc_gateway_paypal' ),
+		),
+		array(
+			'profile'              => 'plugin_klarna',
+			'label'                => 'Klarna for WooCommerce',
+			'plugin'               => 'klarna-payments-for-woocommerce',
+			'dependency_slug'      => 'klarna-payments-for-woocommerce',
+			'entrypoint'           => 'klarna-payments-for-woocommerce/klarna-payments-for-woocommerce.php',
+			'source_env'           => array( 'WC_CHECKOUT_GATEWAY_MATRIX_KLARNA_PATH' ),
+			'prepared_env'         => array( 'WC_CHECKOUT_GATEWAY_MATRIX_KLARNA_PREPARED_PATH' ),
+			'expected_gateway_ids' => array( 'klarna_payments', 'kco' ),
+		),
+	);
+
+	$profile_filter = getenv( 'WC_CHECKOUT_GATEWAY_READINESS_PROFILES' );
+	if ( $profile_filter ) {
+		$allowed  = array_filter( array_map( 'trim', explode( ',', $profile_filter ) ) );
+		$profiles = array_values(
+			array_filter(
+				$profiles,
+				static function ( array $profile ) use ( $allowed ): bool {
+					return in_array( $profile['profile'], $allowed, true ) || in_array( $profile['dependency_slug'], $allowed, true );
+				}
+			)
+		);
+	}
+
+	$get_first_env = static function ( array $names ): string {
+		foreach ( $names as $name ) {
+			$value = getenv( $name );
+			if ( false !== $value && '' !== trim( (string) $value ) ) {
+				return (string) $value;
+			}
+		}
+		return '';
+	};
+
+	$get_git_revision = static function ( string $path ): ?string {
+		if ( '' === $path || ! is_dir( $path ) || ! function_exists( 'shell_exec' ) ) {
+			return null;
+		}
+
+		$revision = shell_exec( 'git -C ' . escapeshellarg( $path ) . ' rev-parse HEAD 2>/dev/null' );
+		$revision = is_string( $revision ) ? trim( $revision ) : '';
+		return '' !== $revision ? $revision : null;
+	};
+
+	$classify_profile = static function ( array $profile ) use ( $get_first_env, $get_git_revision ): array {
+		$log_tail       = array();
+		$source_path    = $get_first_env( $profile['source_env'] );
+		$prepared_path  = $get_first_env( $profile['prepared_env'] );
+		$entrypoint     = (string) $profile['entrypoint'];
+		$entrypoint_path = WP_PLUGIN_DIR . '/' . $entrypoint;
+		$mounted_dir    = WP_PLUGIN_DIR . '/' . $profile['plugin'];
+		$result         = array(
+			'profile'                => $profile['profile'],
+			'label'                  => $profile['label'],
+			'plugin'                 => $profile['plugin'],
+			'dependency_slug'        => $profile['dependency_slug'],
+			'plugin_source_path'     => $source_path,
+			'plugin_source_revision' => $get_git_revision( $source_path ),
+			'prepared_artifact_path' => $prepared_path,
+			'entrypoint'             => $entrypoint,
+			'entrypoint_path'        => $entrypoint_path,
+			'mounted_plugin_dir'     => $mounted_dir,
+			'activation'             => 'not_attempted',
+			'expected_gateway_ids'   => $profile['expected_gateway_ids'],
+			'registered_gateway_ids' => array(),
+			'checkout_surface'       => 'woocommerce_checkout_payment_gateways',
+			'status'                 => 'unknown',
+			'reason'                 => '',
+			'blocked_by'             => array(),
+			'log_tail'               => array(),
+		);
+
+		try {
+			if ( ! file_exists( $entrypoint_path ) ) {
+				if ( '' === $source_path && '' === $prepared_path ) {
+					$result['status']     = 'blocked_dependency_provider';
+					$result['reason']     = 'Gateway plugin source/prepared artifact was not provided by the dependency provider.';
+					$result['blocked_by'] = array(
+						'https://github.com/chubes4/homeboy-rigs/issues/296',
+						'https://github.com/Extra-Chill/homeboy-extensions/issues/1339',
+					);
+				} elseif ( '' !== $prepared_path && ! file_exists( $prepared_path ) ) {
+					$result['status'] = 'artifact_missing';
+					$result['reason'] = 'Prepared artifact path is configured but unavailable in the runtime.';
+				} else {
+					$result['status'] = 'entrypoint_missing';
+					$result['reason'] = 'Configured plugin dependency did not mount the expected WordPress entrypoint.';
+				}
+				$log_tail[] = $result['reason'];
+				$result['log_tail'] = array_slice( $log_tail, -10 );
+				return $result;
+			}
+
+			if ( ! function_exists( 'is_plugin_active' ) || ! function_exists( 'activate_plugin' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/plugin.php';
+			}
+
+			if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( $entrypoint ) ) {
+				$activation = activate_plugin( $entrypoint, '', false, true );
+				if ( is_wp_error( $activation ) ) {
+					$result['activation'] = 'failed';
+					$result['status']     = 'activation_failed';
+					$result['reason']     = $activation->get_error_message();
+					$log_tail[]           = 'Activation failed: ' . $result['reason'];
+					$result['log_tail']   = array_slice( $log_tail, -10 );
+					return $result;
+				}
+				$log_tail[] = 'Plugin activated for readiness classification.';
+			}
+
+			$result['activation'] = function_exists( 'is_plugin_active' ) && is_plugin_active( $entrypoint ) ? 'active' : 'loaded';
+			if ( WC()->payment_gateways && method_exists( WC()->payment_gateways, 'init' ) ) {
+				WC()->payment_gateways->init();
+			}
+
+			$gateways                         = WC()->payment_gateways ? WC()->payment_gateways->payment_gateways() : array();
+			$result['registered_gateway_ids'] = array_values(
+				array_filter(
+					$profile['expected_gateway_ids'],
+					static function ( string $gateway_id ) use ( $gateways ): bool {
+						return isset( $gateways[ $gateway_id ] );
+					}
+				)
+			);
+
+			if ( count( $result['registered_gateway_ids'] ) < 1 ) {
+				$result['status'] = 'gateway_missing';
+				$result['reason'] = 'Plugin loaded but none of the expected gateway IDs registered.';
+			} else {
+				$result['status'] = 'ready';
+				$result['reason'] = 'Plugin activated and registered at least one expected checkout gateway.';
+			}
+			$log_tail[] = $result['reason'];
+		} catch ( Throwable $exception ) {
+			$result['status'] = 'classification_failed';
+			$result['reason'] = $exception->getMessage();
+			$log_tail[]       = 'Classification failed: ' . $exception->getMessage();
+		}
+
+		$result['log_tail'] = array_slice( $log_tail, -10 );
+		return $result;
+	};
+
+	$results = array();
+	foreach ( $profiles as $profile ) {
+		$results[] = $classify_profile( $profile );
+	}
+
+	$summary = array(
+		'success_rate'                                => 1,
+		'gateway_profile_readiness_count'             => count( $results ),
+		'gateway_profile_readiness_ready'             => count( array_filter( $results, static fn ( array $result ): bool => 'ready' === $result['status'] ) ),
+		'gateway_profile_readiness_blocked_dependency_provider' => count( array_filter( $results, static fn ( array $result ): bool => 'blocked_dependency_provider' === $result['status'] ) ),
+		'gateway_profile_readiness_failed'            => count( array_filter( $results, static fn ( array $result ): bool => ! in_array( $result['status'], array( 'ready', 'blocked_dependency_provider' ), true ) ) ),
+	);
+
+	$artifact = array(
+		'run_id'   => $run_id,
+		'issues'   => $issues,
+		'profiles' => $results,
+		'metrics'  => $summary,
+	);
+
+	$artifact_path = '';
+	$shared_state  = getenv( 'HOMEBOY_BENCH_SHARED_STATE' );
+	if ( $shared_state ) {
+		$artifact_dir = rtrim( $shared_state, '/' ) . '/checkout-gateway-profile-readiness';
+		wp_mkdir_p( $artifact_dir );
+		$artifact_path = $artifact_dir . '/' . $run_id . '.json';
+		file_put_contents( $artifact_path, wp_json_encode( $artifact, JSON_PRETTY_PRINT ) . "\n" );
+	}
+
+	return array(
+		'metrics'   => $summary,
+		'metadata'  => array(
+			'runner'   => 'wp-codebox',
+			'workload' => 'checkout-gateway-profile-readiness',
+			'issues'   => $issues,
+			'profiles' => array_map(
+				static function ( array $result ): array {
+					return array(
+						'profile'                => $result['profile'],
+						'dependency_slug'        => $result['dependency_slug'],
+						'plugin_source_path'     => $result['plugin_source_path'],
+						'plugin_source_revision' => $result['plugin_source_revision'],
+						'prepared_artifact_path' => $result['prepared_artifact_path'],
+						'activation'             => $result['activation'],
+						'registered_gateway_ids' => $result['registered_gateway_ids'],
+						'checkout_surface'       => $result['checkout_surface'],
+						'status'                 => $result['status'],
+						'reason'                 => $result['reason'],
+						'log_tail'               => $result['log_tail'],
+					);
+				},
+				$results
+			),
+		),
+		'artifacts' => $artifact_path ? array( 'gateway_profile_readiness' => array( 'path' => $artifact_path, 'kind' => 'json' ) ) : array(),
+	);
+};

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -37,6 +37,7 @@
     "wordpress": [
       { "path": "${package.root}/bench/checkout-concurrent-create-order.php" },
       { "path": "${package.root}/bench/checkout-gateway-compatibility-matrix.php" },
+      { "path": "${package.root}/bench/checkout-gateway-profile-readiness.php" },
       { "path": "${package.root}/bench/checkout-shipping-cache.php" },
       { "path": "${package.root}/bench/layered-nav-count-cache.php" },
       { "path": "${package.root}/bench/layered-nav-catalog-crawl.php" }
@@ -46,6 +47,7 @@
     "smoke": [
       "checkout-concurrent-create-order",
       "checkout-gateway-compatibility-matrix",
+      "checkout-gateway-profile-readiness",
       "checkout-shipping-cache",
       "layered-nav-count-cache",
       "layered-nav-catalog-crawl"
@@ -53,6 +55,7 @@
     "hot": [
       "checkout-concurrent-create-order",
       "checkout-gateway-compatibility-matrix",
+      "checkout-gateway-profile-readiness",
       "checkout-shipping-cache",
       "layered-nav-count-cache",
       "layered-nav-catalog-crawl"


### PR DESCRIPTION
## Summary
- Adds `checkout-gateway-profile-readiness` to classify WooPayments, Stripe, PayPal, Square, Razorpay, Mollie, and Klarna independently before running checkout payment-flow evidence.
- Writes structured readiness artifacts with source path/revision, prepared artifact path, activation status, gateway IDs, checkout surface, status, reason, and log tail.
- Keeps dependency-provider gaps isolated per profile as `blocked_dependency_provider` with links to HBR #296 and HBEX #1339 so one plugin failure does not abort unrelated profiles.

Refs #295.
Coordinates with #296 and Extra-Chill/homeboy-extensions#1339.

## Verification
- `php -l woocommerce/woocommerce/bench/checkout-gateway-profile-readiness.php` passed.
- `node woocommerce/woocommerce/tools/checkout-pr-evidence-report.mjs` passed.
- `node scripts/lint-rig-packages.mjs` passed.
- `homeboy rig check woocommerce-performance` passed on the `homeboy-lab` offload runner. Run ID: `29845e46-70b0-4f91-8ef9-a8a9e49ee40f`.

## Blockers
- Offloaded `homeboy bench --rig woocommerce-performance --scenario checkout-gateway-profile-readiness --iterations 1 --shared-state /tmp/woocommerce-gateway-profile-readiness` did not reach WP Codebox because Homeboy Lab refused the WooCommerce component dependency: `/Users/chubes/Developer/woocommerce` is `detached_unpinned`. I did not mutate or repin that external dependency from this HBR scenario branch.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the readiness workload, rig registration, documentation, and verification notes for Chris to review/test.