### PR TITLE
Add WordPress property API inventory rigs

### DIFF
--- a/Automattic/jetpack/README.md
+++ b/Automattic/jetpack/README.md
@@ -1,0 +1,19 @@
+# Jetpack Rigs
+
+## `jetpack-api-route-inventory`
+
+Captures a lightweight inventory of registered Jetpack REST routes without executing API requests. This is an adapter scaffold for applying generic Homeboy Extensions / WP Codebox API performance primitives to Jetpack later.
+
+Install locally:
+
+```sh
+homeboy rig install $HOME/Developer/homeboy-rigs@<branch>/Automattic/jetpack
+```
+
+Run the route inventory workload:
+
+```sh
+homeboy bench --rig jetpack-api-route-inventory --scenario jetpack-rest-route-inventory --iterations 1 --shared-state /tmp/jetpack-api-inventory
+```
+
+The coverage manifest lives at `manifests/rest-route-coverage.json`. It keeps Jetpack-specific route grouping in this rig package so upstream primitives can stay generic.

--- a/Automattic/jetpack/bench/jetpack-rest-route-inventory.php
+++ b/Automattic/jetpack/bench/jetpack-rest-route-inventory.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * WP Codebox-backed Jetpack REST route inventory workload.
+ *
+ * Captures registered Jetpack route metadata without executing routes.
+ */
+return function (): array {
+	$started = microtime( true );
+
+	$jetpack_entrypoint = WP_PLUGIN_DIR . '/jetpack/jetpack.php';
+	if ( file_exists( $jetpack_entrypoint ) && ! defined( 'JETPACK__VERSION' ) ) {
+		require_once $jetpack_entrypoint;
+	}
+
+	$run_id = 'jetpack-rest-route-inventory-' . getmypid() . '-' . time();
+	$server = rest_get_server();
+	$routes = $server->get_routes();
+	ksort( $routes );
+
+	$summarize_callback = static function ( $callback ): string {
+		if ( is_string( $callback ) ) {
+			return $callback;
+		}
+		if ( $callback instanceof Closure ) {
+			return 'Closure';
+		}
+		if ( is_array( $callback ) && 2 === count( $callback ) ) {
+			$target = is_object( $callback[0] ) ? get_class( $callback[0] ) : (string) $callback[0];
+			return $target . '::' . (string) $callback[1];
+		}
+		if ( is_object( $callback ) && method_exists( $callback, '__invoke' ) ) {
+			return get_class( $callback ) . '::__invoke';
+		}
+
+		return gettype( $callback );
+	};
+
+	$classify_route = static function ( string $route ): string {
+		if ( 0 === strpos( $route, '/jetpack/v4/connection' ) ) {
+			return 'connection';
+		}
+		if ( 0 === strpos( $route, '/jetpack/v4/modules' ) || 0 === strpos( $route, '/jetpack/v4/settings' ) ) {
+			return 'module_settings';
+		}
+		if ( 0 === strpos( $route, '/jetpack/v4/site' ) || 0 === strpos( $route, '/wpcom/v2/' ) ) {
+			return 'site_data';
+		}
+		if ( 0 === strpos( $route, '/jetpack/v4/' ) ) {
+			return 'jetpack_other';
+		}
+
+		return 'non_jetpack';
+	};
+
+	$route_inventory = array();
+	$namespace_counts = array(
+		'connection'      => 0,
+		'module_settings' => 0,
+		'site_data'       => 0,
+		'jetpack_other'   => 0,
+		'non_jetpack'     => 0,
+	);
+
+	foreach ( $routes as $route => $handlers ) {
+		$classification = $classify_route( $route );
+		++$namespace_counts[ $classification ];
+
+		if ( 'non_jetpack' === $classification ) {
+			continue;
+		}
+
+		$endpoints = array();
+		foreach ( $handlers as $handler ) {
+			if ( ! is_array( $handler ) || empty( $handler['callback'] ) ) {
+				continue;
+			}
+
+			$methods = array();
+			foreach ( (array) ( $handler['methods'] ?? array() ) as $method => $enabled ) {
+				if ( is_string( $method ) && $enabled ) {
+					$methods[] = $method;
+				} elseif ( is_string( $enabled ) ) {
+					$methods[] = $enabled;
+				}
+			}
+			sort( $methods );
+
+			$endpoints[] = array(
+				'methods'  => $methods,
+				'callback' => $summarize_callback( $handler['callback'] ),
+			);
+		}
+
+		$route_inventory[] = array(
+			'path'      => $route,
+			'namespace' => $classification,
+			'endpoints' => $endpoints,
+		);
+	}
+
+	$jetpack_route_count = $namespace_counts['connection'] + $namespace_counts['module_settings'] + $namespace_counts['site_data'] + $namespace_counts['jetpack_other'];
+	$summary = array(
+		'success_rate'                         => 1,
+		'total_route_count'                    => count( $routes ),
+		'jetpack_route_count'                  => $jetpack_route_count,
+		'jetpack_connection_route_count'       => $namespace_counts['connection'],
+		'jetpack_module_settings_route_count'  => $namespace_counts['module_settings'],
+		'jetpack_site_data_route_count'        => $namespace_counts['site_data'],
+		'jetpack_other_route_count'            => $namespace_counts['jetpack_other'],
+		'total_elapsed_ms'                     => ( microtime( true ) - $started ) * 1000,
+	);
+
+	$artifact_path = '';
+	$shared_state = getenv( 'HOMEBOY_BENCH_SHARED_STATE' );
+	if ( $shared_state ) {
+		$artifact_dir = rtrim( $shared_state, '/' ) . '/jetpack-rest-route-inventory';
+		wp_mkdir_p( $artifact_dir );
+		$artifact_path = $artifact_dir . '/' . $run_id . '.json';
+		file_put_contents(
+			$artifact_path,
+			wp_json_encode(
+				array(
+					'run_id'           => $run_id,
+					'jetpack_version'  => defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '',
+					'namespace_counts' => $namespace_counts,
+					'routes'           => $route_inventory,
+					'metrics'          => $summary,
+				),
+				JSON_PRETTY_PRINT
+			) . "\n"
+		);
+	}
+
+	return array(
+		'metrics'   => $summary,
+		'metadata'  => array(
+			'runner'         => 'wp-codebox',
+			'workload'       => 'jetpack-rest-route-inventory',
+			'coverage_shape' => 'registered Jetpack REST route inventory',
+			'manifest'       => 'manifests/rest-route-coverage.json',
+		),
+		'artifacts' => $artifact_path ? array( 'route_inventory' => array( 'path' => $artifact_path, 'kind' => 'json' ) ) : array(),
+	);
+};

--- a/Automattic/jetpack/manifests/rest-route-coverage.json
+++ b/Automattic/jetpack/manifests/rest-route-coverage.json
@@ -1,0 +1,44 @@
+{
+  "id": "jetpack-rest-route-coverage",
+  "property": "Automattic/jetpack",
+  "description": "Initial Jetpack REST route inventory coverage shape for API performance primitive adapters.",
+  "route_prefixes": [
+    "/jetpack/v4/",
+    "/jetpack/v4/connection",
+    "/jetpack/v4/modules",
+    "/jetpack/v4/site",
+    "/jetpack/v4/settings",
+    "/wpcom/v2/"
+  ],
+  "coverage_groups": [
+    {
+      "id": "connection",
+      "description": "Connection and identity endpoints that affect Jetpack bootstrap flows.",
+      "route_prefixes": [
+        "/jetpack/v4/connection"
+      ]
+    },
+    {
+      "id": "module-settings",
+      "description": "Module and settings endpoints used by wp-admin Jetpack screens.",
+      "route_prefixes": [
+        "/jetpack/v4/modules",
+        "/jetpack/v4/settings"
+      ]
+    },
+    {
+      "id": "site-data",
+      "description": "Site-level Jetpack and WPCOM compatibility endpoints.",
+      "route_prefixes": [
+        "/jetpack/v4/site",
+        "/wpcom/v2/"
+      ]
+    }
+  ],
+  "future_primitives": [
+    "route inventory",
+    "route coverage diff",
+    "authenticated REST latency matrix",
+    "query profiling"
+  ]
+}

--- a/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
+++ b/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
@@ -1,0 +1,55 @@
+{
+  "id": "jetpack-api-route-inventory",
+  "description": "Jetpack REST route inventory scaffold for adapting generic Homeboy Extensions and WP Codebox API performance primitives.",
+  "components": {
+    "jetpack": {
+      "path": "~/Developer/jetpack/projects/plugins/jetpack",
+      "branch": "trunk",
+      "extensions": {
+        "wordpress": {
+          "wp_codebox_wordpress_version": "7.0",
+          "wp_codebox_source_root": "~/Developer/jetpack",
+          "wp_codebox_source_subpath": "projects/plugins/jetpack"
+        }
+      }
+    }
+  },
+  "resources": {
+    "exclusive": [
+      "jetpack-api-route-inventory:${env.HOMEBOY_SETTINGS_JETPACK_API_INVENTORY_NAMESPACE}"
+    ],
+    "paths": [
+      "${components.jetpack.path}"
+    ]
+  },
+  "bench": {
+    "default_component": "jetpack",
+    "warmup_iterations": 0
+  },
+  "bench_workloads": {
+    "wordpress": [
+      { "path": "${package.root}/bench/jetpack-rest-route-inventory.php" }
+    ]
+  },
+  "bench_profiles": {
+    "smoke": [
+      "jetpack-rest-route-inventory"
+    ],
+    "api-coverage": [
+      "jetpack-rest-route-inventory"
+    ]
+  },
+  "pipeline": {
+    "check": [
+      {
+        "kind": "requirement",
+        "label": "Jetpack plugin checkout exists",
+        "file": "${components.jetpack.path}/jetpack.php",
+        "component": "jetpack",
+        "component_path_contains": "jetpack",
+        "remediation": "Pass homeboy bench --path /path/to/jetpack/projects/plugins/jetpack or update components.jetpack.path before running jetpack-api-route-inventory."
+      }
+    ],
+    "down": []
+  }
+}

--- a/README.md
+++ b/README.md
@@ -302,6 +302,45 @@ homeboy rig check playground-cli-diagnostics
 homeboy bench --rig playground-cli-diagnostics --scenario playground-cli-runphp-errors --iterations 1 --shared-state /tmp/playground-cli-diagnostics
 ```
 
+## WordPress/wordpress
+
+`rigs/wordpress-core-api-route-inventory/rig.json` is a lightweight WordPress
+core REST route inventory scaffold. It records registered route metadata and a
+property-owned coverage grouping manifest without executing API requests, so
+future generic HBX/WP Codebox API primitives can consume the same route shape.
+
+```bash
+homeboy rig install $HOME/Developer/homeboy-rigs@<branch>/WordPress/wordpress
+homeboy rig check wordpress-core-api-route-inventory
+homeboy bench --rig wordpress-core-api-route-inventory --scenario wordpress-core-rest-route-inventory --iterations 1 --shared-state /tmp/wordpress-core-api-inventory
+```
+
+## WordPress/gutenberg
+
+`rigs/gutenberg-api-route-inventory/rig.json` extends the existing Gutenberg
+package with a REST route inventory scaffold for editor-data, dynamic-rendering,
+and experimental route groups. It keeps Gutenberg route grouping in
+`manifests/rest-route-coverage.json` and does not run a browser or heavy
+benchmark workload.
+
+```bash
+homeboy rig install $HOME/Developer/homeboy-rigs@<branch>/WordPress/gutenberg
+homeboy rig check gutenberg-api-route-inventory
+homeboy bench --rig gutenberg-api-route-inventory --scenario gutenberg-rest-route-inventory --iterations 1 --shared-state /tmp/gutenberg-api-inventory
+```
+
+## Automattic/jetpack
+
+`rigs/jetpack-api-route-inventory/rig.json` is the initial Jetpack REST route
+inventory scaffold. It records registered Jetpack/WPCOM-compatible route
+metadata and keeps Jetpack-specific coverage groups beside the rig package.
+
+```bash
+homeboy rig install $HOME/Developer/homeboy-rigs@<branch>/Automattic/jetpack
+homeboy rig check jetpack-api-route-inventory
+homeboy bench --rig jetpack-api-route-inventory --scenario jetpack-rest-route-inventory --iterations 1 --shared-state /tmp/jetpack-api-inventory
+```
+
 ## woocommerce/woocommerce
 
 `rigs/woocommerce-performance/rig.json` runs WooCommerce checkout, shipping,

--- a/WordPress/gutenberg/README.md
+++ b/WordPress/gutenberg/README.md
@@ -1,5 +1,27 @@
 # Gutenberg Rigs
 
+## `gutenberg-api-route-inventory`
+
+Captures a lightweight inventory of registered Gutenberg-facing REST routes
+without executing API requests. This is an adapter scaffold for applying generic
+Homeboy Extensions / WP Codebox API performance primitives to Gutenberg later.
+
+Install locally:
+
+```sh
+homeboy rig install $HOME/Developer/homeboy-rigs@<branch>/WordPress/gutenberg
+```
+
+Run the route inventory workload:
+
+```sh
+homeboy bench --rig gutenberg-api-route-inventory --scenario gutenberg-rest-route-inventory --iterations 1 --shared-state /tmp/gutenberg-api-inventory
+```
+
+The coverage manifest lives at `manifests/rest-route-coverage.json`. It keeps
+Gutenberg-specific route grouping in this rig package so upstream primitives can
+stay generic.
+
 ## `gutenberg-pattern-preview-assets`
 
 Reproduces the pattern preview asset fan-out reported in [WordPress/gutenberg#68979](https://github.com/WordPress/gutenberg/issues/68979), with downstream request-spike symptoms discussed in [WordPress/gutenberg#71547](https://github.com/WordPress/gutenberg/issues/71547).

--- a/WordPress/gutenberg/bench/gutenberg-rest-route-inventory.php
+++ b/WordPress/gutenberg/bench/gutenberg-rest-route-inventory.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * WP Codebox-backed Gutenberg REST route inventory workload.
+ *
+ * Captures registered Gutenberg-facing route metadata without executing routes.
+ */
+return function (): array {
+	$started = microtime( true );
+
+	$gutenberg_entrypoint = WP_PLUGIN_DIR . '/gutenberg/gutenberg.php';
+	if ( file_exists( $gutenberg_entrypoint ) && ! defined( 'GUTENBERG_VERSION' ) ) {
+		require_once $gutenberg_entrypoint;
+	}
+
+	$run_id = 'gutenberg-rest-route-inventory-' . getmypid() . '-' . time();
+	$server = rest_get_server();
+	$routes = $server->get_routes();
+	ksort( $routes );
+
+	$summarize_callback = static function ( $callback ): string {
+		if ( is_string( $callback ) ) {
+			return $callback;
+		}
+		if ( $callback instanceof Closure ) {
+			return 'Closure';
+		}
+		if ( is_array( $callback ) && 2 === count( $callback ) ) {
+			$target = is_object( $callback[0] ) ? get_class( $callback[0] ) : (string) $callback[0];
+			return $target . '::' . (string) $callback[1];
+		}
+		if ( is_object( $callback ) && method_exists( $callback, '__invoke' ) ) {
+			return get_class( $callback ) . '::__invoke';
+		}
+
+		return gettype( $callback );
+	};
+
+	$classify_route = static function ( string $route ): string {
+		$editor_prefixes = array(
+			'/wp/v2/block-patterns',
+			'/wp/v2/global-styles',
+			'/wp/v2/navigation',
+			'/wp/v2/templates',
+			'/wp/v2/template-parts',
+		);
+		foreach ( $editor_prefixes as $prefix ) {
+			if ( 0 === strpos( $route, $prefix ) ) {
+				return 'editor_data';
+			}
+		}
+		if ( 0 === strpos( $route, '/wp/v2/block-directory' ) || 0 === strpos( $route, '/wp/v2/block-renderer' ) ) {
+			return 'dynamic_rendering';
+		}
+		if ( 0 === strpos( $route, '/__experimental' ) ) {
+			return 'experimental';
+		}
+
+		return 'non_gutenberg';
+	};
+
+	$route_inventory = array();
+	$namespace_counts = array(
+		'editor_data'       => 0,
+		'dynamic_rendering' => 0,
+		'experimental'      => 0,
+		'non_gutenberg'     => 0,
+	);
+
+	foreach ( $routes as $route => $handlers ) {
+		$classification = $classify_route( $route );
+		++$namespace_counts[ $classification ];
+
+		if ( 'non_gutenberg' === $classification ) {
+			continue;
+		}
+
+		$endpoints = array();
+		foreach ( $handlers as $handler ) {
+			if ( ! is_array( $handler ) || empty( $handler['callback'] ) ) {
+				continue;
+			}
+
+			$methods = array();
+			foreach ( (array) ( $handler['methods'] ?? array() ) as $method => $enabled ) {
+				if ( is_string( $method ) && $enabled ) {
+					$methods[] = $method;
+				} elseif ( is_string( $enabled ) ) {
+					$methods[] = $enabled;
+				}
+			}
+			sort( $methods );
+
+			$endpoints[] = array(
+				'methods'  => $methods,
+				'callback' => $summarize_callback( $handler['callback'] ),
+			);
+		}
+
+		$route_inventory[] = array(
+			'path'      => $route,
+			'namespace' => $classification,
+			'endpoints' => $endpoints,
+		);
+	}
+
+	$gutenberg_route_count = $namespace_counts['editor_data'] + $namespace_counts['dynamic_rendering'] + $namespace_counts['experimental'];
+	$summary = array(
+		'success_rate'                  => 1,
+		'total_route_count'             => count( $routes ),
+		'gutenberg_route_count'         => $gutenberg_route_count,
+		'gutenberg_editor_route_count'  => $namespace_counts['editor_data'],
+		'gutenberg_dynamic_route_count' => $namespace_counts['dynamic_rendering'],
+		'gutenberg_experimental_count'  => $namespace_counts['experimental'],
+		'total_elapsed_ms'              => ( microtime( true ) - $started ) * 1000,
+	);
+
+	$artifact_path = '';
+	$shared_state = getenv( 'HOMEBOY_BENCH_SHARED_STATE' );
+	if ( $shared_state ) {
+		$artifact_dir = rtrim( $shared_state, '/' ) . '/gutenberg-rest-route-inventory';
+		wp_mkdir_p( $artifact_dir );
+		$artifact_path = $artifact_dir . '/' . $run_id . '.json';
+		file_put_contents(
+			$artifact_path,
+			wp_json_encode(
+				array(
+					'run_id'             => $run_id,
+					'gutenberg_version'  => defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : '',
+					'namespace_counts'   => $namespace_counts,
+					'routes'             => $route_inventory,
+					'metrics'            => $summary,
+				),
+				JSON_PRETTY_PRINT
+			) . "\n"
+		);
+	}
+
+	return array(
+		'metrics'   => $summary,
+		'metadata'  => array(
+			'runner'         => 'wp-codebox',
+			'workload'       => 'gutenberg-rest-route-inventory',
+			'coverage_shape' => 'registered Gutenberg-facing REST route inventory',
+			'manifest'       => 'manifests/rest-route-coverage.json',
+		),
+		'artifacts' => $artifact_path ? array( 'route_inventory' => array( 'path' => $artifact_path, 'kind' => 'json' ) ) : array(),
+	);
+};

--- a/WordPress/gutenberg/manifests/rest-route-coverage.json
+++ b/WordPress/gutenberg/manifests/rest-route-coverage.json
@@ -1,0 +1,42 @@
+{
+  "id": "gutenberg-rest-route-coverage",
+  "property": "WordPress/gutenberg",
+  "description": "Initial Gutenberg REST route inventory coverage shape for API performance primitive adapters.",
+  "route_prefixes": [
+    "/wp/v2/block-directory",
+    "/wp/v2/block-patterns",
+    "/wp/v2/block-renderer",
+    "/wp/v2/global-styles",
+    "/wp/v2/navigation",
+    "/wp/v2/templates",
+    "/wp/v2/template-parts",
+    "/__experimental"
+  ],
+  "coverage_groups": [
+    {
+      "id": "editor-data",
+      "description": "Editor REST surfaces that commonly affect Site Editor and post editor readiness.",
+      "route_prefixes": [
+        "/wp/v2/block-patterns",
+        "/wp/v2/global-styles",
+        "/wp/v2/navigation",
+        "/wp/v2/templates",
+        "/wp/v2/template-parts"
+      ]
+    },
+    {
+      "id": "dynamic-rendering",
+      "description": "Server-rendered block and directory endpoints that can later consume latency/query primitives.",
+      "route_prefixes": [
+        "/wp/v2/block-directory",
+        "/wp/v2/block-renderer"
+      ]
+    }
+  ],
+  "future_primitives": [
+    "route inventory",
+    "route coverage diff",
+    "authenticated REST latency matrix",
+    "query profiling"
+  ]
+}

--- a/WordPress/gutenberg/rigs/gutenberg-api-route-inventory/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-api-route-inventory/rig.json
@@ -1,0 +1,55 @@
+{
+  "id": "gutenberg-api-route-inventory",
+  "description": "Gutenberg REST route inventory scaffold for adapting generic Homeboy Extensions and WP Codebox API performance primitives.",
+  "components": {
+    "gutenberg": {
+      "path": "~/Developer/gutenberg",
+      "branch": "trunk",
+      "extensions": {
+        "wordpress": {
+          "wp_codebox_wordpress_version": "7.0",
+          "wp_codebox_source_root": "~/Developer/gutenberg",
+          "wp_codebox_source_subpath": "."
+        }
+      }
+    }
+  },
+  "resources": {
+    "exclusive": [
+      "gutenberg-api-route-inventory:${env.HOMEBOY_SETTINGS_GUTENBERG_API_INVENTORY_NAMESPACE}"
+    ],
+    "paths": [
+      "${components.gutenberg.path}"
+    ]
+  },
+  "bench": {
+    "default_component": "gutenberg",
+    "warmup_iterations": 0
+  },
+  "bench_workloads": {
+    "wordpress": [
+      { "path": "${package.root}/bench/gutenberg-rest-route-inventory.php" }
+    ]
+  },
+  "bench_profiles": {
+    "smoke": [
+      "gutenberg-rest-route-inventory"
+    ],
+    "api-coverage": [
+      "gutenberg-rest-route-inventory"
+    ]
+  },
+  "pipeline": {
+    "check": [
+      {
+        "kind": "requirement",
+        "label": "Gutenberg checkout exists",
+        "file": "${components.gutenberg.path}/gutenberg.php",
+        "component": "gutenberg",
+        "component_path_contains": "gutenberg",
+        "remediation": "Pass homeboy bench --path /path/to/gutenberg or update components.gutenberg.path before running gutenberg-api-route-inventory."
+      }
+    ],
+    "down": []
+  }
+}

--- a/WordPress/wordpress/README.md
+++ b/WordPress/wordpress/README.md
@@ -1,0 +1,19 @@
+# WordPress Core Rigs
+
+## `wordpress-core-api-route-inventory`
+
+Captures a lightweight inventory of registered WordPress core REST routes without executing API requests. This is an adapter scaffold for applying generic Homeboy Extensions / WP Codebox API performance primitives to WordPress core later.
+
+Install locally:
+
+```sh
+homeboy rig install $HOME/Developer/homeboy-rigs@<branch>/WordPress/wordpress
+```
+
+Run the route inventory workload:
+
+```sh
+homeboy bench --rig wordpress-core-api-route-inventory --scenario wordpress-core-rest-route-inventory --iterations 1 --shared-state /tmp/wordpress-core-api-inventory
+```
+
+The coverage manifest lives at `manifests/rest-route-coverage.json`. It keeps core-specific route grouping in this rig package so upstream primitives can stay generic.

--- a/WordPress/wordpress/bench/wordpress-core-rest-route-inventory.php
+++ b/WordPress/wordpress/bench/wordpress-core-rest-route-inventory.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * WP Codebox-backed WordPress core REST route inventory workload.
+ *
+ * Captures registered core route metadata without executing routes.
+ */
+return function (): array {
+	$started = microtime( true );
+	$run_id = 'wordpress-core-rest-route-inventory-' . getmypid() . '-' . time();
+
+	$server = rest_get_server();
+	$routes = $server->get_routes();
+	ksort( $routes );
+
+	$summarize_callback = static function ( $callback ): string {
+		if ( is_string( $callback ) ) {
+			return $callback;
+		}
+		if ( $callback instanceof Closure ) {
+			return 'Closure';
+		}
+		if ( is_array( $callback ) && 2 === count( $callback ) ) {
+			$target = is_object( $callback[0] ) ? get_class( $callback[0] ) : (string) $callback[0];
+			return $target . '::' . (string) $callback[1];
+		}
+		if ( is_object( $callback ) && method_exists( $callback, '__invoke' ) ) {
+			return get_class( $callback ) . '::__invoke';
+		}
+
+		return gettype( $callback );
+	};
+
+	$classify_route = static function ( string $route ): string {
+		if ( preg_match( '#^/wp/v2/(posts|pages|media|types|taxonomies)(?:/|$)#', $route ) ) {
+			return 'content';
+		}
+		if ( preg_match( '#^/wp/v2/(settings|themes|users)(?:/|$)#', $route ) || 0 === strpos( $route, '/wp-block-editor/v1/' ) ) {
+			return 'editor_bootstrap';
+		}
+		if ( 0 === strpos( $route, '/oembed/' ) || 0 === strpos( $route, '/wp-site-health/v1/' ) ) {
+			return 'diagnostics';
+		}
+		if ( 0 === strpos( $route, '/wp/v2/' ) ) {
+			return 'core_other';
+		}
+
+		return 'non_core';
+	};
+
+	$route_inventory = array();
+	$namespace_counts = array(
+		'content'          => 0,
+		'editor_bootstrap' => 0,
+		'diagnostics'      => 0,
+		'core_other'       => 0,
+		'non_core'         => 0,
+	);
+
+	foreach ( $routes as $route => $handlers ) {
+		$classification = $classify_route( $route );
+		++$namespace_counts[ $classification ];
+
+		if ( 'non_core' === $classification ) {
+			continue;
+		}
+
+		$endpoints = array();
+		foreach ( $handlers as $handler ) {
+			if ( ! is_array( $handler ) || empty( $handler['callback'] ) ) {
+				continue;
+			}
+
+			$methods = array();
+			foreach ( (array) ( $handler['methods'] ?? array() ) as $method => $enabled ) {
+				if ( is_string( $method ) && $enabled ) {
+					$methods[] = $method;
+				} elseif ( is_string( $enabled ) ) {
+					$methods[] = $enabled;
+				}
+			}
+			sort( $methods );
+
+			$endpoints[] = array(
+				'methods'  => $methods,
+				'callback' => $summarize_callback( $handler['callback'] ),
+			);
+		}
+
+		$route_inventory[] = array(
+			'path'      => $route,
+			'namespace' => $classification,
+			'endpoints' => $endpoints,
+		);
+	}
+
+	$core_route_count = $namespace_counts['content'] + $namespace_counts['editor_bootstrap'] + $namespace_counts['diagnostics'] + $namespace_counts['core_other'];
+	$summary = array(
+		'success_rate'                      => 1,
+		'total_route_count'                 => count( $routes ),
+		'core_route_count'                  => $core_route_count,
+		'core_content_route_count'          => $namespace_counts['content'],
+		'core_editor_bootstrap_route_count' => $namespace_counts['editor_bootstrap'],
+		'core_diagnostics_route_count'      => $namespace_counts['diagnostics'],
+		'core_other_route_count'            => $namespace_counts['core_other'],
+		'total_elapsed_ms'                  => ( microtime( true ) - $started ) * 1000,
+	);
+
+	$artifact_path = '';
+	$shared_state = getenv( 'HOMEBOY_BENCH_SHARED_STATE' );
+	if ( $shared_state ) {
+		$artifact_dir = rtrim( $shared_state, '/' ) . '/wordpress-core-rest-route-inventory';
+		wp_mkdir_p( $artifact_dir );
+		$artifact_path = $artifact_dir . '/' . $run_id . '.json';
+		file_put_contents(
+			$artifact_path,
+			wp_json_encode(
+				array(
+					'run_id'           => $run_id,
+					'wordpress_version' => get_bloginfo( 'version' ),
+					'namespace_counts' => $namespace_counts,
+					'routes'           => $route_inventory,
+					'metrics'          => $summary,
+				),
+				JSON_PRETTY_PRINT
+			) . "\n"
+		);
+	}
+
+	return array(
+		'metrics'   => $summary,
+		'metadata'  => array(
+			'runner'         => 'wp-codebox',
+			'workload'       => 'wordpress-core-rest-route-inventory',
+			'coverage_shape' => 'registered WordPress core REST route inventory',
+			'manifest'       => 'manifests/rest-route-coverage.json',
+		),
+		'artifacts' => $artifact_path ? array( 'route_inventory' => array( 'path' => $artifact_path, 'kind' => 'json' ) ) : array(),
+	);
+};

--- a/WordPress/wordpress/manifests/rest-route-coverage.json
+++ b/WordPress/wordpress/manifests/rest-route-coverage.json
@@ -1,0 +1,48 @@
+{
+  "id": "wordpress-core-rest-route-coverage",
+  "property": "WordPress/wordpress",
+  "description": "Initial WordPress core REST route inventory coverage shape for API performance primitive adapters.",
+  "route_prefixes": [
+    "/wp/v2/",
+    "/oembed/",
+    "/wp-site-health/v1/",
+    "/wp-block-editor/v1/"
+  ],
+  "coverage_groups": [
+    {
+      "id": "content",
+      "description": "Core content routes used by editors, front-end previews, and API clients.",
+      "route_prefixes": [
+        "/wp/v2/posts",
+        "/wp/v2/pages",
+        "/wp/v2/media",
+        "/wp/v2/types",
+        "/wp/v2/taxonomies"
+      ]
+    },
+    {
+      "id": "editor-bootstrap",
+      "description": "Core editor bootstrap and settings surfaces.",
+      "route_prefixes": [
+        "/wp/v2/settings",
+        "/wp/v2/themes",
+        "/wp/v2/users",
+        "/wp-block-editor/v1/"
+      ]
+    },
+    {
+      "id": "diagnostics",
+      "description": "Core diagnostics and discovery surfaces.",
+      "route_prefixes": [
+        "/oembed/",
+        "/wp-site-health/v1/"
+      ]
+    }
+  ],
+  "future_primitives": [
+    "route inventory",
+    "route coverage diff",
+    "authenticated REST latency matrix",
+    "query profiling"
+  ]
+}

--- a/WordPress/wordpress/rigs/wordpress-core-api-route-inventory/rig.json
+++ b/WordPress/wordpress/rigs/wordpress-core-api-route-inventory/rig.json
@@ -1,0 +1,48 @@
+{
+  "id": "wordpress-core-api-route-inventory",
+  "description": "WordPress core REST route inventory scaffold for adapting generic Homeboy Extensions and WP Codebox API performance primitives.",
+  "components": {
+    "wordpress": {
+      "path": "~/Developer/wordpress-develop",
+      "branch": "trunk"
+    }
+  },
+  "resources": {
+    "exclusive": [
+      "wordpress-core-api-route-inventory:${env.HOMEBOY_SETTINGS_WORDPRESS_CORE_API_INVENTORY_NAMESPACE}"
+    ],
+    "paths": [
+      "${components.wordpress.path}"
+    ]
+  },
+  "bench": {
+    "default_component": "wordpress",
+    "warmup_iterations": 0
+  },
+  "bench_workloads": {
+    "wordpress": [
+      { "path": "${package.root}/bench/wordpress-core-rest-route-inventory.php" }
+    ]
+  },
+  "bench_profiles": {
+    "smoke": [
+      "wordpress-core-rest-route-inventory"
+    ],
+    "api-coverage": [
+      "wordpress-core-rest-route-inventory"
+    ]
+  },
+  "pipeline": {
+    "check": [
+      {
+        "kind": "requirement",
+        "label": "WordPress core checkout exists",
+        "file": "${components.wordpress.path}/src/wp-includes/rest-api.php",
+        "component": "wordpress",
+        "component_path_contains": "wordpress",
+        "remediation": "Pass homeboy bench --path /path/to/wordpress-develop or update components.wordpress.path before running wordpress-core-api-route-inventory."
+      }
+    ],
+    "down": []
+  }
+}


### PR DESCRIPTION
## Summary
- Add initial API route-inventory rig scaffolds for Gutenberg, WordPress core, and Jetpack.
- Add route coverage manifests and README docs for each property.
- Keep property-specific knowledge in Homeboy Rigs while relying on generic primitives from Homeboy Extensions and WP Codebox.

## Testing
- `node scripts/lint-rig-packages.mjs`
- `php -l WordPress/gutenberg/bench/gutenberg-rest-route-inventory.php`
- `php -l WordPress/wordpress/bench/wordpress-core-rest-route-inventory.php`
- `php -l Automattic/jetpack/bench/jetpack-rest-route-inventory.php`
- JSON parse checks for new manifests and rig files.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Implementing property-specific route inventory scaffolds, docs/manifests, and PR preparation under Chris review.
