### PR TITLE
Centralize Studio agent model rig variants

### DIFF
--- a/Automattic/studio/rigs/studio-agent-model-comparison.variants.json
+++ b/Automattic/studio/rigs/studio-agent-model-comparison.variants.json
@@ -1,0 +1,72 @@
+{
+  "description": "Authoritative variant data for the generated Studio agent model-comparison rigs.",
+  "shared": {
+    "bench": {
+      "default_component": "studio"
+    },
+    "bench_workloads": {
+      "nodejs": [
+        "${package.root}/bench/studio-agent-runtime.bench.mjs",
+        {
+          "path": "${package.root}/bench/studio-agent-site-build.bench.mjs",
+          "port_range_size": 10
+        },
+        "${package.root}/bench/studio-bfb-write-path.bench.mjs"
+      ]
+    },
+    "pipeline": {
+      "up": [
+        {
+          "kind": "command",
+          "label": "Install Studio dependencies",
+          "cwd": "${components.studio.path}",
+          "command": "npm install"
+        },
+        {
+          "kind": "command",
+          "label": "Build Studio CLI",
+          "cwd": "${components.studio.path}",
+          "command": "npm run cli:build --silent"
+        }
+      ],
+      "check": [
+        {
+          "kind": "check",
+          "label": "Studio CLI eval runner built",
+          "file": "${components.studio.path}/apps/cli/dist/cli/eval-runner.mjs"
+        },
+        {
+          "kind": "check",
+          "label": "Studio package dependencies installed",
+          "file": "${components.studio.path}/node_modules"
+        }
+      ]
+    }
+  },
+  "variants": [
+    {
+      "id": "studio-agent-claude-trunk",
+      "description": "Studio Claude Sonnet 4.6 on current Automattic/studio trunk. Used as the reference rig for trunk-vs-SSI comparisons.",
+      "studio_path": "~/Developer/studio@agent-sdk-baseline",
+      "studio_branch": "agent-sdk-baseline",
+      "studio_bench_variant": "claude-sonnet-4-6-trunk",
+      "studio_agent_model": "claude-sonnet-4-6"
+    },
+    {
+      "id": "studio-agent-claude-ssi",
+      "description": "Studio Claude Sonnet 4.6 on the active Static Site Importer draft branch. Pairs with studio-agent-gpt55-ssi so the same SSI substrate can be compared across models.",
+      "studio_path": "~/Developer/studio@bfb-mu-plugin-agent-output",
+      "studio_branch": "bfb-mu-plugin-agent-output-draft",
+      "studio_bench_variant": "claude-sonnet-4-6-ssi",
+      "studio_agent_model": "claude-sonnet-4-6"
+    },
+    {
+      "id": "studio-agent-gpt55-ssi",
+      "description": "Studio GPT 5.5 / pi-agent-core runtime on the active Static Site Importer draft branch. Pairs with studio-agent-claude-ssi so the same SSI substrate can be compared across models.",
+      "studio_path": "~/Developer/studio@bfb-mu-plugin-agent-output",
+      "studio_branch": "bfb-mu-plugin-agent-output-draft",
+      "studio_bench_variant": "gpt-5.5-ssi",
+      "studio_agent_model": "gpt-5.5"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -273,6 +273,13 @@ WooCommerce site-generation benchmarks are tracked as future work until the Stud
 
 `rigs/studio-agent-claude-ssi/rig.json` and `rigs/studio-agent-gpt55-ssi/rig.json` are paired bench rigs for Studio agent-runtime and SSI site-build A/B checks across models. `rigs/studio-agent-claude-trunk/rig.json` remains available for trunk-vs-SSI comparisons. They share `bench/studio-agent-runtime.bench.mjs`, `bench/studio-agent-site-build.bench.mjs`, and `bench/studio-bfb-write-path.bench.mjs`.
 
+Those model-comparison rigs are generated from `rigs/studio-agent-model-comparison.variants.json` so the shared workload and pipeline configuration has one repo-local source of truth while Homeboy still consumes ordinary `rig.json` files. Update the variant data, then run:
+
+```bash
+node scripts/generate-studio-agent-model-rigs.mjs
+node scripts/generate-studio-agent-model-rigs.mjs --check
+```
+
 `stacks/studio-combined.json` rebuilds `fork/dev/combined-fixes` from `origin/trunk` plus Chris's active Automattic/studio local-dev PRs.
 
 ## WordPress/wordpress-playground

--- a/scripts/generate-studio-agent-model-rigs.mjs
+++ b/scripts/generate-studio-agent-model-rigs.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const variantsPath = path.join(repoRoot, 'Automattic/studio/rigs/studio-agent-model-comparison.variants.json');
+const checkOnly = process.argv.includes('--check');
+
+function requiredString(object, key, context) {
+  if (typeof object?.[key] !== 'string' || object[key] === '') {
+    throw new Error(`${context}: missing required string ${key}`);
+  }
+  return object[key];
+}
+
+function stableJson(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function rigFromVariant(variant, shared) {
+  const id = requiredString(variant, 'id', 'variant');
+
+  return {
+    id,
+    description: requiredString(variant, 'description', id),
+    components: {
+      studio: {
+        path: requiredString(variant, 'studio_path', id),
+        branch: requiredString(variant, 'studio_branch', id),
+        extensions: {
+          nodejs: {
+            studio_bench_variant: requiredString(variant, 'studio_bench_variant', id),
+            studio_agent_model: requiredString(variant, 'studio_agent_model', id),
+          },
+        },
+      },
+    },
+    bench: shared.bench,
+    bench_workloads: shared.bench_workloads,
+    pipeline: shared.pipeline,
+  };
+}
+
+const data = JSON.parse(await readFile(variantsPath, 'utf8'));
+const variants = Array.isArray(data.variants) ? data.variants : [];
+const shared = data.shared || {};
+const ids = new Set();
+const failures = [];
+
+if (variants.length === 0) {
+  throw new Error(`${variantsPath}: variants must contain at least one variant`);
+}
+
+for (const variant of variants) {
+  const rig = rigFromVariant(variant, shared);
+  if (ids.has(rig.id)) {
+    throw new Error(`${variantsPath}: duplicate variant id ${rig.id}`);
+  }
+  ids.add(rig.id);
+
+  const rigPath = path.join(repoRoot, 'Automattic/studio/rigs', rig.id, 'rig.json');
+  const next = stableJson(rig);
+
+  if (checkOnly) {
+    const current = existsSync(rigPath) ? await readFile(rigPath, 'utf8') : '';
+    if (current !== next) {
+      failures.push(path.relative(repoRoot, rigPath));
+    }
+    continue;
+  }
+
+  await mkdir(path.dirname(rigPath), { recursive: true });
+  await writeFile(rigPath, next);
+}
+
+if (failures.length > 0) {
+  console.error('Generated Studio agent model rigs are stale:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  console.error('Run `node scripts/generate-studio-agent-model-rigs.mjs` and commit the results.');
+  process.exit(1);
+}
+
+console.log(checkOnly ? 'Studio agent model rigs are up to date.' : 'Generated Studio agent model rigs.');

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -9,6 +9,7 @@ const ignoredDirectories = new Set(['.git', '.claude', '.datamachine', '.opencod
 const phpFiles = [];
 const rigFiles = [];
 const failures = [];
+const studioModelRigGenerator = join(root, 'scripts/generate-studio-agent-model-rigs.mjs');
 
 if (!existsSync(root)) {
   console.error(`Lint root does not exist: ${root}`);
@@ -89,9 +90,22 @@ function reportFailures() {
   process.exit(1);
 }
 
+function lintGeneratedStudioModelRigs() {
+  if (!existsSync(studioModelRigGenerator)) {
+    return;
+  }
+
+  const result = spawnSync('node', [studioModelRigGenerator, '--check'], { encoding: 'utf8' });
+  if (result.status !== 0) {
+    const output = `${result.stdout || ''}${result.stderr || ''}`.trim();
+    failures.push(`Studio agent model rig generation check failed${output ? `: ${output}` : ''}`);
+  }
+}
+
 walk(root);
 
 rigFiles.forEach(lintRigPortability);
+lintGeneratedStudioModelRigs();
 
 reportFailures();
 


### PR DESCRIPTION
## Summary
- Adds repo-local variant data for the generated Studio agent model-comparison rigs.
- Adds a generator/check script so shared bench workload and pipeline config are maintained in one place while committed rig.json files remain compatible with current Homeboy.
- Wires the generated-rig check into the existing rig package lint and documents the update flow.

## Verification
- Studio agent model rigs are up to date.
- Rig package lint passed.
- PHP syntax: 11 file(s)
- rig portability: 14 rig(s)
- Did not run benchmarks.

## Follow-up
- Homeboy core should grow a released rig include/extends or profile overlay primitive so shared rig config and per-model component/settings variants can be declared directly without generated rig.json files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5
- **Used for:** Drafted the repo-local variant generator, lint integration, documentation update, and PR text; Chris remains responsible for review and testing.