### PR TITLE
Fix checkout gateway readiness status contract

### DIFF
--- a/woocommerce/woocommerce/bench/checkout-gateway-profile-readiness.php
+++ b/woocommerce/woocommerce/bench/checkout-gateway-profile-readiness.php
@@ -55,7 +55,7 @@ return function (): array {
 			'expected_gateway_ids' => array( 'stripe' ),
 		),
 		array(
-			'profile'              => 'plugin_paypal',
+			'profile'              => 'plugin_paypal_payments',
 			'label'                => 'WooCommerce PayPal Payments',
 			'plugin'               => 'woocommerce-paypal-payments',
 			'dependency_slug'      => 'woocommerce-paypal-payments',
@@ -107,6 +107,9 @@ return function (): array {
 	);
 
 	$profile_filter = getenv( 'WC_CHECKOUT_GATEWAY_READINESS_PROFILES' );
+	if ( false === $profile_filter || '' === trim( (string) $profile_filter ) ) {
+		$profile_filter = getenv( 'WC_CHECKOUT_GATEWAY_MATRIX_PROFILES' );
+	}
 	if ( $profile_filter ) {
 		$allowed  = array_filter( array_map( 'trim', explode( ',', $profile_filter ) ) );
 		$profiles = array_values(
@@ -177,10 +180,10 @@ return function (): array {
 						'https://github.com/Extra-Chill/homeboy-extensions/issues/1339',
 					);
 				} elseif ( '' !== $prepared_path && ! file_exists( $prepared_path ) ) {
-					$result['status'] = 'artifact_missing';
+					$result['status'] = 'build_failed';
 					$result['reason'] = 'Prepared artifact path is configured but unavailable in the runtime.';
 				} else {
-					$result['status'] = 'entrypoint_missing';
+					$result['status'] = 'missing_gateway';
 					$result['reason'] = 'Configured plugin dependency did not mount the expected WordPress entrypoint.';
 				}
 				$log_tail[] = $result['reason'];
@@ -196,7 +199,7 @@ return function (): array {
 				$activation = activate_plugin( $entrypoint, '', false, true );
 				if ( is_wp_error( $activation ) ) {
 					$result['activation'] = 'failed';
-					$result['status']     = 'activation_failed';
+					$result['status']     = 'fatal';
 					$result['reason']     = $activation->get_error_message();
 					$log_tail[]           = 'Activation failed: ' . $result['reason'];
 					$result['log_tail']   = array_slice( $log_tail, -10 );
@@ -221,7 +224,7 @@ return function (): array {
 			);
 
 			if ( count( $result['registered_gateway_ids'] ) < 1 ) {
-				$result['status'] = 'gateway_missing';
+				$result['status'] = 'missing_gateway';
 				$result['reason'] = 'Plugin loaded but none of the expected gateway IDs registered.';
 			} else {
 				$result['status'] = 'ready';
@@ -229,7 +232,7 @@ return function (): array {
 			}
 			$log_tail[] = $result['reason'];
 		} catch ( Throwable $exception ) {
-			$result['status'] = 'classification_failed';
+			$result['status'] = 'fatal';
 			$result['reason'] = $exception->getMessage();
 			$log_tail[]       = 'Classification failed: ' . $exception->getMessage();
 		}


### PR DESCRIPTION
## Summary
- Align the PayPal readiness profile key with the gateway matrix contract.
- Let readiness runs use `WC_CHECKOUT_GATEWAY_MATRIX_PROFILES`, matching dependency scoping.
- Normalize readiness failure statuses to the documented matrix vocabulary.

## Evidence
- Lab readiness run without materialized gateway deps: `e0c2ed4f-4d26-4f00-9927-ad4e93d4015f`
- Focused Stripe run with unresolved local-path dependency: `c732c239-3651-4af0-9434-9030ee45f5ee`
- wp.org materialization blocker run: `0c55a8a7-b54a-42f6-9c81-76c238be949a`

The wp.org run exposed an upstream WP Codebox activation-order blocker: dependency plugins can be activated before WooCommerce. The companion upstream fix is in https://github.com/Automattic/wp-codebox/pull/938.

## Testing
- `php -l woocommerce/woocommerce/bench/checkout-gateway-profile-readiness.php`
- `node scripts/lint-rig-packages.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed gateway readiness contract mismatches, drafted the minimal workload fix, and ran targeted lint/Lab validation. Chris remains responsible for review and merge.