### PR TITLE
Use extension WP Codebox artifact resolver

### DIFF
--- a/shared/wp-codebox/artifacts.mjs
+++ b/shared/wp-codebox/artifacts.mjs
@@ -1,84 +1,32 @@
+import { createRequire } from 'node:module';
 import path from 'node:path';
 
-function artifactDirectory(output) {
-  return output?.artifacts?.directory || output?.artifactsDir || '';
-}
+const require = createRequire(import.meta.url);
 
-function artifactFiles(output) {
-  const candidates = [
-    output?.artifacts?.files,
-    output?.artifacts?.manifest?.files,
-    output?.manifest?.artifacts?.files,
-    output?.manifest?.files,
-  ];
+function loadArtifactHelper() {
+  const explicit = process.env.HOMEBOY_WP_CODEBOX_ARTIFACT_HELPER;
+  if (explicit) {
+    return require(explicit);
+  }
 
-  for (const candidate of candidates) {
-    if (Array.isArray(candidate)) {
-      return candidate;
-    }
-    if (candidate && typeof candidate === 'object') {
-      return Object.entries(candidate).map(([name, value]) => (
-        typeof value === 'string'
-          ? { name, path: value }
-          : { name, ...value }
-      ));
+  const manifestPath = process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST;
+  if (manifestPath) {
+    const manifestModule = require(manifestPath);
+    const manifest = typeof manifestModule.getWordPressHelperManifest === 'function'
+      ? manifestModule.getWordPressHelperManifest()
+      : manifestModule.WORDPRESS_HELPER_MANIFEST;
+    if (manifest?.extensionRoot) {
+      return require(path.join(manifest.extensionRoot, 'lib', 'wp-codebox-artifacts.js'));
     }
   }
 
-  return [];
-}
-
-function normalizePathname(value) {
-  return String(value || '').replace(/\\/g, '/').replace(/^\.\//, '');
-}
-
-function manifestEntryPath(entry) {
-  if (!entry || typeof entry !== 'object') {
-    return '';
-  }
-
-  return entry.path || entry.pathname || entry.file || entry.relativePath || entry.relative_path || '';
-}
-
-function manifestEntryMatches(entry, relativePath) {
-  const wanted = normalizePathname(relativePath);
-  const values = [
-    entry?.path,
-    entry?.pathname,
-    entry?.file,
-    entry?.relativePath,
-    entry?.relative_path,
-    entry?.name,
-    entry?.id,
-    entry?.label,
-  ].map(normalizePathname).filter(Boolean);
-
-  return values.some((value) => value === wanted || value.endsWith(`/${wanted}`));
+  return require('homeboy-extension-wordpress/wp-codebox-artifacts');
 }
 
 export function wpCodeboxArtifactPath(output, relativePath) {
-  const directory = artifactDirectory(output);
-  if (!directory) {
-    return '';
-  }
-
-  const entry = artifactFiles(output).find((candidate) => manifestEntryMatches(candidate, relativePath));
-  const entryPath = manifestEntryPath(entry);
-  if (entryPath) {
-    return path.isAbsolute(entryPath) ? entryPath : path.join(directory, entryPath);
-  }
-
-  return path.join(directory, relativePath);
+  return loadArtifactHelper().resolveWpCodeboxManifestArtifactPath(output, relativePath);
 }
 
 export function wpCodeboxBrowserArtifacts(output, names) {
-  const result = {
-    directory: wpCodeboxArtifactPath(output, 'files/browser'),
-  };
-
-  for (const name of names) {
-    result[name] = wpCodeboxArtifactPath(output, `files/browser/${name}`);
-  }
-
-  return result;
+  return loadArtifactHelper().wpCodeboxBrowserArtifacts(output, names);
 }

--- a/shared/wp-codebox/artifacts.test.mjs
+++ b/shared/wp-codebox/artifacts.test.mjs
@@ -1,8 +1,50 @@
 import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
-import { wpCodeboxArtifactPath, wpCodeboxBrowserArtifacts } from './artifacts.mjs';
+const helperPath = path.join(await mkdtemp(path.join(tmpdir(), 'wp-codebox-artifact-helper-')), 'helper.cjs');
+await writeFile(helperPath, `
+const path = require('node:path');
+
+function directory(output) {
+  return output?.artifacts?.directory || output?.artifactsDir || '';
+}
+
+function files(output) {
+  return output?.artifacts?.files || [];
+}
+
+function matches(entry, relativePath) {
+  return [entry?.path, entry?.relativePath, entry?.relative_path, entry?.name]
+    .filter(Boolean)
+    .some((value) => value === relativePath || value.endsWith('/' + relativePath));
+}
+
+function resolveWpCodeboxManifestArtifactPath(output, relativePath) {
+  const root = directory(output);
+  if (!root) {
+    return '';
+  }
+  const entry = files(output).find((candidate) => matches(candidate, relativePath));
+  const entryPath = entry?.path || entry?.file || entry?.relativePath || entry?.relative_path || '';
+  return entryPath ? (path.isAbsolute(entryPath) ? entryPath : path.join(root, entryPath)) : path.join(root, relativePath);
+}
+
+function wpCodeboxBrowserArtifacts(output, names) {
+  return Object.fromEntries([
+    ['directory', resolveWpCodeboxManifestArtifactPath(output, 'files/browser')],
+    ...names.map((name) => [name, resolveWpCodeboxManifestArtifactPath(output, 'files/browser/' + name)]),
+  ]);
+}
+
+module.exports = { resolveWpCodeboxManifestArtifactPath, wpCodeboxBrowserArtifacts };
+`, 'utf8');
+
+process.env.HOMEBOY_WP_CODEBOX_ARTIFACT_HELPER = helperPath;
+
+const { wpCodeboxArtifactPath, wpCodeboxBrowserArtifacts } = await import('./artifacts.mjs');
 
 test('WP Codebox artifact lookup falls back to current bundle layout', () => {
   const output = { artifacts: { directory: '/tmp/wp-codebox-artifacts' } };


### PR DESCRIPTION
## Summary
- Replace the local WP Codebox artifact path guessing logic with a thin loader shim.
- Resolve artifacts through the generic helper exported by homeboy-extension-wordpress, with explicit helper and helper-manifest loading paths for Homeboy-managed runs.
- Keep the existing browser artifact API for rigs while moving the resolver contract to homeboy-extensions.

Depends on Extra-Chill/homeboy-extensions#1507.

## Testing
- `node --test shared/wp-codebox/artifacts.test.mjs`
- `node --check shared/wp-codebox/artifacts.mjs && node --check shared/wp-codebox/artifacts.test.mjs`
- Cross-repo verification with `HOMEBOY_WP_CODEBOX_ARTIFACT_HELPER` pointing at the edited extensions helper.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (gpt-5.5)
- **Used for:** Drafted the shim, tests, cross-repo verification, and PR preparation for Chris to review.