### PR TITLE
Use Homeboy Extensions helper primitives

### DIFF
--- a/Automattic/studio/bench/lib/studio-bench.mjs
+++ b/Automattic/studio/bench/lib/studio-bench.mjs
@@ -1,7 +1,23 @@
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { spawn } from 'node:child_process';
+
+const WORKLOAD_UTILS = process.env.HOMEBOY_NODEJS_WORKLOAD_UTILS;
+
+if (!WORKLOAD_UTILS) {
+  throw new Error('HOMEBOY_NODEJS_WORKLOAD_UTILS is required');
+}
+
+const {
+  artifactDir: nodeArtifactDir,
+  expandHome,
+  metric,
+  redactText,
+  runNode,
+  safeResult: nodeSafeResult,
+  sanitizeArtifactFile,
+  setting,
+} = await import(WORKLOAD_UTILS);
 
 const RESULT_PREFIX = 'EVAL_RUNNER_RESULT_FILE=';
 
@@ -12,126 +28,33 @@ if (!STUDIO_PATH) {
   throw new Error('HOMEBOY_COMPONENT_PATH is required');
 }
 
-export function setting(key) {
-  try {
-    const settings = JSON.parse(process.env.HOMEBOY_SETTINGS_JSON || '{}');
-    if (settings && typeof settings[key] === 'string') {
-      return settings[key];
-    }
-  } catch {
-    // Ignore malformed settings and fall back to direct env/debug defaults.
-  }
+export { expandHome, metric, setting };
 
-  return process.env[`HOMEBOY_SETTINGS_${key.toUpperCase()}`] || '';
+export function artifactDir(name, sharedState = SHARED_STATE) {
+  return nodeArtifactDir(name, { sharedState });
 }
 
 export function variant() {
   return setting('studio_bench_variant') || path.basename(STUDIO_PATH);
 }
 
-export function metric(value) {
-  const number = Number(value ?? 0);
-  return Number.isFinite(number) ? number : 0;
-}
-
-export function expandHome(value) {
-  if (!value) {
-    return value;
-  }
-  if (value === '~') {
-    return os.homedir();
-  }
-  if (value.startsWith('~/')) {
-    return path.join(os.homedir(), value.slice(2));
-  }
-  return value;
-}
-
 export function redact(text) {
-  return String(text || '')
-    .replace(/("adminPassword"\s*:\s*")[^"]+(")/g, '$1[redacted]$2')
-    .replace(/(--admin-password\s+)\S+/g, '$1[redacted]')
-    .replace(/(autoLoginUrl"?\s*[:=]\s*"?)[^"\s,}]+/gi, '$1[redacted]')
-    .replace(/([?&](?:token|password|key|nonce)=)[^&#\s]+/gi, '$1[redacted]');
+  return redactText(String(text || ''), { replacement: '[redacted]' });
+}
+
+export function safeResult(result) {
+  return nodeSafeResult(result, { redaction: { replacement: '[redacted]' } });
 }
 
 export async function sanitizeArtifact(artifact) {
   if (!artifact || typeof artifact.path !== 'string') {
     return;
   }
-  await writeFile(artifact.path, redact(await readFile(artifact.path, 'utf8')));
-}
-
-export function safeResult(result) {
-  if (!result) {
-    return result;
-  }
-  return {
-    code: result.code,
-    elapsedMs: result.elapsedMs,
-    stdout: redact(result.stdout),
-    stderr: redact(result.stderr),
-  };
-}
-
-export function artifactDir(name, sharedState = SHARED_STATE) {
-  return path.join(sharedState, name);
+  await sanitizeArtifactFile(artifact.path, { profile: 'web', replacement: '[redacted]' });
 }
 
 export function run(args, options = {}) {
-  return new Promise((resolve, reject) => {
-    const started = Date.now();
-    let settled = false;
-    let stdout = '';
-    let stderr = '';
-    const child = spawn(process.execPath, args, {
-      cwd: options.cwd || STUDIO_PATH,
-      env: { ...process.env, ...(options.env || {}) },
-    });
-
-    const timer = options.timeoutMs
-      ? setTimeout(() => {
-          if (settled) {
-            return;
-          }
-          settled = true;
-          child.kill('SIGKILL');
-          reject(
-            new Error(
-              `${args.join(' ')} timed out after ${options.timeoutMs}ms; stdout=${stdout.slice(-1000)}; stderr=${stderr.slice(-1000)}`
-            )
-          );
-        }, options.timeoutMs)
-      : undefined;
-
-    child.stdout.on('data', (chunk) => {
-      stdout += String(chunk);
-    });
-    child.stderr.on('data', (chunk) => {
-      stderr += String(chunk);
-    });
-    child.on('error', (error) => {
-      if (timer) {
-        clearTimeout(timer);
-      }
-      reject(error);
-    });
-    child.on('close', (code) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      if (timer) {
-        clearTimeout(timer);
-      }
-      const elapsedMs = Date.now() - started;
-      if (code !== 0 && options.allowFailure !== true) {
-        reject(new Error(`${args.join(' ')} exited ${code}; stderr=${stderr.slice(0, 1500)}`));
-        return;
-      }
-      resolve({ code, stdout, stderr, elapsedMs });
-    });
-  });
+  return runNode(args, { cwd: STUDIO_PATH, ...options });
 }
 
 export async function runCli(args, options = {}) {

--- a/Automattic/studio/bench/lib/visual-fidelity.mjs
+++ b/Automattic/studio/bench/lib/visual-fidelity.mjs
@@ -1,10 +1,10 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { createRequire } from 'node:module';
-import { spawn } from 'node:child_process';
 
 import { STUDIO_PATH, expandHome, setting } from './studio-bench.mjs';
 import { loadWordPressLibHelper } from './wordpress-helper-discovery.mjs';
+import { runWpCodeboxRecipe as runWordPressRecipe } from '../../../../shared/wp-codebox/recipe.mjs';
 
 const requireFromBench = createRequire(import.meta.url);
 export const VISUAL_VIEWPORT = { width: 1440, height: 1100 };
@@ -94,44 +94,23 @@ function explainSelectors(groups) {
   return selectors.slice(0, VISUAL_COMPARE_EXPLAIN_SELECTOR_LIMIT);
 }
 
-async function runWpCodeboxRecipe(recipePath) {
+async function runWpCodeboxRecipe(recipePath, artifactsDir) {
   const cliPath = wpCodeboxCliPath();
   if (!cliPath) {
     throw new Error('Studio visual fidelity requires WP Codebox browser evidence. Set studio_wp_codebox_cli_path, HOMEBOY_WP_CODEBOX_CLI, or WP_CODEBOX_CLI_PATH to the WP Codebox CLI entrypoint.');
   }
 
-  const useNode = /\.(?:cjs|mjs|js|ts)$/.test(cliPath);
-  const command = useNode ? process.execPath : cliPath;
-  const args = useNode ? [cliPath, 'recipe-run', '--recipe', recipePath, '--json'] : ['recipe-run', '--recipe', recipePath, '--json'];
-
-  return new Promise((resolve, reject) => {
-    let stdout = '';
-    let stderr = '';
-    const child = spawn(command, args, { cwd: path.dirname(recipePath), stdio: ['ignore', 'pipe', 'pipe'] });
-    child.stdout.on('data', (chunk) => {
-      stdout += String(chunk);
-    });
-    child.stderr.on('data', (chunk) => {
-      stderr += String(chunk);
-    });
-    child.on('error', reject);
-    child.on('close', (code) => {
-      if (code !== 0) {
-        reject(new Error(`WP Codebox visual compare exited with ${code}; stdout=${stdout.slice(-1000)}; stderr=${stderr.slice(-1000)}`));
-        return;
-      }
-      try {
-        const parsed = JSON.parse(stdout);
-        if (parsed?.success === false) {
-          reject(new Error(parsed?.error?.message || 'WP Codebox visual compare failed.'));
-          return;
-        }
-        resolve(parsed);
-      } catch (error) {
-        reject(new Error(`WP Codebox visual compare returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`));
-      }
-    });
+  const result = await runWordPressRecipe({
+    recipeFile: recipePath,
+    artifactsDir,
+    bin: cliPath,
+    cwd: path.dirname(recipePath),
   });
+  const parsed = result.json || JSON.parse(result.stdout);
+  if (parsed?.success === false) {
+    throw new Error(parsed?.error?.message || 'WP Codebox visual compare failed.');
+  }
+  return parsed;
 }
 
 async function runWpCodeboxVisualCompare(target, visualDir, targetSlug, importReport, sitePath, groups) {
@@ -165,7 +144,7 @@ async function runWpCodeboxVisualCompare(target, visualDir, targetSlug, importRe
   await mkdir(visualDir, { recursive: true });
   await writeFile(recipePath, `${JSON.stringify(recipe, null, 2)}\n`);
 
-  const output = await runWpCodeboxRecipe(recipePath);
+  const output = await runWpCodeboxRecipe(recipePath, artifactRoot);
   const artifactDirectory = output?.artifacts?.directory || artifactRoot;
   const summaryPath = path.join(artifactDirectory, 'files', 'browser', 'visual-compare', 'visual-diff.json');
   const summary = JSON.parse(await readFile(summaryPath, 'utf8'));

--- a/Automattic/studio/bench/lib/wordpress-helper-discovery.mjs
+++ b/Automattic/studio/bench/lib/wordpress-helper-discovery.mjs
@@ -1,25 +1,41 @@
 import { createRequire } from 'node:module';
-import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 const require = createRequire(import.meta.url);
-const WORDPRESS_HELPER_CONSUMER_FILENAME = 'wordpress-helper-consumer.js';
 
 function resolveManifestPath(options = {}) {
   return options.manifestPath || process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST || '';
 }
 
-function localManifestForConsumerDiscovery(options = {}) {
-  const manifestPath = resolveManifestPath(options);
-  if (!manifestPath || !existsSync(manifestPath)) {
-    return { path: manifestPath || '', manifest: null };
+function loadWordPressHelperConsumerModule(options = {}) {
+  const explicit = options.consumerPath || process.env.HOMEBOY_WORDPRESS_HELPER_CONSUMER;
+  if (explicit) {
+    return require(explicit);
   }
 
-  const module = require(manifestPath);
-  const manifest = typeof module.getWordPressHelperManifest === 'function'
-    ? module.getWordPressHelperManifest()
-    : module.WORDPRESS_HELPER_MANIFEST;
-  return { path: manifestPath, manifest: manifest || null };
+  const manifestPath = resolveManifestPath(options);
+  if (manifestPath) {
+    const manifestModule = require(manifestPath);
+    const manifest = typeof manifestModule.getWordPressHelperManifest === 'function'
+      ? manifestModule.getWordPressHelperManifest()
+      : manifestModule.WORDPRESS_HELPER_MANIFEST;
+    if (manifest?.extensionRoot) {
+      return require(path.join(manifest.extensionRoot, 'lib', 'wordpress-helper-consumer.js'));
+    }
+  }
+
+  try {
+    return require('homeboy-extension-wordpress/wordpress-helper-consumer');
+  } catch (error) {
+    if (error?.code !== 'MODULE_NOT_FOUND') {
+      throw error;
+    }
+    return null;
+  }
+}
+
+function missingHandle(resolvedPath = '', reason = 'WordPress helper consumer is unavailable') {
+  return { path: resolvedPath, module: null, found: false, reason };
 }
 
 export function wordpressHelperConsumerPath(options = {}) {
@@ -28,64 +44,43 @@ export function wordpressHelperConsumerPath(options = {}) {
     return explicit;
   }
 
-  const { manifest } = localManifestForConsumerDiscovery(options);
-  return manifest?.extensionRoot
-    ? path.join(manifest.extensionRoot, 'lib', WORDPRESS_HELPER_CONSUMER_FILENAME)
-    : '';
+  const consumer = loadWordPressHelperConsumerModule(options);
+  if (!consumer) {
+    return '';
+  }
+  const { manifest } = consumer.loadWordPressHelperManifest(options);
+  return manifest?.extensionRoot ? path.join(manifest.extensionRoot, 'lib', 'wordpress-helper-consumer.js') : '';
 }
 
 export function loadWordPressHelperConsumer(options = {}) {
   const helperConsumerPath = wordpressHelperConsumerPath(options);
-  if (!helperConsumerPath || !existsSync(helperConsumerPath)) {
-    return { path: helperConsumerPath, module: null };
-  }
-
-  return { path: helperConsumerPath, module: require(helperConsumerPath) };
+  const consumer = loadWordPressHelperConsumerModule(options);
+  return consumer ? { path: helperConsumerPath, module: consumer } : missingHandle(helperConsumerPath);
 }
 
 export function loadWordPressHelperManifest(options = {}) {
-  const { module: helperConsumer } = loadWordPressHelperConsumer(options);
-  if (typeof helperConsumer?.loadWordPressHelperManifest === 'function') {
-    return helperConsumer.loadWordPressHelperManifest(options);
-  }
-
-  return localManifestForConsumerDiscovery(options);
+  const consumer = loadWordPressHelperConsumerModule(options);
+  return consumer
+    ? consumer.loadWordPressHelperManifest(options)
+    : { path: '', manifest: null, found: false, reason: 'WordPress helper consumer is unavailable' };
 }
 
 export function wordpressHelperPath(key, options = {}) {
-  const { module: helperConsumer } = loadWordPressHelperConsumer(options);
-  if (typeof helperConsumer?.wordpressHelperPath === 'function') {
-    return helperConsumer.wordpressHelperPath(key, options);
-  }
-
   const explicit = options.override || (options.envVar ? process.env[options.envVar] : '');
   if (explicit) {
     return explicit;
   }
-
-  const { manifest } = localManifestForConsumerDiscovery(options);
-  return manifest?.helpers?.[key] || '';
+  return loadWordPressHelperConsumerModule(options)?.wordpressHelperPath(key, options) || '';
 }
 
 export function wordpressLibHelperPath(fileName, options = {}) {
-  const { module: helperConsumer } = loadWordPressHelperConsumer(options);
-  if (typeof helperConsumer?.wordpressLibHelperPath === 'function') {
-    return helperConsumer.wordpressLibHelperPath(fileName, options);
-  }
-
   const explicit = options.override || (options.envVar ? process.env[options.envVar] : '');
-  return explicit || '';
+  if (explicit) {
+    return explicit;
+  }
+  return loadWordPressHelperConsumerModule(options)?.wordpressLibHelperPath(fileName, options) || '';
 }
 
 export function loadWordPressLibHelper(fileName, options = {}) {
-  const { module: helperConsumer } = loadWordPressHelperConsumer(options);
-  if (typeof helperConsumer?.loadWordPressLibHelper === 'function') {
-    return helperConsumer.loadWordPressLibHelper(fileName, options);
-  }
-
-  const helperPath = wordpressLibHelperPath(fileName, options);
-  if (!helperPath || !existsSync(helperPath)) {
-    return { path: helperPath, module: null };
-  }
-  return { path: helperPath, module: require(helperPath) };
+  return loadWordPressHelperConsumerModule(options)?.loadWordPressLibHelper(fileName, options) || missingHandle(wordpressLibHelperPath(fileName, options));
 }

--- a/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
+++ b/Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs
@@ -6,6 +6,58 @@ import test from 'node:test';
 
 process.env.HOMEBOY_COMPONENT_PATH ||= '/tmp/homeboy-rigs-test-component';
 
+const workloadUtilsDir = await mkdtemp(path.join(os.tmpdir(), 'homeboy-node-workload-utils-'));
+const workloadUtilsPath = path.join(workloadUtilsDir, 'workload-utils.mjs');
+await writeFile(workloadUtilsPath, `
+import { readFile, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+export function artifactDir(name, options = {}) {
+  return path.join(options.sharedState || process.env.HOMEBOY_BENCH_SHARED_STATE || os.tmpdir(), name);
+}
+
+export function expandHome(value) {
+  if (!value) return value;
+  if (value === '~') return os.homedir();
+  if (value.startsWith('~/')) return path.join(os.homedir(), value.slice(2));
+  return value;
+}
+
+export function metric(value, fallback = 0) {
+  const number = Number(value ?? fallback);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+export function redactText(value, options = {}) {
+  const replacement = options.replacement || '[redacted]';
+  return String(value || '').replace(/([?&](?:token|password|key|nonce)=)[^&#\\s]+/gi, '$1' + replacement);
+}
+
+export async function sanitizeArtifactFile(file, options = {}) {
+  await writeFile(file, redactText(await readFile(file, 'utf8'), options));
+  return { path: file };
+}
+
+export function safeResult(result) {
+  if (!result) return result;
+  return { ...result, stdout: redactText(result.stdout), stderr: redactText(result.stderr) };
+}
+
+export function setting(key, fallback = '') {
+  try {
+    const settings = JSON.parse(process.env.HOMEBOY_SETTINGS_JSON || '{}');
+    if (settings && settings[key] !== undefined && settings[key] !== null) return String(settings[key]);
+  } catch {}
+  return process.env['HOMEBOY_SETTINGS_' + String(key).toUpperCase()] || fallback;
+}
+
+export function runNode() {
+  throw new Error('runNode is not used by these unit tests.');
+}
+`);
+process.env.HOMEBOY_NODEJS_WORKLOAD_UTILS ||= workloadUtilsPath;
+
 const DEFAULT_RESOURCE_INCLUDE = Object.freeze([
   '/wp-json/',
   '?rest_route=',

--- a/README.md
+++ b/README.md
@@ -222,8 +222,8 @@ Mixed-source prompt variants such as `astro-docs-content-collection`, `markdown-
 Keep the Studio bench harness layered so each repo owns the smallest stable surface it can support:
 
 - `homeboy-rigs` owns Studio-specific workloads, prompts, and experimental harness wiring while APIs are still moving.
-- `homeboy-extensions/nodejs` is the future home for generic Node and browser benchmark utilities once those helpers are reusable outside Studio.
-- `homeboy-extensions/wordpress` is the future home for generic WordPress and block quality probes once their contracts are stable.
+- `homeboy-extensions/nodejs` owns generic Node benchmark settings, command, artifact, and redaction helpers used by Studio workloads.
+- `homeboy-extensions/wordpress` owns generic WordPress helper discovery, WP Codebox recipe execution, and block quality probes once their contracts are stable.
 - `homeboy` core owns benchmark orchestration only; it should stay generic and substrate-agnostic.
 
 Issue [#185](https://github.com/chubes4/homeboy-rigs/issues/185) tracks thinning duplicated helper logic after upstream promotion. Studio native-block quality probing now uses the promoted Homeboy Extensions block quality probes from `Extra-Chill/homeboy-extensions#1009`; target post metrics remain tracked in `Extra-Chill/homeboy-extensions#1018`. Studio fixture plugin install/restore now delegates to the Homeboy Extensions fixture setup helper from `Extra-Chill/homeboy-extensions#1134`, and helper discovery consumes promoted helper-manifest paths from `Extra-Chill/homeboy-extensions#1141`; rigs should not add local fallback shims for those contracts.

--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -1,18 +1,15 @@
-import { execFile } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { promisify } from 'node:util';
 
-const execFileAsync = promisify( execFile );
+import { runWpCodeboxRecipe } from '../../../shared/wp-codebox/recipe.mjs';
 
 const componentPath = process.env.HOMEBOY_COMPONENT_PATH;
 const componentId = process.env.HOMEBOY_COMPONENT_ID || 'gutenberg';
 const scenarioId = process.env.HOMEBOY_TRACE_SCENARIO || 'notes-unsaved-attachment';
 const resultsFile = process.env.HOMEBOY_TRACE_RESULTS_FILE;
 const artifactDir = process.env.HOMEBOY_TRACE_ARTIFACT_DIR || path.join( tmpdir(), 'gutenberg-notes-unsaved-attachment-artifacts' );
-const wpCodeboxBin = process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN || path.join( process.env.HOME || '', 'Developer/wp-codebox/packages/cli/dist/index.js' );
 const wpVersion = process.env.HOMEBOY_GUTENBERG_NOTES_WP_VERSION || process.env.HOMEBOY_SETTINGS_GUTENBERG_NOTES_WP_VERSION || '7.0';
 const knownCases = new Set( [ 'orphan', 'saved-anchor', 'autosave-anchor', 'live-create', 'dirty-live-create', 'dirty-sibling-live-create', 'dirty-structural-live-create', 'nested-live-create', 'double-live-create', 'matrix' ] );
 const profileCase = process.env.HOMEBOY_TRACE_PROFILE || process.env.HOMEBOY_PROFILE || '';
@@ -50,14 +47,6 @@ function timestampMs() {
 
 function event( source, name, data = {} ) {
 	timeline.push( { t_ms: timestampMs(), source, event: name, data } );
-}
-
-function wpCodeboxCommand() {
-	if ( wpCodeboxBin.endsWith( '.js' ) || wpCodeboxBin.endsWith( '.cjs' ) || wpCodeboxBin.endsWith( '.mjs' ) ) {
-		return { command: 'node', args: [ wpCodeboxBin ] };
-	}
-
-	return { command: wpCodeboxBin, args: [] };
 }
 
 async function readJsonAsync( pathname ) {
@@ -689,12 +678,12 @@ try {
 
 	await writeFile( recipeFile, `${ JSON.stringify( recipe, null, 2 ) }\n` );
 
-	event( 'wp_codebox', 'recipe.start', { recipe_file: recipeFile } );
-	const { command, args } = wpCodeboxCommand();
-	const result = await execFileAsync( command, [ ...args, 'recipe-run', '--recipe', recipeFile, '--artifacts', codeboxArtifacts, '--json' ], {
-		maxBuffer: 1024 * 1024 * 50,
+	const result = await runWpCodeboxRecipe( {
+		recipeFile,
+		artifactsDir: codeboxArtifacts,
+		outputFile,
+		event,
 	} );
-	await writeFile( outputFile, result.stdout );
 
 	const output = JSON.parse( result.stdout );
 	const bundleDir = output.artifacts?.directory;

--- a/shared/wp-codebox/recipe.mjs
+++ b/shared/wp-codebox/recipe.mjs
@@ -1,66 +1,36 @@
-import { execFile } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import path from 'node:path';
-import { promisify } from 'node:util';
 
-const execFileAsync = promisify(execFile);
+const require = createRequire(import.meta.url);
 
-export function wpCodeboxBin(env = process.env) {
-  const explicit = env.HOMEBOY_WP_CODEBOX_BIN || env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN;
+function loadRecipeHelper() {
+  const explicit = process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
   if (explicit) {
-    return explicit;
+    return require(explicit);
   }
 
-  const checkoutBin = path.join(env.HOME || '', 'Developer/wp-codebox/packages/cli/dist/index.js');
-  return existsSync(checkoutBin) ? checkoutBin : 'wp-codebox';
+  const manifestPath = process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST;
+  if (manifestPath) {
+    const manifestModule = require(manifestPath);
+    const manifest = typeof manifestModule.getWordPressHelperManifest === 'function'
+      ? manifestModule.getWordPressHelperManifest()
+      : manifestModule.WORDPRESS_HELPER_MANIFEST;
+    if (manifest?.extensionRoot) {
+      return require(path.join(manifest.extensionRoot, 'lib', 'wp-codebox-recipe-helper.js'));
+    }
+  }
+
+  return require('homeboy-extension-wordpress/wp-codebox-recipe-helper');
+}
+
+export function wpCodeboxBin(env = process.env) {
+  return loadRecipeHelper().wpCodeboxBin({ env });
 }
 
 export function wpCodeboxCommand(bin = wpCodeboxBin()) {
-  if (/\.(?:js|cjs|mjs)$/.test(bin)) {
-    return { command: 'node', args: [bin] };
-  }
-
-  return { command: bin, args: [] };
+  return loadRecipeHelper().wpCodeboxCommand(bin);
 }
 
-export async function runWpCodeboxRecipe({
-  recipeFile,
-  artifactsDir,
-  outputFile,
-  recipeRunArgs = [],
-  event,
-  maxBuffer = 1024 * 1024 * 50,
-}) {
-  const { command, args } = wpCodeboxCommand();
-  const commandArgs = [
-    ...args,
-    'recipe-run',
-    '--recipe',
-    recipeFile,
-    '--artifacts',
-    artifactsDir,
-    ...recipeRunArgs,
-    '--json',
-  ];
-
-  event?.('wp_codebox', 'recipe.start', { recipe_file: recipeFile, artifacts_dir: artifactsDir });
-
-  try {
-    const result = await execFileAsync(command, commandArgs, { maxBuffer });
-    await writeFile(outputFile, result.stdout);
-    event?.('wp_codebox', 'recipe.done', { output_file: outputFile, artifacts_dir: artifactsDir });
-    return result;
-  } catch (error) {
-    if (typeof error?.stdout === 'string' && error.stdout) {
-      await writeFile(outputFile, error.stdout);
-    }
-
-    event?.('wp_codebox', 'recipe.failed', {
-      output_file: outputFile,
-      artifacts_dir: artifactsDir,
-      exit_code: error?.code ?? null,
-    });
-    throw error;
-  }
+export async function runWpCodeboxRecipe(options) {
+  return loadRecipeHelper().runWpCodeboxRecipe(options);
 }

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import test from 'node:test';
@@ -19,18 +19,41 @@ import { wpCodeboxBin, wpCodeboxCommand } from './ece-product-page-wp-codebox.mj
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 test('WP Codebox helper centralizes binary resolution', () => {
-  assert.equal(wpCodeboxBin({}), 'wp-codebox');
-  assert.equal(wpCodeboxBin({ HOMEBOY_SETTINGS_WP_CODEBOX_BIN: '/tmp/wp-codebox-settings.js' }), '/tmp/wp-codebox-settings.js');
-  assert.equal(
-    wpCodeboxBin({
-      HOMEBOY_WP_CODEBOX_BIN: '/tmp/wp-codebox-env.mjs',
-      HOMEBOY_SETTINGS_WP_CODEBOX_BIN: '/tmp/wp-codebox-settings.js',
-    }),
-    '/tmp/wp-codebox-env.mjs'
-  );
+  const helperDir = mkdtempSync(path.join(tmpdir(), 'homeboy-wp-codebox-helper-'));
+  const helperPath = path.join(helperDir, 'wp-codebox-recipe-helper.cjs');
+  writeFileSync(helperPath, `
+module.exports = {
+  wpCodeboxBin({ env = process.env } = {}) {
+    return env.HOMEBOY_WP_CODEBOX_BIN || env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN || env.WP_CODEBOX_BIN || 'wp-codebox';
+  },
+  wpCodeboxCommand(bin = 'wp-codebox') {
+    return /\\.(?:js|cjs|mjs)$/.test(bin) ? { command: process.execPath, args: [bin] } : { command: bin, args: [] };
+  },
+};
+`);
+  const previous = process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
 
-  assert.deepEqual(wpCodeboxCommand('/tmp/wp-codebox.mjs'), { command: 'node', args: ['/tmp/wp-codebox.mjs'] });
-  assert.deepEqual(wpCodeboxCommand('wp-codebox'), { command: 'wp-codebox', args: [] });
+  try {
+    process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER = helperPath;
+    assert.equal(wpCodeboxBin({}), 'wp-codebox');
+    assert.equal(wpCodeboxBin({ HOMEBOY_SETTINGS_WP_CODEBOX_BIN: '/tmp/wp-codebox-settings.js' }), '/tmp/wp-codebox-settings.js');
+    assert.equal(
+      wpCodeboxBin({
+        HOMEBOY_WP_CODEBOX_BIN: '/tmp/wp-codebox-env.mjs',
+        HOMEBOY_SETTINGS_WP_CODEBOX_BIN: '/tmp/wp-codebox-settings.js',
+      }),
+      '/tmp/wp-codebox-env.mjs'
+    );
+
+    assert.deepEqual(wpCodeboxCommand('/tmp/wp-codebox.mjs'), { command: process.execPath, args: ['/tmp/wp-codebox.mjs'] });
+    assert.deepEqual(wpCodeboxCommand('wp-codebox'), { command: 'wp-codebox', args: [] });
+  } finally {
+    if (previous === undefined) {
+      delete process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
+    } else {
+      process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER = previous;
+    }
+  }
 });
 
 test('default smoke profile preserves browser probe defaults', () => {

--- a/woocommerce/woocommerce/bench/cart-session-overwrite-race.trace.mjs
+++ b/woocommerce/woocommerce/bench/cart-session-overwrite-race.trace.mjs
@@ -1,11 +1,9 @@
-import { execFile } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { promisify } from 'node:util';
 
-const execFileAsync = promisify( execFile );
+import { runWpCodeboxRecipe } from '../../../shared/wp-codebox/recipe.mjs';
 
 const packageRoot = process.env.HOMEBOY_COMPONENT_PATH;
 const componentPluginPath = path.join( packageRoot || '', 'plugins/woocommerce' );
@@ -14,7 +12,6 @@ const componentId = process.env.HOMEBOY_COMPONENT_ID || 'woocommerce';
 const scenarioId = process.env.HOMEBOY_TRACE_SCENARIO || 'cart-session-overwrite-race';
 const resultsFile = process.env.HOMEBOY_TRACE_RESULTS_FILE;
 const artifactDir = process.env.HOMEBOY_TRACE_ARTIFACT_DIR || path.join( tmpdir(), 'woocommerce-cart-session-overwrite-race-artifacts' );
-const wpCodeboxBin = process.env.HOMEBOY_WP_CODEBOX_BIN || process.env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN || path.join( process.env.HOME || '', 'Developer/wp-codebox/packages/cli/dist/index.js' );
 const wpVersion = process.env.HOMEBOY_WOOCOMMERCE_CART_RACE_WP_VERSION || process.env.HOMEBOY_SETTINGS_WOOCOMMERCE_CART_RACE_WP_VERSION || '7.0';
 const probeDuration = process.env.HOMEBOY_WOOCOMMERCE_CART_RACE_PROBE_DURATION || '8s';
 const viewport = process.env.HOMEBOY_WOOCOMMERCE_CART_RACE_VIEWPORT || '1366x900';
@@ -52,14 +49,6 @@ function timestampMs() {
 
 function event( source, name, data = {} ) {
 	timeline.push( { t_ms: timestampMs(), source, event: name, data } );
-}
-
-function wpCodeboxCommand() {
-	if ( wpCodeboxBin.endsWith( '.js' ) || wpCodeboxBin.endsWith( '.cjs' ) || wpCodeboxBin.endsWith( '.mjs' ) ) {
-		return { command: 'node', args: [ wpCodeboxBin ] };
-	}
-
-	return { command: wpCodeboxBin, args: [] };
 }
 
 async function readJsonAsync( pathname ) {
@@ -406,12 +395,12 @@ return {
 
 	await writeFile( recipeFile, `${ JSON.stringify( recipe, null, 2 ) }\n` );
 
-	event( 'wp_codebox', 'recipe.start', { recipe_file: recipeFile } );
-	const { command, args } = wpCodeboxCommand();
-	const result = await execFileAsync( command, [ ...args, 'recipe-run', '--recipe', recipeFile, '--artifacts', codeboxArtifacts, '--json' ], {
-		maxBuffer: 1024 * 1024 * 50,
+	const result = await runWpCodeboxRecipe( {
+		recipeFile,
+		artifactsDir: codeboxArtifacts,
+		outputFile,
+		event,
 	} );
-	await writeFile( outputFile, result.stdout );
 
 	const output = JSON.parse( result.stdout );
 	const bundleDir = output.artifacts?.directory;


### PR DESCRIPTION
## Summary
- Delegate Studio Node bench settings, command execution, artifact paths, and redaction to Homeboy Extensions workload utilities.
- Delegate WordPress helper discovery and WP Codebox recipe execution to Homeboy Extensions primitives.
- Remove inline WP Codebox command shims from Gutenberg, Studio visual fidelity, and WooCommerce trace workloads.

## Tests
- `node scripts/lint-rig-packages.mjs`
- `node --test Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`
- `git diff --check origin/main...HEAD`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafted the helper-delegation refactor, updated tests, and ran local validation; Chris remains responsible for review and acceptance.
