### PR TITLE
Isolate checkout gateway readiness runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Local benchmark outputs and artifacts.
 .bench-output/
+**/artifacts/
 
 # macOS Finder metadata.
 .DS_Store

--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -168,6 +168,7 @@ WooCommerce plugin directory.
 homeboy rig up woocommerce-performance
 homeboy bench --rig woocommerce-performance --scenario checkout-concurrent-create-order --iterations 1 --shared-state /tmp/woocommerce-concurrent-checkout
 homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 --shared-state /tmp/woocommerce-gateway-matrix
+HOMEBOY_BIN=/path/to/homeboy node tools/checkout-gateway-readiness-matrix.mjs --runner homeboy-lab --path /path/to/woocommerce/plugins/woocommerce --shared-state /tmp/woocommerce-gateway-profile-readiness --output artifacts/checkout-gateway-readiness-matrix.json
 homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-bench
 homeboy bench --rig woocommerce-performance --scenario checkout-shortcode-place-order-latency --iterations 1 --shared-state /tmp/woocommerce-shortcode-checkout
 homeboy bench --rig woocommerce-performance --scenario admin-dashboard-physical-products-query --iterations 1 --shared-state /tmp/woocommerce-admin-dashboard-products --setting-json 'bench_env={"WC_ADMIN_DASHBOARD_PRODUCTS":"500","WC_ADMIN_DASHBOARD_TERMS":"20"}'
@@ -220,10 +221,13 @@ into `tests/bench/`, and returns the normalized Homeboy `BenchResults` envelope.
   unavailable, activation fails, gateway discovery misses, or credentials/external
   accounts are required, so the core controls remain runnable without gateway
   secrets or third-party materialization.
-- `checkout-gateway-profile-readiness` classifies real gateway plugin profile
-  readiness for WooPayments, Stripe, PayPal, Square, Razorpay, Mollie, and
-  Klarna without running checkout payment flows. Each profile is isolated and
-  writes source/revision/artifact/activation/gateway/surface/status/reason/log
+- `checkout-gateway-profile-readiness` classifies one real gateway plugin profile
+  at a time without running checkout payment flows. Use
+  `tools/checkout-gateway-readiness-matrix.mjs` for the full WooPayments,
+  Stripe, PayPal, Square, Razorpay, Mollie, and Klarna set; it launches one
+  Homeboy bench run per profile so one plugin fatal becomes that profile's
+  structured status instead of aborting unrelated profiles. Each profile writes
+  source/revision/artifact/activation/gateway/surface/status/reason/log
   evidence; dependency-provider gaps are classified as
   `blocked_dependency_provider` rather than failing the full scenario.
 - `checkout-shipping-cache` seeds simple physical products, configures a flat-rate

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -9,6 +9,12 @@
       "extensions": {
         "wordpress": {
           "wp_codebox_wordpress_version": "7.0",
+          "wp_codebox_prepare_steps": [
+            {
+              "command": "php",
+              "args": ["bin/generate-feature-config.php"]
+            }
+          ],
           "bench_env": {
             "WC_CHECKOUT_GATEWAY_MATRIX_PROFILES": "core_bacs,core_cheque,core_cod,plugin_stripe,plugin_woopayments,plugin_paypal_payments,plugin_square,plugin_razorpay,plugin_mollie,plugin_klarna",
             "WC_SHIPPING_CACHE_CART_ITEMS": "40",

--- a/woocommerce/woocommerce/tools/checkout-gateway-readiness-matrix.mjs
+++ b/woocommerce/woocommerce/tools/checkout-gateway-readiness-matrix.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+const profiles = [
+	{
+		profile: 'plugin_woopayments',
+		slug: 'woocommerce-payments',
+		dependency: 'woocommerce-payments',
+		plugin_file: 'woocommerce-payments/woocommerce-payments.php',
+	},
+	{
+		profile: 'plugin_stripe',
+		slug: 'woocommerce-gateway-stripe',
+		dependency: 'woocommerce-gateway-stripe',
+		plugin_file: 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php',
+	},
+	{
+		profile: 'plugin_paypal_payments',
+		slug: 'woocommerce-paypal-payments',
+		dependency: 'woocommerce-paypal-payments',
+		plugin_file: 'woocommerce-paypal-payments/woocommerce-paypal-payments.php',
+	},
+	{
+		profile: 'plugin_square',
+		slug: 'woocommerce-square',
+		dependency: 'woocommerce-square',
+		plugin_file: 'woocommerce-square/woocommerce-square.php',
+	},
+	{
+		profile: 'plugin_razorpay',
+		slug: 'razorpay',
+		dependency: 'razorpay',
+		plugin_file: 'razorpay/razorpay.php',
+	},
+	{
+		profile: 'plugin_mollie',
+		slug: 'mollie-payments-for-woocommerce',
+		dependency: 'mollie-payments-for-woocommerce',
+		plugin_file: 'mollie-payments-for-woocommerce/mollie-payments-for-woocommerce.php',
+	},
+	{
+		profile: 'plugin_klarna',
+		slug: 'klarna-payments-for-woocommerce',
+		dependency: 'klarna-payments-for-woocommerce',
+		plugin_file: 'klarna-payments-for-woocommerce/klarna-payments-for-woocommerce.php',
+	},
+];
+
+function parseArgs(argv) {
+	const options = {
+		runner: '',
+		rig: 'woocommerce-performance',
+		path: '',
+		sharedState: '/tmp/woocommerce-gateway-profile-readiness',
+		output: 'artifacts/checkout-gateway-readiness-matrix.json',
+		profiles: profiles.map((entry) => entry.profile),
+	};
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		const readValue = () => {
+			const value = argv[index + 1];
+			if (!value) {
+				throw new Error(`${arg} requires a value`);
+			}
+			index += 1;
+			return value;
+		};
+
+		if (arg === '--runner') {
+			options.runner = readValue();
+		} else if (arg === '--rig') {
+			options.rig = readValue();
+		} else if (arg === '--path') {
+			options.path = readValue();
+		} else if (arg === '--shared-state') {
+			options.sharedState = readValue();
+		} else if (arg === '--output') {
+			options.output = readValue();
+		} else if (arg === '--profiles') {
+			options.profiles = readValue().split(',').map((profile) => profile.trim()).filter(Boolean);
+		} else if (arg === '--help' || arg === '-h') {
+			usage();
+			process.exit(0);
+		} else {
+			throw new Error(`Unknown argument: ${arg}`);
+		}
+	}
+
+	if (!options.path) {
+		throw new Error('--path is required');
+	}
+
+	return options;
+}
+
+function usage() {
+	console.log(`Usage: node tools/checkout-gateway-readiness-matrix.mjs --path <woocommerce-plugin-path> [options]
+
+Options:
+  --runner <id>          Homeboy Lab runner id.
+  --rig <id>             Homeboy rig id. Default: woocommerce-performance.
+  --shared-state <path>  Shared state prefix. Default: /tmp/woocommerce-gateway-profile-readiness.
+  --profiles <csv>       Profile keys to run. Default: all plugin profiles.
+  --output <path>        Aggregate JSON output path.
+
+Environment:
+  HOMEBOY_BIN            Homeboy executable path. Default: homeboy.
+`);
+}
+
+function extractFatal(output) {
+	const fatalMatch = output.match(/Fatal error:\s*(.*?)\n/i);
+	if (fatalMatch) {
+		return fatalMatch[1].replace(/<[^>]+>/g, '').trim();
+	}
+
+	const errorMatch = output.match(/Error:\s*(.*?)\n/i);
+	return errorMatch ? errorMatch[1].replace(/<[^>]+>/g, '').trim() : '';
+}
+
+function extractRunId(output) {
+	const hintMatch = output.match(/Persisted benchmark run ID:\s*([a-f0-9-]+)/i);
+	if (hintMatch) {
+		return hintMatch[1];
+	}
+
+	const jsonMatch = output.match(/"id"\s*:\s*"([a-f0-9-]{36})"/);
+	return jsonMatch ? jsonMatch[1] : '';
+}
+
+function extractWorkloadStatus(output, profile) {
+	const profilePattern = new RegExp(`"profile"\\s*:\\s*"${profile.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"[\\s\\S]{0,2000}?"status"\\s*:\\s*"([^"]+)"`);
+	const match = output.match(profilePattern);
+	return match ? match[1] : '';
+}
+
+function classifyStatus(exitCode, fatal, workloadStatus) {
+	if (exitCode === 0) {
+		return workloadStatus || 'passed';
+	}
+
+	if (fatal) {
+		return 'fatal';
+	}
+
+	return 'build_failed';
+}
+
+function isPassingStatus(status) {
+	return status === 'ready' || status === 'passed';
+}
+
+function runProfile(options, profile) {
+	const homeboyBin = process.env.HOMEBOY_BIN || 'homeboy';
+	const dependency = {
+		source_type: 'wp.org',
+		slug: profile.slug,
+		dependency: profile.dependency,
+		plugin_file: profile.plugin_file,
+		profiles: [profile.profile],
+		profile_env: 'WC_CHECKOUT_GATEWAY_MATRIX_PROFILES',
+	};
+
+	const args = [
+		'bench',
+		'--rig',
+		options.rig,
+		'--scenario',
+		'checkout-gateway-profile-readiness',
+		'--iterations',
+		'1',
+		'--path',
+		options.path,
+		'--shared-state',
+		`${options.sharedState}-${profile.profile}`,
+		'--setting-json',
+		`bench_env=${JSON.stringify({ WC_CHECKOUT_GATEWAY_MATRIX_PROFILES: profile.profile })}`,
+		'--setting-json',
+		`validation_dependencies=${JSON.stringify([dependency])}`,
+	];
+
+	if (options.runner) {
+		args.splice(1, 0, '--runner', options.runner);
+	}
+
+	const result = spawnSync(homeboyBin, args, { encoding: 'utf8' });
+	const output = `${result.stdout || ''}\n${result.stderr || ''}`;
+	const fatal = result.status === 0 ? '' : extractFatal(output);
+	const workloadStatus = extractWorkloadStatus(output, profile.profile);
+	const status = classifyStatus(result.status, fatal, workloadStatus);
+
+	return {
+		profile: profile.profile,
+		dependency: profile.dependency,
+		plugin_file: profile.plugin_file,
+		status,
+		exit_code: result.status,
+		run_id: extractRunId(output),
+		fatal,
+		workload_status: workloadStatus,
+		output_tail: output.split('\n').slice(-80),
+	};
+}
+
+const options = parseArgs(process.argv.slice(2));
+const selectedProfiles = profiles.filter((profile) => options.profiles.includes(profile.profile));
+const results = [];
+
+for (const profile of selectedProfiles) {
+	console.log(`[gateway-readiness] ${profile.profile}`);
+	const result = runProfile(options, profile);
+	results.push(result);
+	console.log(`[gateway-readiness] ${profile.profile}: ${result.status}${result.run_id ? ` (${result.run_id})` : ''}`);
+}
+
+const artifact = {
+	schema: 'homeboy-rigs/woocommerce-gateway-readiness-matrix/v1',
+	generated_at: new Date().toISOString(),
+	runner: options.runner || 'local',
+	rig: options.rig,
+	homeboy_bin: process.env.HOMEBOY_BIN || 'homeboy',
+	component_path: options.path,
+	profiles: results,
+	summary: {
+		total: results.length,
+		ready: results.filter((result) => result.status === 'ready').length,
+		passed: results.filter((result) => result.status === 'passed').length,
+		fatal: results.filter((result) => result.status === 'fatal').length,
+		build_failed: results.filter((result) => result.status === 'build_failed').length,
+	},
+};
+
+mkdirSync(dirname(resolve(options.output)), { recursive: true });
+writeFileSync(options.output, `${JSON.stringify(artifact, null, 2)}\n`);
+console.log(`[gateway-readiness] wrote ${options.output}`);
+
+process.exitCode = results.some((result) => !isPassingStatus(result.status)) ? 1 : 0;


### PR DESCRIPTION
## Summary
- Add a gateway readiness matrix wrapper that runs each real gateway profile as its own Homeboy bench invocation.
- Add WooCommerce feature-config preparation to the rig so Lab-materialized Woo checkouts can load consistently.
- Ignore generated local artifact directories and document the isolated readiness command.

## Evidence
- `node --check tools/checkout-gateway-readiness-matrix.mjs`
- `HOMEBOY_BIN=/Users/chubes/.cargo/bin/homeboy node tools/checkout-gateway-readiness-matrix.mjs --runner homeboy-lab --path /Users/chubes/Developer/woocommerce@proof-gateway-readiness-woo-20260614/plugins/woocommerce --shared-state /tmp/woocommerce-gateway-profile-readiness-20260614-final --output artifacts/checkout-gateway-readiness-matrix.json`

Final Lab readiness rows:
- `plugin_woopayments`: `ready`, run `030eb06f-8e39-4ad4-8f15-14ab05fac602`
- `plugin_stripe`: `ready`, run `6a0f1ded-01ac-4294-a2d5-5164063a68a2`
- `plugin_paypal_payments`: `ready`, run `bc8296d7-9bef-4de8-ac03-ef1f15188af4`
- `plugin_square`: `fatal`, run `35ab7229-a428-4ceb-b58f-0ca49a62ebfd`
- `plugin_razorpay`: `blocked_dependency_provider`, run `d43eb2c6-ad54-4791-b561-2b8ff9173677`
- `plugin_mollie`: `fatal`, run `05898afd-654d-4614-a3ce-5040cae87bc1`
- `plugin_klarna`: `ready`, run `b05cc2dd-cebe-49e9-92ba-89e082caeeed`

Refs https://github.com/chubes4/homeboy-rigs/issues/303.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the isolated wrapper, rig prep update, documentation, and Lab validation summary for Chris to review.