### PR TITLE
Fix WooCommerce performance rig monorepo prep

### DIFF
--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -8,6 +8,8 @@
       "extensions": {
         "wordpress": {
           "wp_codebox_wordpress_version": "7.0",
+          "wp_codebox_source_root": "~/Developer/woocommerce",
+          "wp_codebox_source_subpath": "plugins/woocommerce",
           "bench_env": {
             "WC_CHECKOUT_GATEWAY_MATRIX_PROFILE_SET": "core_only",
             "WC_CHECKOUT_GATEWAY_MATRIX_PROFILES": "",
@@ -124,8 +126,7 @@
         "kind": "requirement",
         "label": "WooCommerce Composer package autoloader exists or can be prepared",
         "file": "${components.woocommerce.path}/vendor/autoload_packages.php",
-        "cwd": "${components.woocommerce.path}",
-        "prepare_command": "XDEBUG_MODE=off composer install --no-interaction --no-progress",
+        "prepare_command": "woocommerce_source_root=\"${env.HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT}\"; if [ -z \"$woocommerce_source_root\" ]; then woocommerce_source_root=\"${components.woocommerce.path}/../..\"; fi; XDEBUG_MODE=off composer --working-dir=\"$woocommerce_source_root\" install --no-interaction --no-progress",
         "prepare_phases": ["up", "bench_prepare"],
         "remediation": "Install Composer on the runner, then run: homeboy rig up woocommerce-performance"
       },
@@ -144,8 +145,7 @@
         "kind": "requirement",
         "label": "Prepare WooCommerce Composer dependencies when missing",
         "file": "${components.woocommerce.path}/vendor/autoload_packages.php",
-        "cwd": "${components.woocommerce.path}",
-        "prepare_command": "XDEBUG_MODE=off composer install --no-interaction --no-progress",
+        "prepare_command": "woocommerce_source_root=\"${env.HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT}\"; if [ -z \"$woocommerce_source_root\" ]; then woocommerce_source_root=\"${components.woocommerce.path}/../..\"; fi; XDEBUG_MODE=off composer --working-dir=\"$woocommerce_source_root\" install --no-interaction --no-progress",
         "prepare_phases": ["up"],
         "remediation": "Install Composer on the runner, then run: homeboy rig up woocommerce-performance"
       },
@@ -164,8 +164,7 @@
         "kind": "requirement",
         "label": "Prepare WooCommerce Composer dependencies when missing",
         "file": "${components.woocommerce.path}/vendor/autoload_packages.php",
-        "cwd": "${components.woocommerce.path}",
-        "prepare_command": "XDEBUG_MODE=off composer install --no-interaction --no-progress",
+        "prepare_command": "woocommerce_source_root=\"${env.HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT}\"; if [ -z \"$woocommerce_source_root\" ]; then woocommerce_source_root=\"${components.woocommerce.path}/../..\"; fi; XDEBUG_MODE=off composer --working-dir=\"$woocommerce_source_root\" install --no-interaction --no-progress",
         "prepare_phases": ["bench_prepare"],
         "remediation": "Install Composer on the runner, then run: homeboy rig up woocommerce-performance"
       },

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -126,7 +126,7 @@
         "kind": "requirement",
         "label": "WooCommerce Composer package autoloader exists or can be prepared",
         "file": "${components.woocommerce.path}/vendor/autoload_packages.php",
-        "prepare_command": "woocommerce_source_root=\"${env.HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT}\"; if [ -z \"$woocommerce_source_root\" ]; then woocommerce_source_root=\"${components.woocommerce.path}/../..\"; fi; XDEBUG_MODE=off composer --working-dir=\"$woocommerce_source_root\" install --no-interaction --no-progress",
+        "prepare_command": "woocommerce_source_root=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -z \"$woocommerce_source_root\" ]; then woocommerce_source_root=\"${components.woocommerce.path}/../..\"; fi; XDEBUG_MODE=off composer --working-dir=\"$woocommerce_source_root\" install --no-interaction --no-progress",
         "prepare_phases": ["up", "bench_prepare"],
         "remediation": "Install Composer on the runner, then run: homeboy rig up woocommerce-performance"
       },
@@ -145,7 +145,7 @@
         "kind": "requirement",
         "label": "Prepare WooCommerce Composer dependencies when missing",
         "file": "${components.woocommerce.path}/vendor/autoload_packages.php",
-        "prepare_command": "woocommerce_source_root=\"${env.HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT}\"; if [ -z \"$woocommerce_source_root\" ]; then woocommerce_source_root=\"${components.woocommerce.path}/../..\"; fi; XDEBUG_MODE=off composer --working-dir=\"$woocommerce_source_root\" install --no-interaction --no-progress",
+        "prepare_command": "woocommerce_source_root=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -z \"$woocommerce_source_root\" ]; then woocommerce_source_root=\"${components.woocommerce.path}/../..\"; fi; XDEBUG_MODE=off composer --working-dir=\"$woocommerce_source_root\" install --no-interaction --no-progress",
         "prepare_phases": ["up"],
         "remediation": "Install Composer on the runner, then run: homeboy rig up woocommerce-performance"
       },
@@ -164,7 +164,7 @@
         "kind": "requirement",
         "label": "Prepare WooCommerce Composer dependencies when missing",
         "file": "${components.woocommerce.path}/vendor/autoload_packages.php",
-        "prepare_command": "woocommerce_source_root=\"${env.HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT}\"; if [ -z \"$woocommerce_source_root\" ]; then woocommerce_source_root=\"${components.woocommerce.path}/../..\"; fi; XDEBUG_MODE=off composer --working-dir=\"$woocommerce_source_root\" install --no-interaction --no-progress",
+        "prepare_command": "woocommerce_source_root=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -z \"$woocommerce_source_root\" ]; then woocommerce_source_root=\"${components.woocommerce.path}/../..\"; fi; XDEBUG_MODE=off composer --working-dir=\"$woocommerce_source_root\" install --no-interaction --no-progress",
         "prepare_phases": ["bench_prepare"],
         "remediation": "Install Composer on the runner, then run: homeboy rig up woocommerce-performance"
       },


### PR DESCRIPTION
## Summary
- Adds WordPress/WP Codebox source-root settings for the WooCommerce performance rig.
- Runs Composer from the WooCommerce monorepo root instead of the plugin subdirectory.
- Reads the source root from the runtime HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT env var supplied by Homeboy bench_prepare settings.

## Testing
- git diff --check
- homeboy rig install /Users/chubes/Developer/homeboy-rigs@fix-woocommerce-performance-source-root-prepare/woocommerce/woocommerce --id woocommerce-performance --reinstall
- Installed the same rig on homeboy-lab from an isolated branch worktree.
- Confirmed homeboy-lab daemon-backed jobs resolve homeboy 0.240.0 before retrying the WooCommerce proof path.

## Notes
- This is rig/platform plumbing only. It does not change the WooCommerce fix branch.
- The WooCommerce shipping-cache proof run is still in progress and should happen after this rig patch lands.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the rig patch and validation workflow; Chris remains responsible for review and validation.