### PR TITLE
Use declarative Gutenberg checkout requirements

### DIFF
--- a/WordPress/gutenberg/rigs/gutenberg-notes-unsaved-attachment/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-notes-unsaved-attachment/rig.json
@@ -111,9 +111,12 @@
   "pipeline": {
     "check": [
       {
-        "kind": "command",
+        "kind": "requirement",
         "label": "Gutenberg checkout exists",
-        "command": "gutenberg_path=\"${components.gutenberg.path}\"; test -f \"$gutenberg_path/gutenberg.php\" || { printf '%s\n' \"Missing Gutenberg checkout: expected $gutenberg_path/gutenberg.php. Pass --path /path/to/gutenberg or update components.gutenberg.path.\"; exit 1; }"
+        "file": "${components.gutenberg.path}/gutenberg.php",
+        "component": "gutenberg",
+        "component_path_contains": "gutenberg",
+        "remediation": "Pass homeboy trace --path /path/to/gutenberg or update components.gutenberg.path before running gutenberg-notes-unsaved-attachment."
       },
       {
         "kind": "command",

--- a/WordPress/gutenberg/rigs/gutenberg-pattern-preview-assets/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-pattern-preview-assets/rig.json
@@ -54,9 +54,12 @@
   "pipeline": {
     "check": [
       {
-        "kind": "command",
+        "kind": "requirement",
         "label": "Gutenberg checkout exists",
-        "command": "gutenberg_path=\"${components.gutenberg.path}\"; test -f \"$gutenberg_path/gutenberg.php\" || { printf '%s\n' \"Missing Gutenberg checkout: expected $gutenberg_path/gutenberg.php. Pass --path /path/to/gutenberg or update components.gutenberg.path.\"; exit 1; }"
+        "file": "${components.gutenberg.path}/gutenberg.php",
+        "component": "gutenberg",
+        "component_path_contains": "gutenberg",
+        "remediation": "Pass homeboy trace --path /path/to/gutenberg or update components.gutenberg.path before running gutenberg-pattern-preview-assets."
       },
       {
         "kind": "command",


### PR DESCRIPTION
## Summary
- Replace Gutenberg checkout shell preflights with declarative file requirements in the two Gutenberg rigs.
- Keep WP Codebox CLI checks shell-backed because executable/env alias requirements depend on pending Homeboy core support.

## Validation
- node scripts/lint-rig-packages.mjs
- homeboy --force-hot --allow-local-hot rig check gutenberg-pattern-preview-assets
- homeboy --force-hot --allow-local-hot rig check gutenberg-notes-unsaved-attachment

## Notes
- Automatic lab offload hit a stale runner-side linked rig source for these rig IDs before the checks executed, so the successful rig checks were run with Homeboy's explicit local-hot option.
- Follow-up: migrate shared/wp-codebox/check-cli.sh after Homeboy core supports executable discovery with env aliases.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** migrating rig preflights to declarative requirements where supported.