### PR TITLE
Improve rig path portability

### DIFF
--- a/WordPress/gutenberg/rigs/gutenberg-notes-unsaved-attachment/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-notes-unsaved-attachment/rig.json
@@ -113,7 +113,7 @@
       {
         "kind": "command",
         "label": "Gutenberg checkout exists",
-        "command": "test -f \"$HOME/Developer/gutenberg/gutenberg.php\" || { printf '%s\n' 'Missing Gutenberg checkout: expected ~/Developer/gutenberg/gutenberg.php.'; exit 1; }"
+        "command": "gutenberg_path=\"${components.gutenberg.path}\"; test -f \"$gutenberg_path/gutenberg.php\" || { printf '%s\n' \"Missing Gutenberg checkout: expected $gutenberg_path/gutenberg.php. Pass --path /path/to/gutenberg or update components.gutenberg.path.\"; exit 1; }"
       },
       {
         "kind": "command",

--- a/WordPress/gutenberg/rigs/gutenberg-pattern-preview-assets/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-pattern-preview-assets/rig.json
@@ -56,7 +56,7 @@
       {
         "kind": "command",
         "label": "Gutenberg checkout exists",
-        "command": "test -f \"$HOME/Developer/gutenberg/gutenberg.php\" || { printf '%s\n' 'Missing Gutenberg checkout: expected ~/Developer/gutenberg/gutenberg.php.'; exit 1; }"
+        "command": "gutenberg_path=\"${components.gutenberg.path}\"; test -f \"$gutenberg_path/gutenberg.php\" || { printf '%s\n' \"Missing Gutenberg checkout: expected $gutenberg_path/gutenberg.php. Pass --path /path/to/gutenberg or update components.gutenberg.path.\"; exit 1; }"
       },
       {
         "kind": "command",

--- a/chubes4/isolated-block-editor/rigs/isolated-block-editor/rig.json
+++ b/chubes4/isolated-block-editor/rigs/isolated-block-editor/rig.json
@@ -1,9 +1,9 @@
 {
   "id": "isolated-block-editor",
-  "description": "Isolated Block Editor maintenance rig. Runs the build and unit test checks used when shaving IBE toward modern Gutenberg APIs. Worktree-friendly: if node_modules is missing, temporarily symlinks the primary checkout's node_modules for the command duration.",
+  "description": "Isolated Block Editor maintenance rig. Runs the build and unit test checks used when shaving IBE toward modern Gutenberg APIs. Worktree-friendly: if node_modules is missing, temporarily symlinks shared node_modules for the command duration.",
   "components": {
     "isolated-block-editor": {
-      "path": "/var/lib/datamachine/workspace/isolated-block-editor",
+      "path": "~/Developer/isolated-block-editor",
       "branch": "trunk"
     }
   },
@@ -16,9 +16,9 @@
         "contains": "@chubes4/isolated-block-editor"
       },
       {
-        "kind": "check",
-        "label": "Primary node_modules is available",
-        "file": "/var/lib/datamachine/workspace/isolated-block-editor/node_modules/.bin/babel"
+        "kind": "command",
+        "label": "Shared node_modules is available",
+        "command": "component_path=\"${components.isolated-block-editor.path}\"; case \"$component_path\" in '~'/*) component_path=\"$HOME/${component_path#~/}\" ;; esac; shared_node_modules=\"${HOMEBOY_SHARED_NODE_MODULES_PATH:-${HOMEBOY_SETTINGS_SHARED_NODE_MODULES_PATH:-$component_path/node_modules}}\"; case \"$shared_node_modules\" in '~'/*) shared_node_modules=\"$HOME/${shared_node_modules#~/}\" ;; esac; test -x \"$shared_node_modules/.bin/babel\" || { printf '%s\n' \"Missing Babel binary: expected $shared_node_modules/.bin/babel. Set HOMEBOY_SHARED_NODE_MODULES_PATH or HOMEBOY_SETTINGS_SHARED_NODE_MODULES_PATH.\"; exit 1; }"
       }
     ],
     "check": [
@@ -29,21 +29,19 @@
         "contains": "@chubes4/isolated-block-editor"
       },
       {
-        "kind": "check",
-        "label": "Primary node_modules is available",
-        "file": "/var/lib/datamachine/workspace/isolated-block-editor/node_modules/.bin/babel"
+        "kind": "command",
+        "label": "Shared node_modules is available",
+        "command": "component_path=\"${components.isolated-block-editor.path}\"; case \"$component_path\" in '~'/*) component_path=\"$HOME/${component_path#~/}\" ;; esac; shared_node_modules=\"${HOMEBOY_SHARED_NODE_MODULES_PATH:-${HOMEBOY_SETTINGS_SHARED_NODE_MODULES_PATH:-$component_path/node_modules}}\"; case \"$shared_node_modules\" in '~'/*) shared_node_modules=\"$HOME/${shared_node_modules#~/}\" ;; esac; test -x \"$shared_node_modules/.bin/babel\" || { printf '%s\n' \"Missing Babel binary: expected $shared_node_modules/.bin/babel. Set HOMEBOY_SHARED_NODE_MODULES_PATH or HOMEBOY_SETTINGS_SHARED_NODE_MODULES_PATH.\"; exit 1; }"
       },
       {
         "kind": "command",
         "label": "npm run build",
-        "cwd": "${components.isolated-block-editor.path}",
-        "command": "if [ ! -e node_modules ]; then ln -s /var/lib/datamachine/workspace/isolated-block-editor/node_modules node_modules; trap 'rm node_modules' EXIT; fi; npm run build"
+        "command": "bash \"${package.root}/../../shared/node/with-shared-node-modules.sh\" \"${components.isolated-block-editor.path}\" npm run build"
       },
       {
         "kind": "command",
         "label": "npm test -- --runInBand",
-        "cwd": "${components.isolated-block-editor.path}",
-        "command": "if [ ! -e node_modules ]; then ln -s /var/lib/datamachine/workspace/isolated-block-editor/node_modules node_modules; trap 'rm node_modules' EXIT; fi; npm test -- --runInBand"
+        "command": "bash \"${package.root}/../../shared/node/with-shared-node-modules.sh\" \"${components.isolated-block-editor.path}\" npm test -- --runInBand"
       }
     ],
     "down": []

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
 const root = process.argv[2] ? join(process.cwd(), process.argv[2]) : process.cwd();
 const ignoredDirectories = new Set(['.git', '.claude', '.datamachine', '.opencode', 'node_modules', 'vendor']);
 const phpFiles = [];
+const rigFiles = [];
 const failures = [];
 
 if (!existsSync(root)) {
@@ -26,6 +27,36 @@ function walk(directory) {
     if (entry.isFile() && entry.name.endsWith('.php')) {
       phpFiles.push(join(directory, entry.name));
     }
+
+    if (entry.isFile() && entry.name === 'rig.json') {
+      rigFiles.push(join(directory, entry.name));
+    }
+  }
+}
+
+function lintRigPortability(file) {
+  const rel = relative(root, file);
+  const contents = readFileSync(file, 'utf8');
+  let rig;
+
+  try {
+    rig = JSON.parse(contents);
+  } catch (error) {
+    failures.push(`${rel}: invalid JSON: ${error.message}`);
+    return;
+  }
+
+  const pipelineCommands = Object.values(rig.pipeline || {})
+    .flatMap((steps) => Array.isArray(steps) ? steps : [])
+    .map((step) => step.command || '')
+    .join('\n');
+
+  if (rel.startsWith('WordPress/gutenberg/rigs/') && /\$HOME\/Developer\/gutenberg|~\/Developer\/gutenberg/.test(pipelineCommands)) {
+    failures.push(`${rel}: Gutenberg rig checks must reference ${'${components.gutenberg.path}'} instead of a hard-coded personal checkout path`);
+  }
+
+  if (rel === 'chubes4/isolated-block-editor/rigs/isolated-block-editor/rig.json' && contents.includes('/var/lib/datamachine')) {
+    failures.push(`${rel}: isolated-block-editor must use the component path or shared node_modules setting instead of /var/lib/datamachine`);
   }
 }
 
@@ -46,7 +77,23 @@ function hasPhp() {
   }
 }
 
+function reportFailures() {
+  if (failures.length === 0) {
+    return;
+  }
+
+  console.error('Rig package lint failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
 walk(root);
+
+rigFiles.forEach(lintRigPortability);
+
+reportFailures();
 
 if (!hasPhp()) {
   console.warn(`PHP not found; skipped syntax checks for ${phpFiles.length} PHP file(s).`);
@@ -55,13 +102,8 @@ if (!hasPhp()) {
 
 phpFiles.forEach(lintPhp);
 
-if (failures.length > 0) {
-  console.error('Rig package PHP syntax lint failed:');
-  for (const failure of failures) {
-    console.error(`- ${failure}`);
-  }
-  process.exit(1);
-}
+reportFailures();
 
-console.log('Rig package PHP syntax lint passed.');
+console.log('Rig package lint passed.');
 console.log(`- PHP syntax: ${phpFiles.length} file(s)`);
+console.log(`- rig portability: ${rigFiles.length} rig(s)`);

--- a/shared/node/with-shared-node-modules.sh
+++ b/shared/node/with-shared-node-modules.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+	printf '%s\n' 'Usage: with-shared-node-modules.sh <component-path> <command> [args...]' >&2
+	exit 2
+fi
+
+component_path=$1
+shift
+shared_node_modules=${HOMEBOY_SHARED_NODE_MODULES_PATH:-${HOMEBOY_SETTINGS_SHARED_NODE_MODULES_PATH:-$component_path/node_modules}}
+
+case "$component_path" in
+	'~'/*) component_path="$HOME/${component_path#~/}" ;;
+esac
+
+case "$shared_node_modules" in
+	'~'/*) shared_node_modules="$HOME/${shared_node_modules#~/}" ;;
+esac
+
+test -d "$component_path" || {
+	printf '%s\n' "Missing component checkout: expected $component_path." >&2
+	exit 1
+}
+
+cd "$component_path"
+
+if [ ! -e node_modules ]; then
+	test -d "$shared_node_modules" || {
+		printf '%s\n' "Missing shared node_modules: expected $shared_node_modules. Set HOMEBOY_SHARED_NODE_MODULES_PATH or HOMEBOY_SETTINGS_SHARED_NODE_MODULES_PATH." >&2
+		exit 1
+	}
+	ln -s "$shared_node_modules" node_modules
+	trap 'rm node_modules' EXIT
+fi
+
+"$@"


### PR DESCRIPTION
## Summary
- Use declared Gutenberg component paths in rig checkout checks instead of hard-coded ~/Developer/gutenberg paths.
- Move isolated-block-editor off /var/lib/datamachine by using a portable default component path and a shared node_modules setting/helper.
- Extend rig package lint with targeted portability checks for these regressions.

## Verification
- node scripts/lint-rig-packages.mjs
- bash -n shared/node/with-shared-node-modules.sh
- git diff --check
- homeboy rig install --all ./WordPress/gutenberg
- homeboy rig install ./chubes4/isolated-block-editor
- homeboy rig check --force-hot --allow-local-hot gutenberg-pattern-preview-assets
- homeboy rig check --force-hot --allow-local-hot gutenberg-notes-unsaved-attachment
- homeboy rig check --force-hot --allow-local-hot isolated-block-editor (expected local prerequisite failure: missing ~/Developer/isolated-block-editor checkout and node_modules/Babel)

## Blockers
- Default lab offload targeted checks hit stale runner-side linked rig sources, so successful Gutenberg checks were rerun locally with --force-hot --allow-local-hot.
- Isolated Block Editor check cannot fully pass on this machine without the IBE checkout/dependencies; it now fails on the generic ~/Developer/isolated-block-editor / shared node_modules prerequisite instead of /var/lib/datamachine.