### PR TITLE
Collapse Stripe ECE trace workload defaults

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
+++ b/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
@@ -18,239 +18,61 @@
   "trace": {
     "default_component": "woocommerce-gateway-stripe"
   },
+  "trace_workload_defaults": {
+    "nodejs": {
+      "check_groups": [],
+      "port_range_size": 1,
+      "trace_default_phase_preset": "browser-waterfall",
+      "trace_phase_presets": {
+        "browser-waterfall": [
+          "start:scenario.start",
+          "recipe:wp_codebox.recipe.start",
+          "setup:wordpress.fixture.ready",
+          "probe:browser.probe.ready",
+          "metrics:waterfall.metrics.ready"
+        ]
+      },
+      "trace_span_metadata": {
+        "phase.recipe_to_setup": {
+          "category": "runtime_setup",
+          "blocking": true
+        },
+        "phase.setup_to_probe": {
+          "category": "browser_probe",
+          "blocking": true
+        },
+        "phase.probe_to_metrics": {
+          "category": "artifact_extraction",
+          "blocking": true
+        }
+      }
+    }
+  },
   "trace_workloads": {
     "nodejs": [
       {
-        "path": "${package.root}/bench/ece-product-page-waterfall.trace.mjs",
-        "check_groups": [],
-        "port_range_size": 1,
-        "trace_default_phase_preset": "browser-waterfall",
-        "trace_phase_presets": {
-          "browser-waterfall": [
-            "start:scenario.start",
-            "recipe:wp_codebox.recipe.start",
-            "setup:wordpress.fixture.ready",
-            "probe:browser.probe.ready",
-            "metrics:waterfall.metrics.ready"
-          ]
-        },
-        "trace_span_metadata": {
-          "phase.recipe_to_setup": {
-            "category": "runtime_setup",
-            "blocking": true
-          },
-          "phase.setup_to_probe": {
-            "category": "browser_probe",
-            "blocking": true
-          },
-          "phase.probe_to_metrics": {
-            "category": "artifact_extraction",
-            "blocking": true
-          }
-        }
+        "path": "${package.root}/bench/ece-product-page-waterfall.trace.mjs"
       },
       {
-        "path": "${package.root}/bench/ece-product-page-scroll-to-ece.trace.mjs",
-        "check_groups": [],
-        "port_range_size": 1,
-        "trace_default_phase_preset": "browser-waterfall",
-        "trace_phase_presets": {
-          "browser-waterfall": [
-            "start:scenario.start",
-            "recipe:wp_codebox.recipe.start",
-            "setup:wordpress.fixture.ready",
-            "probe:browser.probe.ready",
-            "metrics:waterfall.metrics.ready"
-          ]
-        },
-        "trace_span_metadata": {
-          "phase.recipe_to_setup": {
-            "category": "runtime_setup",
-            "blocking": true
-          },
-          "phase.setup_to_probe": {
-            "category": "browser_probe",
-            "blocking": true
-          },
-          "phase.probe_to_metrics": {
-            "category": "artifact_extraction",
-            "blocking": true
-          }
-        }
+        "path": "${package.root}/bench/ece-product-page-scroll-to-ece.trace.mjs"
       },
       {
-        "path": "${package.root}/bench/ece-product-page-below-fold-load.trace.mjs",
-        "check_groups": [],
-        "port_range_size": 1,
-        "trace_default_phase_preset": "browser-waterfall",
-        "trace_phase_presets": {
-          "browser-waterfall": [
-            "start:scenario.start",
-            "recipe:wp_codebox.recipe.start",
-            "setup:wordpress.fixture.ready",
-            "probe:browser.probe.ready",
-            "metrics:waterfall.metrics.ready"
-          ]
-        },
-        "trace_span_metadata": {
-          "phase.recipe_to_setup": {
-            "category": "runtime_setup",
-            "blocking": true
-          },
-          "phase.setup_to_probe": {
-            "category": "browser_probe",
-            "blocking": true
-          },
-          "phase.probe_to_metrics": {
-            "category": "artifact_extraction",
-            "blocking": true
-          }
-        }
+        "path": "${package.root}/bench/ece-product-page-below-fold-load.trace.mjs"
       },
       {
-        "path": "${package.root}/bench/ece-product-page-below-fold-scroll-to-ece.trace.mjs",
-        "check_groups": [],
-        "port_range_size": 1,
-        "trace_default_phase_preset": "browser-waterfall",
-        "trace_phase_presets": {
-          "browser-waterfall": [
-            "start:scenario.start",
-            "recipe:wp_codebox.recipe.start",
-            "setup:wordpress.fixture.ready",
-            "probe:browser.probe.ready",
-            "metrics:waterfall.metrics.ready"
-          ]
-        },
-        "trace_span_metadata": {
-          "phase.recipe_to_setup": {
-            "category": "runtime_setup",
-            "blocking": true
-          },
-          "phase.setup_to_probe": {
-            "category": "browser_probe",
-            "blocking": true
-          },
-          "phase.probe_to_metrics": {
-            "category": "artifact_extraction",
-            "blocking": true
-          }
-        }
+        "path": "${package.root}/bench/ece-product-page-below-fold-scroll-to-ece.trace.mjs"
       },
       {
-        "path": "${package.root}/bench/ece-product-page-quantity-change.trace.mjs",
-        "check_groups": [],
-        "port_range_size": 1,
-        "trace_default_phase_preset": "browser-waterfall",
-        "trace_phase_presets": {
-          "browser-waterfall": [
-            "start:scenario.start",
-            "recipe:wp_codebox.recipe.start",
-            "setup:wordpress.fixture.ready",
-            "probe:browser.probe.ready",
-            "metrics:waterfall.metrics.ready"
-          ]
-        },
-        "trace_span_metadata": {
-          "phase.recipe_to_setup": {
-            "category": "runtime_setup",
-            "blocking": true
-          },
-          "phase.setup_to_probe": {
-            "category": "browser_probe",
-            "blocking": true
-          },
-          "phase.probe_to_metrics": {
-            "category": "artifact_extraction",
-            "blocking": true
-          }
-        }
+        "path": "${package.root}/bench/ece-product-page-quantity-change.trace.mjs"
       },
       {
-        "path": "${package.root}/bench/ece-product-page-variation-change.trace.mjs",
-        "check_groups": [],
-        "port_range_size": 1,
-        "trace_default_phase_preset": "browser-waterfall",
-        "trace_phase_presets": {
-          "browser-waterfall": [
-            "start:scenario.start",
-            "recipe:wp_codebox.recipe.start",
-            "setup:wordpress.fixture.ready",
-            "probe:browser.probe.ready",
-            "metrics:waterfall.metrics.ready"
-          ]
-        },
-        "trace_span_metadata": {
-          "phase.recipe_to_setup": {
-            "category": "runtime_setup",
-            "blocking": true
-          },
-          "phase.setup_to_probe": {
-            "category": "browser_probe",
-            "blocking": true
-          },
-          "phase.probe_to_metrics": {
-            "category": "artifact_extraction",
-            "blocking": true
-          }
-        }
+        "path": "${package.root}/bench/ece-product-page-variation-change.trace.mjs"
       },
       {
-        "path": "${package.root}/bench/ece-product-page-simulated-cls.trace.mjs",
-        "check_groups": [],
-        "port_range_size": 1,
-        "trace_default_phase_preset": "browser-waterfall",
-        "trace_phase_presets": {
-          "browser-waterfall": [
-            "start:scenario.start",
-            "recipe:wp_codebox.recipe.start",
-            "setup:wordpress.fixture.ready",
-            "probe:browser.probe.ready",
-            "metrics:waterfall.metrics.ready"
-          ]
-        },
-        "trace_span_metadata": {
-          "phase.recipe_to_setup": {
-            "category": "runtime_setup",
-            "blocking": true
-          },
-          "phase.setup_to_probe": {
-            "category": "browser_probe",
-            "blocking": true
-          },
-          "phase.probe_to_metrics": {
-            "category": "artifact_extraction",
-            "blocking": true
-          }
-        }
+        "path": "${package.root}/bench/ece-product-page-simulated-cls.trace.mjs"
       },
       {
-        "path": "${package.root}/bench/ece-product-page-simulated-cls-reserved.trace.mjs",
-        "check_groups": [],
-        "port_range_size": 1,
-        "trace_default_phase_preset": "browser-waterfall",
-        "trace_phase_presets": {
-          "browser-waterfall": [
-            "start:scenario.start",
-            "recipe:wp_codebox.recipe.start",
-            "setup:wordpress.fixture.ready",
-            "probe:browser.probe.ready",
-            "metrics:waterfall.metrics.ready"
-          ]
-        },
-        "trace_span_metadata": {
-          "phase.recipe_to_setup": {
-            "category": "runtime_setup",
-            "blocking": true
-          },
-          "phase.setup_to_probe": {
-            "category": "browser_probe",
-            "blocking": true
-          },
-          "phase.probe_to_metrics": {
-            "category": "artifact_extraction",
-            "blocking": true
-          }
-        }
+        "path": "${package.root}/bench/ece-product-page-simulated-cls-reserved.trace.mjs"
       }
     ]
   },


### PR DESCRIPTION
## Summary
- move repeated Stripe ECE trace workload check groups, port sizing, phase presets, and span metadata into core-supported trace_workload_defaults
- leave each ECE trace workload entry as the portable workload path only

## Validation
- cargo test rig (homeboy core worktree; 415 rig-related lib tests plus filtered integration tests passed)
- node scripts/lint-rig-packages.mjs
- node JSON parse lint for all *.json files
- cargo run -- rig install --all <local woocommerce-gateway-stripe rig package> && cargo run -- rig check woocommerce-stripe-ece-product-page --force-hot with HOMEBOY_WC_STRIPE_COMPONENT_PATH and HOMEBOY_WC_STRIPE_WOOCOMMERCE_PATH set to local dependency checkouts

## Notes
- No homeboy core PR needed: main already includes the generic trace_workload_defaults primitive and test coverage.
- Follow-up: consider a generic trace workload/profile matrix expansion primitive if future rig specs keep accumulating scenario/profile repetition beyond shared workload defaults.