### PR TITLE
Remove Studio rig paper-over fallbacks

### DIFF
--- a/Automattic/studio/bench/lib/site-build-runtime.mjs
+++ b/Automattic/studio/bench/lib/site-build-runtime.mjs
@@ -37,22 +37,9 @@ function envPath(key) {
 export async function createStudioBenchRuntime(sharedState = SHARED_STATE) {
   const helperPath = envPath('HOMEBOY_NODEJS_INVOCATION_RUNTIME_HELPER');
   if (!helperPath) {
-    const artifactDir = path.join(sharedState, 'studio-agent-site-build-artifacts');
-    return {
-      invocationId: '',
-      artifactDir,
-      siteRoot: path.join(artifactDir, 'sites'),
-      stateDir: '',
-      cliConfigDir: '',
-      appDataDir: '',
-      processManagerHome: '',
-      tmpDir: '',
-      portBase: null,
-      portMax: null,
-      env: {},
-      async prepareDirs() {},
-      assertPort() {},
-    };
+    throw new Error(
+      'Studio site-build requires HOMEBOY_NODEJS_INVOCATION_RUNTIME_HELPER for isolated state, appdata, temp dirs, and port ranges.'
+    );
   }
 
   const { resolveHomeboyInvocationRuntime } = await import(helperPath);

--- a/Automattic/studio/bench/playground-web-startup.trace.mjs
+++ b/Automattic/studio/bench/playground-web-startup.trace.mjs
@@ -1,6 +1,6 @@
 import { createWriteStream } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
@@ -11,7 +11,7 @@ const HELPER_DIR = process.env.HOMEBOY_TRACE_HELPER_DIR;
 if (!HELPER_DIR) {
 	throw new Error('HOMEBOY_TRACE_HELPER_DIR is required');
 }
-const PLAYGROUND_PATH = process.env.PLAYGROUND_WEB_TRACE_PLAYGROUND_PATH || '/Users/chubes/Developer/wordpress-playground@investigate-preinstalled-sqlite-template';
+const PLAYGROUND_PATH = process.env.PLAYGROUND_WEB_TRACE_PLAYGROUND_PATH || path.join(homedir(), 'Developer/wordpress-playground');
 const BASE_URL = process.env.PLAYGROUND_WEB_TRACE_BASE_URL || 'http://127.0.0.1:5400/website-server/';
 const WP_VERSION = process.env.PLAYGROUND_WEB_TRACE_WP_VERSION || '6.8';
 const PHP_VERSION = process.env.PLAYGROUND_WEB_TRACE_PHP_VERSION || '8.3';

--- a/Automattic/studio/bench/studio-agent-site-build.test.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.test.mjs
@@ -184,20 +184,16 @@ test('site-build rejects unknown Workflow Bench scenario IDs', async () => {
   await rm(tempDir, { recursive: true, force: true });
 });
 
-test('bench runtime falls back to shared-state artifacts without invocation helper', async () => {
+test('bench runtime requires the Homeboy invocation helper', async () => {
   await withEnv(
     {
       HOMEBOY_NODEJS_INVOCATION_RUNTIME_HELPER: undefined,
     },
     async () => {
-      const runtime = await createStudioBenchRuntime('/tmp/shared-state');
-
-      assert.equal(runtime.invocationId, '');
-      assert.equal(runtime.artifactDir, '/tmp/shared-state/studio-agent-site-build-artifacts');
-      assert.equal(runtime.siteRoot, '/tmp/shared-state/studio-agent-site-build-artifacts/sites');
-      assert.deepEqual(runtime.env, {});
-      assert.equal(runtime.portBase, null);
-      assert.equal(runtime.portMax, null);
+      await assert.rejects(
+        () => createStudioBenchRuntime('/tmp/shared-state'),
+        /HOMEBOY_NODEJS_INVOCATION_RUNTIME_HELPER.*isolated state/
+      );
     }
   );
 });

--- a/Automattic/studio/bench/studio-datamachine-pipelines-scale-profile.bench.mjs
+++ b/Automattic/studio/bench/studio-datamachine-pipelines-scale-profile.bench.mjs
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -8,11 +9,13 @@ function defaultPluginPath(envName, repoName) {
   if (process.env[envName]) {
     return process.env[envName];
   }
-  const studioPluginPath = path.join('/Users/chubes/Studio/intelligence-chubes4/wp-content/plugins', repoName);
+  const studioPluginDir = process.env.HOMEBOY_STUDIO_WORDPRESS_PLUGIN_DIR || '';
+  const studioPluginPath = studioPluginDir ? path.join(studioPluginDir, repoName) : '';
   if (existsSync(studioPluginPath)) {
     return studioPluginPath;
   }
-  return path.join('/Users/chubes/Developer', repoName);
+  const workspaceRoot = process.env.HOMEBOY_PLUGIN_WORKSPACE_ROOT || path.join(homedir(), 'Developer');
+  return path.join(workspaceRoot, repoName);
 }
 
 process.env.HOMEBOY_WORDPRESS_PAGE_PROFILE_ID ||= 'datamachine-pipelines-scale';

--- a/Automattic/studio/rigs/studio-combined/rig.json
+++ b/Automattic/studio/rigs/studio-combined/rig.json
@@ -308,7 +308,7 @@
         "trace_guardrails": [
           {
             "label": "Playground Web trace checkout exists",
-            "file": "/Users/chubes/Developer/wordpress-playground@investigate-preinstalled-sqlite-template/package.json"
+            "file": "${components.wordpress-playground.path}/package.json"
           }
         ]
       },
@@ -468,33 +468,27 @@
         "contains": "http://127.0.0.1:9724/studio-dev/"
       },
       {
-        "kind": "patch",
-        "component": "wordpress-playground",
-        "file": "packages/php-wasm/compile/php-wasm-dns-polyfill/dns_polyfill.c",
-        "marker": "PHP-WASM-COMBINED-FIXES TSRMLS fallback",
-        "content": "/* PHP-WASM-COMBINED-FIXES TSRMLS fallback */\n#ifndef TSRMLS_CC\n#define TSRMLS_CC\n#endif\n#ifndef TSRMLS_DC\n#define TSRMLS_DC\n#endif\n#ifndef TSRMLS_C\n#define TSRMLS_C\n#endif\n#ifndef TSRMLS_D\n#define TSRMLS_D\n#endif\n",
-        "op": "verify",
-        "label": "TSRMLS_CC fallback patched (dns_polyfill.c)"
+        "kind": "check",
+        "label": "Upstream TSRMLS fallback present (dns_polyfill.c, WordPress/wordpress-playground#3512)",
+        "file": "${components.wordpress-playground.path}/packages/php-wasm/compile/php-wasm-dns-polyfill/dns_polyfill.c",
+        "contains": "#define TSRMLS_DC"
       },
       {
-        "kind": "patch",
-        "component": "wordpress-playground",
-        "file": "packages/php-wasm/compile/php-post-message-to-js/post_message_to_js.c",
-        "marker": "PHP-WASM-COMBINED-FIXES TSRMLS fallback",
-        "content": "/* PHP-WASM-COMBINED-FIXES TSRMLS fallback */\n#ifndef TSRMLS_CC\n#define TSRMLS_CC\n#endif\n#ifndef TSRMLS_DC\n#define TSRMLS_DC\n#endif\n#ifndef TSRMLS_C\n#define TSRMLS_C\n#endif\n#ifndef TSRMLS_D\n#define TSRMLS_D\n#endif\n",
-        "op": "verify",
-        "label": "TSRMLS_CC fallback patched (post_message_to_js.c)"
+        "kind": "check",
+        "label": "Upstream TSRMLS fallback present (post_message_to_js.c, WordPress/wordpress-playground#3512)",
+        "file": "${components.wordpress-playground.path}/packages/php-wasm/compile/php-post-message-to-js/post_message_to_js.c",
+        "contains": "#define TSRMLS_DC"
       },
       {
         "kind": "check",
         "label": "Compiled jspi glue has proc_open VFS-cwd fix",
-        "command": "test \"$(grep -c 'cwdstr = null' ~/Developer/studio/node_modules/@php-wasm/node-8-3/jspi/php_8_3.js)\" -ge 3",
+        "command": "test \"$(grep -c 'cwdstr = null' \"${components.studio.path}/node_modules/@php-wasm/node-8-3/jspi/php_8_3.js\")\" -ge 3",
         "expect_exit": 0
       },
       {
         "kind": "check",
         "label": "Compiled asyncify glue has proc_open VFS-cwd fix",
-        "command": "test \"$(grep -c 'cwdstr = null' ~/Developer/studio/node_modules/@php-wasm/node-8-3/asyncify/php_8_3.js)\" -ge 3",
+        "command": "test \"$(grep -c 'cwdstr = null' \"${components.studio.path}/node_modules/@php-wasm/node-8-3/asyncify/php_8_3.js\")\" -ge 3",
         "expect_exit": 0
       },
       {
@@ -569,26 +563,6 @@
         "label": "Rebase Playground onto upstream/trunk"
       },
       {
-        "kind": "patch",
-        "component": "wordpress-playground",
-        "file": "packages/php-wasm/compile/php-wasm-dns-polyfill/dns_polyfill.c",
-        "marker": "PHP-WASM-COMBINED-FIXES TSRMLS fallback",
-        "after": "#define TSRMLS_CC",
-        "content": "/* PHP-WASM-COMBINED-FIXES TSRMLS fallback (DC/C/D missing upstream) */\n#ifndef TSRMLS_DC\n#define TSRMLS_DC\n#endif\n#ifndef TSRMLS_C\n#define TSRMLS_C\n#endif\n#ifndef TSRMLS_D\n#define TSRMLS_D\n#endif\n",
-        "op": "apply",
-        "label": "Apply TSRMLS_DC/C/D fallback (dns_polyfill.c)"
-      },
-      {
-        "kind": "patch",
-        "component": "wordpress-playground",
-        "file": "packages/php-wasm/compile/php-post-message-to-js/post_message_to_js.c",
-        "marker": "PHP-WASM-COMBINED-FIXES TSRMLS fallback",
-        "after": "#define TSRMLS_CC",
-        "content": "/* PHP-WASM-COMBINED-FIXES TSRMLS fallback (DC/C/D missing upstream) */\n#ifndef TSRMLS_DC\n#define TSRMLS_DC\n#endif\n#ifndef TSRMLS_C\n#define TSRMLS_C\n#endif\n#ifndef TSRMLS_D\n#define TSRMLS_D\n#endif\n",
-        "op": "apply",
-        "label": "Apply TSRMLS_DC/C/D fallback (post_message_to_js.c)"
-      },
-      {
         "kind": "command",
         "label": "Compile PHP-WASM 8.3 (JSPI variant)",
         "command": "node packages/php-wasm/compile/build.js --PLATFORM=node --PHP_VERSION=8.3 --WITH_JSPI=yes",
@@ -629,7 +603,7 @@
       {
         "kind": "command",
         "label": "Rewire Studio package.jsons to local tarballs",
-        "command": "VER=$(jq -r '.version' ~/Developer/wordpress-playground/lerna.json); for pkg in apps/cli/package.json apps/studio/package.json tools/benchmark-site-editor/package.json tools/common/package.json; do PACKAGE_BASE_URL=http://127.0.0.1:9724/studio-dev PACKAGE_VERSION=$VER bash ~/Developer/wordpress-playground/packages/playground/test-built-npm-packages/use-local-packages.sh \"$pkg\"; done",
+        "command": "VER=$(jq -r '.version' \"${components.wordpress-playground.path}/lerna.json\"); for pkg in apps/cli/package.json apps/studio/package.json tools/benchmark-site-editor/package.json tools/common/package.json; do PACKAGE_BASE_URL=http://127.0.0.1:9724/studio-dev PACKAGE_VERSION=$VER bash \"${components.wordpress-playground.path}/packages/playground/test-built-npm-packages/use-local-packages.sh\" \"$pkg\"; done",
         "cwd": "${components.studio.path}"
       },
       {

--- a/README.md
+++ b/README.md
@@ -196,12 +196,12 @@ homeboy bench --rig studio-agent-claude-ssi --scenario studio-agent-site-build -
 The site-build workload accepts a runtime namespace for parallel Workflow Bench runs. Select canonical Studio Web Workflow Bench scenarios with `studio_workflow_bench_scenario_id` and point `studio_workflow_bench_root`, `STUDIO_WEB_WORKFLOW_BENCH_ROOT`, or `WORKFLOW_BENCH_ROOT` at a Studio Web checkout. Homeboy Rigs consumes the canonical corpus directly; Studio Web owns scenario prompts, categories, proof surfaces, success gates, and matrix selection. `studio_bench_namespace` only isolates runtime resources such as artifacts, Studio CLI config, appdata, daemon sockets, temp files, site roots, and the derived port range.
 
 ```bash
-STUDIO_WEB_WORKFLOW_BENCH_ROOT=/Users/chubes/Developer/studio-web \
+STUDIO_WEB_WORKFLOW_BENCH_ROOT=$HOME/Developer/studio-web \
 HOMEBOY_SETTINGS_STUDIO_WORKFLOW_BENCH_SCENARIO_ID=homeboy-plain-site-restaurant \
 HOMEBOY_SETTINGS_STUDIO_BENCH_NAMESPACE=restaurant-a \
 homeboy bench --rig studio-agent-claude-ssi --scenario studio-agent-site-build --iterations 1 --shared-state /tmp/studio-agent-bench &
 
-STUDIO_WEB_WORKFLOW_BENCH_ROOT=/Users/chubes/Developer/studio-web \
+STUDIO_WEB_WORKFLOW_BENCH_ROOT=$HOME/Developer/studio-web \
 HOMEBOY_SETTINGS_STUDIO_WORKFLOW_BENCH_SCENARIO_ID=homeboy-plain-site-saas \
 HOMEBOY_SETTINGS_STUDIO_BENCH_NAMESPACE=saas-a \
 homeboy bench --rig studio-agent-gpt55-ssi --scenario studio-agent-site-build --iterations 1 --shared-state /tmp/studio-agent-bench &
@@ -284,7 +284,7 @@ node scripts/generate-studio-agent-model-rigs.mjs --check
 
 ## WordPress/wordpress-playground
 
-`stacks/playground-combined.json` rebuilds `origin/dev/combined-fixes` from `upstream/trunk` plus Chris's active PHP-WASM and worker-pool PRs.
+`stacks/playground-combined.json` rebuilds `origin/dev/combined-fixes` from `upstream/trunk` plus Chris's active PHP-WASM and worker-pool PRs. TSRMLS fallback defines are owned upstream by WordPress/wordpress-playground#3512; `studio-combined` checks for that upstream source instead of patching Playground files at rig runtime.
 
 `rigs/playground-cli-diagnostics/rig.json` runs focused Playground CLI repros against the local `~/Developer/wordpress-playground` checkout. The first workload captures whether Blueprint `runPHP` fatal errors surface useful diagnostics or collapse to a blank `Error:` line.
 
@@ -301,7 +301,7 @@ catalog, and admin-dashboard performance workloads against a local WooCommerce
 monorepo checkout mounted into the WP Codebox WordPress bench runtime.
 
 ```bash
-homeboy rig install /Users/chubes/Developer/homeboy-rigs@<branch>/woocommerce/woocommerce
+homeboy rig install $HOME/Developer/homeboy-rigs@<branch>/woocommerce/woocommerce
 homeboy rig check woocommerce-performance
 homeboy rig up woocommerce-performance
 homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-bench
@@ -324,7 +324,7 @@ Express Checkout Element browser waterfall trace against a local WooCommerce
 Stripe checkout plus a packaged WooCommerce dependency.
 
 ```bash
-homeboy rig install /Users/chubes/Developer/homeboy-rigs@<branch>/woocommerce/woocommerce-gateway-stripe
+homeboy rig install $HOME/Developer/homeboy-rigs@<branch>/woocommerce/woocommerce-gateway-stripe
 homeboy rig check woocommerce-stripe-ece-product-page
 homeboy trace --rig woocommerce-stripe-ece-product-page woocommerce-gateway-stripe ece-product-page-waterfall --output /tmp/wc-stripe-ece-waterfall.json
 ```
@@ -406,7 +406,7 @@ homeboy trace --rig woocommerce-stripe-ece-product-page \
 - **Package directories** use the owning repo's fully qualified name. Cross-repo rigs live under the product/workflow owner.
 - **Bench workloads** live beside their owning rig and use `${package.root}` so installed rig packages resolve their own portable workload files.
 - **Branches** in `components.<id>.branch` document the expected branch — rigs don't currently enforce branch state, but the field hints to humans reading the spec.
-- **Patches** carry a unique marker string (`PHP-WASM-COMBINED-FIXES TSRMLS fallback`, etc.) that identifies the patch in the file. Marker-based idempotency means re-running `up` is safe.
+- **Patches** carry a unique marker string that identifies the patch in the file. Marker-based idempotency means re-running `up` is safe.
 - **External services** (`kind: external`) are processes the rig didn't spawn — the rig only knows how to *stop* them via `discover.pattern`. Use this for stale daemons that need recycling after a build.
 
 ## What does NOT belong here

--- a/WordPress/gutenberg/README.md
+++ b/WordPress/gutenberg/README.md
@@ -9,7 +9,7 @@ The workload mounts the local Gutenberg checkout plus a generated fixture plugin
 Install locally:
 
 ```sh
-homeboy rig install /Users/chubes/Developer/homeboy-rigs@<branch>/WordPress/gutenberg
+homeboy rig install $HOME/Developer/homeboy-rigs@<branch>/WordPress/gutenberg
 ```
 
 Run the baseline repro:

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -8,8 +8,11 @@ const root = process.argv[2] ? join(process.cwd(), process.argv[2]) : process.cw
 const ignoredDirectories = new Set(['.git', '.claude', '.datamachine', '.opencode', 'node_modules', 'vendor']);
 const phpFiles = [];
 const rigFiles = [];
+const portableSourceFiles = [];
 const failures = [];
 const studioModelRigGenerator = join(root, 'scripts/generate-studio-agent-model-rigs.mjs');
+const personalPathPrefix = '/Users/' + 'chubes/';
+const tsrmlsPatchMarker = 'PHP-WASM-COMBINED-FIXES ' + 'TSRMLS fallback';
 
 if (!existsSync(root)) {
   console.error(`Lint root does not exist: ${root}`);
@@ -31,6 +34,10 @@ function walk(directory) {
 
     if (entry.isFile() && entry.name === 'rig.json') {
       rigFiles.push(join(directory, entry.name));
+    }
+
+    if (entry.isFile() && /\.(json|mjs|js)$/.test(entry.name)) {
+      portableSourceFiles.push(join(directory, entry.name));
     }
   }
 }
@@ -58,6 +65,19 @@ function lintRigPortability(file) {
 
   if (rel === 'chubes4/isolated-block-editor/rigs/isolated-block-editor/rig.json' && contents.includes('/var/lib/datamachine')) {
     failures.push(`${rel}: isolated-block-editor must use the component path or shared node_modules setting instead of /var/lib/datamachine`);
+  }
+}
+
+function lintPortableSource(file) {
+  const rel = relative(root, file);
+  const contents = readFileSync(file, 'utf8');
+
+  if (contents.includes(personalPathPrefix)) {
+    failures.push(`${rel}: use $HOME, homedir(), component paths, or settings instead of hard-coded /Users/chubes paths`);
+  }
+
+  if (contents.includes(tsrmlsPatchMarker)) {
+    failures.push(`${rel}: TSRMLS fallback defines are owned by WordPress/wordpress-playground#3512; do not patch Playground source in rigs`);
   }
 }
 
@@ -105,6 +125,7 @@ function lintGeneratedStudioModelRigs() {
 walk(root);
 
 rigFiles.forEach(lintRigPortability);
+portableSourceFiles.forEach(lintPortableSource);
 lintGeneratedStudioModelRigs();
 
 reportFailures();
@@ -121,3 +142,4 @@ reportFailures();
 console.log('Rig package lint passed.');
 console.log(`- PHP syntax: ${phpFiles.length} file(s)`);
 console.log(`- rig portability: ${rigFiles.length} rig(s)`);
+console.log(`- portable source paths: ${portableSourceFiles.length} file(s)`);

--- a/woocommerce/woocommerce-gateway-stripe/README.md
+++ b/woocommerce/woocommerce-gateway-stripe/README.md
@@ -115,7 +115,7 @@ export HOMEBOY_WP_CODEBOX_BIN=/path/to/wp-codebox/packages/cli/dist/index.js
 ## Install
 
 ```bash
-homeboy rig install /Users/chubes/Developer/homeboy-rigs@<branch>/woocommerce/woocommerce-gateway-stripe
+homeboy rig install $HOME/Developer/homeboy-rigs@<branch>/woocommerce/woocommerce-gateway-stripe
 homeboy rig check woocommerce-stripe-ece-product-page
 ```
 

--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -29,7 +29,7 @@ performance bugs in disposable WordPress/WooCommerce runtimes.
 ## Install
 
 ```bash
-homeboy rig install /Users/chubes/Developer/homeboy-rigs@<branch>/woocommerce/woocommerce
+homeboy rig install $HOME/Developer/homeboy-rigs@<branch>/woocommerce/woocommerce
 homeboy rig check woocommerce-performance
 ```
 


### PR DESCRIPTION
## Summary
- Remove rig-level TSRMLS source patching from studio-combined now that WordPress/wordpress-playground#3512 owns the fallback defines upstream.
- Make the Studio site-build invocation runtime helper mandatory so runs fail fast instead of falling back to shared-state dirs.
- Replace hard-coded local Studio/Playground/plugin paths with component paths, HOME-derived defaults, or explicit settings.
- Extend rig lint to reject personal absolute paths and the old TSRMLS patch marker in runnable source.

## Upstream dependency
- WordPress/wordpress-playground#3512 is merged, so this PR is not blocked on the TSRMLS upstream dependency.

## Validation
- node --test --test-name-pattern "bench runtime" Automattic/studio/bench/studio-agent-site-build.test.mjs
- node scripts/lint-rig-packages.mjs
- node -e "for (const f of ['Automattic/studio/rigs/studio-combined/rig.json','WordPress/wordpress-playground/stacks/playground-combined.json']) JSON.parse(require('fs').readFileSync(f,'utf8'));"

## Blockers
- Full studio-agent-site-build.test.mjs still requires a Homeboy Extensions materialized-site-quality helper manifest in this environment; targeted runtime tests pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted and validated the rig cleanup, runtime-helper enforcement, lint coverage, documentation updates, and PR description; Chris remains responsible for review and merge.