### PR TITLE
Extract Woo shipping cache evidence matrix

### DIFF
--- a/woocommerce/woocommerce/docs/checkout-shipping-cache-matrix-report.md
+++ b/woocommerce/woocommerce/docs/checkout-shipping-cache-matrix-report.md
@@ -10,6 +10,12 @@ Generate the current report shape locally:
 node woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs
 ```
 
+The domain matrix lives in
+`woocommerce/woocommerce/tools/checkout-shipping-cache-matrix.json`; the report
+script only renders that data plus optional workload artifacts. This keeps the
+Woo-specific matrix shape close to the future Homeboy core evidence-matrix
+primitive without depending on unreleased core.
+
 Generate from one shared-state directory:
 
 ```bash

--- a/woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs
+++ b/woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs
@@ -1,23 +1,13 @@
 #!/usr/bin/env node
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { basename, join } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const issues = [
-	'https://github.com/woocommerce/woocommerce/issues/26569',
-	'https://github.com/woocommerce/woocommerce/issues/32055',
-	'https://github.com/woocommerce/woocommerce/issues/49259',
-];
-
-const plannedMatrix = [
-	{ cartItems: 40, packages: 1, totalChurnRuns: 3, profile: 'smoke' },
-	{ cartItems: 40, packages: 8, totalChurnRuns: 3, profile: 'smoke' },
-	{ cartItems: 200, packages: 8, totalChurnRuns: 5, profile: 'hot' },
-	{ cartItems: 200, packages: 40, totalChurnRuns: 5, profile: 'hot' },
-	{ cartItems: 1000, packages: 40, totalChurnRuns: 5, profile: 'hot' },
-];
-
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const defaultMatrixPath = resolve(__dirname, 'checkout-shipping-cache-matrix.json');
 const args = parseArgs(process.argv.slice(2));
+const matrix = readJson(args.matrix || defaultMatrixPath);
 const baselineRuns = readRuns(args.baseline || args.input);
 const candidateRuns = readRuns(args.candidate);
 const hasComparison = baselineRuns.length > 0 && candidateRuns.length > 0;
@@ -27,11 +17,11 @@ process.stdout.write(renderReport());
 
 function renderReport() {
 	const lines = [];
-	lines.push('# WooCommerce Shipping Cache Matrix Report');
+	lines.push(`# ${matrix.title}`);
 	lines.push('');
 	lines.push('## Issue Links');
 	lines.push('');
-	for (const issue of issues) {
+	for (const issue of matrix.issues || []) {
 		lines.push(`- ${issue}`);
 	}
 	lines.push('');
@@ -44,17 +34,17 @@ function renderReport() {
 	} else {
 		lines.push('- Mode: planned matrix only. No baseline or candidate values are present.');
 	}
-	lines.push('- Timing evidence and shipping-rate call-count evidence are reported separately.');
-	lines.push('- Deterministic expensive shipping-method fixture support landed in Extra-Chill/homeboy-extensions#1089.');
-	lines.push('- Baseline/candidate export wiring is pending Extra-Chill/homeboy#3516.');
+	for (const note of matrix.status_notes || []) {
+		lines.push(`- ${note}`);
+	}
 	lines.push('');
 	lines.push('## Matrix Knobs');
 	lines.push('');
 	lines.push('| Profile | Cart items | Packages | Total churn runs | Command settings |');
 	lines.push('|---|---:|---:|---:|---|');
-	for (const row of plannedMatrix) {
-		const settings = `bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"${row.cartItems}","WC_SHIPPING_CACHE_PACKAGES":"${row.packages}","WC_SHIPPING_CACHE_TOTAL_CHURN_RUNS":"${row.totalChurnRuns}"}`;
-		lines.push(`| ${row.profile} | ${row.cartItems} | ${row.packages} | ${row.totalChurnRuns} | \`${settings}\` |`);
+	for (const row of matrix.matrix_knobs || []) {
+		const settings = `bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"${row.cart_items}","WC_SHIPPING_CACHE_PACKAGES":"${row.packages}","WC_SHIPPING_CACHE_TOTAL_CHURN_RUNS":"${row.total_churn_runs}"}`;
+		lines.push(`| ${row.profile} | ${row.cart_items} | ${row.packages} | ${row.total_churn_runs} | \`${settings}\` |`);
 	}
 	lines.push('');
 	lines.push('## Timing Evidence');
@@ -69,12 +59,9 @@ function renderReport() {
 	lines.push('');
 	lines.push('| Control | Expected cache behavior | Current coverage |');
 	lines.push('|---|---|---|');
-	lines.push('| Warm repeat, unchanged package hash | Stay cached | Covered by `warm_*` rows |');
-	lines.push('| Package subtotal/total-only churn | Should stay cached if shipping inputs are unchanged | Covered by `total_churn_*` rows; sharpening tracked in homeboy-rigs#166 |');
-	lines.push('| Destination/postcode changes | Invalidate cache | Covered by `rehash_*` rows |');
-	lines.push('| Cart contents changes | Invalidate cache | Planned follow-up |');
-	lines.push('| Contents cost, coupon, tax, fee inputs | Validate expected behavior per WooCommerce cache key contract | Planned follow-up |');
-	lines.push('| Expensive deterministic shipping method | Amplify call-count regressions without browser noise | Available via Extra-Chill/homeboy-extensions#1089 |');
+	for (const control of matrix.controls || []) {
+		lines.push(`| ${control.control} | ${control.expected_cache_behavior} | ${control.current_coverage} |`);
+	}
 	lines.push('');
 	return `${lines.join('\n')}\n`;
 }
@@ -84,7 +71,7 @@ function renderTimingTable() {
 		return [
 			'| Status | Cart items | Packages | Cold ms | Warm p50 ms | Total churn p50 ms | Rehash p50 ms |',
 			'|---|---:|---:|---:|---:|---:|---:|',
-			...plannedMatrix.map((row) => `| pending | ${row.cartItems} | ${row.packages} |  |  |  |  |`),
+			...(matrix.matrix_knobs || []).map((row) => `| pending | ${row.cart_items} | ${row.packages} |  |  |  |  |`),
 		];
 	}
 
@@ -111,7 +98,7 @@ function renderCallTable() {
 		return [
 			'| Status | Cart items | Packages | Cold rate calls | Warm rate calls | Total churn rate calls | Rehash rate calls |',
 			'|---|---:|---:|---:|---:|---:|---:|',
-			...plannedMatrix.map((row) => `| pending | ${row.cartItems} | ${row.packages} |  |  |  |  |`),
+			...(matrix.matrix_knobs || []).map((row) => `| pending | ${row.cart_items} | ${row.packages} |  |  |  |  |`),
 		];
 	}
 
@@ -180,6 +167,13 @@ function readdirSafe(directory) {
 	}
 }
 
+function readJson(path) {
+	if (!existsSync(path)) {
+		throw new Error(`Matrix file does not exist: ${path}`);
+	}
+	return JSON.parse(readFileSync(path, 'utf8'));
+}
+
 function pairRuns(baseline, candidate) {
 	return candidate.map((candidateRun, index) => ({
 		baseline: baseline[index] || { metrics: {}, label: 'missing-baseline' },
@@ -207,7 +201,7 @@ function parseArgs(rawArgs) {
 	const parsed = {};
 	for (let i = 0; i < rawArgs.length; i++) {
 		const arg = rawArgs[i];
-		if (arg === '--input' || arg === '--baseline' || arg === '--candidate') {
+		if (arg === '--input' || arg === '--baseline' || arg === '--candidate' || arg === '--matrix') {
 			parsed[arg.slice(2)] = rawArgs[++i];
 		}
 	}

--- a/woocommerce/woocommerce/tools/checkout-shipping-cache-matrix.json
+++ b/woocommerce/woocommerce/tools/checkout-shipping-cache-matrix.json
@@ -1,0 +1,76 @@
+{
+  "schema": "homeboy-rigs.evidence-matrix.v1",
+  "title": "WooCommerce Shipping Cache Matrix Report",
+  "issues": [
+    "https://github.com/woocommerce/woocommerce/issues/26569",
+    "https://github.com/woocommerce/woocommerce/issues/32055",
+    "https://github.com/woocommerce/woocommerce/issues/49259"
+  ],
+  "status_notes": [
+    "Timing evidence and shipping-rate call-count evidence are reported separately.",
+    "Deterministic expensive shipping-method fixture support landed in Extra-Chill/homeboy-extensions#1089.",
+    "Baseline/candidate export wiring is pending Extra-Chill/homeboy#3516."
+  ],
+  "matrix_knobs": [
+    { "cart_items": 40, "packages": 1, "total_churn_runs": 3, "profile": "smoke" },
+    { "cart_items": 40, "packages": 8, "total_churn_runs": 3, "profile": "smoke" },
+    { "cart_items": 200, "packages": 8, "total_churn_runs": 5, "profile": "hot" },
+    { "cart_items": 200, "packages": 40, "total_churn_runs": 5, "profile": "hot" },
+    { "cart_items": 1000, "packages": 40, "total_churn_runs": 5, "profile": "hot" }
+  ],
+  "evidence_sections": [
+    {
+      "id": "timing",
+      "title": "Timing Evidence",
+      "metrics": [
+        "cold_shipping_ms",
+        "warm_shipping_p50_ms",
+        "total_churn_shipping_p50_ms",
+        "rehash_shipping_p50_ms"
+      ]
+    },
+    {
+      "id": "call_count",
+      "title": "Call-Count Evidence",
+      "metrics": [
+        "cold_rate_calculation_calls",
+        "warm_rate_calculation_calls",
+        "total_churn_rate_calculation_calls",
+        "rehash_rate_calculation_calls"
+      ]
+    }
+  ],
+  "controls": [
+    {
+      "control": "Warm repeat, unchanged package hash",
+      "expected_cache_behavior": "Stay cached",
+      "current_coverage": "Covered by `warm_*` rows"
+    },
+    {
+      "control": "Package subtotal/total-only churn",
+      "expected_cache_behavior": "Should stay cached if shipping inputs are unchanged",
+      "current_coverage": "Covered by `total_churn_*` rows; sharpening tracked in homeboy-rigs#166"
+    },
+    {
+      "control": "Destination/postcode changes",
+      "expected_cache_behavior": "Invalidate cache",
+      "current_coverage": "Covered by `rehash_*` rows"
+    },
+    {
+      "control": "Cart contents changes",
+      "expected_cache_behavior": "Invalidate cache",
+      "current_coverage": "Planned follow-up"
+    },
+    {
+      "control": "Contents cost, coupon, tax, fee inputs",
+      "expected_cache_behavior": "Validate expected behavior per WooCommerce cache key contract",
+      "current_coverage": "Planned follow-up"
+    },
+    {
+      "control": "Expensive deterministic shipping method",
+      "expected_cache_behavior": "Amplify call-count regressions without browser noise",
+      "current_coverage": "Available via Extra-Chill/homeboy-extensions#1089"
+    }
+  ],
+  "follow_up_primitive": "Homeboy core evidence-matrix primitive that accepts a matrix definition, baseline/candidate artifact selectors, metric sections, delta policies, and Markdown/JSON renderers."
+}


### PR DESCRIPTION
## Summary
- Move the Woo shipping-cache matrix definition, issue links, status notes, controls, and follow-up primitive note into `checkout-shipping-cache-matrix.json`.
- Keep `checkout-shipping-cache-matrix-report.mjs` as the Markdown renderer plus optional workload artifact reader.
- Document the data/rendering boundary so this stays compatible with a future Homeboy core evidence-matrix primitive without requiring unreleased core.

## Verification
- `node --check woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs`
- `node woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs`
- `node scripts/lint-rig-packages.mjs`
- Benchmarks were not run.

## Core follow-up
- Add a Homeboy core evidence-matrix primitive that accepts a matrix definition, baseline/candidate artifact selectors, metric sections, delta policies, and Markdown/JSON renderers.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implemented the matrix-data extraction, updated renderer wiring/docs, and ran non-benchmark verification.
