### PR TITLE
Add WooCommerce REST route inventory workload

### DIFF
--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -129,6 +129,7 @@ homeboy bench --rig woocommerce-performance --scenario checkout-shortcode-place-
 homeboy bench --rig woocommerce-performance --scenario admin-dashboard-physical-products-query --iterations 1 --shared-state /tmp/woocommerce-admin-dashboard-products --setting-json 'bench_env={"WC_ADMIN_DASHBOARD_PRODUCTS":"500","WC_ADMIN_DASHBOARD_TERMS":"20"}'
 homeboy bench --rig woocommerce-performance --scenario layered-nav-count-cache --iterations 1 --shared-state /tmp/woocommerce-layered-nav-cache --setting-json 'bench_env={"WC_LAYERED_NAV_CACHE_ITERATIONS":"150","WC_LAYERED_NAV_CACHE_LIMIT":"25"}'
 homeboy bench --rig woocommerce-performance --scenario layered-nav-catalog-crawl --iterations 1 --shared-state /tmp/woocommerce-layered-nav-crawl --setting-json 'bench_env={"WC_LAYERED_NAV_CRAWL_REQUESTS":"150","WC_LAYERED_NAV_CRAWL_LIMIT":"25"}'
+homeboy bench --rig woocommerce-performance --profile api-coverage --iterations 1 --shared-state /tmp/woocommerce-api-coverage
 homeboy bench --rig woocommerce-performance --profile hot --iterations 1 --shared-state /tmp/woocommerce-performance-hot --setting-json 'bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"120","WC_SHIPPING_CACHE_PACKAGES":"24"}' --force-hot
 ```
 
@@ -191,6 +192,13 @@ into `tests/bench/`, and returns the normalized Homeboy `BenchResults` envelope.
 - `layered-nav-catalog-crawl` uses real `filter_*` request combinations and
   renders the layered-nav widget list path for each request shape, measuring
   the same transient growth through a crawler/catalog-traffic-shaped path.
+- `woocommerce-rest-route-inventory` loads WooCommerce in the WP Codebox bench
+  runtime, registers REST routes, calls `rest_get_server()->get_routes()`, and
+  writes a shared-state JSON inventory of WooCommerce route paths, methods,
+  argument names/required flags, and callback summaries. It classifies registered
+  routes into `wc/v*`, `wc/store*`, `wc-admin`, `wc-analytics`, and `wc_other` so
+  future API performance scenarios can start from full route coverage instead of
+  hand-picked endpoints.
 
 ## Metrics
 
@@ -230,6 +238,9 @@ The first slice reports:
 - `final_transient_entry_count`, `max_transient_entry_count`,
   `final_serialized_value_bytes`, and `cache_exceeded_limit` for layered-nav
   count cache growth.
+- `total_route_count`, `woocommerce_route_count`, `wc_rest_route_count`,
+  `wc_store_route_count`, `wc_admin_route_count`, `wc_analytics_route_count`, and
+  `wc_other_route_count` for the first full WooCommerce API coverage primitive.
 - `direct_has_physical_products_ms`, `dashboard_setup_widget_ms`,
   `matching_query_elapsed_ms`, `matching_query_count`, `total_query_count`,
   seeded product/term counts, physical/virtual split, onboarding state, and

--- a/woocommerce/woocommerce/bench/woocommerce-rest-route-inventory.php
+++ b/woocommerce/woocommerce/bench/woocommerce-rest-route-inventory.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * WP Codebox-backed WooCommerce REST route inventory workload.
+ *
+ * Captures deterministic route coverage metadata without executing API requests.
+ */
+return function (): array {
+	$started = microtime( true );
+
+	if ( ! class_exists( 'WooCommerce' ) ) {
+		$woocommerce_entrypoint = WP_PLUGIN_DIR . '/woocommerce/woocommerce.php';
+		if ( ! file_exists( $woocommerce_entrypoint ) ) {
+			throw new RuntimeException( 'WooCommerce plugin entrypoint is not mounted.' );
+		}
+		require_once $woocommerce_entrypoint;
+	}
+
+	if ( ! class_exists( 'WooCommerce' ) || ! function_exists( 'WC' ) ) {
+		throw new RuntimeException( 'WooCommerce is not loaded.' );
+	}
+	if ( ! did_action( 'woocommerce_init' ) ) {
+		WC()->init();
+	}
+
+	$run_id = 'woocommerce-rest-route-inventory-' . getmypid() . '-' . time();
+
+	$server = rest_get_server();
+	if ( class_exists( Automattic\WooCommerce\RestApi\Server::class ) ) {
+		Automattic\WooCommerce\RestApi\Server::instance()->register_rest_routes();
+	}
+
+	$routes = $server->get_routes();
+	ksort( $routes );
+
+	$summarize_callback = static function ( $callback ): string {
+		if ( is_string( $callback ) ) {
+			return $callback;
+		}
+		if ( $callback instanceof Closure ) {
+			return 'Closure';
+		}
+		if ( is_array( $callback ) && 2 === count( $callback ) ) {
+			$target = is_object( $callback[0] ) ? get_class( $callback[0] ) : (string) $callback[0];
+			return $target . '::' . (string) $callback[1];
+		}
+		if ( is_object( $callback ) && method_exists( $callback, '__invoke' ) ) {
+			return get_class( $callback ) . '::__invoke';
+		}
+
+		return gettype( $callback );
+	};
+
+	$classify_route = static function ( string $route ): string {
+		if ( preg_match( '#^/wc/v\d+(?:/|$)#', $route ) ) {
+			return 'wc_rest';
+		}
+		if ( preg_match( '#^/wc/store(?:/|$)#', $route ) ) {
+			return 'wc_store';
+		}
+		if ( preg_match( '#^/wc-admin(?:/|$)#', $route ) ) {
+			return 'wc_admin';
+		}
+		if ( preg_match( '#^/wc-analytics(?:/|$)#', $route ) ) {
+			return 'wc_analytics';
+		}
+
+		return 0 === strpos( $route, '/wc/' ) ? 'wc_other' : 'non_woocommerce';
+	};
+
+	$route_inventory = array();
+	$namespace_counts = array(
+		'wc_rest'        => 0,
+		'wc_store'       => 0,
+		'wc_admin'       => 0,
+		'wc_analytics'   => 0,
+		'wc_other'       => 0,
+		'non_woocommerce' => 0,
+	);
+
+	foreach ( $routes as $route => $handlers ) {
+		$classification = $classify_route( $route );
+		++$namespace_counts[ $classification ];
+
+		if ( 'non_woocommerce' === $classification ) {
+			continue;
+		}
+
+		$endpoints = array();
+		foreach ( $handlers as $handler ) {
+			if ( ! is_array( $handler ) || empty( $handler['callback'] ) ) {
+				continue;
+			}
+
+			$methods = array();
+			foreach ( (array) ( $handler['methods'] ?? array() ) as $method => $enabled ) {
+				if ( is_string( $method ) && $enabled ) {
+					$methods[] = $method;
+				} elseif ( is_string( $enabled ) ) {
+					$methods[] = $enabled;
+				}
+			}
+			sort( $methods );
+
+			$args = array();
+			foreach ( (array) ( $handler['args'] ?? array() ) as $arg_name => $arg_schema ) {
+				$args[] = array(
+					'name'     => (string) $arg_name,
+					'required' => is_array( $arg_schema ) && ! empty( $arg_schema['required'] ),
+				);
+			}
+			usort(
+				$args,
+				static function ( array $a, array $b ): int {
+					return strcmp( $a['name'], $b['name'] );
+				}
+			);
+
+			$endpoints[] = array(
+				'methods'  => $methods,
+				'args'     => $args,
+				'callback' => $summarize_callback( $handler['callback'] ),
+			);
+		}
+
+		$route_inventory[] = array(
+			'path'      => $route,
+			'namespace' => $classification,
+			'endpoints' => $endpoints,
+		);
+	}
+
+	$woocommerce_route_count = $namespace_counts['wc_rest'] + $namespace_counts['wc_store'] + $namespace_counts['wc_admin'] + $namespace_counts['wc_analytics'] + $namespace_counts['wc_other'];
+	$summary                 = array(
+		'success_rate'               => 1,
+		'total_route_count'          => count( $routes ),
+		'woocommerce_route_count'    => $woocommerce_route_count,
+		'wc_rest_route_count'        => $namespace_counts['wc_rest'],
+		'wc_store_route_count'       => $namespace_counts['wc_store'],
+		'wc_admin_route_count'       => $namespace_counts['wc_admin'],
+		'wc_analytics_route_count'   => $namespace_counts['wc_analytics'],
+		'wc_other_route_count'       => $namespace_counts['wc_other'],
+		'total_elapsed_ms'           => ( microtime( true ) - $started ) * 1000,
+	);
+
+	$artifact_path = '';
+	$shared_state  = getenv( 'HOMEBOY_BENCH_SHARED_STATE' );
+	if ( $shared_state ) {
+		$artifact_dir = rtrim( $shared_state, '/' ) . '/woocommerce-rest-route-inventory';
+		wp_mkdir_p( $artifact_dir );
+		$artifact_path = $artifact_dir . '/' . $run_id . '.json';
+		file_put_contents(
+			$artifact_path,
+			wp_json_encode(
+				array(
+					'run_id'           => $run_id,
+					'woocommerce_version' => defined( 'WC_VERSION' ) ? WC_VERSION : '',
+					'namespace_counts' => $namespace_counts,
+					'routes'           => $route_inventory,
+					'metrics'          => $summary,
+				),
+				JSON_PRETTY_PRINT
+			) . "\n"
+		);
+	}
+
+	return array(
+		'metrics'   => $summary,
+		'metadata'  => array(
+			'runner'   => 'wp-codebox',
+			'workload' => 'woocommerce-rest-route-inventory',
+			'coverage_shape' => 'registered WooCommerce REST route inventory',
+			'namespaces' => array( 'wc/v*', 'wc/store*', 'wc-admin', 'wc-analytics' ),
+		),
+		'artifacts' => $artifact_path ? array( 'route_inventory' => array( 'path' => $artifact_path, 'kind' => 'json' ) ) : array(),
+	);
+};

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -70,6 +70,7 @@
       { "path": "${package.root}/bench/admin-dashboard-physical-products-query.php" },
       { "path": "${package.root}/bench/layered-nav-count-cache.php" },
       { "path": "${package.root}/bench/layered-nav-catalog-crawl.php" },
+      { "path": "${package.root}/bench/woocommerce-rest-route-inventory.php" },
       { "path": "${package.root}/bench/rest-product-batch-import.php" }
     ]
   },
@@ -83,6 +84,7 @@
       "admin-dashboard-physical-products-query",
       "layered-nav-count-cache",
       "layered-nav-catalog-crawl",
+      "woocommerce-rest-route-inventory",
       "rest-product-batch-import"
     ],
     "hot": [
@@ -94,7 +96,11 @@
       "admin-dashboard-physical-products-query",
       "layered-nav-count-cache",
       "layered-nav-catalog-crawl",
+      "woocommerce-rest-route-inventory",
       "rest-product-batch-import"
+    ],
+    "api-coverage": [
+      "woocommerce-rest-route-inventory"
     ],
     "checkout-concurrent": [
       "checkout-concurrent-create-order"


### PR DESCRIPTION
## Summary
- Add a `woocommerce-rest-route-inventory` benchmark workload.
- Register the workload in the WooCommerce performance rig and add an `api-coverage` profile.
- Document the route inventory as the first full API coverage primitive for WooCommerce performance work.

## Testing
- `php -l woocommerce/woocommerce/bench/woocommerce-rest-route-inventory.php`
- `php -r "json_decode(file_get_contents('woocommerce/woocommerce/rigs/woocommerce-performance/rig.json')); if (json_last_error()) { fwrite(STDERR, json_last_error_msg()); exit(1); }"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing the WooCommerce route inventory workload, rig registration, docs, and PR preparation under Chris review.
