### PR TITLE
Use typed check for WooCommerce plugin preflight

### DIFF
--- a/woocommerce/woocommerce/rigs/woocommerce-cart-session-race-browser/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-cart-session-race-browser/rig.json
@@ -63,9 +63,9 @@
   "pipeline": {
     "check": [
       {
-        "kind": "command",
+        "kind": "check",
         "label": "WooCommerce monorepo plugin exists",
-        "command": "woocommerce_root=\"${components.woocommerce.path}\"; test -f \"$woocommerce_root/plugins/woocommerce/woocommerce.php\" || { printf '%s\\n' \"Missing WooCommerce plugin entrypoint: expected $woocommerce_root/plugins/woocommerce/woocommerce.php. Pass homeboy trace --path /path/to/woocommerce-monorepo or update components.woocommerce.path.\"; exit 1; }"
+        "file": "${components.woocommerce.path}/plugins/woocommerce/woocommerce.php"
       }
     ],
     "up": [],


### PR DESCRIPTION
## Summary
- Replace the WooCommerce cart-session race rig shell `test -f` preflight with Homeboy's typed `file` check.
- Keep command/executable checks and generated Studio model rigs unchanged because the current Homeboy rig schema does not expose executable requirements or rig `extends`.

## Tests
- `node scripts/lint-rig-packages.mjs`
- `homeboy --force-hot --allow-local-hot rig check woocommerce-cart-session-race-browser` did not reach the rig because the installed Homeboy rig source points at a removed worktree: `/Users/chubes/Developer/homeboy-rigs@fix-issue-272-gateway-profiles/woocommerce/woocommerce`. I did not mutate the global rig-source registry for this PR.

## Skipped findings requiring upstream support
- `command -v` checks for `node`, `npm`, `npx`, and `jq`: no typed executable/command availability requirement exists in the current Homeboy rig schema.
- `real-wallet-ece-compare.sh`: no existing Homeboy primitive appears to replace the script's argument/env validation and compare-bundle wrapper without losing workflow behavior.
- Studio model rig generator replacement with `extends`: the current Homeboy rig schema does not expose an `extends` primitive.
- Trace experiment setup file checks: `trace_experiments.setup` currently accepts command specs, not typed `CheckSpec` entries.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Inspected Homeboy/Homeboy Rigs primitives, drafted the minimal rig JSON change, ran local verification, and prepared this PR body.