### PR TITLE
Own Stripe ECE fixture in rig package

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,29 @@ homeboy trace --rig woocommerce-stripe-ece-product-page woocommerce-gateway-stri
 homeboy trace --rig woocommerce-stripe-ece-product-page woocommerce-gateway-stripe ece-product-page-variation-change
 ```
 
+Use Homeboy's visual compare hook with the WP Codebox provider when collecting
+reviewer-facing parity proof for a PR:
+
+```bash
+homeboy trace compare \
+  --rig woocommerce-stripe-ece-product-page \
+  --baseline-target origin/develop \
+  --candidate <candidate-ref-or-sha> \
+  --schedule interleaved \
+  --repeat 3 \
+  --report markdown \
+  --visual-compare \
+  --visual-compare-provider node \
+  --visual-provider-arg "$HOME/Developer/homeboy-extensions/wordpress/lib/wp-codebox-visual-compare.js" \
+  --visual-threshold 0.1 \
+  woocommerce-gateway-stripe ece-product-page-waterfall \
+  --output /tmp/wc-stripe-ece-product-page-proof.md
+```
+
+The provider calls WP Codebox's `wordpress.visual-compare` primitive against the
+baseline/candidate screenshots captured by the trace workload and emits source,
+candidate, diff, JSON diff, and explanation artifacts.
+
 The `smoke` profile keeps the default WP Codebox browser behavior. The optional
 `secure-browser` profile depends on generic upstream preview/profile contracts
 from Extra-Chill/homeboy#3554 and Automattic/wp-codebox#651/#652 and keeps

--- a/woocommerce/woocommerce-gateway-stripe/README.md
+++ b/woocommerce/woocommerce-gateway-stripe/README.md
@@ -58,8 +58,9 @@ Secondary noisy metrics:
 
 ## Prerequisites
 
-The Stripe checkout must include `tests/benchmarks/fixture-bootstrap.php`, which
-is added by https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5522.
+The deterministic benchmark fixture is owned by this rig package at
+`bench/fixture-bootstrap.php`; the Stripe checkout under test does not need to
+carry benchmark fixture files.
 
 For `homeboy rig check`, use `HOMEBOY_WC_STRIPE_COMPONENT_PATH` when the target
 Stripe checkout is a worktree instead of `~/Developer/woocommerce-gateway-stripe`:
@@ -132,6 +133,31 @@ homeboy trace \
   woocommerce-gateway-stripe ece-product-page-waterfall
 ```
 
+Run baseline/candidate proof with WP Codebox visual parity artifacts:
+
+```bash
+homeboy trace compare \
+  --rig woocommerce-stripe-ece-product-page \
+  --baseline-target origin/develop \
+  --candidate <candidate-ref-or-sha> \
+  --schedule interleaved \
+  --repeat 3 \
+  --report markdown \
+  --visual-compare \
+  --visual-compare-provider node \
+  --visual-provider-arg "$HOME/Developer/homeboy-extensions/wordpress/lib/wp-codebox-visual-compare.js" \
+  --visual-threshold 0.1 \
+  woocommerce-gateway-stripe ece-product-page-waterfall \
+  --output /tmp/wc-stripe-ece-product-page-proof.md
+```
+
+`--visual-compare` reuses the screenshots captured by the trace workload and
+passes them to Homeboy Extensions' WP Codebox visual compare provider. The
+provider calls WP Codebox's `wordpress.visual-compare` primitive and writes
+source, candidate, diff, `visual-diff.json`, and `visual-explanation.json`
+artifacts under the trace compare output directory. This keeps the rig focused
+on producing browser evidence while WP Codebox owns the visual diff primitive.
+
 Useful settings:
 
 - `HOMEBOY_WC_STRIPE_ECE_LOCATIONS=product`
@@ -142,9 +168,9 @@ Useful settings:
 ## Real Wallet Profile
 
 The default `smoke`, `hot`, and interaction profiles remain synthetic lifecycle
-evidence. They intentionally keep working with the Stripe benchmark fixture's
-placeholder keys so network, DOM, and CLS-style render timing can be collected
-without real Stripe credentials.
+evidence. They intentionally keep working with the rig-owned Stripe benchmark
+fixture's placeholder keys so network, DOM, and CLS-style render timing can be
+collected without real Stripe credentials.
 
 Use the `real-wallet` profile when collecting real-wallet-capable ECE evidence:
 

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -22,6 +22,7 @@ const eceLocations = process.env.HOMEBOY_WC_STRIPE_ECE_LOCATIONS || 'product';
 const acceptedPaymentMethods = process.env.HOMEBOY_WC_STRIPE_ACCEPTED_PAYMENT_METHODS || 'card,link';
 const probeDuration = process.env.HOMEBOY_WC_STRIPE_ECE_PROBE_DURATION || '7s';
 const viewport = process.env.HOMEBOY_WC_STRIPE_ECE_VIEWPORT || '1366x900';
+const fixtureBootstrapPath = path.join(import.meta.dirname, 'fixture-bootstrap.php');
 const profileOptions = buildEceProfileOptions();
 const encodedStripePublishableKey = profileOptions.stripePublishableKey ? Buffer.from(profileOptions.stripePublishableKey).toString('base64') : '';
 const encodedStripeSecretKey = profileOptions.stripeSecretKey ? Buffer.from(profileOptions.stripeSecretKey).toString('base64') : '';
@@ -32,8 +33,8 @@ if (!componentPath) {
 if (!resultsFile) {
   throw new Error('HOMEBOY_TRACE_RESULTS_FILE is required');
 }
-if (!existsSync(path.join(componentPath, 'tests/benchmarks/fixture-bootstrap.php'))) {
-  throw new Error('Missing tests/benchmarks/fixture-bootstrap.php in the Stripe checkout. Run against woocommerce-gateway-stripe#5522 or later.');
+if (!existsSync(fixtureBootstrapPath)) {
+  throw new Error(`Missing rig-owned Stripe fixture at ${fixtureBootstrapPath}.`);
 }
 if (!existsSync(path.join(woocommercePath, 'woocommerce.php'))) {
   throw new Error(`Missing WooCommerce dependency plugin at ${woocommercePath}. Set HOMEBOY_WC_STRIPE_WOOCOMMERCE_PATH to a packaged WooCommerce plugin directory.`);
@@ -172,7 +173,7 @@ try {
   await writeFile(
     setupFile,
     `<?php
-require_once WP_PLUGIN_DIR . '/woocommerce-gateway-stripe/tests/benchmarks/fixture-bootstrap.php';
+${(await readFile(fixtureBootstrapPath, 'utf8')).replace(/^<\?php\s*/, '')}
 
 $ece_locations = json_decode( '${JSON.stringify(csvToJsonArray(eceLocations))}', true );
 $accepted_payment_methods = json_decode( '${JSON.stringify(csvToJsonArray(acceptedPaymentMethods))}', true );

--- a/woocommerce/woocommerce-gateway-stripe/bench/fixture-bootstrap.php
+++ b/woocommerce/woocommerce-gateway-stripe/bench/fixture-bootstrap.php
@@ -1,0 +1,372 @@
+<?php
+/**
+ * Plain WordPress fixture bootstrap for WooCommerce Stripe benchmark rigs.
+ *
+ * @package Homeboy_Rigs\WooCommerce_Gateway_Stripe
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	return;
+}
+
+if ( ! class_exists( 'WC_Stripe_Benchmark_Fixture_Bootstrap' ) ) {
+	/**
+	 * Builds deterministic WooCommerce/Stripe state for benchmark workloads.
+	 */
+	class WC_Stripe_Benchmark_Fixture_Bootstrap {
+		private const DEFAULT_ARGS = [
+			'currency'                 => 'USD',
+			'product_name'             => 'Stripe Benchmark Product',
+			'product_sku'              => 'stripe-benchmark-product',
+			'product_price'            => '10.00',
+			'cart_quantity'            => 1,
+			'checkout_page_title'      => 'Checkout',
+			'cart_page_title'          => 'Cart',
+			'stripe_publishable_key'   => '',
+			'stripe_secret_key'        => '',
+			'stripe_webhook_secret'    => '',
+			'ece_locations'            => [ 'product', 'cart', 'checkout' ],
+			'optimized_checkout'       => false,
+			'accepted_payment_methods' => [ 'card', 'link' ],
+		];
+
+		/**
+		 * Bootstrap fixture state and assert it is ready for benchmark timing.
+		 *
+		 * @param array<string, mixed> $args Fixture overrides.
+		 * @return array<string, mixed> Fixture state for workload logging.
+		 */
+		public static function bootstrap( array $args = [] ): array {
+			$args = array_merge( self::DEFAULT_ARGS, self::env_args(), $args );
+
+			self::assert_runtime_loaded();
+			self::ensure_woocommerce_install_state();
+			self::ensure_store_settings( (string) $args['currency'] );
+
+			$cart_page_id     = self::ensure_page( 'woocommerce_cart_page_id', (string) $args['cart_page_title'], '[woocommerce_cart]' );
+			$checkout_page_id = self::ensure_page( 'woocommerce_checkout_page_id', (string) $args['checkout_page_title'], '[woocommerce_checkout]' );
+			$shipping_zone    = self::ensure_flat_rate_shipping();
+			$product_id       = self::ensure_simple_product(
+				(string) $args['product_name'],
+				(string) $args['product_sku'],
+				(string) $args['product_price']
+			);
+
+			self::configure_stripe_settings( $args );
+			self::setup_cart( $product_id, (int) $args['cart_quantity'] );
+
+			$state = [
+				'product_id'       => $product_id,
+				'cart_page_id'     => $cart_page_id,
+				'checkout_page_id' => $checkout_page_id,
+				'shipping_zone_id' => $shipping_zone['zone_id'],
+				'shipping_rate_id' => $shipping_zone['rate_id'],
+				'cart_quantity'    => (int) $args['cart_quantity'],
+				'currency'         => (string) $args['currency'],
+				'ece_locations'    => array_values( (array) $args['ece_locations'] ),
+			];
+
+			self::assert_preflight( $state );
+
+			return $state;
+		}
+
+		/**
+		 * Assert the fixture is ready. Call this immediately before benchmark timing.
+		 *
+		 * @param array<string, mixed> $state Fixture state from bootstrap().
+		 */
+		public static function assert_preflight( array $state ): void {
+			self::assert_runtime_loaded();
+
+			$product = wc_get_product( (int) $state['product_id'] );
+			if ( ! $product || ! $product->is_purchasable() || ! $product->is_in_stock() ) {
+				throw new RuntimeException( 'Benchmark fixture setup failed: benchmark product is missing, not purchasable, or out of stock.' );
+			}
+
+			$checkout_page = get_post( (int) $state['checkout_page_id'] );
+			if ( ! $checkout_page || 'publish' !== $checkout_page->post_status ) {
+				throw new RuntimeException( 'Benchmark fixture setup failed: checkout page is missing or not published.' );
+			}
+
+			if ( ! WC()->cart || WC()->cart->is_empty() ) {
+				throw new RuntimeException( 'Benchmark fixture setup failed: WooCommerce cart is empty.' );
+			}
+
+			$packages = WC()->shipping()->calculate_shipping( WC()->cart->get_shipping_packages() );
+			$rates    = [];
+			foreach ( $packages as $package ) {
+				$rates = array_merge( $rates, (array) ( $package['rates'] ?? [] ) );
+			}
+
+			if ( empty( $rates ) ) {
+				throw new RuntimeException( 'Benchmark fixture setup failed: no WooCommerce shipping rates are available for the benchmark cart.' );
+			}
+
+			$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+			foreach ( [ 'enabled', 'testmode', 'test_publishable_key', 'test_secret_key' ] as $key ) {
+				if ( empty( $stripe_settings[ $key ] ) ) {
+					throw new RuntimeException( sprintf( 'Benchmark fixture setup failed: Stripe setting "%s" is empty.', $key ) );
+				}
+			}
+
+			if ( 'yes' !== $stripe_settings['enabled'] || 'yes' !== $stripe_settings['testmode'] || 'yes' !== ( $stripe_settings['payment_request'] ?? '' ) ) {
+				throw new RuntimeException( 'Benchmark fixture setup failed: Stripe gateway and express checkout must be enabled in test mode.' );
+			}
+
+			$locations = (array) ( $stripe_settings['payment_request_button_locations'] ?? [] );
+			foreach ( (array) $state['ece_locations'] as $location ) {
+				if ( ! in_array( $location, $locations, true ) ) {
+					throw new RuntimeException( sprintf( 'Benchmark fixture setup failed: Stripe express checkout must be enabled for "%s".', $location ) );
+				}
+			}
+
+			$available_gateways = WC()->payment_gateways()->get_available_payment_gateways();
+			if ( empty( $available_gateways['stripe'] ) ) {
+				throw new RuntimeException( 'Benchmark fixture setup failed: Stripe is not available as a checkout gateway.' );
+			}
+		}
+
+		private static function assert_runtime_loaded(): void {
+			$required_classes = [
+				'WooCommerce'       => class_exists( 'WooCommerce' ),
+				'WC_Product_Simple' => class_exists( 'WC_Product_Simple' ),
+				'WC_Stripe'         => class_exists( 'WC_Stripe' ),
+				'WC_Stripe_Helper'  => class_exists( 'WC_Stripe_Helper' ),
+			];
+
+			foreach ( $required_classes as $label => $loaded ) {
+				if ( ! $loaded ) {
+					throw new RuntimeException( sprintf( 'Benchmark fixture setup failed: required runtime class "%s" is not loaded.', $label ) );
+				}
+			}
+
+			if ( ! function_exists( 'WC' ) || ! WC() ) {
+				throw new RuntimeException( 'Benchmark fixture setup failed: WooCommerce runtime is not initialized.' );
+			}
+		}
+
+		private static function ensure_woocommerce_install_state(): void {
+			if ( class_exists( 'WC_Install' ) ) {
+				WC_Install::create_tables();
+				WC_Install::create_roles();
+			}
+
+			if ( function_exists( 'wc_update_product_lookup_tables_is_running' ) && ! wc_update_product_lookup_tables_is_running() ) {
+				delete_transient( 'wc_product_loop' );
+			}
+		}
+
+		private static function ensure_store_settings( string $currency ): void {
+			update_option( 'woocommerce_store_address', '60 29th Street' );
+			update_option( 'woocommerce_store_address_2', '#343' );
+			update_option( 'woocommerce_store_city', 'San Francisco' );
+			update_option( 'woocommerce_default_country', 'US:CA' );
+			update_option( 'woocommerce_store_postcode', '94110' );
+			update_option( 'woocommerce_currency', $currency );
+			update_option( 'woocommerce_product_type', 'both' );
+			update_option( 'woocommerce_allow_tracking', 'no' );
+			update_option( 'woocommerce_coming_soon', 'no' );
+		}
+
+		private static function ensure_page( string $option_name, string $title, string $content ): int {
+			$page_id = absint( get_option( $option_name ) );
+			$page    = $page_id ? get_post( $page_id ) : null;
+
+			if ( $page && 'page' === $page->post_type && 'publish' === $page->post_status ) {
+				return $page_id;
+			}
+
+			$page_id = wp_insert_post(
+				[
+					'post_title'   => $title,
+					'post_name'    => sanitize_title( $title ),
+					'post_type'    => 'page',
+					'post_status'  => 'publish',
+					'post_content' => $content,
+				],
+				true
+			);
+
+			if ( is_wp_error( $page_id ) ) {
+				throw new RuntimeException( 'Benchmark fixture setup failed: could not create ' . $title . ' page. ' . $page_id->get_error_message() );
+			}
+
+			update_option( $option_name, (int) $page_id );
+
+			return (int) $page_id;
+		}
+
+		private static function ensure_simple_product( string $name, string $sku, string $price ): int {
+			$product_id = wc_get_product_id_by_sku( $sku );
+			$product    = $product_id ? wc_get_product( $product_id ) : null;
+
+			if ( ! $product ) {
+				$product = new WC_Product_Simple();
+				$product->set_sku( $sku );
+			}
+
+			$product->set_name( $name );
+			$product->set_regular_price( $price );
+			$product->set_price( $price );
+			$product->set_manage_stock( false );
+			$product->set_stock_status( 'instock' );
+			$product->set_catalog_visibility( 'visible' );
+			$product->set_virtual( false );
+			$product->set_downloadable( false );
+			$product->save();
+
+			return (int) $product->get_id();
+		}
+
+		private static function ensure_flat_rate_shipping(): array {
+			if ( ! class_exists( 'WC_Shipping_Zones' ) || ! class_exists( 'WC_Shipping_Zone' ) ) {
+				throw new RuntimeException( 'Benchmark fixture setup failed: WooCommerce shipping zones are not available.' );
+			}
+
+			$zone_id = 0;
+			foreach ( WC_Shipping_Zones::get_zones() as $zone ) {
+				if ( 'Benchmark Everywhere' === ( $zone['zone_name'] ?? '' ) ) {
+					$zone_id = (int) $zone['zone_id'];
+					break;
+				}
+			}
+
+			$shipping_zone = $zone_id ? new WC_Shipping_Zone( $zone_id ) : new WC_Shipping_Zone();
+			if ( ! $zone_id ) {
+				$shipping_zone->set_zone_name( 'Benchmark Everywhere' );
+				$shipping_zone->save();
+			}
+
+			$instance_id = 0;
+			foreach ( $shipping_zone->get_shipping_methods() as $method ) {
+				if ( 'flat_rate' === $method->id ) {
+					$instance_id = (int) $method->get_instance_id();
+					break;
+				}
+			}
+
+			if ( ! $instance_id ) {
+				$instance_id = (int) $shipping_zone->add_shipping_method( 'flat_rate' );
+			}
+
+			update_option(
+				'woocommerce_flat_rate_' . $instance_id . '_settings',
+				[
+					'title'      => 'Benchmark flat rate',
+					'tax_status' => 'taxable',
+					'cost'       => '10',
+				]
+			);
+
+			WC_Cache_Helper::get_transient_version( 'shipping', true );
+
+			return [
+				'zone_id' => $shipping_zone->get_id(),
+				'rate_id' => 'flat_rate:' . $instance_id,
+			];
+		}
+
+		private static function configure_stripe_settings( array $args ): void {
+			$locations                = array_values( (array) $args['ece_locations'] );
+			$accepted_payment_methods = array_values( (array) $args['accepted_payment_methods'] );
+
+			$settings = array_merge(
+				WC_Stripe_Helper::get_stripe_settings(),
+				[
+					'enabled'                                   => 'yes',
+					'title'                                     => 'Credit Card (Stripe)',
+					'description'                               => 'Pay with your credit card via Stripe.',
+					'api_credentials'                           => '',
+					'testmode'                                  => 'yes',
+					'test_publishable_key'                      => (string) $args['stripe_publishable_key'],
+					'test_secret_key'                           => (string) $args['stripe_secret_key'],
+					'publishable_key'                           => '',
+					'secret_key'                                => '',
+					'webhook'                                   => '',
+					'test_webhook_secret'                       => (string) $args['stripe_webhook_secret'],
+					'webhook_secret'                            => '',
+					'inline_cc_form'                            => 'no',
+					'statement_descriptor'                      => '',
+					'short_statement_descriptor'                => '',
+					'capture'                                   => 'yes',
+					'payment_request'                           => 'yes',
+					'payment_request_button_type'               => 'buy',
+					'payment_request_button_theme'              => 'dark',
+					'payment_request_button_locations'          => $locations,
+					'payment_request_button_size'               => 'default',
+					'express_checkout'                          => 'yes',
+					'express_checkout_button_type'              => 'buy',
+					'express_checkout_button_theme'             => 'dark',
+					'express_checkout_button_locations'         => $locations,
+					'express_checkout_button_size'              => 'default',
+					'saved_cards'                               => 'yes',
+					'logging'                                   => 'no',
+					'upe_checkout_experience_enabled'           => 'yes',
+					'upe_checkout_experience_accepted_payments' => $accepted_payment_methods,
+					'optimized_checkout_element'                => ! empty( $args['optimized_checkout'] ) ? 'yes' : 'no',
+				]
+			);
+
+			WC_Stripe_Helper::update_main_stripe_settings( $settings );
+
+			if ( function_exists( 'woocommerce_gateway_stripe' ) && class_exists( 'WC_Stripe' ) ) {
+				$closure = Closure::bind(
+					function () {
+						$this->stripe_gateway = null;
+					},
+					woocommerce_gateway_stripe(),
+					WC_Stripe::class
+				);
+				$closure();
+			}
+
+			if ( WC()->payment_gateways() ) {
+				WC()->payment_gateways()->payment_gateways = [];
+				WC()->payment_gateways()->init();
+			}
+		}
+
+		private static function setup_cart( int $product_id, int $quantity ): void {
+			if ( function_exists( 'wc_load_cart' ) ) {
+				wc_load_cart();
+			}
+
+			if ( ! WC()->session && class_exists( 'WC_Session_Handler' ) ) {
+				WC()->session = new WC_Session_Handler();
+				WC()->session->init();
+			}
+
+			if ( ! WC()->cart && class_exists( 'WC_Cart' ) ) {
+				WC()->cart = new WC_Cart();
+			}
+
+			if ( ! WC()->customer && class_exists( 'WC_Customer' ) ) {
+				WC()->customer = new WC_Customer( 0, true );
+			}
+
+			WC()->cart->empty_cart();
+			$cart_key = WC()->cart->add_to_cart( $product_id, max( 1, $quantity ) );
+			if ( ! $cart_key ) {
+				throw new RuntimeException( 'Benchmark fixture setup failed: could not add benchmark product to cart.' );
+			}
+
+			WC()->cart->calculate_totals();
+		}
+
+		private static function env_args(): array {
+			return [
+				'stripe_publishable_key' => self::env( 'STRIPE_PUBLISHABLE_KEY', 'pk_test_benchmark_fixture' ),
+				'stripe_secret_key'      => self::env( 'STRIPE_SECRET_KEY', 'sk_test_benchmark_fixture' ),
+				'stripe_webhook_secret'  => self::env( 'STRIPE_WEBHOOK_SECRET', '' ),
+			];
+		}
+
+		private static function env( string $name, string $default ): string {
+			$value = getenv( $name );
+			return false === $value ? $default : (string) $value;
+		}
+	}
+}

--- a/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
+++ b/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
@@ -8,7 +8,7 @@ https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1439.
 
 1. Start a disposable WP Codebox WordPress runtime.
 2. Activate WooCommerce and WooCommerce Stripe.
-3. Run `tests/benchmarks/fixture-bootstrap.php` from the Stripe checkout.
+3. Run the rig-owned `bench/fixture-bootstrap.php` fixture.
 4. Configure Stripe test/ECE settings with product-page ECE enabled.
 5. Create a simple purchasable product.
 6. Open the product page in a browser probe.
@@ -107,6 +107,33 @@ The stable signals are structural:
   `browser_layout_shift_count`, `ece_render_final_container_height`,
   `ece_render_final_wallets_link_height`, and metadata-level layout-shift source
   rectangles for the ECE container/sentinel path.
+
+## Visual Parity
+
+Use Homeboy's trace compare visual hook with Homeboy Extensions' WP Codebox
+provider when a PR needs reviewer-facing visual parity evidence:
+
+```bash
+homeboy trace compare \
+  --rig woocommerce-stripe-ece-product-page \
+  --baseline-target origin/develop \
+  --candidate <candidate-ref-or-sha> \
+  --schedule interleaved \
+  --repeat 3 \
+  --report markdown \
+  --visual-compare \
+  --visual-compare-provider node \
+  --visual-provider-arg "$HOME/Developer/homeboy-extensions/wordpress/lib/wp-codebox-visual-compare.js" \
+  --visual-threshold 0.1 \
+  woocommerce-gateway-stripe ece-product-page-waterfall \
+  --output /tmp/wc-stripe-ece-product-page-proof.md
+```
+
+The ECE workload already captures screenshots through `wordpress.browser-probe`.
+`--visual-compare` pairs the baseline and candidate screenshots, then calls WP
+Codebox's `wordpress.visual-compare` primitive through the provider. The proof
+artifacts include `source.png`, `candidate.png`, `diff.png`, `visual-diff.json`,
+and `visual-explanation.json` for the compared browser variant.
 
 ## Secondary Signals
 

--- a/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
+++ b/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
@@ -304,8 +304,8 @@
       },
       {
         "kind": "command",
-        "label": "Stripe benchmark fixture exists",
-        "command": "stripe_path=\"${HOMEBOY_WC_STRIPE_COMPONENT_PATH:-$HOME/Developer/woocommerce-gateway-stripe}\"; test -f \"$stripe_path/tests/benchmarks/fixture-bootstrap.php\" || { printf '%s\\n' \"Missing Stripe benchmark fixture at $stripe_path/tests/benchmarks/fixture-bootstrap.php. Run against a checkout containing woocommerce-gateway-stripe#5522 or later.\"; exit 1; }"
+        "label": "Rig-owned Stripe benchmark fixture exists",
+        "command": "test -f \"${package.root}/bench/fixture-bootstrap.php\" || { printf '%s\\n' \"Missing rig-owned Stripe benchmark fixture at ${package.root}/bench/fixture-bootstrap.php.\"; exit 1; }"
       },
       {
         "kind": "command",


### PR DESCRIPTION
## Summary

- Moves the WooCommerce Stripe ECE benchmark fixture into the rig package so Stripe checkouts under test do not need to carry benchmark fixture files.
- Updates the ECE product-page workload and rig check to use the rig-owned fixture.
- Documents the Homeboy visual-compare path using the WP Codebox `wordpress.visual-compare` provider for reviewer-facing parity proof.

## Verification

- `node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs`
- `php -l woocommerce/woocommerce-gateway-stripe/bench/fixture-bootstrap.php`
- `node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`
- `git diff --check`
- `homeboy rig check woocommerce-stripe-ece-product-page` via `homeboy-lab`: pass, run `a56064c8-7ead-4125-9033-e1ed00ab6b20`

Did not run the rig locally after operator instruction not to run local validation.

## Homeboy follow-ups

- Extra-Chill/homeboy#4442: stale runner-side rig source registry blocked offloaded rig checks; fixed by Extra-Chill/homeboy#4447.
- Extra-Chill/homeboy#4441: `rig sources`/`rig install` help advertised `--runner`, but runtime rejected it; fixed by Extra-Chill/homeboy#4447.
- Extra-Chill/homeboy#4466: `homeboy upgrade --method source --force` did not activate a newer same-semver build, so validation used the fixed source binary for runner registry repair before rerunning the normal offloaded rig check.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the rig fixture migration, docs updates, and verification notes for Chris to review.