### PR TITLE
Add below-fold Stripe ECE webperf profile

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
@@ -11,7 +11,7 @@ import { validateStripeEceAssetProvenance } from './ece-product-page-assets.mjs'
 import { evaluateEceRealWalletAssetHealth, realWalletAssetHealthSummary } from './ece-product-page-asset-health.mjs';
 import { evaluateEceFixtureHealth, fixtureHealthSummary } from './ece-product-page-fixture-health.mjs';
 import { buildEceProfileOptions } from './ece-product-page-profile.mjs';
-import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceProductPageScenario, eceProductPageScenarioIds, eceSimulatedClsScript } from './ece-product-page-scenarios.mjs';
+import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceLayoutScript, eceProductPageScenario, eceProductPageScenarioIds, eceSimulatedClsScript } from './ece-product-page-scenarios.mjs';
 import { classifyEceWalletFanoutEvidence, ECE_FANOUT_REVIEWER_READY, ECE_FANOUT_SUPPLEMENTAL, groupedWalletLayoutSummary } from './ece-product-page-wallet-classification.mjs';
 import { wpCodeboxBin, wpCodeboxCommand } from './ece-product-page-wp-codebox.mjs';
 
@@ -178,6 +178,26 @@ test('rig manifest exposes the ECE webperf profile matrix', () => {
   });
   assert.deepEqual(manifest.trace_profiles['webperf-wallet-fanout'], {
     scenario: 'ece-product-page-waterfall',
+    settings: {
+      woocommerce_stripe_ece_browser_profile: 'webperf-desktop-slow-4g',
+      woocommerce_stripe_accepted_payment_methods: 'card,link,apple_pay,google_pay',
+      woocommerce_stripe_ece_require_fanout_proof: '1',
+    },
+  });
+  assert.deepEqual(manifest.trace_profiles['webperf-below-fold-load'], {
+    scenario: 'ece-product-page-below-fold-load',
+    settings: {
+      woocommerce_stripe_ece_browser_profile: 'webperf-desktop-load',
+    },
+  });
+  assert.deepEqual(manifest.trace_profiles['webperf-below-fold-scroll-to-ece'], {
+    scenario: 'ece-product-page-below-fold-scroll-to-ece',
+    settings: {
+      woocommerce_stripe_ece_browser_profile: 'webperf-desktop-load',
+    },
+  });
+  assert.deepEqual(manifest.trace_profiles['webperf-below-fold-wallet-fanout'], {
+    scenario: 'ece-product-page-below-fold-scroll-to-ece',
     settings: {
       woocommerce_stripe_ece_browser_profile: 'webperf-desktop-slow-4g',
       woocommerce_stripe_accepted_payment_methods: 'card,link,apple_pay,google_pay',
@@ -437,6 +457,10 @@ test('ECE scenario registry preserves load-only default and exposes interactions
   assert.equal(eceProductPageScenario().id, DEFAULT_ECE_SCENARIO_ID);
   assert.equal(eceProductPageScenario(DEFAULT_ECE_SCENARIO_ID).interaction, 'load-only');
   assert.equal(eceProductPageScenario('ece-product-page-scroll-to-ece').interaction, 'scroll-to-ece');
+  assert.equal(eceProductPageScenario('ece-product-page-below-fold-load').layout, 'below-fold');
+  assert.equal(eceProductPageScenario('ece-product-page-below-fold-load').interaction, 'load-only');
+  assert.equal(eceProductPageScenario('ece-product-page-below-fold-scroll-to-ece').layout, 'below-fold');
+  assert.equal(eceProductPageScenario('ece-product-page-below-fold-scroll-to-ece').interaction, 'scroll-to-ece');
   assert.equal(eceProductPageScenario('ece-product-page-quantity-change').interaction, 'quantity-change');
   assert.equal(eceProductPageScenario('ece-product-page-simulated-cls').simulatedCls, 'unreserved');
   assert.equal(eceProductPageScenario('ece-product-page-simulated-cls-reserved').simulatedCls, 'reserved');
@@ -444,12 +468,17 @@ test('ECE scenario registry preserves load-only default and exposes interactions
   assert.equal(eceProductPageScenario('ece-product-page-simulated-cls-reserved').waitFor, 'load');
   assert.ok(eceProductPageScenarioIds().includes(DEFAULT_ECE_SCENARIO_ID));
   assert.ok(eceProductPageScenarioIds().includes('ece-product-page-scroll-to-ece'));
+  assert.ok(eceProductPageScenarioIds().includes('ece-product-page-below-fold-load'));
+  assert.ok(eceProductPageScenarioIds().includes('ece-product-page-below-fold-scroll-to-ece'));
   assert.ok(eceProductPageScenarioIds().includes('ece-product-page-simulated-cls'));
   assert.ok(eceProductPageScenarioIds().includes('ece-product-page-simulated-cls-reserved'));
 });
 
 test('ECE interaction scripts keep Stripe selectors in the rig', () => {
   assert.match(eceInteractionScript(eceProductPageScenario('ece-product-page-scroll-to-ece')), /#wc-stripe-express-checkout-element/);
+  assert.match(eceInteractionScript(eceProductPageScenario('ece-product-page-below-fold-scroll-to-ece')), /before_scroll_to_ece/);
+  assert.match(eceLayoutScript(eceProductPageScenario('ece-product-page-below-fold-load')), /#wc-stripe-express-checkout-element \{ display: block !important; margin-top: 1400px !important; \}/);
+  assert.match(eceLayoutScript(eceProductPageScenario('ece-product-page-below-fold-load')), /insertAdjacentElement\('afterend', root\)/);
   assert.match(eceInteractionScript(eceProductPageScenario('ece-product-page-quantity-change')), /quantity_change/);
   assert.match(eceInteractionScript(eceProductPageScenario('ece-product-page-simulated-cls')), /simulated_cls_render/);
 });
@@ -625,6 +654,9 @@ test('waterfall recipe passes structural assertions to browser-probe', () => {
   assert.match(traceSource, /id: 'fixture-health'/);
   assert.match(traceSource, /id: 'stripe-ece-asset-provenance'/);
   assert.match(traceSource, /id: 'real-wallet-asset-health'/);
+  assert.match(traceSource, /productContentMetrics/);
+  assert.match(traceSource, /product_content_visible_ms/);
+  assert.match(traceSource, /id: 'product-content-visible'/);
   assert.match(traceSource, /buildRequestSummary/);
   assert.match(traceSource, /build\/express-checkout\.js/);
   assert.match(traceSource, /npm', \['run', 'build:webpack'\]/);

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
@@ -12,7 +12,7 @@ import { evaluateEceRealWalletAssetHealth, realWalletAssetHealthSummary } from '
 import { evaluateEceFixtureHealth, fixtureHealthSummary } from './ece-product-page-fixture-health.mjs';
 import { buildEceProfileOptions } from './ece-product-page-profile.mjs';
 import { summarizeEceReadinessMetrics } from './ece-product-page-readiness-metrics.mjs';
-import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceProductPageScenario, eceProductPageScenarioIds, eceSimulatedClsScript } from './ece-product-page-scenarios.mjs';
+import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceLayoutScript, eceProductPageScenario, eceProductPageScenarioIds, eceSimulatedClsScript } from './ece-product-page-scenarios.mjs';
 import { classifyEceWalletFanoutEvidence, ECE_FANOUT_REVIEWER_READY, ECE_FANOUT_SUPPLEMENTAL, groupedWalletLayoutSummary } from './ece-product-page-wallet-classification.mjs';
 import { wpCodeboxBin, wpCodeboxCommand } from './ece-product-page-wp-codebox.mjs';
 
@@ -179,6 +179,26 @@ test('rig manifest exposes the ECE webperf profile matrix', () => {
   });
   assert.deepEqual(manifest.trace_profiles['webperf-wallet-fanout'], {
     scenario: 'ece-product-page-waterfall',
+    settings: {
+      woocommerce_stripe_ece_browser_profile: 'webperf-desktop-slow-4g',
+      woocommerce_stripe_accepted_payment_methods: 'card,link,apple_pay,google_pay',
+      woocommerce_stripe_ece_require_fanout_proof: '1',
+    },
+  });
+  assert.deepEqual(manifest.trace_profiles['webperf-below-fold-load'], {
+    scenario: 'ece-product-page-below-fold-load',
+    settings: {
+      woocommerce_stripe_ece_browser_profile: 'webperf-desktop-load',
+    },
+  });
+  assert.deepEqual(manifest.trace_profiles['webperf-below-fold-scroll-to-ece'], {
+    scenario: 'ece-product-page-below-fold-scroll-to-ece',
+    settings: {
+      woocommerce_stripe_ece_browser_profile: 'webperf-desktop-load',
+    },
+  });
+  assert.deepEqual(manifest.trace_profiles['webperf-below-fold-wallet-fanout'], {
+    scenario: 'ece-product-page-below-fold-scroll-to-ece',
     settings: {
       woocommerce_stripe_ece_browser_profile: 'webperf-desktop-slow-4g',
       woocommerce_stripe_accepted_payment_methods: 'card,link,apple_pay,google_pay',
@@ -438,6 +458,10 @@ test('ECE scenario registry preserves load-only default and exposes interactions
   assert.equal(eceProductPageScenario().id, DEFAULT_ECE_SCENARIO_ID);
   assert.equal(eceProductPageScenario(DEFAULT_ECE_SCENARIO_ID).interaction, 'load-only');
   assert.equal(eceProductPageScenario('ece-product-page-scroll-to-ece').interaction, 'scroll-to-ece');
+  assert.equal(eceProductPageScenario('ece-product-page-below-fold-load').layout, 'below-fold');
+  assert.equal(eceProductPageScenario('ece-product-page-below-fold-load').interaction, 'load-only');
+  assert.equal(eceProductPageScenario('ece-product-page-below-fold-scroll-to-ece').layout, 'below-fold');
+  assert.equal(eceProductPageScenario('ece-product-page-below-fold-scroll-to-ece').interaction, 'scroll-to-ece');
   assert.equal(eceProductPageScenario('ece-product-page-quantity-change').interaction, 'quantity-change');
   assert.equal(eceProductPageScenario('ece-product-page-simulated-cls').simulatedCls, 'unreserved');
   assert.equal(eceProductPageScenario('ece-product-page-simulated-cls-reserved').simulatedCls, 'reserved');
@@ -445,12 +469,17 @@ test('ECE scenario registry preserves load-only default and exposes interactions
   assert.equal(eceProductPageScenario('ece-product-page-simulated-cls-reserved').waitFor, 'load');
   assert.ok(eceProductPageScenarioIds().includes(DEFAULT_ECE_SCENARIO_ID));
   assert.ok(eceProductPageScenarioIds().includes('ece-product-page-scroll-to-ece'));
+  assert.ok(eceProductPageScenarioIds().includes('ece-product-page-below-fold-load'));
+  assert.ok(eceProductPageScenarioIds().includes('ece-product-page-below-fold-scroll-to-ece'));
   assert.ok(eceProductPageScenarioIds().includes('ece-product-page-simulated-cls'));
   assert.ok(eceProductPageScenarioIds().includes('ece-product-page-simulated-cls-reserved'));
 });
 
 test('ECE interaction scripts keep Stripe selectors in the rig', () => {
   assert.match(eceInteractionScript(eceProductPageScenario('ece-product-page-scroll-to-ece')), /#wc-stripe-express-checkout-element/);
+  assert.match(eceInteractionScript(eceProductPageScenario('ece-product-page-below-fold-scroll-to-ece')), /before_scroll_to_ece/);
+  assert.match(eceLayoutScript(eceProductPageScenario('ece-product-page-below-fold-load')), /#wc-stripe-express-checkout-element \{ display: block !important; margin-top: 1400px !important; \}/);
+  assert.match(eceLayoutScript(eceProductPageScenario('ece-product-page-below-fold-load')), /insertAdjacentElement\('afterend', root\)/);
   assert.match(eceInteractionScript(eceProductPageScenario('ece-product-page-quantity-change')), /quantity_change/);
   assert.match(eceInteractionScript(eceProductPageScenario('ece-product-page-simulated-cls')), /simulated_cls_render/);
 });
@@ -669,6 +698,9 @@ test('waterfall recipe passes structural assertions to browser-probe', () => {
   assert.match(traceSource, /id: 'fixture-health'/);
   assert.match(traceSource, /id: 'stripe-ece-asset-provenance'/);
   assert.match(traceSource, /id: 'real-wallet-asset-health'/);
+  assert.match(traceSource, /productContentMetrics/);
+  assert.match(traceSource, /product_content_visible_ms/);
+  assert.match(traceSource, /id: 'product-content-visible'/);
   assert.match(traceSource, /buildRequestSummary/);
   assert.match(traceSource, /build\/express-checkout\.js/);
   assert.match(traceSource, /npm', \['run', 'build:webpack'\]/);

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-scenarios.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-scenarios.mjs
@@ -152,14 +152,37 @@ export function eceLayoutScript(scenario) {
 
       const style = document.createElement('style');
       style.id = 'homeboy-ece-below-fold-layout';
-      style.textContent = 'form.cart { margin-top: 1400px !important; }';
+      style.textContent = '#wc-stripe-express-checkout-element { display: block !important; margin-top: 1400px !important; }';
       document.head.appendChild(style);
+    };
+
+    const moveEceBelowProductControls = () => {
+      const form = document.querySelector('form.cart');
+      const root = document.querySelector('#wc-stripe-express-checkout-element');
+      if (!form || !root || root.previousElementSibling === form) {
+        return;
+      }
+
+      form.insertAdjacentElement('afterend', root);
+    };
+
+    const observeEcePlacement = () => {
+      moveEceBelowProductControls();
+      const observer = new MutationObserver(moveEceBelowProductControls);
+      observer.observe(document.documentElement, { childList: true, subtree: true });
+      window.setTimeout(() => observer.disconnect(), 15000);
     };
 
     if (document.head) {
       installBelowFoldLayout();
     } else {
       document.addEventListener('DOMContentLoaded', installBelowFoldLayout, { once: true });
+    }
+
+    if (document.documentElement) {
+      observeEcePlacement();
+    } else {
+      document.addEventListener('DOMContentLoaded', observeEcePlacement, { once: true });
     }
   `;
 }

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -719,6 +719,30 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
       ece_cls_sentinel_rect: rectForNode(sentinel),
     };
   };
+  const productContentMetrics = () => {
+    const title = document.querySelector('h1.product_title, .product_title, h1');
+    const price = document.querySelector('.summary .price, p.price, .price');
+    const addToCart = document.querySelector('form.cart button[type="submit"], form.cart .single_add_to_cart_button');
+    const titleRect = rectForNode(title);
+    const priceRect = rectForNode(price);
+    const addToCartRect = rectForNode(addToCart);
+    const viewportHeight = window.innerHeight || document.documentElement?.clientHeight || 0;
+    const aboveFold = (rect) => !!rect && rect.y >= 0 && rect.y < viewportHeight;
+
+    return {
+      product_title_visible: isVisible(title),
+      product_price_visible: isVisible(price),
+      product_add_to_cart_visible: isVisible(addToCart),
+      product_content_visible: isVisible(title) && isVisible(price) && isVisible(addToCart),
+      product_title_above_fold: aboveFold(titleRect),
+      product_price_above_fold: aboveFold(priceRect),
+      product_add_to_cart_above_fold: aboveFold(addToCartRect),
+      product_content_above_fold: aboveFold(titleRect) && aboveFold(priceRect) && aboveFold(addToCartRect),
+      product_title_rect: titleRect,
+      product_price_rect: priceRect,
+      product_add_to_cart_rect: addToCartRect,
+    };
+  };
   try {
     const layoutShiftObserver = new PerformanceObserver((list) => {
       for (const entry of list.getEntries()) {
@@ -750,8 +774,26 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     record('layout_shift_observer_unavailable', { message: error?.message || String(error) });
   }
   const sample = () => {
+    const productMetrics = productContentMetrics();
+    if (productMetrics.product_title_visible) {
+      mark('product_title_visible');
+    }
+    if (productMetrics.product_price_visible) {
+      mark('product_price_visible');
+    }
+    if (productMetrics.product_add_to_cart_visible) {
+      mark('product_add_to_cart_visible');
+    }
+    if (productMetrics.product_content_visible) {
+      mark('product_content_visible');
+    }
+
     const container = document.querySelector('#wc-stripe-express-checkout-element');
     if (!container) {
+      state.latestProduct = {
+        t_ms: elapsed(),
+        ...productMetrics,
+      };
       return;
     }
     mark('container_seen');
@@ -783,7 +825,12 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
       button_count: buttons.length,
       visible_button_count: visibleButtons.length,
       container_visible: isVisible(container),
+      ...productMetrics,
       ...trackedContainerMetrics(),
+    };
+    state.latestProduct = {
+      t_ms: state.latest.t_ms,
+      ...productMetrics,
     };
     state.samples.push(state.latest);
   };
@@ -855,6 +902,29 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
         const rect = node.getBoundingClientRect();
         return style.visibility !== 'hidden' && style.display !== 'none' && rect.width > 0 && rect.height > 0;
       };
+      const productNodes = {
+        title: document.querySelector('h1.product_title, .product_title, h1'),
+        price: document.querySelector('.summary .price, p.price, .price'),
+        add_to_cart: document.querySelector('form.cart button[type="submit"], form.cart .single_add_to_cart_button'),
+      };
+      const viewportHeight = window.innerHeight || document.documentElement?.clientHeight || 0;
+      const aboveFold = (rect) => !!rect && rect.y >= 0 && rect.y < viewportHeight;
+      const productRects = {
+        title: rectForNode(productNodes.title),
+        price: rectForNode(productNodes.price),
+        add_to_cart: rectForNode(productNodes.add_to_cart),
+      };
+      const productContent = {
+        title_visible: isVisible(productNodes.title),
+        price_visible: isVisible(productNodes.price),
+        add_to_cart_visible: isVisible(productNodes.add_to_cart),
+        content_visible: isVisible(productNodes.title) && isVisible(productNodes.price) && isVisible(productNodes.add_to_cart),
+        title_above_fold: aboveFold(productRects.title),
+        price_above_fold: aboveFold(productRects.price),
+        add_to_cart_above_fold: aboveFold(productRects.add_to_cart),
+        content_above_fold: aboveFold(productRects.title) && aboveFold(productRects.price) && aboveFold(productRects.add_to_cart),
+        rects: productRects,
+      };
       if (!container) {
         return {
           ece_container: false,
@@ -865,6 +935,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
           ece_visible_button_count: 0,
           ece_wallet_containers: walletContainers,
           ece_wallet_rects: walletRects,
+          product_content: productContent,
         };
       }
       const iframes = Array.from(container.querySelectorAll('iframe'));
@@ -878,6 +949,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
         ece_visible_button_count: buttons.filter(isVisible).length,
         ece_wallet_containers: walletContainers,
         ece_wallet_rects: walletRects,
+        product_content: productContent,
       };
     };
     const interactionSnapshot = (name) => {
@@ -1019,6 +1091,8 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   const eceMountTargetIds = Array.isArray(eceInstrumentation.mount_target_ids) ? eceInstrumentation.mount_target_ids : [];
   const eceMountTargetSelectors = Array.isArray(eceInstrumentation.mount_target_selectors) ? eceInstrumentation.mount_target_selectors : [];
   const renderSamples = renderProbe?.samples || [];
+  const latestProduct = renderProbe?.latestProduct || renderLatest;
+  const finalProductContent = scriptResult?.finalSnapshot?.product_content || {};
   const layoutShifts = Array.isArray(renderProbe?.layoutShifts) ? renderProbe.layoutShifts : [];
   const layoutShiftSourceDetails = layoutShifts.flatMap((entry) =>
     Array.isArray(entry.sources)
@@ -1156,6 +1230,21 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     browser_dom_node_count: browserMetrics.browser_dom_node_count ?? performanceSummary?.final?.dom?.nodes ?? null,
     browser_document_count: performanceSummary?.final?.dom?.documents ?? null,
     browser_js_event_listener_count: cdpMetrics.JSEventListeners ?? null,
+    product_title_visible_ms: numberOrNull(renderMarks.product_title_visible),
+    product_price_visible_ms: numberOrNull(renderMarks.product_price_visible),
+    product_add_to_cart_visible_ms: numberOrNull(renderMarks.product_add_to_cart_visible),
+    product_content_visible_ms: numberOrNull(renderMarks.product_content_visible),
+    product_title_visible: latestProduct.product_title_visible === true || finalProductContent.title_visible === true,
+    product_price_visible: latestProduct.product_price_visible === true || finalProductContent.price_visible === true,
+    product_add_to_cart_visible: latestProduct.product_add_to_cart_visible === true || finalProductContent.add_to_cart_visible === true,
+    product_content_visible: latestProduct.product_content_visible === true || finalProductContent.content_visible === true,
+    product_title_above_fold: latestProduct.product_title_above_fold === true || finalProductContent.title_above_fold === true,
+    product_price_above_fold: latestProduct.product_price_above_fold === true || finalProductContent.price_above_fold === true,
+    product_add_to_cart_above_fold: latestProduct.product_add_to_cart_above_fold === true || finalProductContent.add_to_cart_above_fold === true,
+    product_content_above_fold: latestProduct.product_content_above_fold === true || finalProductContent.content_above_fold === true,
+    product_title_rect: pickRect(latestProduct.product_title_rect, finalProductContent.rects?.title),
+    product_price_rect: pickRect(latestProduct.product_price_rect, finalProductContent.rects?.price),
+    product_add_to_cart_rect: pickRect(latestProduct.product_add_to_cart_rect, finalProductContent.rects?.add_to_cart),
     ece_render_container_seen_ms: numberOrNull(renderMarks.container_seen),
     ece_render_container_visible_ms: numberOrNull(renderMarks.container_visible),
     ece_render_first_child_ms: numberOrNull(renderMarks.first_child),
@@ -1307,6 +1396,10 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
         request_summary: requestSummary,
         wallet_fanout_evidence: walletFanoutEvidence,
         grouped_wallet_layout: groupedWalletLayout,
+        product_content: {
+          latest: latestProduct,
+          final: finalProductContent,
+        },
         express_checkout_instrumentation: {
           stripe_factory_calls: Array.isArray(eceInstrumentation.stripe_factory_calls) ? eceInstrumentation.stripe_factory_calls : [],
           elements_calls: Array.isArray(eceInstrumentation.elements_calls) ? eceInstrumentation.elements_calls : [],
@@ -1358,14 +1451,17 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   const groupedLayoutRequired = requireFanoutProof && metrics.ece_instance_count <= 1;
   const groupedLayoutPass = !groupedLayoutRequired || groupedWalletLayout.dimensionsPass;
   const fanoutProofPass = !requireFanoutProof || (walletFanoutEvidence.valid_fanout_proof && groupedLayoutPass);
+  const productContentPass = metrics.product_content_visible && (scenario.layout !== 'below-fold' || metrics.product_content_above_fold);
   const browserProbeCompleted = responses.length > 0 && existsSync(networkPath) && existsSync(performancePath);
-  const pass = fixtureHealth.ok && realWalletAssetHealth.ok && browserProbeCompleted && stripeUrls.length > 0 && simulatedClsPass && stripeLoadPass && fanoutProofPass;
+  const pass = fixtureHealth.ok && realWalletAssetHealth.ok && productContentPass && browserProbeCompleted && stripeUrls.length > 0 && simulatedClsPass && stripeLoadPass && fanoutProofPass;
   const summaryText = pass
     ? `Captured Stripe ECE product-page browser waterfall: ${stripeUrls.length} Stripe responses across ${responses.length} total responses.`
     : !fixtureHealth.ok
       ? fixtureHealthSummary(fixtureHealth)
       : !realWalletAssetHealth.ok
       ? realWalletAssetHealthSummary(realWalletAssetHealth)
+      : !productContentPass
+      ? `Product visible proof failed: visible=${metrics.product_content_visible}; above-fold=${metrics.product_content_above_fold}; title=${JSON.stringify(metrics.product_title_rect)}; price=${JSON.stringify(metrics.product_price_rect)}; add-to-cart=${JSON.stringify(metrics.product_add_to_cart_rect)}.`
       : !fanoutProofPass
       ? `ECE fan-out proof classified as ${walletFanoutEvidence.classification}; grouped layout valid=${groupedWalletLayout.dimensionsPass}; reason codes=${walletFanoutEvidence.reason_codes.join(',') || 'none'}. Requested ${requestedAcceptedPaymentMethods.join(',')}.`
       : stripeLoadPass
@@ -1404,6 +1500,11 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     id: 'stripe-load-errors',
     status: stripeLoadPass ? 'pass' : 'fail',
     message: `Recorded ${stripeLoadPageErrors.length} Stripe-related page error(s).`,
+  });
+  trace.assertion({
+    id: 'product-content-visible',
+    status: productContentPass ? 'pass' : 'fail',
+    message: `Product visible timing=${metrics.product_content_visible_ms}ms; visible=${metrics.product_content_visible}; above-fold=${metrics.product_content_above_fold}; title=${JSON.stringify(metrics.product_title_rect)}; price=${JSON.stringify(metrics.product_price_rect)}; add-to-cart=${JSON.stringify(metrics.product_add_to_cart_rect)}.`,
   });
   trace.assertion({
     id: 'real-wallet-asset-health',

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -717,6 +717,30 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
       ece_cls_sentinel_rect: rectForNode(sentinel),
     };
   };
+  const productContentMetrics = () => {
+    const title = document.querySelector('h1.product_title, .product_title, h1');
+    const price = document.querySelector('.summary .price, p.price, .price');
+    const addToCart = document.querySelector('form.cart button[type="submit"], form.cart .single_add_to_cart_button');
+    const titleRect = rectForNode(title);
+    const priceRect = rectForNode(price);
+    const addToCartRect = rectForNode(addToCart);
+    const viewportHeight = window.innerHeight || document.documentElement?.clientHeight || 0;
+    const aboveFold = (rect) => !!rect && rect.y >= 0 && rect.y < viewportHeight;
+
+    return {
+      product_title_visible: isVisible(title),
+      product_price_visible: isVisible(price),
+      product_add_to_cart_visible: isVisible(addToCart),
+      product_content_visible: isVisible(title) && isVisible(price) && isVisible(addToCart),
+      product_title_above_fold: aboveFold(titleRect),
+      product_price_above_fold: aboveFold(priceRect),
+      product_add_to_cart_above_fold: aboveFold(addToCartRect),
+      product_content_above_fold: aboveFold(titleRect) && aboveFold(priceRect) && aboveFold(addToCartRect),
+      product_title_rect: titleRect,
+      product_price_rect: priceRect,
+      product_add_to_cart_rect: addToCartRect,
+    };
+  };
   try {
     const layoutShiftObserver = new PerformanceObserver((list) => {
       for (const entry of list.getEntries()) {
@@ -748,8 +772,26 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     record('layout_shift_observer_unavailable', { message: error?.message || String(error) });
   }
   const sample = () => {
+    const productMetrics = productContentMetrics();
+    if (productMetrics.product_title_visible) {
+      mark('product_title_visible');
+    }
+    if (productMetrics.product_price_visible) {
+      mark('product_price_visible');
+    }
+    if (productMetrics.product_add_to_cart_visible) {
+      mark('product_add_to_cart_visible');
+    }
+    if (productMetrics.product_content_visible) {
+      mark('product_content_visible');
+    }
+
     const container = document.querySelector('#wc-stripe-express-checkout-element');
     if (!container) {
+      state.latestProduct = {
+        t_ms: elapsed(),
+        ...productMetrics,
+      };
       return;
     }
     mark('container_seen');
@@ -781,7 +823,12 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
       button_count: buttons.length,
       visible_button_count: visibleButtons.length,
       container_visible: isVisible(container),
+      ...productMetrics,
       ...trackedContainerMetrics(),
+    };
+    state.latestProduct = {
+      t_ms: state.latest.t_ms,
+      ...productMetrics,
     };
     state.samples.push(state.latest);
   };
@@ -853,6 +900,29 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
         const rect = node.getBoundingClientRect();
         return style.visibility !== 'hidden' && style.display !== 'none' && rect.width > 0 && rect.height > 0;
       };
+      const productNodes = {
+        title: document.querySelector('h1.product_title, .product_title, h1'),
+        price: document.querySelector('.summary .price, p.price, .price'),
+        add_to_cart: document.querySelector('form.cart button[type="submit"], form.cart .single_add_to_cart_button'),
+      };
+      const viewportHeight = window.innerHeight || document.documentElement?.clientHeight || 0;
+      const aboveFold = (rect) => !!rect && rect.y >= 0 && rect.y < viewportHeight;
+      const productRects = {
+        title: rectForNode(productNodes.title),
+        price: rectForNode(productNodes.price),
+        add_to_cart: rectForNode(productNodes.add_to_cart),
+      };
+      const productContent = {
+        title_visible: isVisible(productNodes.title),
+        price_visible: isVisible(productNodes.price),
+        add_to_cart_visible: isVisible(productNodes.add_to_cart),
+        content_visible: isVisible(productNodes.title) && isVisible(productNodes.price) && isVisible(productNodes.add_to_cart),
+        title_above_fold: aboveFold(productRects.title),
+        price_above_fold: aboveFold(productRects.price),
+        add_to_cart_above_fold: aboveFold(productRects.add_to_cart),
+        content_above_fold: aboveFold(productRects.title) && aboveFold(productRects.price) && aboveFold(productRects.add_to_cart),
+        rects: productRects,
+      };
       if (!container) {
         return {
           ece_container: false,
@@ -863,6 +933,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
           ece_visible_button_count: 0,
           ece_wallet_containers: walletContainers,
           ece_wallet_rects: walletRects,
+          product_content: productContent,
         };
       }
       const iframes = Array.from(container.querySelectorAll('iframe'));
@@ -876,6 +947,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
         ece_visible_button_count: buttons.filter(isVisible).length,
         ece_wallet_containers: walletContainers,
         ece_wallet_rects: walletRects,
+        product_content: productContent,
       };
     };
     const interactionSnapshot = (name) => {
@@ -1017,6 +1089,8 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   const eceMountTargetIds = Array.isArray(eceInstrumentation.mount_target_ids) ? eceInstrumentation.mount_target_ids : [];
   const eceMountTargetSelectors = Array.isArray(eceInstrumentation.mount_target_selectors) ? eceInstrumentation.mount_target_selectors : [];
   const renderSamples = renderProbe?.samples || [];
+  const latestProduct = renderProbe?.latestProduct || renderLatest;
+  const finalProductContent = scriptResult?.finalSnapshot?.product_content || {};
   const layoutShifts = Array.isArray(renderProbe?.layoutShifts) ? renderProbe.layoutShifts : [];
   const layoutShiftSourceDetails = layoutShifts.flatMap((entry) =>
     Array.isArray(entry.sources)
@@ -1154,6 +1228,21 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     browser_dom_node_count: browserMetrics.browser_dom_node_count ?? performanceSummary?.final?.dom?.nodes ?? null,
     browser_document_count: performanceSummary?.final?.dom?.documents ?? null,
     browser_js_event_listener_count: cdpMetrics.JSEventListeners ?? null,
+    product_title_visible_ms: numberOrNull(renderMarks.product_title_visible),
+    product_price_visible_ms: numberOrNull(renderMarks.product_price_visible),
+    product_add_to_cart_visible_ms: numberOrNull(renderMarks.product_add_to_cart_visible),
+    product_content_visible_ms: numberOrNull(renderMarks.product_content_visible),
+    product_title_visible: latestProduct.product_title_visible === true || finalProductContent.title_visible === true,
+    product_price_visible: latestProduct.product_price_visible === true || finalProductContent.price_visible === true,
+    product_add_to_cart_visible: latestProduct.product_add_to_cart_visible === true || finalProductContent.add_to_cart_visible === true,
+    product_content_visible: latestProduct.product_content_visible === true || finalProductContent.content_visible === true,
+    product_title_above_fold: latestProduct.product_title_above_fold === true || finalProductContent.title_above_fold === true,
+    product_price_above_fold: latestProduct.product_price_above_fold === true || finalProductContent.price_above_fold === true,
+    product_add_to_cart_above_fold: latestProduct.product_add_to_cart_above_fold === true || finalProductContent.add_to_cart_above_fold === true,
+    product_content_above_fold: latestProduct.product_content_above_fold === true || finalProductContent.content_above_fold === true,
+    product_title_rect: pickRect(latestProduct.product_title_rect, finalProductContent.rects?.title),
+    product_price_rect: pickRect(latestProduct.product_price_rect, finalProductContent.rects?.price),
+    product_add_to_cart_rect: pickRect(latestProduct.product_add_to_cart_rect, finalProductContent.rects?.add_to_cart),
     ece_render_container_seen_ms: numberOrNull(renderMarks.container_seen),
     ece_render_container_visible_ms: numberOrNull(renderMarks.container_visible),
     ece_render_first_child_ms: numberOrNull(renderMarks.first_child),
@@ -1288,6 +1377,10 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
         request_summary: requestSummary,
         wallet_fanout_evidence: walletFanoutEvidence,
         grouped_wallet_layout: groupedWalletLayout,
+        product_content: {
+          latest: latestProduct,
+          final: finalProductContent,
+        },
         express_checkout_instrumentation: {
           stripe_factory_calls: Array.isArray(eceInstrumentation.stripe_factory_calls) ? eceInstrumentation.stripe_factory_calls : [],
           elements_calls: Array.isArray(eceInstrumentation.elements_calls) ? eceInstrumentation.elements_calls : [],
@@ -1339,14 +1432,17 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   const groupedLayoutRequired = requireFanoutProof && metrics.ece_instance_count <= 1;
   const groupedLayoutPass = !groupedLayoutRequired || groupedWalletLayout.dimensionsPass;
   const fanoutProofPass = !requireFanoutProof || (walletFanoutEvidence.valid_fanout_proof && groupedLayoutPass);
+  const productContentPass = metrics.product_content_visible && (scenario.layout !== 'below-fold' || metrics.product_content_above_fold);
   const browserProbeCompleted = responses.length > 0 && existsSync(networkPath) && existsSync(performancePath);
-  const pass = fixtureHealth.ok && realWalletAssetHealth.ok && browserProbeCompleted && stripeUrls.length > 0 && simulatedClsPass && stripeLoadPass && fanoutProofPass;
+  const pass = fixtureHealth.ok && realWalletAssetHealth.ok && productContentPass && browserProbeCompleted && stripeUrls.length > 0 && simulatedClsPass && stripeLoadPass && fanoutProofPass;
   const summaryText = pass
     ? `Captured Stripe ECE product-page browser waterfall: ${stripeUrls.length} Stripe responses across ${responses.length} total responses.`
     : !fixtureHealth.ok
       ? fixtureHealthSummary(fixtureHealth)
       : !realWalletAssetHealth.ok
       ? realWalletAssetHealthSummary(realWalletAssetHealth)
+      : !productContentPass
+      ? `Product visible proof failed: visible=${metrics.product_content_visible}; above-fold=${metrics.product_content_above_fold}; title=${JSON.stringify(metrics.product_title_rect)}; price=${JSON.stringify(metrics.product_price_rect)}; add-to-cart=${JSON.stringify(metrics.product_add_to_cart_rect)}.`
       : !fanoutProofPass
       ? `ECE fan-out proof classified as ${walletFanoutEvidence.classification}; grouped layout valid=${groupedWalletLayout.dimensionsPass}; reason codes=${walletFanoutEvidence.reason_codes.join(',') || 'none'}. Requested ${requestedAcceptedPaymentMethods.join(',')}.`
       : stripeLoadPass
@@ -1385,6 +1481,11 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     id: 'stripe-load-errors',
     status: stripeLoadPass ? 'pass' : 'fail',
     message: `Recorded ${stripeLoadPageErrors.length} Stripe-related page error(s).`,
+  });
+  trace.assertion({
+    id: 'product-content-visible',
+    status: productContentPass ? 'pass' : 'fail',
+    message: `Product visible timing=${metrics.product_content_visible_ms}ms; visible=${metrics.product_content_visible}; above-fold=${metrics.product_content_above_fold}; title=${JSON.stringify(metrics.product_title_rect)}; price=${JSON.stringify(metrics.product_price_rect)}; add-to-cart=${JSON.stringify(metrics.product_add_to_cart_rect)}.`,
   });
   trace.assertion({
     id: 'real-wallet-asset-health',

--- a/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
+++ b/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
@@ -34,6 +34,9 @@ Homeboy core reporting change.
 | `webperf-desktop-load` | `load` | none | Normal-ish desktop LCP/FCP/TTFB/load/navigation timing shape. | Use for non-throttled absolute load context, not stable synthetic fan-out deltas. |
 | `webperf-desktop-slow-4g` | `load` | `low-end-mobile-slow-4g` | Stable synthetic third-party response fan-out and relative waterfall deltas. | Desktop rendering is intentionally paired with a slow synthetic throttle; do not present these as normal desktop absolute timings. |
 | `webperf-wallet-fanout` | `load` | `low-end-mobile-slow-4g` | Deterministic ECE create/mount count proof with `card,link,apple_pay,google_pay` requested. | Constructor and mount counts are primary proof; Stripe network/session counters are supporting evidence only. |
+| `webperf-below-fold-load` | `load` | none | Product content visible timing while ECE is below the initial viewport and no scroll occurs. | Use to prove deferred startup improves visible product load without requiring ECE readiness before proximity. |
+| `webperf-below-fold-scroll-to-ece` | `load` | none | Product content visible timing, then scroll-to-ECE readiness after viewport proximity. | Use for normal-ish desktop below-fold UX validation; not stable synthetic fan-out deltas. |
+| `webperf-below-fold-wallet-fanout` | `load` | `low-end-mobile-slow-4g` | Below-fold product-visible proof, post-scroll ECE readiness, and deterministic wallet fan-out evidence. | Constructor and mount counts are primary proof; Stripe network/session counters are supporting evidence only. |
 
 Set `woocommerce_stripe_ece_browser_profile=webperf-desktop-load` to keep the
 desktop browser context without synthetic CPU/network throttling. This profile
@@ -75,6 +78,25 @@ homeboy trace --rig woocommerce-stripe-ece-product-page \
   --profile webperf-wallet-fanout \
   woocommerce-gateway-stripe ece-product-page-waterfall \
   --output /tmp/wc-stripe-ece-wallet-fanout.json
+```
+
+Use the below-fold profiles when validating delayed or viewport-proximity ECE
+startup strategies. They keep the product title, price, and add-to-cart controls
+above the fold while moving the ECE container after `form.cart` and below the
+initial viewport. `webperf-below-fold-load` intentionally does not scroll, while
+`webperf-below-fold-scroll-to-ece` and `webperf-below-fold-wallet-fanout` record
+initial product timing first and then scroll near ECE to prove readiness.
+
+```bash
+homeboy trace compare woocommerce-gateway-stripe ece-product-page-below-fold-scroll-to-ece \
+  --rig woocommerce-stripe-ece-product-page \
+  --profile webperf-below-fold-wallet-fanout \
+  --baseline-target origin/develop \
+  --candidate ./candidate-worktree \
+  --repeat 5 \
+  --schedule interleaved \
+  --canonical \
+  --output /tmp/wc-stripe-ece-below-fold-fanout.compare.json
 ```
 
 Set `woocommerce_stripe_ece_browser_profile=secure-browser` to run the same
@@ -149,6 +171,11 @@ homeboy trace --rig woocommerce-stripe-ece-product-page \
 The stable signals are structural:
 
 - ECE container, child, iframe, visible iframe, and visible button timing.
+- Product title, price, and add-to-cart visible timing plus above-fold rects:
+  `product_title_visible_ms`, `product_price_visible_ms`,
+  `product_add_to_cart_visible_ms`, `product_content_visible_ms`,
+  `product_content_above_fold`, `product_title_rect`, `product_price_rect`, and
+  `product_add_to_cart_rect`.
 - Stripe/Stripe Network response count.
 - Total network response count.
 - Browser document count.

--- a/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
+++ b/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
@@ -278,6 +278,26 @@
         "woocommerce_stripe_ece_require_fanout_proof": "1"
       }
     },
+    "webperf-below-fold-load": {
+      "scenario": "ece-product-page-below-fold-load",
+      "settings": {
+        "woocommerce_stripe_ece_browser_profile": "webperf-desktop-load"
+      }
+    },
+    "webperf-below-fold-scroll-to-ece": {
+      "scenario": "ece-product-page-below-fold-scroll-to-ece",
+      "settings": {
+        "woocommerce_stripe_ece_browser_profile": "webperf-desktop-load"
+      }
+    },
+    "webperf-below-fold-wallet-fanout": {
+      "scenario": "ece-product-page-below-fold-scroll-to-ece",
+      "settings": {
+        "woocommerce_stripe_ece_browser_profile": "webperf-desktop-slow-4g",
+        "woocommerce_stripe_accepted_payment_methods": "card,link,apple_pay,google_pay",
+        "woocommerce_stripe_ece_require_fanout_proof": "1"
+      }
+    },
     "secure-browser": {
       "scenario": "ece-product-page-waterfall",
       "settings": {


### PR DESCRIPTION
## Summary
- Add below-fold Stripe ECE webperf trace profiles for load-only, scroll-to-ECE, and slow-4G wallet fanout compares.
- Keep product title, price, and add-to-cart above the fold while moving the ECE container below the viewport for deferred startup validation.
- Record product visible timing/above-fold rect metrics alongside existing ECE readiness, FCP/LCP/CLS, fanout, and error metrics.

Closes #316.

## Tests
- `node --test bench/ece-product-page-profile.test.mjs`
- `node --check bench/ece-product-page-waterfall.trace.mjs`
- `git diff --check`