### PR TITLE
Suppress checkout evidence emails

### DIFF
--- a/woocommerce/woocommerce/bench/checkout-concurrent-create-order.php
+++ b/woocommerce/woocommerce/bench/checkout-concurrent-create-order.php
@@ -44,6 +44,13 @@ return function (): array {
 	if ( ! WC()->payment_gateways && class_exists( 'WC_Payment_Gateways' ) ) {
 		WC()->payment_gateways = new WC_Payment_Gateways();
 	}
+	if ( method_exists( WC(), 'mailer' ) ) {
+		foreach ( WC()->mailer()->get_emails() as $email ) {
+			if ( isset( $email->id ) ) {
+				add_filter( 'woocommerce_email_enabled_' . $email->id, '__return_false', 999 );
+			}
+		}
+	}
 
 	global $wpdb;
 

--- a/woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php
+++ b/woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php
@@ -35,6 +35,13 @@ return function (): array {
 	if ( ! WC()->payment_gateways && class_exists( 'WC_Payment_Gateways' ) ) {
 		WC()->payment_gateways = new WC_Payment_Gateways();
 	}
+	if ( method_exists( WC(), 'mailer' ) ) {
+		foreach ( WC()->mailer()->get_emails() as $email ) {
+			if ( isset( $email->id ) ) {
+				add_filter( 'woocommerce_email_enabled_' . $email->id, '__return_false', 999 );
+			}
+		}
+	}
 
 	$run_id = 'woocommerce-checkout-gateway-compatibility-matrix-' . getmypid() . '-' . time() . '-' . wp_generate_password( 6, false );
 	$issues = array(


### PR DESCRIPTION
## Summary
- Disable Woo transactional email sends in the checkout evidence workloads.
- Keep status transitions and checkout hooks active while avoiding email template rendering noise in synthetic benchmark flows.

## Evidence
- `php -l woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php`
- `php -l woocommerce/woocommerce/bench/checkout-concurrent-create-order.php`
- `homeboy rig check woocommerce-performance` on `homeboy-lab`: `f92344df-0679-4327-b1cb-c2fb60377e76`
- Rerun moved past the prior `wc_get_email_order_items()` email-template fatal and produced bench-result metrics, but WP Codebox still failed parsing because a non-fatal PHP warning was printed before JSON. Follow-up upstream blocker: https://github.com/Automattic/wp-codebox/issues/959

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Diagnosed checkout evidence email rendering noise, drafted the workload filter change, and ran validation for Chris to review.