### PR TITLE
Fix Stripe ECE lab trace recipe

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -449,7 +449,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
       },
     },
     inputs: {
-      extraPlugins: [
+      extra_plugins: [
         { source: woocommercePath, slug: 'woocommerce', activate: true },
         { source: componentPath, slug: 'woocommerce-gateway-stripe', pluginFile: 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php', activate: true },
       ],

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -173,7 +173,7 @@ try {
   await writeFile(
     setupFile,
     `<?php
-${(await readFile(fixtureBootstrapPath, 'utf8')).replace(/^<\?php\s*/, '')}
+${(await readFile(fixtureBootstrapPath, 'utf8')).replace(/^<\?php\s*/, '').replace(/declare\(strict_types=1\);\s*/, '')}
 
 $ece_locations = json_decode( '${JSON.stringify(csvToJsonArray(eceLocations))}', true );
 $accepted_payment_methods = json_decode( '${JSON.stringify(csvToJsonArray(acceptedPaymentMethods))}', true );


### PR DESCRIPTION
## Summary

- Updates the Stripe ECE trace recipe to use WP Codebox's supported `inputs.extra_plugins` key.
- Strips `declare(strict_types=1)` when embedding the rig-owned PHP fixture into WP Codebox eval code.

## Verification

- `node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs`
- `git diff --check`
- `homeboy trace --rig woocommerce-stripe-ece-product-page woocommerce-gateway-stripe ece-product-page-waterfall` via `homeboy-lab`: pass

## Lab Trace Result

- Component: `woocommerce-gateway-stripe`
- Target branch/SHA: `develop` / `1efb1280161edf8a769a8ffa89881d90194d4e7d`
- Scenario: `ece-product-page-waterfall`
- Status: pass
- Summary: Captured Stripe ECE product-page browser waterfall: 6 Stripe responses across 88 total responses.

## Key Metrics

- Stripe responses: 6
- Total network responses: 88
- Browser CLS: 0.2296
- DOMContentLoaded: 12091 ms
- First meaningful paint: 6575 ms
- Transfer size: 3434410 bytes
- Page errors recorded: 16
- Browser long tasks: 0

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Fixed the rig recipe/runtime compatibility issues and ran lab verification for Chris to review.