### PR TITLE
Declare rig portability dependencies

### DIFF
--- a/Automattic/studio/rigs/studio-agent-claude-ssi/rig.json
+++ b/Automattic/studio/rigs/studio-agent-claude-ssi/rig.json
@@ -13,6 +13,11 @@
       }
     }
   },
+  "resources": {
+    "paths": [
+      "${components.studio.path}"
+    ]
+  },
   "bench": {
     "default_component": "studio"
   },
@@ -29,6 +34,12 @@
   "pipeline": {
     "up": [
       {
+        "kind": "check",
+        "label": "npm available",
+        "command": "command -v npm >/dev/null 2>&1",
+        "expect_exit": 0
+      },
+      {
         "kind": "command",
         "label": "Install Studio dependencies",
         "cwd": "${components.studio.path}",
@@ -42,6 +53,12 @@
       }
     ],
     "check": [
+      {
+        "kind": "check",
+        "label": "npm available",
+        "command": "command -v npm >/dev/null 2>&1",
+        "expect_exit": 0
+      },
       {
         "kind": "check",
         "label": "Studio CLI eval runner built",

--- a/Automattic/studio/rigs/studio-agent-claude-trunk/rig.json
+++ b/Automattic/studio/rigs/studio-agent-claude-trunk/rig.json
@@ -13,6 +13,11 @@
       }
     }
   },
+  "resources": {
+    "paths": [
+      "${components.studio.path}"
+    ]
+  },
   "bench": {
     "default_component": "studio"
   },
@@ -29,6 +34,12 @@
   "pipeline": {
     "up": [
       {
+        "kind": "check",
+        "label": "npm available",
+        "command": "command -v npm >/dev/null 2>&1",
+        "expect_exit": 0
+      },
+      {
         "kind": "command",
         "label": "Install Studio dependencies",
         "cwd": "${components.studio.path}",
@@ -42,6 +53,12 @@
       }
     ],
     "check": [
+      {
+        "kind": "check",
+        "label": "npm available",
+        "command": "command -v npm >/dev/null 2>&1",
+        "expect_exit": 0
+      },
       {
         "kind": "check",
         "label": "Studio CLI eval runner built",

--- a/Automattic/studio/rigs/studio-agent-gpt55-ssi/rig.json
+++ b/Automattic/studio/rigs/studio-agent-gpt55-ssi/rig.json
@@ -13,6 +13,11 @@
       }
     }
   },
+  "resources": {
+    "paths": [
+      "${components.studio.path}"
+    ]
+  },
   "bench": {
     "default_component": "studio"
   },
@@ -29,6 +34,12 @@
   "pipeline": {
     "up": [
       {
+        "kind": "check",
+        "label": "npm available",
+        "command": "command -v npm >/dev/null 2>&1",
+        "expect_exit": 0
+      },
+      {
         "kind": "command",
         "label": "Install Studio dependencies",
         "cwd": "${components.studio.path}",
@@ -42,6 +53,12 @@
       }
     ],
     "check": [
+      {
+        "kind": "check",
+        "label": "npm available",
+        "command": "command -v npm >/dev/null 2>&1",
+        "expect_exit": 0
+      },
       {
         "kind": "check",
         "label": "Studio CLI eval runner built",

--- a/Automattic/studio/rigs/studio-agent-model-comparison.variants.json
+++ b/Automattic/studio/rigs/studio-agent-model-comparison.variants.json
@@ -4,6 +4,11 @@
     "bench": {
       "default_component": "studio"
     },
+    "resources": {
+      "paths": [
+        "${components.studio.path}"
+      ]
+    },
     "bench_workloads": {
       "nodejs": [
         "${package.root}/bench/studio-agent-runtime.bench.mjs",
@@ -16,6 +21,12 @@
     },
     "pipeline": {
       "up": [
+        {
+          "kind": "check",
+          "label": "npm available",
+          "command": "command -v npm >/dev/null 2>&1",
+          "expect_exit": 0
+        },
         {
           "kind": "command",
           "label": "Install Studio dependencies",
@@ -30,6 +41,12 @@
         }
       ],
       "check": [
+        {
+          "kind": "check",
+          "label": "npm available",
+          "command": "command -v npm >/dev/null 2>&1",
+          "expect_exit": 0
+        },
         {
           "kind": "check",
           "label": "Studio CLI eval runner built",

--- a/Automattic/studio/rigs/studio-combined/rig.json
+++ b/Automattic/studio/rigs/studio-combined/rig.json
@@ -36,6 +36,18 @@
     }
   },
 
+  "resources": {
+    "ports": [9724],
+    "paths": [
+      "${components.studio.path}",
+      "${components.wordpress-playground.path}"
+    ],
+    "process_patterns": [
+      "wordpress-server-child.mjs",
+      "playground-server-child.mjs"
+    ]
+  },
+
   "symlinks": [
     {
       "link": "~/.local/bin/studio",
@@ -423,16 +435,16 @@
     "diagnostic-seeded-sqlite-db": {
       "setup": [
         {
-          "command": "test -f /tmp/studio-template-probe/seed.ht.sqlite"
+          "command": "test -n \"$HOMEBOY_SETTINGS_STUDIO_TRACE_SEED_DB_PATH\" && test -f \"$HOMEBOY_SETTINGS_STUDIO_TRACE_SEED_DB_PATH\""
         }
       ],
       "env": {
-        "STUDIO_TRACE_SEED_DB_PATH": "/tmp/studio-template-probe/seed.ht.sqlite"
+        "STUDIO_TRACE_SEED_DB_PATH": "${env.HOMEBOY_SETTINGS_STUDIO_TRACE_SEED_DB_PATH}"
       },
       "artifacts": [
         {
           "label": "diagnostic seed SQLite DB",
-          "path": "/tmp/studio-template-probe/seed.ht.sqlite"
+          "path": "${env.HOMEBOY_SETTINGS_STUDIO_TRACE_SEED_DB_PATH}"
         }
       ]
     }
@@ -440,6 +452,30 @@
 
   "pipeline": {
     "check": [
+      {
+        "kind": "check",
+        "label": "Node.js available",
+        "command": "command -v node >/dev/null 2>&1",
+        "expect_exit": 0
+      },
+      {
+        "kind": "check",
+        "label": "npm available",
+        "command": "command -v npm >/dev/null 2>&1",
+        "expect_exit": 0
+      },
+      {
+        "kind": "check",
+        "label": "npx available",
+        "command": "command -v npx >/dev/null 2>&1",
+        "expect_exit": 0
+      },
+      {
+        "kind": "check",
+        "label": "jq available",
+        "command": "command -v jq >/dev/null 2>&1",
+        "expect_exit": 0
+      },
       {
         "kind": "check",
         "label": "Docker daemon running",
@@ -507,8 +543,8 @@
       },
       {
         "kind": "check",
-        "label": "Live proc_open end-to-end (the truth)",
-        "command": "site_path=${STUDIO_PROC_OPEN_CHECK_SITE_PATH:-$HOME/Studio/intelligence-chubes4}; rm -f /tmp/_studio_rig_check_marker && out=$(studio wp --path \"$site_path\" eval '$h = proc_open(\"touch /tmp/_studio_rig_check_marker && echo ok\", [1=>[\"pipe\",\"w\"]], $p); if (is_resource($h)) { echo stream_get_contents($p[1]); proc_close($h); } sleep(1);' 2>&1 | tail -1) && test -f /tmp/_studio_rig_check_marker && echo \"$out\" | grep -q ok",
+        "label": "Live proc_open end-to-end (optional configured Studio site)",
+        "command": "site_path=${STUDIO_PROC_OPEN_CHECK_SITE_PATH:-${HOMEBOY_SETTINGS_STUDIO_PROC_OPEN_CHECK_SITE_PATH:-}}; if [ -z \"$site_path\" ]; then printf '%s\\n' 'Skipping live proc_open check; set STUDIO_PROC_OPEN_CHECK_SITE_PATH or HOMEBOY_SETTINGS_STUDIO_PROC_OPEN_CHECK_SITE_PATH.'; exit 0; fi; marker_dir=$(mktemp -d \"${TMPDIR:-/tmp}/studio-rig-check.XXXXXX\") && marker=$marker_dir/marker && trap 'rm -rf \"$marker_dir\"' EXIT && export STUDIO_PROC_OPEN_CHECK_MARKER=\"$marker\" && out=$(studio wp --path \"$site_path\" eval '$marker = getenv(\"STUDIO_PROC_OPEN_CHECK_MARKER\"); $h = proc_open(\"touch \" . escapeshellarg($marker) . \" && echo ok\", [1=>[\"pipe\",\"w\"]], $p); if (is_resource($h)) { echo stream_get_contents($p[1]); proc_close($h); } sleep(1);' 2>&1 | tail -1) && test -f \"$marker\" && echo \"$out\" | grep -q ok",
         "expect_exit": 0
       }
     ],

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ GitHub Actions runs the PHP syntax pass with PHP installed.
 
 `rigs/studio-combined/rig.json` is the Studio + Playground combined-fixes dev environment: forks rebased onto trunk, open PRs cherry-picked, Docker-compiled PHP-WASM glue, tarball server, and Studio CLI rewired to local tarballs.
 
+The rig declares the local tarball server port, touched component paths, and adopted Studio/Playground process patterns in `resources` so concurrent rig commands can see the same ownership assumptions that the pipeline uses. The fixed tarball port remains `9724` because Homeboy `http-static` services currently require an integer port in the rig spec.
+
 ```bash
 homeboy rig check studio-combined
 homeboy rig up studio-combined
@@ -185,6 +187,8 @@ Canonical Studio create-site trace spans, pending Homeboy's trace span summary s
 | `ready_to_state` | `probe.http_ready` | `probe.site_details_running_true` |
 | `state_to_ui` | `probe.site_details_running_true` | `ui.site.running_visible` |
 | `submit_to_running` | `ui.create_site.submit_clicked` | `ui.site.running_visible` |
+
+The optional `diagnostic-seeded-sqlite-db` trace experiment no longer assumes a seed database under `/tmp`; set `HOMEBOY_SETTINGS_STUDIO_TRACE_SEED_DB_PATH=/path/to/seed.ht.sqlite` when using that experiment. The optional live `proc_open` check also requires `STUDIO_PROC_OPEN_CHECK_SITE_PATH` or `HOMEBOY_SETTINGS_STUDIO_PROC_OPEN_CHECK_SITE_PATH`, so package checks do not assume Chris's local Studio site path.
 
 The Studio agent site-build rigs are model/substrate-specific. Use `studio-agent-claude-ssi` or `studio-agent-gpt55-ssi` for current Static Site Importer site-build runs, and `studio-agent-claude-trunk` as the trunk reference.
 

--- a/WordPress/wordpress-playground/rigs/playground-cli-diagnostics/rig.json
+++ b/WordPress/wordpress-playground/rigs/playground-cli-diagnostics/rig.json
@@ -13,6 +13,11 @@
   "bench": {
     "default_component": "wordpress-playground"
   },
+  "resources": {
+    "paths": [
+      "${components.wordpress-playground.path}"
+    ]
+  },
   "bench_workloads": {
     "nodejs": [
       "${package.root}/bench/playground-cli-runphp-errors.bench.mjs"
@@ -21,6 +26,12 @@
   "pipeline": {
     "up": [
       {
+        "kind": "check",
+        "label": "npm available",
+        "command": "command -v npm >/dev/null 2>&1",
+        "expect_exit": 0
+      },
+      {
         "kind": "command",
         "label": "Install Playground dependencies",
         "cwd": "${components.wordpress-playground.path}",
@@ -28,6 +39,12 @@
       }
     ],
     "check": [
+      {
+        "kind": "check",
+        "label": "npm available",
+        "command": "command -v npm >/dev/null 2>&1",
+        "expect_exit": 0
+      },
       {
         "kind": "check",
         "label": "Playground checkout exists",

--- a/scripts/generate-studio-agent-model-rigs.mjs
+++ b/scripts/generate-studio-agent-model-rigs.mjs
@@ -38,6 +38,7 @@ function rigFromVariant(variant, shared) {
         },
       },
     },
+    resources: shared.resources,
     bench: shared.bench,
     bench_workloads: shared.bench_workloads,
     pipeline: shared.pipeline,


### PR DESCRIPTION
## Summary
- Declare Studio combined resource ownership for its fixed tarball port, component paths, and adopted Studio/Playground process patterns.
- Replace the hardcoded diagnostic seed DB path and Chris-local proc_open site default with explicit settings/env inputs.
- Add lightweight npm/tool availability checks to rigs that install/build component dependencies, including generated Studio agent model rigs.
- Preserve generated rig output by teaching the Studio agent rig generator to carry shared resources.

## Tests
- `node scripts/generate-studio-agent-model-rigs.mjs && node scripts/lint-rig-packages.mjs`
- `node --test shared/wp-codebox/artifacts.test.mjs shared/webperf/deferred-init-webperf.test.mjs Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs`

## Verification notes
- `homeboy rig check studio-combined` was attempted, but the lab runner failed before running checks because its installed `studio-combined` rig source points at a stale missing runner workspace. I left that runner registry untouched.
- A broader Node test command including `Automattic/studio/bench/studio-agent-site-build.test.mjs` still requires `HOMEBOY_NODEJS_WORKLOAD_UTILS` at import time; that is unrelated to this rig-spec cleanup.

## Upstream primitive still missing
- Homeboy `http-static` services still require a literal integer `port`, so the Studio tarball service remains fixed at `9724` and documented as such. A future typed service setting/default primitive would let this become fully configurable without shell wrappers.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the rig declaration cleanup, regenerated derived rig specs, and ran local verification; Chris remains responsible for review and merge.
