### PR TITLE
Use shared browser bench result helper

### DIFF
--- a/Automattic/studio/bench/studio-dashboard-browser.bench.mjs
+++ b/Automattic/studio/bench/studio-dashboard-browser.bench.mjs
@@ -25,7 +25,7 @@ if (!REDACTION_HELPER) {
   throw new Error('HOMEBOY_NODEJS_BENCH_REDACTION is required');
 }
 
-const { runBrowserPageScenario } = await import(BROWSER_HELPER);
+const { buildBrowserBenchResult, runBrowserPageScenario } = await import(BROWSER_HELPER);
 const { createBenchArtifactContext } = await import(ARTIFACT_CONTEXT_HELPER);
 const { sanitizeArtifactFile } = await import(REDACTION_HELPER);
 
@@ -144,7 +144,7 @@ export default async function studioDashboardBrowserBench() {
       throw new Error(`Browser trace/screenshot artifacts missing; raw_result=${artifactFile}`);
     }
 
-    return {
+    return buildBrowserBenchResult({
       metrics: {
         success_rate: 1,
         elapsed_ms: totalElapsedMs,
@@ -156,12 +156,12 @@ export default async function studioDashboardBrowserBench() {
         total_elapsed_ms: totalElapsedMs,
         ...browserResult.metrics,
       },
+      rawResultArtifact,
       artifacts: {
-        raw_result: rawResultArtifact,
         site_path: sitePath,
         ...browserResult.artifacts,
       },
-    };
+    });
   } finally {
     if (!stop) {
       stop = await stopSite(sitePath);


### PR DESCRIPTION
## Summary
- Convert the Studio dashboard browser bench result writer to use `buildBrowserBenchResult()`.
- Keep Studio-specific metrics and artifacts local while delegating Homeboy browser evidence result composition to the shared helper.

## Dependency
- Depends on Extra-Chill/homeboy-extensions#1479, which adds `buildBrowserBenchResult()` to `HOMEBOY_NODEJS_BROWSER_BENCH_HELPER`.

## Verification
- `node --check Automattic/studio/bench/studio-dashboard-browser.bench.mjs`
- `node scripts/lint-rig-packages.mjs`
- No local benchmark execution.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the Studio workload conversion and local static verification; Chris remains responsible for review and merge.