### PR TITLE
Extract Studio WordPress profile helpers

### DIFF
--- a/Automattic/studio/bench/lib/studio-wordpress-profile.mjs
+++ b/Automattic/studio/bench/lib/studio-wordpress-profile.mjs
@@ -1,0 +1,109 @@
+import { pathToFileURL } from 'node:url';
+
+import {
+  createStudioSite,
+  expandHome,
+  parseStudioSiteStatus,
+  redact,
+  stopStudioSite,
+  studioSiteStatus,
+  variant,
+} from './studio-bench.mjs';
+import {
+  installStudioWordPressFixturePlugins,
+  restoreStudioWordPressFixturePlugins,
+} from './wordpress-fixture-plugins.mjs';
+
+export async function createStudioWordPressProfileSite(sitePath, options = {}) {
+  const wp = envValue(options.wpEnv, options.fallbackWpEnv);
+  const php = envValue(options.phpEnv, options.fallbackPhpEnv);
+  return createStudioSite(sitePath, {
+    name: options.name || `Studio Bench ${variant()} ${options.nameSuffix || 'WordPress Profile'} ${process.pid}`,
+    wp,
+    php,
+    timeoutMs: options.timeoutMs || 420000,
+  });
+}
+
+export async function studioWordPressProfileSiteStatus(sitePath, options = {}) {
+  return studioSiteStatus(sitePath, { timeoutMs: 90000, ...options });
+}
+
+export async function stopStudioWordPressProfileSite(sitePath, options = {}) {
+  return stopStudioSite(sitePath, { timeoutMs: 90000, ...options });
+}
+
+export async function installStudioWordPressProfilePlugins(sitePath, options = {}) {
+  return installStudioWordPressFixturePlugins(sitePath, options);
+}
+
+export async function restoreStudioWordPressProfilePlugins(installedPlugins) {
+  return restoreStudioWordPressFixturePlugins(installedPlugins);
+}
+
+export async function loadStudioWordPressProfileExtensionModule(envVars = []) {
+  const modulePath = expandHome(envValue(...envVars, ''));
+  if (!modulePath) {
+    return null;
+  }
+  return import(pathToFileURL(modulePath).href);
+}
+
+export function parseStudioWordPressProfileSiteStatus(statusResult) {
+  const status = parseStudioSiteStatus(statusResult.stdout);
+  if (!status.siteUrl || !status.autoLoginUrl) {
+    throw new Error(`site status missing siteUrl/autoLoginUrl: ${redact(statusResult.stdout).slice(0, 1000)}`);
+  }
+  return status;
+}
+
+export function summarizeStudioWordPressRequests(entries = [], options = {}) {
+  const byRequest = new Map();
+  for (const entry of entries || []) {
+    const id = entry.request_id || 'unknown';
+    if (!byRequest.has(id)) {
+      byRequest.set(id, []);
+    }
+    byRequest.get(id).push(entry);
+  }
+
+  return [...byRequest.values()]
+    .map((events) => summarizeRequestEvents(events, options))
+    .sort((a, b) => b.duration_ms - a.duration_ms)
+    .slice(0, options.limit || 80);
+}
+
+function summarizeRequestEvents(events, options) {
+  events.sort((a, b) => (a.t_ms || 0) - (b.t_ms || 0));
+  const last = events[events.length - 1];
+  const summary = {
+    uri: redact(last?.uri || ''),
+    method: last?.method,
+    duration_ms: last?.t_ms || 0,
+  };
+
+  if (options.includeHttpUrls) {
+    summary.http_urls = events
+      .filter((event) => event.event === 'http.request.start')
+      .map((event) => redact(event.data?.url || ''));
+  }
+
+  if (options.includeHooks) {
+    summary.hooks = events
+      .filter((event) => event.event === 'hook.stop')
+      .sort((a, b) => (b.data?.duration_ms || 0) - (a.data?.duration_ms || 0))
+      .slice(0, options.hookLimit || 8)
+      .map((event) => ({ hook: event.data?.hook, duration_ms: event.data?.duration_ms }));
+  }
+
+  return summary;
+}
+
+function envValue(...envVars) {
+  for (const envVar of envVars) {
+    if (envVar && process.env[envVar]) {
+      return process.env[envVar];
+    }
+  }
+  return '';
+}

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs
@@ -1,26 +1,28 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
-import { pathToFileURL } from 'node:url';
 import {
   STUDIO_PATH,
   artifactDir as studioArtifactDir,
-  createStudioSite,
+  expandHome,
   metric,
-  parseStudioSiteStatus,
   redact,
   runCli,
   safeResult,
   sanitizeArtifact,
   startStudioSite,
-  stopStudioSite,
-  studioSiteStatus,
   variant,
 } from './lib/studio-bench.mjs';
 import {
-  installStudioWordPressFixturePlugins,
-  restoreStudioWordPressFixturePlugins,
-} from './lib/wordpress-fixture-plugins.mjs';
+  createStudioWordPressProfileSite,
+  installStudioWordPressProfilePlugins,
+  loadStudioWordPressProfileExtensionModule,
+  parseStudioWordPressProfileSiteStatus,
+  restoreStudioWordPressProfilePlugins,
+  stopStudioWordPressProfileSite,
+  studioWordPressProfileSiteStatus,
+  summarizeStudioWordPressRequests,
+} from './lib/studio-wordpress-profile.mjs';
 import {
   buildTimingDeltaSummary,
   flattenPhasedResourceTimings,
@@ -49,20 +51,19 @@ if (!BROWSER_HELPER) {
 const { runBrowserBench } = await import(BROWSER_HELPER);
 
 async function createSite(sitePath) {
-  return createStudioSite(sitePath, {
-    name: `Studio Bench ${variant()} Site Editor Diagnostics ${process.pid}`,
-    wp: process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_WP_VERSION,
-    php: process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_PHP_VERSION,
-    timeoutMs: 420000,
+  return createStudioWordPressProfileSite(sitePath, {
+    nameSuffix: 'Site Editor Diagnostics',
+    wpEnv: 'HOMEBOY_WORDPRESS_PAGE_PROFILE_WP_VERSION',
+    phpEnv: 'HOMEBOY_WORDPRESS_PAGE_PROFILE_PHP_VERSION',
   });
 }
 
 async function siteStatus(sitePath) {
-  return studioSiteStatus(sitePath, { timeoutMs: 90000 });
+  return studioWordPressProfileSiteStatus(sitePath);
 }
 
 async function stopSite(sitePath) {
-  return stopStudioSite(sitePath, { timeoutMs: 90000 });
+  return stopStudioWordPressProfileSite(sitePath);
 }
 
 function siteAdminUrl(siteUrl, relativePath = '') {
@@ -79,14 +80,6 @@ function scrubUrl(url) {
   }
 }
 
-async function loadProfileExtensionModule() {
-  const modulePath = expandHome(process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_EXTENSION_MODULE || '');
-  if (!modulePath) {
-    return null;
-  }
-  return import(pathToFileURL(modulePath).href);
-}
-
 function summarizeNetwork(network, phase) {
   return network
     .filter((request) => request.phase === phase)
@@ -97,38 +90,6 @@ function summarizeNetwork(network, phase) {
       ...request,
       url: scrubUrl(request.url),
     }));
-}
-
-function summarizeWordPressRequests(entries) {
-  const byRequest = new Map();
-  for (const entry of entries || []) {
-    const id = entry.request_id || 'unknown';
-    if (!byRequest.has(id)) {
-      byRequest.set(id, []);
-    }
-    byRequest.get(id).push(entry);
-  }
-
-  return [...byRequest.values()]
-    .map((events) => {
-      events.sort((a, b) => (a.t_ms || 0) - (b.t_ms || 0));
-      const last = events[events.length - 1];
-      return {
-        uri: redact(last?.uri || ''),
-        method: last?.method,
-        duration_ms: last?.t_ms || 0,
-        http_urls: events
-          .filter((event) => event.event === 'http.request.start')
-          .map((event) => redact(event.data?.url || '')),
-        hooks: events
-          .filter((event) => event.event === 'hook.stop')
-          .sort((a, b) => (b.data?.duration_ms || 0) - (a.data?.duration_ms || 0))
-          .slice(0, 8)
-          .map((event) => ({ hook: event.data?.hook, duration_ms: event.data?.duration_ms })),
-      };
-    })
-    .sort((a, b) => b.duration_ms - a.duration_ms)
-    .slice(0, 80);
 }
 
 export default async function studioSiteEditorDiagnosticsBench() {
@@ -173,12 +134,12 @@ export default async function studioSiteEditorDiagnosticsBench() {
       start = await startStudioSite(sitePath, { timeoutMs: 240000 });
     }
     initialStatusResult = await siteStatus(sitePath);
-    installedPlugins = await installStudioWordPressFixturePlugins(sitePath, {
+    installedPlugins = await installStudioWordPressProfilePlugins(sitePath, {
       jsonEnv: 'HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGINS_JSON',
       pathsEnv: 'HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGIN_PATHS',
       activateTimeoutEnv: 'HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGIN_ACTIVATE_TIMEOUT_MS',
     });
-    profileExtension = await loadProfileExtensionModule();
+    profileExtension = await loadStudioWordPressProfileExtensionModule(['HOMEBOY_WORDPRESS_PAGE_PROFILE_EXTENSION_MODULE']);
     if (profileExtension?.setupWordPressPageProfile) {
       const startedSetup = Date.now();
       setupProfile = await profileExtension.setupWordPressPageProfile({
@@ -193,10 +154,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
       };
     }
     statusResult = await siteStatus(sitePath);
-    status = parseStudioSiteStatus(statusResult.stdout);
-    if (!status.siteUrl || !status.autoLoginUrl) {
-      throw new Error(`site status missing siteUrl/autoLoginUrl: ${redact(statusResult.stdout).slice(0, 1000)}`);
-    }
+    status = parseStudioWordPressProfileSiteStatus(statusResult);
 
     const bootstrapTimeline = await installWordPressBootstrapTimeline(sitePath, { clearArtifact: true });
     bootstrapTimelineArtifactPath = bootstrapTimeline.artifactPath;
@@ -341,7 +299,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
             dashboardBetweenRuns: summarizeNetwork(network, 'dashboard-between-runs'),
             measurePage: summarizeNetwork(network, 'measure-page'),
           },
-          wordpressRequests: summarizeWordPressRequests(wordpressRequests),
+          wordpressRequests: summarizeStudioWordPressRequests(wordpressRequests, { includeHttpUrls: true, includeHooks: true, limit: 80 }),
           wordpressBootstrapTimeline: summarizeWordPressBootstrapTimeline(wordpressBootstrapTimeline),
           pageDiagnosis,
           timingDeltas,
@@ -444,7 +402,7 @@ export default async function studioSiteEditorDiagnosticsBench() {
       profiler.uninstallWordPressRequestProfiler?.(sitePath);
     }
     await uninstallWordPressBootstrapTimeline(sitePath);
-    await restoreStudioWordPressFixturePlugins(installedPlugins);
+    await restoreStudioWordPressProfilePlugins(installedPlugins);
     if (createdSite && !stop) {
       stop = await stopSite(sitePath);
     }

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -61,6 +61,10 @@ const {
   installStudioWordPressFixturePlugins,
   restoreStudioWordPressFixturePlugins,
 } = await import('./lib/wordpress-fixture-plugins.mjs');
+const {
+  loadStudioWordPressProfileExtensionModule,
+  summarizeStudioWordPressRequests,
+} = await import('./lib/studio-wordpress-profile.mjs');
 
 function withEnv(values, callback) {
   const previous = {};
@@ -350,6 +354,66 @@ test('Studio WordPress fixture plugins delegate install and restore to Homeboy E
   } finally {
     await rm(fixture.tempDir, { recursive: true, force: true });
   }
+});
+
+test('Studio WordPress profile extension loader honors page profile and admin fallback env prefixes', async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'homeboy-wordpress-profile-extension-'));
+  const pageModulePath = path.join(tempDir, 'page-extension.mjs');
+  const adminModulePath = path.join(tempDir, 'admin-extension.mjs');
+  await writeFile(pageModulePath, 'export const source = "page";\n');
+  await writeFile(adminModulePath, 'export const source = "admin";\n');
+
+  try {
+    await withEnvAsync(
+      {
+        HOMEBOY_WORDPRESS_PAGE_PROFILE_EXTENSION_MODULE: pageModulePath,
+        HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_EXTENSION_MODULE: undefined,
+      },
+      async () => {
+        const extension = await loadStudioWordPressProfileExtensionModule([
+          'HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_EXTENSION_MODULE',
+          'HOMEBOY_WORDPRESS_PAGE_PROFILE_EXTENSION_MODULE',
+        ]);
+        assert.equal(extension.source, 'page');
+      }
+    );
+
+    await withEnvAsync(
+      {
+        HOMEBOY_WORDPRESS_PAGE_PROFILE_EXTENSION_MODULE: pageModulePath,
+        HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_EXTENSION_MODULE: adminModulePath,
+      },
+      async () => {
+        const extension = await loadStudioWordPressProfileExtensionModule([
+          'HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_EXTENSION_MODULE',
+          'HOMEBOY_WORDPRESS_PAGE_PROFILE_EXTENSION_MODULE',
+        ]);
+        assert.equal(extension.source, 'admin');
+      }
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('Studio WordPress request summaries support diagnostics and admin scale shapes', () => {
+  const entries = [
+    { request_id: 'slow', uri: '/wp-admin/site-editor.php?token=secret', method: 'GET', t_ms: 10, event: 'request.start' },
+    { request_id: 'slow', uri: '/wp-admin/site-editor.php?token=secret', method: 'GET', t_ms: 75, event: 'hook.stop', data: { hook: 'init', duration_ms: 20 } },
+    { request_id: 'slow', uri: '/wp-admin/site-editor.php?token=secret', method: 'GET', t_ms: 80, event: 'http.request.start', data: { url: 'https://example.test/?nonce=abc' } },
+    { request_id: 'fast', uri: '/wp-admin/', method: 'GET', t_ms: 5, event: 'request.start' },
+  ];
+
+  const diagnostics = summarizeStudioWordPressRequests(entries, { includeHttpUrls: true, includeHooks: true, limit: 80 });
+  assert.equal(diagnostics[0].duration_ms, 80);
+  assert.match(diagnostics[0].uri, /token=\[redacted\]/);
+  assert.deepEqual(diagnostics[0].hooks, [{ hook: 'init', duration_ms: 20 }]);
+  assert.deepEqual(diagnostics[0].http_urls, ['https://example.test/?nonce=[redacted]']);
+
+  const admin = summarizeStudioWordPressRequests(entries, { limit: 120 });
+  assert.equal(admin[0].duration_ms, 80);
+  assert.equal(admin[0].hooks, undefined);
+  assert.equal(admin[0].http_urls, undefined);
 });
 
 test('timingCorrelatorPath honors the direct WordPress helper env var', () => {

--- a/Automattic/studio/bench/studio-wordpress-admin-scale-sweep.bench.mjs
+++ b/Automattic/studio/bench/studio-wordpress-admin-scale-sweep.bench.mjs
@@ -1,27 +1,27 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
 
 import {
   artifactDir as studioArtifactDir,
-  createStudioSite,
   expandHome,
   metric,
-  parseStudioSiteStatus,
-  redact,
   runCli,
   safeResult,
   sanitizeArtifact,
   setting,
   startStudioSite,
-  stopStudioSite,
-  studioSiteStatus,
   variant,
 } from './lib/studio-bench.mjs';
 import {
-  installStudioWordPressFixturePlugins,
-  restoreStudioWordPressFixturePlugins,
-} from './lib/wordpress-fixture-plugins.mjs';
+  createStudioWordPressProfileSite,
+  installStudioWordPressProfilePlugins,
+  loadStudioWordPressProfileExtensionModule,
+  parseStudioWordPressProfileSiteStatus,
+  restoreStudioWordPressProfilePlugins,
+  stopStudioWordPressProfileSite,
+  studioWordPressProfileSiteStatus,
+  summarizeStudioWordPressRequests,
+} from './lib/studio-wordpress-profile.mjs';
 import {
   loadWordPressAdminScaleSweepManifest,
 } from './lib/wordpress-admin-scale-sweep.mjs';
@@ -39,32 +39,21 @@ if (!BROWSER_HELPER) {
 const { runBrowserBench } = await import(BROWSER_HELPER);
 
 async function createSite(sitePath) {
-  return createStudioSite(sitePath, {
-    name: `Studio Bench ${variant()} WordPress Admin Scale Sweep ${process.pid}`,
-    wp: process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_WP_VERSION || process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_WP_VERSION,
-    php: process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_PHP_VERSION || process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_PHP_VERSION,
-    timeoutMs: 420000,
+  return createStudioWordPressProfileSite(sitePath, {
+    nameSuffix: 'WordPress Admin Scale Sweep',
+    wpEnv: 'HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_WP_VERSION',
+    fallbackWpEnv: 'HOMEBOY_WORDPRESS_PAGE_PROFILE_WP_VERSION',
+    phpEnv: 'HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_PHP_VERSION',
+    fallbackPhpEnv: 'HOMEBOY_WORDPRESS_PAGE_PROFILE_PHP_VERSION',
   });
 }
 
 async function siteStatus(sitePath) {
-  return studioSiteStatus(sitePath, { timeoutMs: 90000 });
+  return studioWordPressProfileSiteStatus(sitePath);
 }
 
 async function stopSite(sitePath) {
-  return stopStudioSite(sitePath, { timeoutMs: 90000 });
-}
-
-async function loadProfileExtensionModule() {
-  const modulePath = expandHome(
-    process.env.HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_EXTENSION_MODULE ||
-      process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_EXTENSION_MODULE ||
-      ''
-  );
-  if (!modulePath) {
-    return null;
-  }
-  return import(pathToFileURL(modulePath).href);
+  return stopStudioWordPressProfileSite(sitePath);
 }
 
 function manifestHasInteractions(manifest) {
@@ -125,30 +114,6 @@ function adaptAdminPageSummary({ pageSpec, pageSummary, profile, artifacts }) {
   };
 }
 
-function summarizeWordPressRequests(entries = []) {
-  const byRequest = new Map();
-  for (const entry of entries) {
-    const id = entry.request_id || 'unknown';
-    if (!byRequest.has(id)) {
-      byRequest.set(id, []);
-    }
-    byRequest.get(id).push(entry);
-  }
-
-  return [...byRequest.values()]
-    .map((events) => {
-      events.sort((a, b) => (a.t_ms || 0) - (b.t_ms || 0));
-      const last = events[events.length - 1];
-      return {
-        uri: redact(last?.uri || ''),
-        method: last?.method,
-        duration_ms: last?.t_ms || 0,
-      };
-    })
-    .sort((a, b) => b.duration_ms - a.duration_ms)
-    .slice(0, 120);
-}
-
 export default async function studioWordPressAdminScaleSweepBench() {
   const currentVariant = variant();
   const { path: profilerPath, module: profiler } = loadWordPressRequestProfiler();
@@ -193,14 +158,17 @@ export default async function studioWordPressAdminScaleSweepBench() {
       start = await startStudioSite(sitePath, { timeoutMs: 240000 });
     }
     initialStatusResult = await siteStatus(sitePath);
-    installedPlugins = await installStudioWordPressFixturePlugins(sitePath, {
+    installedPlugins = await installStudioWordPressProfilePlugins(sitePath, {
       jsonEnv: 'HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_PLUGINS_JSON',
       pathsEnv: 'HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_PLUGIN_PATHS',
       fallbackJsonEnv: 'HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGINS_JSON',
       fallbackPathsEnv: 'HOMEBOY_WORDPRESS_PAGE_PROFILE_PLUGIN_PATHS',
       activateTimeoutEnv: 'HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_PLUGIN_ACTIVATE_TIMEOUT_MS',
     });
-    profileExtension = await loadProfileExtensionModule();
+    profileExtension = await loadStudioWordPressProfileExtensionModule([
+      'HOMEBOY_WORDPRESS_ADMIN_SCALE_SWEEP_EXTENSION_MODULE',
+      'HOMEBOY_WORDPRESS_PAGE_PROFILE_EXTENSION_MODULE',
+    ]);
     assertInteractionSupport({ manifest, pageProfiler, profileExtension });
     assertAdminSweepSummarySupport({ pageProfiler, profileExtension });
     if (profileExtension?.setupWordPressAdminScaleSweep || profileExtension?.setupWordPressPageProfile) {
@@ -211,10 +179,7 @@ export default async function studioWordPressAdminScaleSweepBench() {
     }
 
     statusResult = await siteStatus(sitePath);
-    status = parseStudioSiteStatus(statusResult.stdout);
-    if (!status.siteUrl || !status.autoLoginUrl) {
-      throw new Error(`site status missing siteUrl/autoLoginUrl: ${redact(statusResult.stdout).slice(0, 1000)}`);
-    }
+    status = parseStudioWordPressProfileSiteStatus(statusResult);
 
     profiler?.installWordPressRequestProfiler?.(sitePath);
 
@@ -315,7 +280,7 @@ export default async function studioWordPressAdminScaleSweepBench() {
           },
           pages: pageResults,
           combinedSummary: summary,
-          wordpressRequests: summarizeWordPressRequests(wordpressRequests),
+          wordpressRequests: summarizeStudioWordPressRequests(wordpressRequests, { limit: 120 }),
           commands: {
             create: safeResult(create),
             start: safeResult(start),
@@ -371,7 +336,7 @@ export default async function studioWordPressAdminScaleSweepBench() {
     if (profiler) {
       profiler.uninstallWordPressRequestProfiler?.(sitePath);
     }
-    await restoreStudioWordPressFixturePlugins(installedPlugins);
+    await restoreStudioWordPressProfilePlugins(installedPlugins);
     if (createdSite && !stop) {
       stop = await stopSite(sitePath);
     }


### PR DESCRIPTION
## Summary
- Extract shared Studio WordPress profile/site lifecycle helpers into `bench/lib/studio-wordpress-profile.mjs`.
- Update Site Editor diagnostics and WordPress admin scale sweep workloads to configure env-specific behavior instead of duplicating helpers.
- Add coverage for admin fallback extension env resolution and request summary shapes.

Fixes #281.

## Verification
- `node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `node --check Automattic/studio/bench/lib/studio-wordpress-profile.mjs && node --check Automattic/studio/bench/studio-site-editor-diagnostics.bench.mjs && node --check Automattic/studio/bench/studio-wordpress-admin-scale-sweep.bench.mjs`

Broader repo Node test sweep was attempted with `node --test Automattic/studio/bench/*.test.mjs shared/webperf/*.test.mjs woocommerce/woocommerce-gateway-stripe/bench/*.test.mjs`; touched tests passed, but existing `studio-agent-site-build.test.mjs` cases failed because `HOMEBOY_WORDPRESS_HELPER_MANIFEST` / materialized site quality helper was unavailable in this local environment.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and verified the helper extraction and PR description; Chris remains responsible for review and merge.