### PR TITLE
Add Stripe ECE readiness timing metrics

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
@@ -11,6 +11,7 @@ import { validateStripeEceAssetProvenance } from './ece-product-page-assets.mjs'
 import { evaluateEceRealWalletAssetHealth, realWalletAssetHealthSummary } from './ece-product-page-asset-health.mjs';
 import { evaluateEceFixtureHealth, fixtureHealthSummary } from './ece-product-page-fixture-health.mjs';
 import { buildEceProfileOptions } from './ece-product-page-profile.mjs';
+import { summarizeEceReadinessMetrics } from './ece-product-page-readiness-metrics.mjs';
 import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceProductPageScenario, eceProductPageScenarioIds, eceSimulatedClsScript } from './ece-product-page-scenarios.mjs';
 import { classifyEceWalletFanoutEvidence, ECE_FANOUT_REVIEWER_READY, ECE_FANOUT_SUPPLEMENTAL, groupedWalletLayoutSummary } from './ece-product-page-wallet-classification.mjs';
 import { wpCodeboxBin, wpCodeboxCommand } from './ece-product-page-wp-codebox.mjs';
@@ -489,6 +490,49 @@ test('ECE request summary counts responses by host and type', () => {
       },
     }
   );
+});
+
+test('ECE readiness metrics expose explicit readiness timings and payment method details', () => {
+  const summary = summarizeEceReadinessMetrics({
+    metrics: {
+      ece_requested_accepted_payment_methods: ['card', 'link', 'apple_pay'],
+      ece_create_payment_methods: [['link', 'apple_pay']],
+      ece_render_container_visible_ms: 125.4,
+      ece_render_first_child_ms: 180.2,
+      ece_render_first_iframe_ms: 240.8,
+      ece_render_first_visible_button_ms: 310.1,
+    },
+    networkEntries: [
+      { url: 'https://example.test/product', resourceType: 'document', t_ms: 10 },
+      { url: 'https://js.stripe.com/v3/', resourceType: 'script', responseEnd: 95.6 },
+    ],
+    walletFanoutEvidence: {
+      wallets: {
+        apple_pay: { requested: true, eligible: true, rendered: true, observed: true },
+        google_pay: { requested: false, eligible: true, rendered: false, observed: false },
+        link: { requested: true, eligible: true, rendered: true, observed: true },
+      },
+    },
+  });
+
+  assert.equal(summary.ece_ready_ms, 310);
+  assert.equal(summary.ece_visible_ms, 125);
+  assert.equal(summary.ece_first_iframe_ms, 241);
+  assert.equal(summary.stripe_js_loaded_ms, 96);
+  assert.deepEqual(summary.ece_available_payment_methods, {
+    requested: ['card', 'link', 'apple_pay'],
+    created: ['link', 'apple_pay'],
+    rendered: ['apple_pay', 'link'],
+    observed: ['apple_pay', 'link'],
+  });
+  assert.deepEqual(summary.ece_available_payment_method_details.find((entry) => entry.method === 'google_pay'), {
+    method: 'google_pay',
+    requested: false,
+    created: false,
+    eligible: true,
+    rendered: false,
+    observed: false,
+  });
 });
 
 test('fixture health passes for a structurally valid ECE product page', () => {

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-readiness-metrics.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-readiness-metrics.mjs
@@ -1,0 +1,118 @@
+function finiteRoundedNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.round(value) : null;
+}
+
+function firstNumber(...values) {
+  for (const value of values) {
+    const rounded = finiteRoundedNumber(value);
+    if (rounded !== null) {
+      return rounded;
+    }
+  }
+
+  return null;
+}
+
+function entryUrl(entry) {
+  return entry?.url || entry?.request?.url || entry?.response?.url || '';
+}
+
+function entryResourceType(entry) {
+  return entry?.resourceType || entry?.request?.resourceType || entry?.type || '';
+}
+
+function entryTimingMs(entry) {
+  return firstNumber(
+    entry?.responseEnd,
+    entry?.response?.responseEnd,
+    entry?.endTime,
+    entry?.response?.endTime,
+    entry?.t_ms,
+    entry?.time_ms,
+    entry?.timestamp_ms,
+    entry?.startTime,
+    entry?.request?.startTime
+  );
+}
+
+function isStripeJsEntry(entry) {
+  const url = entryUrl(entry);
+  if (!/https?:\/\/js\.stripe\.com\//i.test(url)) {
+    return false;
+  }
+
+  const resourceType = entryResourceType(entry);
+  return !resourceType || /script|response|request/i.test(resourceType) || /\.js(?:\?|$|#)/i.test(url);
+}
+
+function normalizeMethod(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/-/g, '_');
+}
+
+function normalizeMethods(value) {
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => normalizeMethods(entry));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.keys(value).filter((key) => value[key] !== false).map(normalizeMethod).filter(Boolean);
+  }
+
+  if (typeof value === 'string') {
+    return value.split(',').map(normalizeMethod).filter(Boolean);
+  }
+
+  return [];
+}
+
+function uniqueMethods(values) {
+  return [...new Set(values.flatMap((value) => normalizeMethods(value)))];
+}
+
+export function summarizeEceReadinessMetrics({ metrics = {}, networkEntries = [], walletFanoutEvidence = {} } = {}) {
+  const requestedMethods = uniqueMethods([metrics.ece_requested_accepted_payment_methods]);
+  const createdMethods = uniqueMethods([metrics.ece_create_payment_methods]);
+  const walletMethods = Object.keys(walletFanoutEvidence.wallets || {}).map(normalizeMethod).filter(Boolean);
+  const methodSet = new Set([...requestedMethods, ...createdMethods, ...walletMethods]);
+  const paymentMethodDetails = [...methodSet].sort().map((method) => {
+    const wallet = walletFanoutEvidence.wallets?.[method] || null;
+
+    return {
+      method,
+      requested: requestedMethods.includes(method) || wallet?.requested === true,
+      created: createdMethods.includes(method),
+      eligible: wallet?.eligible ?? null,
+      rendered: wallet?.rendered ?? null,
+      observed: wallet?.observed ?? null,
+    };
+  });
+  const observedPaymentMethods = paymentMethodDetails.filter((entry) => entry.observed === true).map((entry) => entry.method);
+  const renderedPaymentMethods = paymentMethodDetails.filter((entry) => entry.rendered === true).map((entry) => entry.method);
+
+  return {
+    ece_ready_ms: firstNumber(
+      metrics.ece_render_first_visible_button_ms,
+      metrics.ece_render_first_visible_iframe_ms,
+      metrics.ece_render_first_iframe_ms,
+      metrics.ece_render_first_child_ms,
+      metrics.ece_render_container_visible_ms,
+      metrics.ece_render_container_seen_ms
+    ),
+    ece_visible_ms: firstNumber(metrics.ece_render_container_visible_ms),
+    ece_first_iframe_ms: firstNumber(metrics.ece_render_first_iframe_ms),
+    stripe_js_loaded_ms: firstNumber(
+      metrics.stripe_js_available_ms,
+      ...networkEntries.filter(isStripeJsEntry).map(entryTimingMs)
+    ),
+    ece_available_payment_methods: {
+      requested: requestedMethods,
+      created: createdMethods,
+      rendered: renderedPaymentMethods,
+      observed: observedPaymentMethods,
+    },
+    ece_available_payment_method_details: paymentMethodDetails,
+  };
+}

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -10,6 +10,7 @@ import { validateStripeEceAssetProvenance } from './ece-product-page-assets.mjs'
 import { evaluateEceRealWalletAssetHealth, realWalletAssetHealthSummary } from './ece-product-page-asset-health.mjs';
 import { buildEceProfileOptions, setting } from './ece-product-page-profile.mjs';
 import { evaluateEceFixtureHealth, fixtureHealthSummary } from './ece-product-page-fixture-health.mjs';
+import { summarizeEceReadinessMetrics } from './ece-product-page-readiness-metrics.mjs';
 import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceLayoutScript, eceProductPageScenario, eceSimulatedClsScript } from './ece-product-page-scenarios.mjs';
 import { classifyEceWalletFanoutEvidence, groupedWalletLayoutSummary } from './ece-product-page-wallet-classification.mjs';
 import { runWpCodeboxRecipe } from './ece-product-page-wp-codebox.mjs';
@@ -584,6 +585,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
       if (typeof StripeFactory !== 'function' || StripeFactory.__homeboyEceInstrumented) {
         return StripeFactory;
       }
+      mark('stripe_js_available');
       const wrappedFactory = new Proxy(StripeFactory, {
         apply(target, thisArg, stripeArgs) {
           instrumentation.stripe_factory_calls.push({ mode: 'call', t_ms: elapsed(), args: jsonSafe(stripeArgs) });
@@ -1157,6 +1159,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     ece_render_container_seen_ms: numberOrNull(renderMarks.container_seen),
     ece_render_container_visible_ms: numberOrNull(renderMarks.container_visible),
     ece_render_first_child_ms: numberOrNull(renderMarks.first_child),
+    stripe_js_available_ms: numberOrNull(renderMarks.stripe_js_available),
     ece_render_first_iframe_ms: numberOrNull(renderMarks.first_iframe),
     ece_render_first_visible_iframe_ms: numberOrNull(renderMarks.first_visible_iframe),
     ece_render_first_visible_button_ms: numberOrNull(renderMarks.first_visible_button),
@@ -1229,6 +1232,14 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     metrics[`${prefix}_rendered`] = evidence.rendered;
     metrics[`${prefix}_observed`] = evidence.observed;
   }
+  Object.assign(
+    metrics,
+    summarizeEceReadinessMetrics({
+      metrics,
+      networkEntries: network,
+      walletFanoutEvidence,
+    })
+  );
 
   const realWalletAssetHealth = evaluateEceRealWalletAssetHealth({
     networkEntries: network,
@@ -1284,6 +1295,14 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
         stripe_elements_session: {
           response_count: elementsSessionResponses.length,
           statuses: elementsSessionStatuses,
+        },
+        ece_readiness: {
+          ece_ready_ms: metrics.ece_ready_ms,
+          ece_visible_ms: metrics.ece_visible_ms,
+          ece_first_iframe_ms: metrics.ece_first_iframe_ms,
+          stripe_js_loaded_ms: metrics.stripe_js_loaded_ms,
+          payment_methods: metrics.ece_available_payment_methods,
+          payment_method_details: metrics.ece_available_payment_method_details,
         },
         request_summary: requestSummary,
         wallet_fanout_evidence: walletFanoutEvidence,


### PR DESCRIPTION
## Summary
- Adds explicit WooCommerce Stripe ECE product-page readiness metrics: `ece_ready_ms`, `ece_visible_ms`, `ece_first_iframe_ms`, and `stripe_js_loaded_ms` when observable.
- Captures Stripe.js factory availability in the browser probe and falls back to Stripe.js network timing when available.
- Emits normalized ECE payment method summaries and per-method details for requested, created, eligible, rendered, and observed methods.

## Tests
- `node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`
- `node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-readiness-metrics.mjs`
- `node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs`
- `node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`

## Broader Sweep
- `node --test **/*.test.mjs` currently has 8 failures in `Automattic/studio/bench/studio-agent-site-build.test.mjs` because `HOMEBOY_WORDPRESS_HELPER_MANIFEST` / the Homeboy WordPress materialized site quality helper is unavailable in this environment. The Stripe ECE focused suite passes.

Closes #314