### PR TITLE
Surface ECE readiness metrics in compare reports

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/README.md
+++ b/woocommerce/woocommerce-gateway-stripe/README.md
@@ -240,6 +240,9 @@ The wrapper writes:
 - `README.md` with baseline/candidate/profile/preview settings.
 - `ece-product-page-waterfall.compare.json` and `.compare.log`.
 - `ece-product-page-scroll-to-ece.compare.json` and `.compare.log`.
+- `ece-product-page-waterfall.compare.md` and
+  `ece-product-page-scroll-to-ece.compare.md` markdown summaries copied from
+  Homeboy's trace compare `summary.md` artifacts.
 
 Reviewer evidence fields to inspect in each compare artifact:
 
@@ -250,6 +253,10 @@ Reviewer evidence fields to inspect in each compare artifact:
   `ece_render_first_child_ms`, `ece_render_first_iframe_ms`,
   `ece_render_first_visible_iframe_ms`, `ece_render_first_visible_button_ms`,
   and `ece_rendered_visible_button`.
+- ECE readiness UX timing: `ece_ready_ms`, `ece_visible_ms`,
+  `ece_first_iframe_ms`, and `stripe_js_loaded_ms`.
+- ECE payment method availability: `ece_available_payment_methods` and
+  `ece_available_payment_method_details`.
 - Child/iframe/button counts: `ece_render_peak_child_count`,
   `ece_render_peak_iframe_count`, and
   `ece_render_peak_visible_iframe_count`.

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -104,6 +104,10 @@ function csvToJsonArray(value) {
     .filter(Boolean);
 }
 
+function methodListForSummary(methods) {
+  return Array.isArray(methods) && methods.length > 0 ? methods.join(',') : 'none';
+}
+
 function pickRect(...rects) {
   return rects.find((rect) => rect && typeof rect === 'object') || null;
 }
@@ -1666,6 +1670,11 @@ if ( ! get_permalink( (int) $state['product_id'] ) ) {
     id: 'ece-construction-observed',
     status: observedEceConstruction ? 'pass' : 'fail',
     message: `Observed ${metrics.ece_instance_count} Express Checkout Element create call(s) and ${metrics.ece_mount_count} mount call(s) targeting ${eceMountTargetSelectors.join(', ') || 'no targets'}.`,
+  });
+  trace.assertion({
+    id: 'ece-readiness-timings',
+    status: metrics.ece_ready_ms === null && metrics.ece_visible_ms === null && metrics.ece_first_iframe_ms === null ? 'skip' : 'pass',
+    message: `ECE readiness timings: ece_ready_ms=${metrics.ece_ready_ms ?? 'null'}, ece_visible_ms=${metrics.ece_visible_ms ?? 'null'}, ece_first_iframe_ms=${metrics.ece_first_iframe_ms ?? 'null'}, stripe_js_loaded_ms=${metrics.stripe_js_loaded_ms ?? 'null'}; payment methods requested=${methodListForSummary(metrics.ece_available_payment_methods?.requested)}, created=${methodListForSummary(metrics.ece_available_payment_methods?.created)}, rendered=${methodListForSummary(metrics.ece_available_payment_methods?.rendered)}, observed=${methodListForSummary(metrics.ece_available_payment_methods?.observed)}.`,
   });
   trace.assertion({
     id: 'scenario-interaction',

--- a/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
+++ b/woocommerce/woocommerce-gateway-stripe/docs/ece-product-page-waterfall.md
@@ -228,6 +228,10 @@ The stable signals are structural:
 - Deterministic ECE construction fields: `ece_create_call_count`,
   `ece_instance_count`, `ece_mount_count`, `ece_mount_target_ids`,
   `ece_mount_target_selectors`, and `ece_create_payment_methods`.
+- Explicit ECE readiness fields: `ece_ready_ms`, `ece_visible_ms`,
+  `ece_first_iframe_ms`, `stripe_js_loaded_ms`,
+  `ece_available_payment_methods`, and
+  `ece_available_payment_method_details`.
 - Stripe Elements session status/error counts and visible-button outcome.
 - Deterministic CLS fields for simulated profiles: `browser_cls`,
   `browser_layout_shift_count`, `ece_render_final_container_height`,
@@ -264,8 +268,16 @@ WooCommerce product fixture:
 | `ece_container_reserved_ms` | `#wc-stripe-express-checkout-element` with a non-zero bounding-box height |
 
 These fields are written to `ece-waterfall-metrics.json`; ECE-specific render
-fields keep the `ece_render_*` prefix. The raw observer events are also preserved in
-`ece-waterfall-metadata.json` for debugging false positives or missing marks.
+fields keep the `ece_render_*` prefix. The raw observer events are also preserved
+in `ece-waterfall-metadata.json` for debugging false positives or missing marks.
+The trace also promotes shopper-facing readiness fields into
+`ece-waterfall-metrics.json`: `ece_ready_ms` for first usable ECE signal,
+`ece_visible_ms` for visible container timing, `ece_first_iframe_ms` for Stripe
+iframe arrival, `stripe_js_loaded_ms` when Stripe.js load/factory timing is
+observable, and normalized requested/created/rendered/observed payment method
+details. Homeboy trace compare markdown reports include the scalar timing
+metrics in their metric delta table when observed, and the trace assertion
+summary includes the readiness/payment-method snapshot for reviewers.
 
 For `webperf-wallet-fanout`, the pre-page script also wraps the Stripe factory,
 `stripe.elements()`, `elements.create('expressCheckout', ...)`, and each ECE

--- a/woocommerce/woocommerce-gateway-stripe/tools/real-wallet-ece-compare.sh
+++ b/woocommerce/woocommerce-gateway-stripe/tools/real-wallet-ece-compare.sh
@@ -119,6 +119,8 @@ run_compare() {
   local scenario="$1"
   local output="$OUTPUT_DIR/${scenario}.compare.json"
   local log="$OUTPUT_DIR/${scenario}.compare.log"
+  local compare_dir="$OUTPUT_DIR/${scenario}.trace-compare"
+  local markdown="$OUTPUT_DIR/${scenario}.compare.md"
   local -a command=(
     homeboy trace compare "$COMPONENT" "$scenario"
     --rig "$RIG_ID"
@@ -128,11 +130,13 @@ run_compare() {
     --repeat "$REPEAT"
     --schedule interleaved
     --canonical
+    --output-dir "$compare_dir"
     --output "$output"
   )
 
   printf '\n== %s ==\n' "$scenario"
   printf 'JSON: %s\n' "$output"
+  printf 'Markdown: %s\n' "$markdown"
   printf 'Log:  %s\n' "$log"
   printf 'Command:'
   printf ' %q' "${command[@]}"
@@ -140,6 +144,9 @@ run_compare() {
 
   if [[ "$DRY_RUN" -eq 0 ]]; then
     "${command[@]}" 2>&1 | tee "$log"
+    if [[ -f "$compare_dir/summary.md" ]]; then
+      cp "$compare_dir/summary.md" "$markdown"
+    fi
   fi
 }
 
@@ -155,7 +162,7 @@ cat > "$OUTPUT_DIR/README.md" <<EOF
 - Preview port: \`$PREVIEW_PORT\`
 - Public URL: $PREVIEW_PUBLIC_URL
 
-Review \`ece-product-page-waterfall.compare.json\` and \`ece-product-page-scroll-to-ece.compare.json\` together. The command logs live beside each JSON file.
+Review \`ece-product-page-waterfall.compare.json\` and \`ece-product-page-scroll-to-ece.compare.json\` together. Markdown compare summaries are copied to matching \`.compare.md\` files, and command logs live beside each JSON file.
 EOF
 
 printf 'Evidence directory: %s\n' "$OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- Copies Homeboy trace compare `summary.md` artifacts into canonical real-wallet ECE evidence as matching `.compare.md` files.
- Adds a trace assertion that summarizes `ece_ready_ms`, `ece_visible_ms`, `ece_first_iframe_ms`, `stripe_js_loaded_ms`, and payment-method availability for reviewer-facing markdown.
- Documents the readiness timing and payment-method fields in the ECE rig docs and real-wallet compare workflow.

## Tests
- `node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs`
- `node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`
- `STRIPE_PUBLISHABLE_KEY=pk_test_dummy STRIPE_SECRET_KEY=sk_test_dummy woocommerce/woocommerce-gateway-stripe/tools/real-wallet-ece-compare.sh --candidate HEAD --preview-port 49800 --public-url https://example.test --output-dir /tmp/homeboy-rigs-ece-dry-run --dry-run`

Follow-up for #314.