### PR TITLE
Add Stripe ECE hint experiment profiles

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.mjs
@@ -2,6 +2,18 @@ export const DEFAULT_PROFILE = 'smoke';
 export const REAL_WALLET_PROFILE = 'real-wallet';
 export const WEBPERF_DESKTOP_LOAD_PROFILE = 'webperf-desktop-load';
 export const WEBPERF_DESKTOP_SLOW_4G_PROFILE = 'webperf-desktop-slow-4g';
+export const WEBPERF_STRIPE_HINTS_NONE_PROFILE = 'webperf-stripe-hints-none';
+export const WEBPERF_STRIPE_PRECONNECT_PROFILE = 'webperf-stripe-preconnect';
+export const WEBPERF_STRIPE_JS_PRELOAD_PROFILE = 'webperf-stripe-js-preload';
+export const WEBPERF_STRIPE_DEFERRED_PRECONNECT_PROFILE = 'webperf-stripe-deferred-preconnect';
+
+const STRIPE_HINT_ORIGINS = [
+  'https://js.stripe.com',
+  'https://api.stripe.com',
+  'https://m.stripe.network',
+];
+
+const STRIPE_JS_URL = 'https://js.stripe.com/v3/';
 
 const DESKTOP_BROWSER_PROBE_ARGS = [
   'browser=chromium',
@@ -53,6 +65,26 @@ const PROFILE_METADATA = {
     caveat: 'Desktop slow-4g profile keeps desktop rendering while applying deterministic low-end-mobile-slow-4g throttle; use it for stable synthetic third-party fan-out deltas, not absolute desktop timings.',
     conclusion: 'Stable synthetic third-party response fan-out and relative waterfall deltas.',
   },
+  [WEBPERF_STRIPE_HINTS_NONE_PROFILE]: {
+    label: 'Stripe hints baseline',
+    caveat: 'Stripe hints baseline uses the slow-4g webperf browser profile without preconnect, preload, or deferred ECE startup.',
+    conclusion: 'Opt-in no-hint control for Stripe hint experiments.',
+  },
+  [WEBPERF_STRIPE_PRECONNECT_PROFILE]: {
+    label: 'Stripe preconnect',
+    caveat: 'Stripe preconnect profile warms Stripe origins during product-page head parsing; compare against the no-hint control for visible-load regressions.',
+    conclusion: 'Opt-in Stripe origin connection warming experiment.',
+  },
+  [WEBPERF_STRIPE_JS_PRELOAD_PROFILE]: {
+    label: 'Stripe.js preload',
+    caveat: 'Stripe.js preload profile models an aggressive Stripe.js script preload and may compete with product-page critical resources.',
+    conclusion: 'Opt-in Stripe.js preload experiment for readiness versus visible-load tradeoffs.',
+  },
+  [WEBPERF_STRIPE_DEFERRED_PRECONNECT_PROFILE]: {
+    label: 'Deferred ECE plus Stripe preconnect',
+    caveat: 'Deferred ECE plus preconnect profile warms Stripe origins while deferring Woo Stripe Express Checkout script execution.',
+    conclusion: 'Opt-in deferred ECE startup with connection warming experiment.',
+  },
 };
 
 const SYNTHETIC_FANOUT_PUBLISHABLE_KEY = 'pk_test_TYooMQauvdEDq54NiTphI7jx';
@@ -101,6 +133,65 @@ function syntheticFanoutPublishableKey() {
   return process.env.HOMEBOY_WC_STRIPE_SYNTHETIC_PUBLISHABLE_KEY || SYNTHETIC_FANOUT_PUBLISHABLE_KEY;
 }
 
+function profileHintStrategy(profile) {
+  const configured = setting('woocommerce_stripe_ece_hint_strategy', process.env.HOMEBOY_WC_STRIPE_ECE_HINT_STRATEGY || '').trim();
+  if (configured) {
+    return configured;
+  }
+
+  switch (profile) {
+    case WEBPERF_STRIPE_PRECONNECT_PROFILE:
+      return 'stripe-preconnect';
+    case WEBPERF_STRIPE_JS_PRELOAD_PROFILE:
+      return 'stripe-js-preload';
+    case WEBPERF_STRIPE_DEFERRED_PRECONNECT_PROFILE:
+      return 'stripe-deferred-preconnect';
+    default:
+      return 'none';
+  }
+}
+
+function buildHintOptions(strategy) {
+  const preconnectLinks = ['stripe-preconnect', 'stripe-js-preload', 'stripe-deferred-preconnect'].includes(strategy)
+    ? STRIPE_HINT_ORIGINS.map((href) => ({ rel: 'preconnect', href, crossorigin: true }))
+    : [];
+  const preloadLinks = strategy === 'stripe-js-preload'
+    ? [{ rel: 'preload', href: STRIPE_JS_URL, as: 'script', crossorigin: true }]
+    : [];
+
+  return {
+    hintStrategy: strategy,
+    hintLinks: [...preconnectLinks, ...preloadLinks],
+    deferExpressCheckoutScript: strategy === 'stripe-deferred-preconnect',
+  };
+}
+
+function webperfProfileOptions(profile, metadata, { throttleProfile = null, hintStrategy = 'none' } = {}) {
+  const fanoutProof = requireSyntheticFanoutProof();
+  const hintOptions = buildHintOptions(hintStrategy);
+
+  return {
+    profile,
+    profileLabel: metadata.label,
+    profileCaveat: metadata.caveat,
+    profileConclusion: metadata.conclusion,
+    throttleProfile,
+    realWalletCapable: false,
+    syntheticOnly: true,
+    stripePublishableKey: fanoutProof ? syntheticFanoutPublishableKey() : null,
+    stripeSecretKey: null,
+    runtimePreview: null,
+    recipeRunArgs: [],
+    browserProbeArgs: [
+      ...DESKTOP_BROWSER_PROBE_ARGS,
+      ...(throttleProfile ? [`throttle=${throttleProfile}`] : []),
+    ],
+    browserProbeAssertions: WEBPERF_BROWSER_ASSERTIONS,
+    waitFor: 'load',
+    ...hintOptions,
+  };
+}
+
 function validateHttpsPublicUrl(value) {
   try {
     const url = new URL(value);
@@ -128,50 +219,23 @@ function requireRealWalletProfileEnv(publicUrl) {
 
 export function buildEceProfileOptions(profile = eceBrowserProfile()) {
   const metadata = profileMetadata(profile);
+  const hintStrategy = profileHintStrategy(profile);
 
   if (profile === WEBPERF_DESKTOP_LOAD_PROFILE) {
-    const fanoutProof = requireSyntheticFanoutProof();
-
-    return {
-      profile,
-      profileLabel: metadata.label,
-      profileCaveat: metadata.caveat,
-      profileConclusion: metadata.conclusion,
-      throttleProfile: null,
-      realWalletCapable: false,
-      syntheticOnly: true,
-      stripePublishableKey: fanoutProof ? syntheticFanoutPublishableKey() : null,
-      stripeSecretKey: null,
-      runtimePreview: null,
-      recipeRunArgs: [],
-      browserProbeArgs: DESKTOP_BROWSER_PROBE_ARGS,
-      browserProbeAssertions: WEBPERF_BROWSER_ASSERTIONS,
-      waitFor: 'load',
-    };
+    return webperfProfileOptions(profile, metadata, { hintStrategy });
   }
 
-  if (profile === WEBPERF_DESKTOP_SLOW_4G_PROFILE) {
-    const fanoutProof = requireSyntheticFanoutProof();
-
-    return {
-      profile,
-      profileLabel: metadata.label,
-      profileCaveat: metadata.caveat,
-      profileConclusion: metadata.conclusion,
+  if ([
+    WEBPERF_DESKTOP_SLOW_4G_PROFILE,
+    WEBPERF_STRIPE_HINTS_NONE_PROFILE,
+    WEBPERF_STRIPE_PRECONNECT_PROFILE,
+    WEBPERF_STRIPE_JS_PRELOAD_PROFILE,
+    WEBPERF_STRIPE_DEFERRED_PRECONNECT_PROFILE,
+  ].includes(profile)) {
+    return webperfProfileOptions(profile, metadata, {
       throttleProfile: 'low-end-mobile-slow-4g',
-      realWalletCapable: false,
-      syntheticOnly: true,
-      stripePublishableKey: fanoutProof ? syntheticFanoutPublishableKey() : null,
-      stripeSecretKey: null,
-      runtimePreview: null,
-      recipeRunArgs: [],
-      browserProbeArgs: [
-        ...DESKTOP_BROWSER_PROBE_ARGS,
-        'throttle=low-end-mobile-slow-4g',
-      ],
-      browserProbeAssertions: WEBPERF_BROWSER_ASSERTIONS,
-      waitFor: 'load',
-    };
+      hintStrategy,
+    });
   }
 
   if (!['secure-browser', REAL_WALLET_PROFILE].includes(profile)) {
@@ -190,6 +254,7 @@ export function buildEceProfileOptions(profile = eceBrowserProfile()) {
       browserProbeArgs: [],
       browserProbeAssertions: STRUCTURAL_BROWSER_ASSERTIONS,
       waitFor: null,
+      ...buildHintOptions(hintStrategy),
     };
   }
 
@@ -226,5 +291,6 @@ export function buildEceProfileOptions(profile = eceBrowserProfile()) {
     browserProbeArgs: DESKTOP_BROWSER_PROBE_ARGS,
     browserProbeAssertions: STRUCTURAL_BROWSER_ASSERTIONS,
     waitFor: null,
+    ...buildHintOptions(hintStrategy),
   };
 }

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
@@ -131,6 +131,65 @@ test('webperf desktop slow 4g profile keeps desktop context while applying Codeb
   assert.ok(!options.browserProbeArgs.includes('profile=low-end-mobile-slow-4g'));
 });
 
+test('Stripe hint experiment profiles are opt-in and expose active hint strategy', () => {
+  const none = buildEceProfileOptions('webperf-stripe-hints-none');
+  const preconnect = buildEceProfileOptions('webperf-stripe-preconnect');
+  const preload = buildEceProfileOptions('webperf-stripe-js-preload');
+  const deferred = buildEceProfileOptions('webperf-stripe-deferred-preconnect');
+
+  assert.equal(none.hintStrategy, 'none');
+  assert.deepEqual(none.hintLinks, []);
+  assert.equal(none.deferExpressCheckoutScript, false);
+
+  assert.equal(preconnect.hintStrategy, 'stripe-preconnect');
+  assert.deepEqual(
+    preconnect.hintLinks.map((link) => [link.rel, link.href]),
+    [
+      ['preconnect', 'https://js.stripe.com'],
+      ['preconnect', 'https://api.stripe.com'],
+      ['preconnect', 'https://m.stripe.network'],
+    ]
+  );
+  assert.equal(preconnect.deferExpressCheckoutScript, false);
+
+  assert.equal(preload.hintStrategy, 'stripe-js-preload');
+  assert.ok(preload.hintLinks.some((link) => link.rel === 'preload' && link.href === 'https://js.stripe.com/v3/' && link.as === 'script'));
+
+  assert.equal(deferred.hintStrategy, 'stripe-deferred-preconnect');
+  assert.equal(deferred.deferExpressCheckoutScript, true);
+  assert.ok(deferred.hintLinks.every((link) => link.rel === 'preconnect'));
+
+  for (const options of [none, preconnect, preload, deferred]) {
+    assert.equal(options.throttleProfile, 'low-end-mobile-slow-4g');
+    assert.equal(options.waitFor, 'load');
+    assert.ok(options.browserProbeAssertions.includes('assert=metric:browser_lcp_ms>=0'));
+  }
+});
+
+test('manual hint strategy setting can override browser profile defaults', () => {
+  const previous = {
+    HOMEBOY_SETTINGS_WOOCOMMERCE_STRIPE_ECE_HINT_STRATEGY: process.env.HOMEBOY_SETTINGS_WOOCOMMERCE_STRIPE_ECE_HINT_STRATEGY,
+    HOMEBOY_WC_STRIPE_ECE_HINT_STRATEGY: process.env.HOMEBOY_WC_STRIPE_ECE_HINT_STRATEGY,
+  };
+
+  process.env.HOMEBOY_SETTINGS_WOOCOMMERCE_STRIPE_ECE_HINT_STRATEGY = 'stripe-preconnect';
+
+  try {
+    const options = buildEceProfileOptions('webperf-desktop-load');
+
+    assert.equal(options.hintStrategy, 'stripe-preconnect');
+    assert.equal(options.hintLinks.length, 3);
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+});
+
 test('webperf wallet fanout profile supplies a non-secret synthetic publishable key', () => {
   const previous = {
     HOMEBOY_SETTINGS_WOOCOMMERCE_STRIPE_ECE_REQUIRE_FANOUT_PROOF: process.env.HOMEBOY_SETTINGS_WOOCOMMERCE_STRIPE_ECE_REQUIRE_FANOUT_PROOF,
@@ -183,6 +242,25 @@ test('rig manifest exposes the ECE webperf profile matrix', () => {
       woocommerce_stripe_accepted_payment_methods: 'card,link,apple_pay,google_pay',
       woocommerce_stripe_ece_require_fanout_proof: '1',
     },
+  });
+  assert.deepEqual(manifest.trace_profiles['webperf-stripe-hints-none'], {
+    scenario: 'ece-product-page-waterfall',
+    settings: {
+      woocommerce_stripe_ece_browser_profile: 'webperf-stripe-hints-none',
+      woocommerce_stripe_ece_hint_strategy: 'none',
+    },
+  });
+  assert.deepEqual(manifest.trace_profiles['webperf-stripe-preconnect'].settings, {
+    woocommerce_stripe_ece_browser_profile: 'webperf-stripe-preconnect',
+    woocommerce_stripe_ece_hint_strategy: 'stripe-preconnect',
+  });
+  assert.deepEqual(manifest.trace_profiles['webperf-stripe-js-preload'].settings, {
+    woocommerce_stripe_ece_browser_profile: 'webperf-stripe-js-preload',
+    woocommerce_stripe_ece_hint_strategy: 'stripe-js-preload',
+  });
+  assert.deepEqual(manifest.trace_profiles['webperf-stripe-deferred-preconnect'].settings, {
+    woocommerce_stripe_ece_browser_profile: 'webperf-stripe-deferred-preconnect',
+    woocommerce_stripe_ece_hint_strategy: 'stripe-deferred-preconnect',
   });
   assert.equal(manifest.trace_profiles['real-wallet'].public_preview, undefined);
 });
@@ -630,6 +708,11 @@ test('waterfall recipe passes structural assertions to browser-probe', () => {
   assert.match(traceSource, /npm', \['run', 'build:webpack'\]/);
   assert.match(traceSource, /profile_publishable_key/);
   assert.match(traceSource, /stripe_publishable_key/);
+  assert.match(traceSource, /stripe_hint_strategy/);
+  assert.match(traceSource, /stripe_hint_comparison_signals/);
+  assert.match(traceSource, /product_content_visible_ms/);
+  assert.match(traceSource, /homeboy-stripe-ece-hint-strategy/);
+  assert.match(traceSource, /script_loader_tag/);
   assert.match(traceSource, /homeboy_stripe_ece_asset_src_or_empty_data_uri/);
   assert.match(traceSource, /data:" \. \$mime_type \. ","/);
 });

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -36,6 +36,9 @@ const assetCheckBaseRef = process.env.HOMEBOY_WC_STRIPE_ECE_ASSET_BASE_REF || ''
 const profileOptions = buildEceProfileOptions();
 const encodedStripePublishableKey = profileOptions.stripePublishableKey ? Buffer.from(profileOptions.stripePublishableKey).toString('base64') : '';
 const encodedStripeSecretKey = profileOptions.stripeSecretKey ? Buffer.from(profileOptions.stripeSecretKey).toString('base64') : '';
+const stripeHintLinksJson = JSON.stringify(profileOptions.hintLinks || []);
+const encodedStripeHintLinks = Buffer.from(stripeHintLinksJson).toString('base64');
+const deferExpressCheckoutScript = profileOptions.deferExpressCheckoutScript === true;
 const traceHelperDir = process.env.HOMEBOY_TRACE_HELPER_DIR;
 const fixtureBootstrapPath = fileURLToPath(new URL('./fixture-bootstrap.php', import.meta.url));
 
@@ -274,6 +277,9 @@ try {
     browser_profile_caveat: profileOptions.profileCaveat,
     browser_wait_for: profileOptions.waitFor || scenario.waitFor || 'networkidle',
     browser_throttle_profile: profileOptions.throttleProfile,
+    stripe_hint_strategy: profileOptions.hintStrategy,
+    stripe_hint_link_count: profileOptions.hintLinks?.length || 0,
+    stripe_defer_express_checkout_script: deferExpressCheckoutScript,
     real_wallet_capable: profileOptions.realWalletCapable,
     synthetic_only: profileOptions.syntheticOnly,
   });
@@ -331,6 +337,9 @@ if ( ! is_dir( $mu_plugin_dir ) && ! wp_mkdir_p( $mu_plugin_dir ) ) {
 file_put_contents(
 	$mu_plugin_dir . '/homeboy-stripe-ece-fixture-dependencies.php',
 	'<?php
+$homeboy_stripe_ece_hint_links              = json_decode( base64_decode( "${encodedStripeHintLinks}" ), true );
+$homeboy_stripe_ece_defer_express_checkout = ${deferExpressCheckoutScript ? 'true' : 'false'};
+$homeboy_stripe_ece_active_hint_strategy   = "${profileOptions.hintStrategy}";
 add_action(
 	"wp_enqueue_scripts",
 	function () {
@@ -342,11 +351,34 @@ add_action(
 );
 add_action(
 	"wp_head",
-	function () {
+	function () use ( $homeboy_stripe_ece_hint_links, $homeboy_stripe_ece_active_hint_strategy ) {
 		if ( ! function_exists( "is_product" ) || ! is_product() ) {
 			return;
 		}
+		if ( is_array( $homeboy_stripe_ece_hint_links ) ) {
+			foreach ( $homeboy_stripe_ece_hint_links as $hint_link ) {
+				if ( ! is_array( $hint_link ) || empty( $hint_link["rel"] ) || empty( $hint_link["href"] ) ) {
+					continue;
+				}
+				$attrs = array(
+					"rel"  => $hint_link["rel"],
+					"href" => $hint_link["href"],
+				);
+				if ( ! empty( $hint_link["as"] ) ) {
+					$attrs["as"] = $hint_link["as"];
+				}
+				if ( ! empty( $hint_link["crossorigin"] ) ) {
+					$attrs["crossorigin"] = "anonymous";
+				}
+				$attr_html = "";
+				foreach ( $attrs as $attr_name => $attr_value ) {
+					$attr_html .= " " . esc_attr( $attr_name ) . "=\"" . esc_attr( $attr_value ) . "\"";
+				}
+				echo "<link" . $attr_html . ">\n";
+			}
+		}
 		?>
+<meta name="homeboy-stripe-ece-hint-strategy" content="<?php echo esc_attr( $homeboy_stripe_ece_active_hint_strategy ); ?>">
 <script id="homeboy-stripe-ece-wc-settings-shim">
 window.wc = window.wc || {};
 window.wcSettings = window.wcSettings || {};
@@ -359,6 +391,23 @@ window.wc.wcSettings = window.wc.wcSettings || {
 		<?php
 	},
 	0
+);
+add_filter(
+	"script_loader_tag",
+	function ( $tag, $handle, $src ) use ( $homeboy_stripe_ece_defer_express_checkout ) {
+		if ( ! $homeboy_stripe_ece_defer_express_checkout ) {
+			return $tag;
+		}
+		if ( ! is_string( $src ) || ! preg_match( "#/woocommerce-gateway-stripe/.*/express-checkout(\\.min)?\\.js#", $src ) ) {
+			return $tag;
+		}
+		if ( false !== strpos( $tag, " defer" ) ) {
+			return $tag;
+		}
+		return str_replace( "<script ", "<script defer ", $tag );
+	},
+	20,
+	3
 );
 add_filter(
 	"script_loader_src",
@@ -747,7 +796,38 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   } catch (error) {
     record('layout_shift_observer_unavailable', { message: error?.message || String(error) });
   }
+  const productContentNodes = () => ({
+    title: document.querySelector('h1.product_title, .product_title, h1'),
+    summary: document.querySelector('.summary'),
+    cart: document.querySelector('form.cart'),
+  });
+  const sampleProductContent = () => {
+    const nodes = productContentNodes();
+    const visible = Object.values(nodes).filter(isVisible);
+    if (visible.length > 0) {
+      mark('product_content_visible', { visible_count: visible.length });
+    }
+    if (isVisible(nodes.title)) {
+      mark('product_title_visible');
+    }
+    if (isVisible(nodes.summary)) {
+      mark('product_summary_visible');
+    }
+    if (isVisible(nodes.cart)) {
+      mark('product_cart_visible');
+    }
+    state.productLatest = {
+      t_ms: elapsed(),
+      title_visible: isVisible(nodes.title),
+      summary_visible: isVisible(nodes.summary),
+      cart_visible: isVisible(nodes.cart),
+      title_rect: rectForNode(nodes.title),
+      summary_rect: rectForNode(nodes.summary),
+      cart_rect: rectForNode(nodes.cart),
+    };
+  };
   const sample = () => {
+    sampleProductContent();
     const container = document.querySelector('#wc-stripe-express-checkout-element');
     if (!container) {
       return;
@@ -902,6 +982,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
       wallets: finalSnapshot.ece_wallet_containers,
       interactionEvents,
       renderProbe: probe,
+      productLatest: probe?.productLatest || null,
       stripeAvailability,
       eceInstrumentation: probe?.eceInstrumentation || null,
     });
@@ -929,6 +1010,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
         hasBelowFoldLayout: !!document.querySelector('#homeboy-ece-below-fold-layout'),
       },
       renderProbe: probe,
+      productLatest: probe?.productLatest || null,
       eceInstrumentation: probe?.eceInstrumentation || null,
     };
   `;
@@ -1098,6 +1180,10 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     browser_profile_conclusion: profileOptions.profileConclusion,
     browser_wait_for: profileOptions.waitFor || scenario.waitFor || 'networkidle',
     browser_throttle_profile: profileOptions.throttleProfile,
+    stripe_hint_strategy: profileOptions.hintStrategy,
+    stripe_hint_link_count: profileOptions.hintLinks?.length || 0,
+    stripe_hint_links: profileOptions.hintLinks || [],
+    stripe_defer_express_checkout_script: deferExpressCheckoutScript,
     ece_requested_accepted_payment_methods: requestedAcceptedPaymentMethods,
     ece_requested_payment_method_count: requestedAcceptedPaymentMethods.length,
     ece_requires_fanout_proof: requireFanoutProof,
@@ -1124,6 +1210,10 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     browser_secure_context_effective: scriptResult?.isSecureContext === true,
     browser_cls: roundedNumberOrNull(renderProbe.cls),
     browser_layout_shift_count: layoutShifts.length,
+    product_content_visible_ms: numberOrNull(renderMarks.product_content_visible),
+    product_title_visible_ms: numberOrNull(renderMarks.product_title_visible),
+    product_summary_visible_ms: numberOrNull(renderMarks.product_summary_visible),
+    product_cart_visible_ms: numberOrNull(renderMarks.product_cart_visible),
     ece_real_wallet_capable: profileOptions.realWalletCapable,
     ece_synthetic_only: profileOptions.syntheticOnly,
     ece_rendered_visible_button: eceRenderedVisibleButton,
@@ -1237,6 +1327,33 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
   });
   metrics.ece_real_wallet_asset_health_passed = realWalletAssetHealth.ok;
   metrics.ece_real_wallet_asset_health_failure_count = realWalletAssetHealth.failures.length;
+  metrics.stripe_hint_comparison_signals = {
+    visible_load: {
+      product_content_visible_ms: metrics.product_content_visible_ms,
+      fcp_ms: metrics.browser_fcp_ms,
+      lcp_ms: metrics.browser_lcp_ms,
+      cls: metrics.browser_cls,
+    },
+    ece_readiness: {
+      container_visible_ms: metrics.ece_render_container_visible_ms,
+      first_child_ms: metrics.ece_render_first_child_ms,
+      first_iframe_ms: metrics.ece_render_first_iframe_ms,
+      first_visible_button_ms: metrics.ece_render_first_visible_button_ms,
+      rendered_visible_button: metrics.ece_rendered_visible_button,
+    },
+    resources: {
+      network_response_count: metrics.network_response_count,
+      stripe_response_count: metrics.stripe_response_count,
+      browser_resource_count: metrics.browser_resource_count,
+      browser_transfer_size_bytes: metrics.browser_transfer_size_bytes,
+    },
+    errors: {
+      page_error_count: metrics.page_error_count,
+      console_message_count: metrics.console_message_count,
+      stripe_load_page_error_count: metrics.stripe_load_page_error_count,
+      stripe_elements_session_error_count: metrics.stripe_elements_session_error_count,
+    },
+  };
   const requestSummary = buildRequestSummary(responses);
 
   await writeFile(fixtureHealthPath, `${JSON.stringify(fixtureHealth, null, 2)}\n`);
@@ -1262,6 +1379,9 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
         browser_profile_label: profileOptions.profileLabel,
         browser_profile_caveat: profileOptions.profileCaveat,
         browser_profile_conclusion: profileOptions.profileConclusion,
+        stripe_hint_strategy: profileOptions.hintStrategy,
+        stripe_hint_links: profileOptions.hintLinks || [],
+        stripe_defer_express_checkout_script: deferExpressCheckoutScript,
         requested_browser_context: {
           viewport,
           browser_profile: profileOptions.profile,
@@ -1269,6 +1389,9 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
           throttle_profile: profileOptions.throttleProfile,
           runtime_preview: profileOptions.runtimePreview,
           browser_probe_args: profileOptions.browserProbeArgs,
+          stripe_hint_strategy: profileOptions.hintStrategy,
+          stripe_hint_links: profileOptions.hintLinks || [],
+          stripe_defer_express_checkout_script: deferExpressCheckoutScript,
           secure_context_profile: ['secure-browser', 'real-wallet'].includes(profileOptions.profile),
           real_wallet_capable: profileOptions.realWalletCapable,
           synthetic_only: profileOptions.syntheticOnly,
@@ -1286,6 +1409,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
           statuses: elementsSessionStatuses,
         },
         request_summary: requestSummary,
+        stripe_hint_comparison_signals: metrics.stripe_hint_comparison_signals,
         wallet_fanout_evidence: walletFanoutEvidence,
         grouped_wallet_layout: groupedWalletLayout,
         express_checkout_instrumentation: {

--- a/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
+++ b/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
@@ -34,6 +34,10 @@ Homeboy core reporting change.
 | `webperf-desktop-load` | `load` | none | Normal-ish desktop LCP/FCP/TTFB/load/navigation timing shape. | Use for non-throttled absolute load context, not stable synthetic fan-out deltas. |
 | `webperf-desktop-slow-4g` | `load` | `low-end-mobile-slow-4g` | Stable synthetic third-party response fan-out and relative waterfall deltas. | Desktop rendering is intentionally paired with a slow synthetic throttle; do not present these as normal desktop absolute timings. |
 | `webperf-wallet-fanout` | `load` | `low-end-mobile-slow-4g` | Deterministic ECE create/mount count proof with `card,link,apple_pay,google_pay` requested. | Constructor and mount counts are primary proof; Stripe network/session counters are supporting evidence only. |
+| `webperf-stripe-hints-none` | `load` | `low-end-mobile-slow-4g` | Opt-in no-hint control for Stripe hint experiments. | Use as the baseline for hint comparisons; it does not alter default/fanout profiles. |
+| `webperf-stripe-preconnect` | `load` | `low-end-mobile-slow-4g` | Adds product-page preconnect hints for `https://js.stripe.com`, `https://api.stripe.com`, and `https://m.stripe.network`. | Compare against `webperf-stripe-hints-none` to catch visible-load regressions from connection warming. |
+| `webperf-stripe-js-preload` | `load` | `low-end-mobile-slow-4g` | Adds Stripe origin preconnect hints plus a `https://js.stripe.com/v3/` script preload. | Aggressive preload can compete with critical product-page resources; treat regressions as expected experiment evidence. |
+| `webperf-stripe-deferred-preconnect` | `load` | `low-end-mobile-slow-4g` | Adds Stripe origin preconnect hints and defers Woo Stripe Express Checkout script execution. | Models deferred ECE startup plus connection warming; compare ECE readiness and visible load together. |
 
 Set `woocommerce_stripe_ece_browser_profile=webperf-desktop-load` to keep the
 desktop browser context without synthetic CPU/network throttling. This profile
@@ -76,6 +80,32 @@ homeboy trace --rig woocommerce-stripe-ece-product-page \
   woocommerce-gateway-stripe ece-product-page-waterfall \
   --output /tmp/wc-stripe-ece-wallet-fanout.json
 ```
+
+Use the opt-in Stripe hint profiles to compare whether connection warming or
+preloading improves ECE readiness without hurting visible load. These profiles
+all write the active `stripe_hint_strategy`, emitted `stripe_hint_links`, and
+`stripe_defer_express_checkout_script` values into `ece-waterfall-metrics.json`
+and `ece-waterfall-metadata.json`.
+
+```bash
+homeboy trace compare woocommerce-gateway-stripe ece-product-page-waterfall \
+  --rig woocommerce-stripe-ece-product-page \
+  --baseline-profile webperf-stripe-hints-none \
+  --candidate-profile webperf-stripe-preconnect \
+  --repeat 5 \
+  --schedule interleaved \
+  --output /tmp/wc-stripe-ece-preconnect-compare.json
+```
+
+For each run, review `stripe_hint_comparison_signals` first. It groups the
+fields that decide whether a hint strategy helped or regressed the product page:
+
+| Group | Fields |
+| --- | --- |
+| Visible load | `product_content_visible_ms`, `browser_fcp_ms`, `browser_lcp_ms`, `browser_cls` |
+| ECE readiness | `ece_render_container_visible_ms`, `ece_render_first_child_ms`, `ece_render_first_iframe_ms`, `ece_render_first_visible_button_ms`, `ece_rendered_visible_button` |
+| Resources | `network_response_count`, `stripe_response_count`, `browser_resource_count`, `browser_transfer_size_bytes` |
+| Errors | `page_error_count`, `console_message_count`, `stripe_load_page_error_count`, `stripe_elements_session_error_count` |
 
 Set `woocommerce_stripe_ece_browser_profile=secure-browser` to run the same
 Stripe product-page scenario through generic secure/browser-visible upstream
@@ -159,6 +189,12 @@ The stable signals are structural:
   `browser_profile_label`, `browser_profile_caveat`,
   `browser_profile_conclusion`, `browser_wait_for`, and
   `browser_throttle_profile`.
+- Active Stripe hint strategy: `stripe_hint_strategy`, `stripe_hint_links`,
+  `stripe_defer_express_checkout_script`, and grouped
+  `stripe_hint_comparison_signals` for compare reports.
+- Visible product-page timing: `product_content_visible_ms`,
+  `product_title_visible_ms`, `product_summary_visible_ms`, and
+  `product_cart_visible_ms`.
 - WP Codebox web performance metrics when available: `browser_ttfb_ms`,
   `browser_fcp_ms`, `browser_lcp_ms`, and `browser_nav_duration_ms`.
 - Real-wallet evidence classification: `ece_real_wallet_capable` and

--- a/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
+++ b/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
@@ -278,6 +278,34 @@
         "woocommerce_stripe_ece_require_fanout_proof": "1"
       }
     },
+    "webperf-stripe-hints-none": {
+      "scenario": "ece-product-page-waterfall",
+      "settings": {
+        "woocommerce_stripe_ece_browser_profile": "webperf-stripe-hints-none",
+        "woocommerce_stripe_ece_hint_strategy": "none"
+      }
+    },
+    "webperf-stripe-preconnect": {
+      "scenario": "ece-product-page-waterfall",
+      "settings": {
+        "woocommerce_stripe_ece_browser_profile": "webperf-stripe-preconnect",
+        "woocommerce_stripe_ece_hint_strategy": "stripe-preconnect"
+      }
+    },
+    "webperf-stripe-js-preload": {
+      "scenario": "ece-product-page-waterfall",
+      "settings": {
+        "woocommerce_stripe_ece_browser_profile": "webperf-stripe-js-preload",
+        "woocommerce_stripe_ece_hint_strategy": "stripe-js-preload"
+      }
+    },
+    "webperf-stripe-deferred-preconnect": {
+      "scenario": "ece-product-page-waterfall",
+      "settings": {
+        "woocommerce_stripe_ece_browser_profile": "webperf-stripe-deferred-preconnect",
+        "woocommerce_stripe_ece_hint_strategy": "stripe-deferred-preconnect"
+      }
+    },
     "secure-browser": {
       "scenario": "ece-product-page-waterfall",
       "settings": {


### PR DESCRIPTION
## Summary
- Adds opt-in WooCommerce Stripe ECE product-page hint profiles for no-hint baseline, Stripe preconnect, Stripe.js preload, and deferred ECE plus preconnect.
- Emits the active hint strategy, hint links, deferred-script state, product-visible timings, and grouped comparison signals in waterfall metrics/metadata.
- Documents the compare workflow and adds focused profile/manifest/report-field tests.

Closes #317.

## Verification
- `node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`
- `node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.mjs && node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs`
- `node -e "JSON.parse(require('node:fs').readFileSync('woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json','utf8'))"`
- `git diff --check`