### PR TITLE
Promote Stripe ECE trace request metrics

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
+import { buildRequestSummary } from './ece-request-summary.mjs';
 import { validateStripeEceAssetProvenance } from './ece-product-page-assets.mjs';
 import { buildEceProfileOptions } from './ece-product-page-profile.mjs';
 import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceProductPageScenario, eceProductPageScenarioIds, eceSimulatedClsScript } from './ece-product-page-scenarios.mjs';
@@ -192,6 +193,31 @@ test('ECE simulated CLS scripts track root and grouped ECE containers', () => {
   assert.ok(!unreservedScript.includes("].join('\n');"));
   assert.doesNotMatch(unreservedScript, /min-height: 48px/);
   assert.match(reservedScript, /min-height: 48px/);
+});
+
+test('ECE request summary counts responses by host and type', () => {
+  assert.deepEqual(
+    buildRequestSummary([
+      { url: 'https://example.test/product', resourceType: 'document' },
+      { url: 'https://api.stripe.com/v1/elements/sessions', request: { resourceType: 'fetch' } },
+      { request: { url: 'https://api.stripe.com/v1/payment_methods', resourceType: 'xhr' } },
+      { url: 'not a url', type: 'response' },
+    ]),
+    {
+      total: 4,
+      by_host: {
+        'api.stripe.com': 2,
+        'example.test': 1,
+        unknown: 1,
+      },
+      by_type: {
+        document: 1,
+        fetch: 1,
+        response: 1,
+        xhr: 1,
+      },
+    }
+  );
 });
 
 async function writeStripeEceFixture({ includeBuild = true } = {}) {

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -4,6 +4,7 @@ import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
+import { buildRequestSummary } from './ece-request-summary.mjs';
 import { validateStripeEceAssetProvenance } from './ece-product-page-assets.mjs';
 import { buildEceProfileOptions } from './ece-product-page-profile.mjs';
 import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceLayoutScript, eceProductPageScenario, eceSimulatedClsScript } from './ece-product-page-scenarios.mjs';
@@ -608,6 +609,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     ece_interaction_event_count: interactionEvents.length,
     ece_interaction_succeeded: interactionSucceeded,
   };
+  const requestSummary = buildRequestSummary(responses);
 
   await writeFile(metricsPath, `${JSON.stringify(metrics, null, 2)}\n`);
   await writeFile(
@@ -675,6 +677,8 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     summary: pass
       ? `Captured Stripe ECE product-page browser waterfall: ${stripeUrls.length} Stripe responses across ${responses.length} total responses.`
       : 'Browser waterfall capture did not observe Stripe network responses.',
+    metrics,
+    request_summary: requestSummary,
     timeline,
     assertions: [
       {

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-request-summary.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-request-summary.mjs
@@ -1,0 +1,34 @@
+function countBy(items, callback) {
+  const counts = {};
+  for (const item of items) {
+    const key = callback(item) || 'unknown';
+    counts[key] = (counts[key] || 0) + 1;
+  }
+
+  return Object.fromEntries(Object.entries(counts).sort(([left], [right]) => left.localeCompare(right)));
+}
+
+function requestHost(entry) {
+  const url = entry.url || entry.request?.url || '';
+  if (!url) {
+    return 'unknown';
+  }
+
+  try {
+    return new URL(url).host || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function requestType(entry) {
+  return entry.resourceType || entry.request?.resourceType || entry.type || 'unknown';
+}
+
+export function buildRequestSummary(responses) {
+  return {
+    total: responses.length,
+    by_host: countBy(responses, requestHost),
+    by_type: countBy(responses, requestType),
+  };
+}


### PR DESCRIPTION
## Summary
- Promote the existing Stripe ECE waterfall metrics into top-level `trace.json` as `metrics`.
- Add top-level `request_summary` with response totals grouped by host and resource type.
- Cover request-summary grouping with the existing ECE Node test suite.

Fixes #310.

## Validation
- `node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs`
- `node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`

## Full trace validation
- Attempted Lab smoke trace: `homeboy trace --rig woocommerce-stripe-ece-product-page --profile smoke --allow-local-toolchain --json-summary`
- The workload did not reach browser capture because the Lab Stripe checkout is missing required build artifacts:
  - `build/express-checkout.js`
  - `build/express-checkout.css`
  - `build/express-checkout.asset.php`
- This preserves the existing rig asset-provenance gate from #312; a 1x compare should be rerun after mounting/building a packaged Stripe plugin.