### PR TITLE
Stabilize checkout side-effect evidence rigs

### DIFF
--- a/woocommerce/woocommerce/bench/checkout-concurrent-create-order.php
+++ b/woocommerce/woocommerce/bench/checkout-concurrent-create-order.php
@@ -92,6 +92,9 @@ return function (): array {
 			'enable_for_virtual' => 'yes',
 		)
 	);
+	if ( class_exists( 'WC_Payment_Gateways' ) ) {
+		WC()->payment_gateways = new WC_Payment_Gateways();
+	}
 
 	if ( ! WC()->session ) {
 		if ( method_exists( WC(), 'initialize_session' ) ) {
@@ -104,6 +107,7 @@ return function (): array {
 	if ( WC()->session ) {
 		WC()->session->set_customer_session_cookie( true );
 		WC()->session->__unset( 'order_awaiting_payment' );
+		WC()->session->__unset( 'checkout_pending_order_id' );
 	}
 
 	wc_load_cart();
@@ -174,6 +178,7 @@ return function (): array {
 		}
 		if ( WC()->session ) {
 			WC()->session->__unset( 'order_awaiting_payment' );
+			WC()->session->__unset( 'checkout_pending_order_id' );
 		}
 
 		$cart_item_key = 'homeboy_concurrent_checkout_' . md5( $run_id . ':' . $cart_product->get_id() . ':' . $quantity );
@@ -275,6 +280,9 @@ return function (): array {
 		$previous_scenario      = $hook_observer_scenario;
 		$hook_observer_scenario = $scenario;
 		$before_index           = count( $hook_events );
+		if ( function_exists( 'wc_clear_notices' ) ) {
+			wc_clear_notices();
+		}
 		try {
 			$result = $callback();
 			return array(
@@ -284,6 +292,9 @@ return function (): array {
 				'hook_events'      => array_slice( $hook_events, $before_index ),
 			);
 		} finally {
+			if ( function_exists( 'wc_clear_notices' ) ) {
+				wc_clear_notices();
+			}
 			$hook_observer_scenario = $previous_scenario;
 		}
 	};
@@ -437,6 +448,7 @@ return function (): array {
 				WC()->session->set( 'order_awaiting_payment', $order->get_id() );
 			} else {
 				WC()->session->__unset( 'order_awaiting_payment' );
+				WC()->session->__unset( 'checkout_pending_order_id' );
 			}
 		}
 
@@ -519,6 +531,7 @@ return function (): array {
 		$cart_session->set_session();
 		$session->set( 'chosen_payment_method', 'free' === $payment_mode ? '' : 'cod' );
 		$session->set( 'order_awaiting_payment', null );
+		$session->set( 'checkout_pending_order_id', null );
 		$session->set(
 			'customer',
 			array(
@@ -927,6 +940,7 @@ return function (): array {
 			$set_cart( 1 );
 			if ( WC()->session ) {
 				WC()->session->__unset( 'order_awaiting_payment' );
+				WC()->session->__unset( 'checkout_pending_order_id' );
 			}
 
 			$fresh_data                         = $data;
@@ -937,6 +951,8 @@ return function (): array {
 			$fresh_redirect                     = '';
 			$unexpected_process_checkout_output = '';
 			$sentinel_message                   = 'homeboy-fresh-checkout-hook-observer-complete-' . $run_id;
+			$process_checkout_error             = '';
+			$process_checkout_notices           = array();
 
 			$capture_processed_order = static function ( int $order_id ) use ( &$fresh_order_id ): void {
 				$fresh_order_id = $order_id;
@@ -960,30 +976,32 @@ return function (): array {
 
 			add_action( 'woocommerce_checkout_order_processed', $capture_processed_order, 1, 1 );
 			add_filter( 'woocommerce_payment_successful_result', $intercept_redirect, 1000, 1 );
+			wc_clear_notices();
 			ob_start();
 			try {
 				WC()->checkout()->process_checkout();
-			} catch ( RuntimeException $exception ) {
+			} catch ( Throwable $exception ) {
 				if ( $sentinel_message !== $exception->getMessage() ) {
-					throw $exception;
+					$process_checkout_error = $exception->getMessage();
 				}
 			} finally {
 				$unexpected_process_checkout_output = (string) ob_get_clean();
+				$process_checkout_notices           = function_exists( 'wc_get_notices' ) ? wc_get_notices() : array();
+				wc_clear_notices();
 				remove_action( 'woocommerce_checkout_order_processed', $capture_processed_order, 1 );
 				remove_filter( 'woocommerce_payment_successful_result', $intercept_redirect, 1000 );
 				$_POST    = $post_before;
 				$_REQUEST = $request_before;
 			}
 
-			if ( ! $fresh_order_id ) {
-				throw new RuntimeException( 'Fresh process_checkout did not reach woocommerce_checkout_order_processed.' );
-			}
-
-			$fresh_order = wc_get_order( $fresh_order_id );
+			$fresh_order = $fresh_order_id ? wc_get_order( $fresh_order_id ) : null;
 			return array(
 				'order_id'                => $fresh_order_id,
 				'order_status'            => $fresh_order instanceof WC_Order ? $fresh_order->get_status() : '',
 				'redirect'                => $fresh_redirect,
+				'reached_order_processed' => $fresh_order_id > 0,
+				'error'                   => $process_checkout_error,
+				'notices'                 => $process_checkout_notices,
 				'unexpected_output_bytes' => strlen( $unexpected_process_checkout_output ),
 			);
 		}
@@ -1144,9 +1162,14 @@ return function (): array {
 		$changed_coupon_after_first = $coupon_snapshot( $changed_cart_coupon, $changed_coupon_first_order_id );
 		WC()->session->set( 'order_awaiting_payment', $changed_coupon_first_order_id );
 		$changed_coupon_original_hash = wc_get_order( $changed_coupon_first_order_id )->get_cart_hash();
-		$changed_coupon_cart = $set_cart( 2 );
+		$set_cart( 2 );
 		WC()->cart->apply_coupon( $changed_cart_coupon->get_code() );
 		WC()->cart->calculate_totals();
+		$changed_coupon_cart = array(
+			'cart_hash'  => WC()->cart->get_cart_hash(),
+			'cart_count' => WC()->cart->get_cart_contents_count(),
+			'cart_total' => (float) WC()->cart->get_total( 'edit' ),
+		);
 		WC()->session->set( 'order_awaiting_payment', $changed_coupon_first_order_id );
 		$changed_coupon_retry_order_id = $create_order( $data );
 		$changed_coupon_retry_order = wc_get_order( $changed_coupon_retry_order_id );
@@ -1214,6 +1237,7 @@ return function (): array {
 		WC()->cart->calculate_totals();
 		if ( WC()->session ) {
 			WC()->session->__unset( 'order_awaiting_payment' );
+			WC()->session->__unset( 'checkout_pending_order_id' );
 		}
 		$public_second_order_id = $create_order( $data );
 		$public_after_second = $coupon_snapshot( $public_coupon, $public_second_order_id );
@@ -1357,7 +1381,7 @@ return function (): array {
 		'order_pay_failed_order_resume_clears_cart'               => $order_pay_metrics['cart_cleared_after_pay_action'],
 		'order_pay_failed_order_resume_redirects_to_received'     => $order_pay_metrics['redirect_contains_order_received'],
 		'order_pay_endpoint_sets_session_cookie'                  => $order_pay_metrics['session_cookie_after_order_pay'],
-		'legacy_coupon_independence'                              => ! $coupon_metrics['covered'] || ( ! $coupon_metrics['public_create_order_sets_session'] && ! $coupon_metrics['public_create_order_clears_cart'] && $coupon_metrics['order_coupon_line_count'] > 0 ),
+		'legacy_coupon_independence'                              => ! $coupon_metrics['covered'] || (bool) ( $coupon_metrics['guardrails']['public_create_order_independent_coupon_orders'] ?? false ),
 		'hook_fresh_checkout_order_processed_once'                => 1 === $hook_count( 'fresh_checkout_process_checkout', 'woocommerce_checkout_order_processed' ),
 		'hook_public_create_order_skips_order_processed'          => 0 === $hook_count( 'public_create_order_outside_process_checkout', 'woocommerce_checkout_order_processed' ),
 		'hook_same_cart_pending_retry_resumes_once'                => 1 === $hook_count( 'same_cart_retry_pending', 'woocommerce_resume_order' ),
@@ -1378,9 +1402,6 @@ return function (): array {
 			}
 		)
 	);
-	if ( $failed_guardrails ) {
-		throw new RuntimeException( 'Checkout side-effect guardrail failure: ' . implode( ', ', $failed_guardrails ) );
-	}
 
 	$concurrent_iterations = array();
 	$concurrent_metrics    = array();
@@ -1578,7 +1599,7 @@ return function (): array {
 	);
 
 	$summary = array(
-		'success_rate'                                            => 1,
+		'success_rate'                                            => $failed_guardrails ? 0 : 1,
 		'duplicate_reproduced'                                    => $duplicate_created,
 		'order_create_attempts'                                   => 2,
 		'unique_order_count'                                      => count( $unique_order_ids ),

--- a/woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php
+++ b/woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php
@@ -546,11 +546,13 @@ return function (): array {
 
 	$snapshot = static function (): array {
 		$order_awaiting_payment = WC()->session ? WC()->session->get( 'order_awaiting_payment' ) : null;
+		$checkout_pending_order_id = WC()->session ? WC()->session->get( 'checkout_pending_order_id' ) : null;
 		return array(
 			'cart_items'              => WC()->cart ? WC()->cart->get_cart_contents_count() : null,
 			'cart_total'              => WC()->cart ? (float) WC()->cart->get_total( 'edit' ) : null,
 			'cart_hash'               => WC()->cart ? WC()->cart->get_cart_hash() : null,
 			'order_awaiting_payment'  => $order_awaiting_payment ? absint( $order_awaiting_payment ) : null,
+			'checkout_pending_order_id' => $checkout_pending_order_id ? absint( $checkout_pending_order_id ) : null,
 		);
 	};
 
@@ -627,6 +629,12 @@ return function (): array {
 		$order_ids      = array( $order_id_1, $order_id_2 );
 		$unique_ids     = array_values( array_unique( $order_ids ) );
 		$orders         = array_filter( array_map( 'wc_get_order', $order_ids ) );
+		$create_order_order_awaiting_payment_observations = count(
+			array_filter(
+				array( $after_first['order_awaiting_payment'], $after_second['order_awaiting_payment'] )
+			)
+		);
+		$reused_order_awaiting_payment_branch = 1 === count( $unique_ids ) && in_array( $after_first['order_awaiting_payment'], $unique_ids, true );
 
 		$success_cart = $prepare_cart( $profile['profile'], 'payment-success' );
 		$success_data = $get_checkout_data( $profile['gateway_id'], $success_cart['email'], $profile['profile'], 'payment-success' );
@@ -678,11 +686,13 @@ return function (): array {
 			'duplicate_order_count'               => max( 0, count( $unique_ids ) - 1 ),
 			'duplicate_checkout_attempts'         => count( $order_ids ),
 			'duplicate_reproduced'                => count( $unique_ids ) > 1,
-			'reused_order_awaiting_payment_branch' => 1 === count( $unique_ids ),
+			'reused_order_awaiting_payment_branch' => $reused_order_awaiting_payment_branch,
 			'elapsed_ms'                          => $elapsed_ms,
 			'cart_after_duplicate_attempts'       => $after_second,
 			'order_awaiting_payment_after_first'  => $after_first['order_awaiting_payment'],
 			'order_awaiting_payment_after_second' => $after_second['order_awaiting_payment'],
+			'checkout_pending_order_id_after_first' => $after_first['checkout_pending_order_id'],
+			'checkout_pending_order_id_after_second' => $after_second['checkout_pending_order_id'],
 			'same_cart_hash_order_count'          => count(
 				array_filter(
 					$orders,
@@ -725,7 +735,8 @@ return function (): array {
 
 		$result['metrics'] = array(
 			'available'                                  => 1,
-			'order_awaiting_payment_writes'              => $order_awaiting_payment_write_count,
+			'order_awaiting_payment_writes'              => $create_order_order_awaiting_payment_observations,
+			'manual_order_awaiting_payment_writes'       => $order_awaiting_payment_write_count,
 			'order_awaiting_payment_duplicate_branches'  => $result['duplicate_flow']['reused_order_awaiting_payment_branch'] ? 1 : 0,
 			'duplicate_checkout_attempts'                => $result['duplicate_flow']['duplicate_checkout_attempts'],
 			'duplicate_order_count'                      => $result['duplicate_flow']['duplicate_order_count'],
@@ -786,6 +797,7 @@ return function (): array {
 		'duplicate_checkout_attempts'         => array_sum( array_map( static fn ( array $result ): int => (int) ( $result['metrics']['duplicate_checkout_attempts'] ?? 0 ), $results ) ),
 		'duplicate_order_count'               => array_sum( array_map( static fn ( array $result ): int => (int) ( $result['metrics']['duplicate_order_count'] ?? 0 ), $results ) ),
 		'order_awaiting_payment_writes'       => array_sum( array_map( static fn ( array $result ): int => (int) ( $result['metrics']['order_awaiting_payment_writes'] ?? 0 ), $results ) ),
+		'manual_order_awaiting_payment_writes' => array_sum( array_map( static fn ( array $result ): int => (int) ( $result['metrics']['manual_order_awaiting_payment_writes'] ?? 0 ), $results ) ),
 		'order_awaiting_payment_branches'     => array_sum( array_map( static fn ( array $result ): int => (int) ( $result['metrics']['order_awaiting_payment_duplicate_branches'] ?? 0 ), $results ) ),
 		'unexpected_cart_clearing_profiles'   => array_sum( array_map( static fn ( array $result ): int => (int) ( $result['metrics']['unexpected_cart_clearing'] ?? 0 ), $results ) ),
 	);


### PR DESCRIPTION
## Summary
- Stabilizes checkout side-effect rig workloads so guardrail failures are reported as structured evidence instead of pre-artifact crashes.
- Splits unexpected `order_awaiting_payment` observations from deliberate payment-boundary setup writes in the gateway compatibility matrix.
- Resets `checkout_pending_order_id`, refreshes COD gateway state, isolates notices, and captures fresh checkout errors/notices for clearer WooCommerce checkout PR evidence.

## Evidence
- `php -l woocommerce/woocommerce/bench/checkout-concurrent-create-order.php`
- `php -l woocommerce/woocommerce/bench/checkout-gateway-compatibility-matrix.php`
- `git diff --check`
- Green broad concurrent matrix: `750e518a-8a06-4c12-8390-e81c466bf8a6`
- Repeat green broad concurrent matrix: `bf646d04-95db-4430-97af-5bc8a6d8872b`
- Green core gateway matrix: `f84fceb6-3392-4356-9b3f-9f2633f82d76`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the rig cleanup changes and validation summary; Chris remains responsible for review and final acceptance.