### PR TITLE
Add WordPress REST route budget manifests

### DIFF
--- a/Automattic/jetpack/manifests/rest-route-budgets.json
+++ b/Automattic/jetpack/manifests/rest-route-budgets.json
@@ -1,0 +1,17 @@
+{
+  "schema": "homeboy/wordpress-rest-route-matrix-budgets/v1",
+  "type": "wordpress-rest-route-matrix-budgets",
+  "defaults": {
+    "maxDurationMs": 400,
+    "maxQueryCount": 45,
+    "allowedStatuses": [200, 201, 204, 401, 403, 404]
+  },
+  "namespaces": [
+    { "namespace": "jetpack/v4", "maxDurationMs": 450, "maxQueryCount": 50 },
+    { "namespace": "wpcom/v2", "maxDurationMs": 500, "maxQueryCount": 55 }
+  ],
+  "routes": [
+    { "route": "/jetpack/v4/connection", "method": "GET", "maxDurationMs": 600, "maxQueryCount": 65 },
+    { "route": "/jetpack/v4/modules", "method": "GET", "maxDurationMs": 450, "maxQueryCount": 50 }
+  ]
+}

--- a/Automattic/jetpack/manifests/rest-route-coverage.json
+++ b/Automattic/jetpack/manifests/rest-route-coverage.json
@@ -41,5 +41,6 @@
     "authenticated REST latency matrix",
     "query profiling"
   ],
-  "fixture_manifest": "manifests/performance-fixtures.json"
+  "fixture_manifest": "manifests/performance-fixtures.json",
+  "budget_manifest": "manifests/rest-route-budgets.json"
 }

--- a/WordPress/gutenberg/manifests/rest-route-budgets.json
+++ b/WordPress/gutenberg/manifests/rest-route-budgets.json
@@ -1,0 +1,17 @@
+{
+  "schema": "homeboy/wordpress-rest-route-matrix-budgets/v1",
+  "type": "wordpress-rest-route-matrix-budgets",
+  "defaults": {
+    "maxDurationMs": 300,
+    "maxQueryCount": 40,
+    "allowedStatuses": [200, 201, 204, 401, 403, 404]
+  },
+  "namespaces": [
+    { "namespace": "wp/v2", "maxDurationMs": 250, "maxQueryCount": 35 },
+    { "namespace": "__experimental", "maxDurationMs": 400, "maxQueryCount": 50 }
+  ],
+  "routes": [
+    { "route": "/wp/v2/block-renderer", "method": "GET", "maxDurationMs": 500, "maxQueryCount": 60 },
+    { "route": "/wp/v2/templates", "method": "GET", "maxDurationMs": 350, "maxQueryCount": 45 }
+  ]
+}

--- a/WordPress/gutenberg/manifests/rest-route-coverage.json
+++ b/WordPress/gutenberg/manifests/rest-route-coverage.json
@@ -39,5 +39,6 @@
     "authenticated REST latency matrix",
     "query profiling"
   ],
-  "fixture_manifest": "manifests/performance-fixtures.json"
+  "fixture_manifest": "manifests/performance-fixtures.json",
+  "budget_manifest": "manifests/rest-route-budgets.json"
 }

--- a/WordPress/wordpress/manifests/rest-route-budgets.json
+++ b/WordPress/wordpress/manifests/rest-route-budgets.json
@@ -1,0 +1,18 @@
+{
+  "schema": "homeboy/wordpress-rest-route-matrix-budgets/v1",
+  "type": "wordpress-rest-route-matrix-budgets",
+  "defaults": {
+    "maxDurationMs": 250,
+    "maxQueryCount": 35,
+    "allowedStatuses": [200, 201, 204, 301, 302, 401, 403]
+  },
+  "namespaces": [
+    { "namespace": "wp/v2", "maxDurationMs": 200, "maxQueryCount": 30 },
+    { "namespace": "wp-block-editor/v1", "maxDurationMs": 250, "maxQueryCount": 35 },
+    { "namespace": "wp-site-health/v1", "maxDurationMs": 500, "maxQueryCount": 50 }
+  ],
+  "routes": [
+    { "route": "/wp/v2/posts", "method": "GET", "maxDurationMs": 300, "maxQueryCount": 40 },
+    { "route": "/wp/v2/media", "method": "GET", "maxDurationMs": 350, "maxQueryCount": 45 }
+  ]
+}

--- a/WordPress/wordpress/manifests/rest-route-coverage.json
+++ b/WordPress/wordpress/manifests/rest-route-coverage.json
@@ -45,5 +45,6 @@
     "authenticated REST latency matrix",
     "query profiling"
   ],
-  "fixture_manifest": "manifests/performance-fixtures.json"
+  "fixture_manifest": "manifests/performance-fixtures.json",
+  "budget_manifest": "manifests/rest-route-budgets.json"
 }

--- a/woocommerce/woocommerce/manifests/rest-route-budgets.json
+++ b/woocommerce/woocommerce/manifests/rest-route-budgets.json
@@ -1,0 +1,20 @@
+{
+  "schema": "homeboy/wordpress-rest-route-matrix-budgets/v1",
+  "type": "wordpress-rest-route-matrix-budgets",
+  "defaults": {
+    "maxDurationMs": 500,
+    "maxQueryCount": 60,
+    "allowedStatuses": [200, 201, 204, 400, 401, 403, 404]
+  },
+  "namespaces": [
+    { "namespace": "wc/v3", "maxDurationMs": 650, "maxQueryCount": 75 },
+    { "namespace": "wc/store/v1", "maxDurationMs": 450, "maxQueryCount": 55 },
+    { "namespace": "wc-admin", "maxDurationMs": 700, "maxQueryCount": 80 }
+  ],
+  "routes": [
+    { "route": "/wc/v3/products", "method": "GET", "maxDurationMs": 800, "maxQueryCount": 90 },
+    { "route": "/wc/v3/products/batch", "method": "POST", "maxDurationMs": 1500, "maxQueryCount": 160 },
+    { "route": "/wc/store/v1/cart", "method": "GET", "maxDurationMs": 350, "maxQueryCount": 45 },
+    { "route": "/wc/store/v1/checkout", "method": "POST", "maxDurationMs": 900, "maxQueryCount": 100 }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add property-owned REST route budget manifests for WordPress core, Gutenberg, Jetpack, and WooCommerce.
- Link budget manifests from existing REST route coverage manifests where adapters exist.
- Keep thresholds in Homeboy Rigs so generic runtime layers stay property-agnostic.

## Testing
- `node scripts/lint-rig-packages.mjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafting property budget manifests, coverage manifest references, and PR preparation under Chris review.
