### PR TITLE
Add WordPress performance fixture profiles

### DIFF
--- a/Automattic/jetpack/manifests/performance-fixtures.json
+++ b/Automattic/jetpack/manifests/performance-fixtures.json
@@ -1,0 +1,30 @@
+{
+  "id": "jetpack-performance-fixtures",
+  "schema": "homeboy-rigs/wordpress-performance-fixtures/v1",
+  "property": "Automattic/jetpack",
+  "description": "Fixture profiles for Jetpack API performance runs that exercise connection, module settings, and site data REST surfaces.",
+  "profiles": [
+    {
+      "id": "connected-site-small",
+      "description": "Small Jetpack-enabled site shape for route inventory, generated REST cases, and DB query profiling.",
+      "entities": {
+        "posts": 12,
+        "pages": 4,
+        "media": 6,
+        "enabled_modules": [
+          "stats",
+          "publicize",
+          "related-posts"
+        ]
+      },
+      "route_groups": [
+        "connection",
+        "module-settings",
+        "site-data"
+      ],
+      "expected_workloads": [
+        "jetpack-rest-route-inventory"
+      ]
+    }
+  ]
+}

--- a/Automattic/jetpack/manifests/rest-route-coverage.json
+++ b/Automattic/jetpack/manifests/rest-route-coverage.json
@@ -40,5 +40,6 @@
     "route coverage diff",
     "authenticated REST latency matrix",
     "query profiling"
-  ]
+  ],
+  "fixture_manifest": "manifests/performance-fixtures.json"
 }

--- a/WordPress/gutenberg/manifests/performance-fixtures.json
+++ b/WordPress/gutenberg/manifests/performance-fixtures.json
@@ -1,0 +1,27 @@
+{
+  "id": "gutenberg-performance-fixtures",
+  "schema": "homeboy-rigs/wordpress-performance-fixtures/v1",
+  "property": "WordPress/gutenberg",
+  "description": "Fixture profiles for Gutenberg API performance runs that exercise editor bootstrap and dynamic rendering REST surfaces.",
+  "profiles": [
+    {
+      "id": "editor-bootstrap-small",
+      "description": "Small authenticated editor data set for route inventory, generated REST cases, and DB query profiling.",
+      "entities": {
+        "posts": 12,
+        "pages": 6,
+        "patterns": 8,
+        "navigation_menus": 2,
+        "templates": 6,
+        "template_parts": 8
+      },
+      "route_groups": [
+        "editor-data",
+        "dynamic-rendering"
+      ],
+      "expected_workloads": [
+        "gutenberg-rest-route-inventory"
+      ]
+    }
+  ]
+}

--- a/WordPress/gutenberg/manifests/rest-route-coverage.json
+++ b/WordPress/gutenberg/manifests/rest-route-coverage.json
@@ -38,5 +38,6 @@
     "route coverage diff",
     "authenticated REST latency matrix",
     "query profiling"
-  ]
+  ],
+  "fixture_manifest": "manifests/performance-fixtures.json"
 }

--- a/WordPress/wordpress/manifests/performance-fixtures.json
+++ b/WordPress/wordpress/manifests/performance-fixtures.json
@@ -1,0 +1,28 @@
+{
+  "id": "wordpress-core-performance-fixtures",
+  "schema": "homeboy-rigs/wordpress-performance-fixtures/v1",
+  "property": "WordPress/wordpress",
+  "description": "Fixture profiles for WordPress core API performance runs that exercise content, editor bootstrap, and diagnostics REST surfaces.",
+  "profiles": [
+    {
+      "id": "content-editor-small",
+      "description": "Small mixed content site for route inventory, generated REST cases, and DB query profiling.",
+      "entities": {
+        "posts": 25,
+        "pages": 8,
+        "media": 10,
+        "users": 3,
+        "categories": 6,
+        "tags": 12
+      },
+      "route_groups": [
+        "content",
+        "editor-bootstrap",
+        "diagnostics"
+      ],
+      "expected_workloads": [
+        "wordpress-core-rest-route-inventory"
+      ]
+    }
+  ]
+}

--- a/WordPress/wordpress/manifests/rest-route-coverage.json
+++ b/WordPress/wordpress/manifests/rest-route-coverage.json
@@ -44,5 +44,6 @@
     "route coverage diff",
     "authenticated REST latency matrix",
     "query profiling"
-  ]
+  ],
+  "fixture_manifest": "manifests/performance-fixtures.json"
 }

--- a/woocommerce/woocommerce/manifests/performance-fixtures.json
+++ b/woocommerce/woocommerce/manifests/performance-fixtures.json
@@ -1,0 +1,32 @@
+{
+  "id": "woocommerce-performance-fixtures",
+  "schema": "homeboy-rigs/wordpress-performance-fixtures/v1",
+  "property": "woocommerce/woocommerce",
+  "description": "Fixture profiles for WooCommerce large-merchant performance runs that exercise catalog, cart, checkout, and REST batch surfaces.",
+  "profiles": [
+    {
+      "id": "large-catalog-checkout-small",
+      "description": "Bounded local fixture for route inventory, generated REST cases, DB query profiling, and checkout/shipping cache workloads.",
+      "entities": {
+        "products": 500,
+        "variations_per_variable_product": 12,
+        "attributes": 6,
+        "terms_per_attribute": 20,
+        "shipping_zones": 4,
+        "shipping_methods_per_zone": 3,
+        "historical_orders": 50
+      },
+      "route_groups": [
+        "catalog",
+        "cart-checkout",
+        "admin"
+      ],
+      "expected_workloads": [
+        "woocommerce-rest-route-inventory",
+        "rest-product-batch-import",
+        "checkout-shipping-cache",
+        "layered-nav-count-cache"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add initial performance fixture profile manifests for WooCommerce, Gutenberg, WordPress core, and Jetpack.
- Reference fixture manifests from the new REST route coverage manifests where those adapters exist.
- Keep the change data-only so property-specific fixture shape lives in Homeboy Rigs, not generic runtime layers.

## Testing
- `node scripts/lint-rig-packages.mjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafting fixture profile manifests, coverage manifest references, and PR preparation under Chris review.
