### PR TITLE
Use browser bench helper for Studio results

### DIFF
--- a/Automattic/studio/bench/studio-admin-theme-page-browser.bench.mjs
+++ b/Automattic/studio/bench/studio-admin-theme-page-browser.bench.mjs
@@ -25,7 +25,7 @@ if (!REDACTION_HELPER) {
   throw new Error('HOMEBOY_NODEJS_BENCH_REDACTION is required');
 }
 
-const { runBrowserPageScenario } = await import(BROWSER_HELPER);
+const { buildBrowserBenchResult, runBrowserPageScenario } = await import(BROWSER_HELPER);
 const { createBenchArtifactContext } = await import(ARTIFACT_CONTEXT_HELPER);
 const { sanitizeArtifactFile } = await import(REDACTION_HELPER);
 
@@ -153,7 +153,7 @@ export default async function studioAdminThemePageBrowserBench() {
       throw new Error(`Browser trace/screenshot artifacts missing; raw_result=${artifactFile}`);
     }
 
-    return {
+    return buildBrowserBenchResult({
       metrics: {
         success_rate: 1,
         elapsed_ms: totalElapsedMs,
@@ -165,12 +165,12 @@ export default async function studioAdminThemePageBrowserBench() {
         total_elapsed_ms: totalElapsedMs,
         ...browserResult.metrics,
       },
+      rawResultArtifact,
       artifacts: {
-        raw_result: rawResultArtifact,
         site_path: sitePath,
         ...browserResult.artifacts,
       },
-    };
+    });
   } finally {
     if (!stop) {
       stop = await stopSite(sitePath);

--- a/Automattic/studio/bench/studio-site-editor-browser.bench.mjs
+++ b/Automattic/studio/bench/studio-site-editor-browser.bench.mjs
@@ -31,7 +31,7 @@ if (!REDACTION_HELPER) {
   throw new Error('HOMEBOY_NODEJS_BENCH_REDACTION is required');
 }
 
-const { runBrowserPageScenario } = await import(BROWSER_HELPER);
+const { buildBrowserBenchResult, runBrowserPageScenario } = await import(BROWSER_HELPER);
 const { createBenchArtifactContext } = await import(ARTIFACT_CONTEXT_HELPER);
 const { sanitizeArtifactFile } = await import(REDACTION_HELPER);
 
@@ -196,9 +196,9 @@ export default async function studioSiteEditorBrowserBench() {
       throw new Error(`Browser trace/screenshot artifacts missing; raw_result=${artifactFile}`);
     }
 
-    return {
+    return buildBrowserBenchResult({
+      browserResult,
       metrics: {
-        ...browserResult.metrics,
         success_rate: 1,
         elapsed_ms: totalElapsedMs,
         site_create_ms: metric(create.elapsedMs),
@@ -213,12 +213,11 @@ export default async function studioSiteEditorBrowserBench() {
         site_editor_warmup_ready_ms: metric(warmupTimings.site_editor_ready_ms),
         total_elapsed_ms: totalElapsedMs,
       },
+      rawResultArtifact,
       artifacts: {
-        raw_result: rawResultArtifact,
         site_path: sitePath,
-        ...browserResult.artifacts,
       },
-    };
+    });
   } finally {
     if (!stop) {
       stop = await stopSite(sitePath);


### PR DESCRIPTION
## Summary
- Refactor Studio Site Editor browser workload results through `buildBrowserBenchResult`.
- Refactor Studio Add Themes browser workload results through `buildBrowserBenchResult`.
- Keep workload-specific metrics, raw-result artifacts, and browser trace/screenshot assertions intact.

## Tests
- `node --check "Automattic/studio/bench/studio-site-editor-browser.bench.mjs" && node --check "Automattic/studio/bench/studio-admin-theme-page-browser.bench.mjs"`
- `node --test "Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs"`
- `HOMEBOY_NODEJS_WORKLOAD_UTILS="/Users/chubes/Developer/homeboy-extensions/nodejs/scripts/bench/lib/workload-utils.mjs" HOMEBOY_WORDPRESS_HELPER_MANIFEST="/Users/chubes/Developer/homeboy-extensions/wordpress/lib/helper-manifest.js" node --test "Automattic/studio/bench/studio-agent-site-build.test.mjs"`
- `git diff --check origin/main...HEAD`

## Notes
- `homeboy lint --changed-only --summary` was blocked by warm-machine resource policy before executing. Rerunning with the suggested local-hot override reached component autodetection, but this bare rigs checkout has no `homeboy.json` component ID for Homeboy lint to run against.
- No browser bench result helper gap was found for these workloads; the helper is already exposed by `HOMEBOY_NODEJS_BROWSER_BENCH_HELPER` and used by the dashboard workload.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the small workload refactor, ran local verification, and prepared this PR body; Chris remains responsible for review and merge.
