### PR TITLE
Share WP Codebox CLI rig check

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ Keep the Studio bench harness layered so each repo owns the smallest stable surf
 
 Issue [#185](https://github.com/chubes4/homeboy-rigs/issues/185) tracks thinning duplicated helper logic after upstream promotion. Studio native-block quality probing now uses the promoted Homeboy Extensions block quality probes from `Extra-Chill/homeboy-extensions#1009`; target post metrics remain tracked in `Extra-Chill/homeboy-extensions#1018`. Studio fixture plugin install/restore now delegates to the Homeboy Extensions fixture setup helper from `Extra-Chill/homeboy-extensions#1134`, and helper discovery consumes promoted helper-manifest paths from `Extra-Chill/homeboy-extensions#1141`; rigs should not add local fallback shims for those contracts.
 
+Rig-side WP Codebox recipe execution should import `shared/wp-codebox/recipe.mjs`, and rig check pipelines should call `shared/wp-codebox/check-cli.sh` instead of duplicating `command -v wp-codebox`, local checkout guesses, or env-var precedence. The remaining upstream primitive gaps are typed rig requirements for executable discovery, shared node dependency availability, temporary symlink setup, and command-scoped filesystem assertions; keep local helpers small until Homeboy/Homeboy Extensions exposes those contracts.
+
 Cleanup should move in small waves:
 
 1. Build a shared local Studio bench helper foundation for repeated filesystem, artifact, CLI, and appdata setup.

--- a/WordPress/gutenberg/rigs/gutenberg-notes-unsaved-attachment/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-notes-unsaved-attachment/rig.json
@@ -118,7 +118,7 @@
       {
         "kind": "command",
         "label": "WP Codebox CLI exists",
-        "command": "if [ -n \"${HOMEBOY_WP_CODEBOX_BIN:-${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-}}\" ]; then test -f \"${HOMEBOY_WP_CODEBOX_BIN:-${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-}}\" || { printf '%s\n' \"Configured WP Codebox CLI not found: ${HOMEBOY_WP_CODEBOX_BIN:-${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-}}\"; exit 1; }; else test -f \"$HOME/Developer/wp-codebox/packages/cli/dist/index.js\" || command -v wp-codebox >/dev/null 2>&1 || { printf '%s\n' 'Missing WP Codebox CLI. Expected ~/Developer/wp-codebox/packages/cli/dist/index.js, wp-codebox on PATH, or HOMEBOY_SETTINGS_WP_CODEBOX_BIN.'; exit 1; }; fi"
+        "command": "bash \"${package.root}/../../shared/wp-codebox/check-cli.sh\""
       }
     ],
     "down": []

--- a/WordPress/gutenberg/rigs/gutenberg-pattern-preview-assets/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-pattern-preview-assets/rig.json
@@ -61,7 +61,7 @@
       {
         "kind": "command",
         "label": "WP Codebox CLI exists",
-        "command": "if [ -n \"${HOMEBOY_WP_CODEBOX_BIN:-${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-}}\" ]; then test -f \"${HOMEBOY_WP_CODEBOX_BIN:-${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-}}\" || { printf '%s\n' \"Configured WP Codebox CLI not found: ${HOMEBOY_WP_CODEBOX_BIN:-${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-}}\"; exit 1; }; else test -f \"$HOME/Developer/wp-codebox/packages/cli/dist/index.js\" || command -v wp-codebox >/dev/null 2>&1 || { printf '%s\n' 'Missing WP Codebox CLI. Expected ~/Developer/wp-codebox/packages/cli/dist/index.js, wp-codebox on PATH, or HOMEBOY_SETTINGS_WP_CODEBOX_BIN.'; exit 1; }; fi"
+        "command": "bash \"${package.root}/../../shared/wp-codebox/check-cli.sh\""
       }
     ],
     "down": []

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -66,6 +66,10 @@ function lintRigPortability(file) {
   if (rel === 'chubes4/isolated-block-editor/rigs/isolated-block-editor/rig.json' && contents.includes('/var/lib/datamachine')) {
     failures.push(`${rel}: isolated-block-editor must use the component path or shared node_modules setting instead of /var/lib/datamachine`);
   }
+
+  if (/WP Codebox CLI/.test(pipelineCommands) && /command -v wp-codebox|Developer\/wp-codebox|HOMEBOY_WP_CODEBOX_BIN/.test(pipelineCommands)) {
+    failures.push(`${rel}: use shared/wp-codebox/check-cli.sh instead of duplicating WP Codebox CLI discovery in rig commands`);
+  }
 }
 
 function lintPortableSource(file) {

--- a/shared/wp-codebox/check-cli.sh
+++ b/shared/wp-codebox/check-cli.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+wp_codebox_bin=${HOMEBOY_WP_CODEBOX_BIN:-${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-${WP_CODEBOX_BIN:-}}}
+
+case "$wp_codebox_bin" in
+	'~'/*) wp_codebox_bin="$HOME/${wp_codebox_bin#~/}" ;;
+esac
+
+if [ -n "$wp_codebox_bin" ]; then
+	test -f "$wp_codebox_bin" || {
+		printf '%s\n' "Configured WP Codebox CLI not found: $wp_codebox_bin" >&2
+		exit 1
+	}
+	exit 0
+fi
+
+command -v wp-codebox >/dev/null 2>&1 || {
+	printf '%s\n' 'Missing WP Codebox CLI. Install wp-codebox or set HOMEBOY_WP_CODEBOX_BIN, HOMEBOY_SETTINGS_WP_CODEBOX_BIN, or WP_CODEBOX_BIN.' >&2
+	exit 1
+}

--- a/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
+++ b/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
@@ -215,7 +215,7 @@
       {
         "kind": "command",
         "label": "WP Codebox CLI available",
-        "command": "if [ -n \"${HOMEBOY_WP_CODEBOX_BIN:-}\" ]; then test -f \"$HOMEBOY_WP_CODEBOX_BIN\" || { printf '%s\\n' \"HOMEBOY_WP_CODEBOX_BIN is set but not found: $HOMEBOY_WP_CODEBOX_BIN\"; exit 1; }; else command -v wp-codebox >/dev/null 2>&1 || { printf '%s\\n' 'Missing wp-codebox CLI. Install WP Codebox or set HOMEBOY_WP_CODEBOX_BIN to packages/cli/dist/index.js.'; exit 1; }; fi"
+        "command": "bash \"${package.root}/../../shared/wp-codebox/check-cli.sh\""
       }
     ],
     "up": [],


### PR DESCRIPTION
## Summary
- Add a shared WP Codebox CLI availability check for rig check pipelines.
- Replace duplicated inline WP Codebox CLI discovery in Gutenberg and Woo Stripe rigs.
- Add lint coverage against reintroducing inline WP Codebox CLI probes and document remaining typed primitive gaps.

## Tests
- `node scripts/lint-rig-packages.mjs`
- `bash -n shared/wp-codebox/check-cli.sh shared/node/with-shared-node-modules.sh`
- `node --test shared/webperf/deferred-init-webperf.test.mjs woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`
- `tmpfile=$(mktemp ...); HOMEBOY_WP_CODEBOX_BIN="$tmpfile" bash shared/wp-codebox/check-cli.sh`
- Missing configured WP Codebox CLI exits nonzero as expected.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the focused helper extraction, rig manifest updates, lint guard, documentation note, and local verification commands for Chris to review.