### PR TITLE
Add product visible-load metrics for Stripe ECE

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/README.md
+++ b/woocommerce/woocommerce-gateway-stripe/README.md
@@ -23,6 +23,10 @@ scenario IDs reuse the same fixture and add post-load product-page interactions:
 
 Primary metrics:
 
+- `product_content_visible_ms`
+- `product_summary_visible_ms`
+- `add_to_cart_visible_ms`
+- `ece_container_reserved_ms`
 - `ece_render_container_seen_ms`
 - `ece_render_first_child_ms`
 - `ece_render_first_iframe_ms`

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
@@ -771,6 +771,16 @@ test('waterfall recipe passes structural assertions to browser-probe', () => {
   assert.match(traceSource, /ece_instance_count/);
   assert.match(traceSource, /ece_mount_count/);
   assert.match(traceSource, /ece_mount_target_selectors/);
+  assert.match(traceSource, /productContentSelectors/);
+  assert.match(traceSource, /product_content_visible_ms/);
+  assert.match(traceSource, /product_summary_visible_ms/);
+  assert.match(traceSource, /add_to_cart_visible_ms/);
+  assert.match(traceSource, /ece_container_reserved_ms/);
+  assert.match(traceSource, /\.product_title/);
+  assert.match(traceSource, /\.summary/);
+  assert.match(traceSource, /form\.cart/);
+  assert.match(traceSource, /\.single_add_to_cart_button/);
+  assert.match(traceSource, /product_content_selectors/);
   assert.match(traceSource, /id: 'ece-construction-observed'/);
   assert.match(traceSource, /id: 'ece-grouped-wallet-layout'/);
   assert.match(traceSource, /id: 'fixture-health'/);

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -85,6 +85,13 @@ const metricsPath = path.join(artifactDir, 'ece-waterfall-metrics.json');
 const metadataPath = path.join(artifactDir, 'ece-waterfall-metadata.json');
 const fixtureHealthPath = path.join(artifactDir, 'ece-fixture-health.json');
 const realWalletAssetHealthPath = path.join(artifactDir, 'ece-real-wallet-asset-health.json');
+const productContentSelectors = {
+  title: ['h1.product_title', '.product_title', 'h1'],
+  summary: ['.summary'],
+  price: ['.summary .price', 'p.price', '.price'],
+  cart: ['form.cart'],
+  add_to_cart: ['form.cart button[type="submit"]', 'form.cart .single_add_to_cart_button'],
+};
 
 function event(source, name, data = {}) {
   return trace.mark(name, data, source);
@@ -854,6 +861,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     }
     if (metrics.product_add_to_cart_visible) {
       mark('product_add_to_cart_visible');
+      mark('add_to_cart_visible');
     }
     state.latestProduct = metrics;
     state.productLatest = {
@@ -878,6 +886,9 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
       return;
     }
     mark('container_seen');
+    if ((rectForNode(container)?.height ?? 0) > 0) {
+      mark('ece_container_reserved', { rect: rectForNode(container) });
+    }
     if (isVisible(container)) {
       mark('container_visible');
     }
@@ -1291,6 +1302,8 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     product_title_visible_ms: numberOrNull(renderMarks.product_title_visible),
     product_summary_visible_ms: numberOrNull(renderMarks.product_summary_visible),
     product_cart_visible_ms: numberOrNull(renderMarks.product_cart_visible),
+    add_to_cart_visible_ms: numberOrNull(renderMarks.add_to_cart_visible),
+    ece_container_reserved_ms: numberOrNull(renderMarks.ece_container_reserved),
     ece_real_wallet_capable: profileOptions.realWalletCapable,
     ece_synthetic_only: profileOptions.syntheticOnly,
     ece_rendered_visible_button: eceRenderedVisibleButton,
@@ -1496,6 +1509,7 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
           synthetic_only: profileOptions.syntheticOnly,
           required_env: profileOptions.realWalletCapable ? ['STRIPE_PUBLISHABLE_KEY', 'STRIPE_SECRET_KEY', 'HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL'] : [],
         },
+        product_content_selectors: productContentSelectors,
         effective_browser_context: {
           viewport: effectiveViewport,
           is_secure_context: scriptResult?.isSecureContext === true,

--- a/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
+++ b/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
@@ -201,11 +201,13 @@ homeboy trace --rig woocommerce-stripe-ece-product-page \
 The stable signals are structural:
 
 - ECE container, child, iframe, visible iframe, and visible button timing.
-- Product title, price, and add-to-cart visible timing plus above-fold rects:
+- Product title, price, summary, cart, add-to-cart, and content visible timing
+  plus above-fold rects: `product_content_visible_ms`,
   `product_title_visible_ms`, `product_price_visible_ms`,
-  `product_add_to_cart_visible_ms`, `product_content_visible_ms`,
-  `product_content_above_fold`, `product_title_rect`, `product_price_rect`, and
-  `product_add_to_cart_rect`.
+  `product_summary_visible_ms`, `product_cart_visible_ms`,
+  `product_add_to_cart_visible_ms`, `add_to_cart_visible_ms`,
+  `ece_container_reserved_ms`, `product_content_above_fold`,
+  `product_title_rect`, `product_price_rect`, and `product_add_to_cart_rect`.
 - Stripe/Stripe Network response count.
 - Total network response count.
 - Browser document count.
@@ -219,9 +221,6 @@ The stable signals are structural:
 - Active Stripe hint strategy: `stripe_hint_strategy`, `stripe_hint_links`,
   `stripe_defer_express_checkout_script`, and grouped
   `stripe_hint_comparison_signals` for compare reports.
-- Visible product-page timing: `product_content_visible_ms`,
-  `product_title_visible_ms`, `product_summary_visible_ms`, and
-  `product_cart_visible_ms`.
 - WP Codebox web performance metrics when available: `browser_ttfb_ms`,
   `browser_fcp_ms`, `browser_lcp_ms`, and `browser_nav_duration_ms`.
 - Real-wallet evidence classification: `ece_real_wallet_capable` and
@@ -245,14 +244,27 @@ browser scheduling, and third-party Stripe network variance.
 ## Render Timing Instrumentation
 
 The browser probe injects a pre-page observer before WooCommerce or Stripe page
-scripts run. It records the first time the ECE container is seen, becomes
-visible, receives children, receives Stripe iframes, receives visible iframes,
-receives visible buttons, and fires a transition event inside the ECE container.
+scripts run. It records the first time stable product content selectors become
+visible, the first time the ECE container reserves layout space, the first time
+the ECE container is seen, becomes visible, receives children, receives Stripe
+iframes, receives visible iframes, receives visible buttons, and fires a
+transition event inside the ECE container.
 It also records peak child/iframe/button counts because Stripe can add and then
 remove surfaces during wallet eligibility checks.
 
-These fields are written to `ece-waterfall-metrics.json` with the
-`ece_render_*` prefix. The raw observer events are also preserved in
+Product visible-load selectors are rig-owned defaults for the disposable classic
+WooCommerce product fixture:
+
+| Metric | Selectors |
+| --- | --- |
+| `product_content_visible_ms` | `h1.product_title, .product_title, h1`, `.summary .price, p.price, .price`, and `form.cart button[type="submit"], form.cart .single_add_to_cart_button` all visible |
+| `product_summary_visible_ms` | `.summary` |
+| `product_price_visible_ms` | `.summary .price, p.price, .price` |
+| `product_add_to_cart_visible_ms` / `add_to_cart_visible_ms` | `form.cart button[type="submit"], form.cart .single_add_to_cart_button` |
+| `ece_container_reserved_ms` | `#wc-stripe-express-checkout-element` with a non-zero bounding-box height |
+
+These fields are written to `ece-waterfall-metrics.json`; ECE-specific render
+fields keep the `ece_render_*` prefix. The raw observer events are also preserved in
 `ece-waterfall-metadata.json` for debugging false positives or missing marks.
 
 For `webperf-wallet-fanout`, the pre-page script also wraps the Stripe factory,


### PR DESCRIPTION
## Summary
- Add rig-owned product visible-load selectors and trace marks for product content, product summary, add-to-cart visibility, and ECE reserved space.
- Emit `product_content_visible_ms`, `product_summary_visible_ms`, `add_to_cart_visible_ms`, and `ece_container_reserved_ms` in `ece-waterfall-metrics.json` so trace aggregates/compares can report medians.
- Document the stable selectors and guard the instrumentation contract with focused tests.

Fixes #315.

## Verification
- `node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`
- `node scripts/lint-rig-packages.mjs`
- `node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs`
- `git diff --check`
- `homeboy rig check woocommerce-stripe-ece-product-page`
- Non-canonical smoke trace before rebase passed and emitted the new metrics.

## Caveat
- A post-rebase non-canonical smoke trace rerun failed fixture health on the lab Stripe checkout before useful product/ECE content rendered. The failure output still showed the new metric keys present, but the run is not reviewer-facing proof because the lab target checkout is dirty/detached and the fixture page failed to resolve.