### PR TITLE
Add full surface coverage manifests

### DIFF
--- a/Automattic/jetpack/manifests/full-surface-coverage.json
+++ b/Automattic/jetpack/manifests/full-surface-coverage.json
@@ -1,0 +1,33 @@
+{
+  "schema": "homeboy-rigs/wordpress-full-surface-coverage/v1",
+  "property": "Automattic/jetpack",
+  "description": "Coverage targets for Jetpack across REST API, database schema, server requests, and browser requests.",
+  "requires_primitives": [
+    "wordpress-rest-route-matrix",
+    "wordpress-rest-request-cases",
+    "wordpress-rest-db-query-profiler",
+    "wordpress-db-inventory",
+    "wordpress-external-http-guardrail",
+    "browser-request-capture"
+  ],
+  "surfaces": {
+    "rest_api": {
+      "manifest": "manifests/rest-route-coverage.json",
+      "budget_manifest": "manifests/rest-route-budgets.json",
+      "coverage_goal": "all_registered_jetpack_and_wpcom_routes_and_generated_safe_cases"
+    },
+    "database": {
+      "coverage_goal": "all_tables_rows_columns_indexes_after_connected_site_fixture_setup",
+      "inventory_artifact": "homeboy/wordpress-db-inventory/v1",
+      "query_profile_artifact": "homeboy/wordpress-rest-db-query-profile/v1"
+    },
+    "server_requests": {
+      "coverage_goal": "all_connection_wpcom_sync_and_module_http_hosts_with_unapproved_requests_blocked",
+      "guardrail": "wordpress-external-http-guardrail"
+    },
+    "browser_requests": {
+      "coverage_goal": "all_wp_admin_jetpack_screen_fetch_xhr_websocket_asset_requests",
+      "scenarios": ["dashboard", "connection", "modules", "settings"]
+    }
+  }
+}

--- a/Automattic/jetpack/manifests/performance-fixtures.json
+++ b/Automattic/jetpack/manifests/performance-fixtures.json
@@ -3,6 +3,7 @@
   "schema": "homeboy-rigs/wordpress-performance-fixtures/v1",
   "property": "Automattic/jetpack",
   "description": "Fixture profiles for Jetpack API performance runs that exercise connection, module settings, and site data REST surfaces.",
+  "full_surface_coverage_manifest": "manifests/full-surface-coverage.json",
   "profiles": [
     {
       "id": "connected-site-small",

--- a/WordPress/gutenberg/manifests/full-surface-coverage.json
+++ b/WordPress/gutenberg/manifests/full-surface-coverage.json
@@ -1,0 +1,33 @@
+{
+  "schema": "homeboy-rigs/wordpress-full-surface-coverage/v1",
+  "property": "WordPress/gutenberg",
+  "description": "Coverage targets for Gutenberg across editor REST, database schema impact, server requests, and browser requests.",
+  "requires_primitives": [
+    "wordpress-rest-route-matrix",
+    "wordpress-rest-request-cases",
+    "wordpress-rest-db-query-profiler",
+    "wordpress-db-inventory",
+    "wordpress-external-http-guardrail",
+    "browser-request-capture"
+  ],
+  "surfaces": {
+    "rest_api": {
+      "manifest": "manifests/rest-route-coverage.json",
+      "budget_manifest": "manifests/rest-route-budgets.json",
+      "coverage_goal": "all_registered_editor_routes_and_generated_safe_cases"
+    },
+    "database": {
+      "coverage_goal": "all_tables_rows_columns_indexes_after_editor_fixture_setup",
+      "inventory_artifact": "homeboy/wordpress-db-inventory/v1",
+      "query_profile_artifact": "homeboy/wordpress-rest-db-query-profile/v1"
+    },
+    "server_requests": {
+      "coverage_goal": "all_outbound_http_hosts_and_blocked_unapproved_requests",
+      "guardrail": "wordpress-external-http-guardrail"
+    },
+    "browser_requests": {
+      "coverage_goal": "all_editor_bootstrap_fetch_xhr_websocket_asset_requests",
+      "scenarios": ["post_editor", "site_editor", "template_editor", "patterns"]
+    }
+  }
+}

--- a/WordPress/gutenberg/manifests/performance-fixtures.json
+++ b/WordPress/gutenberg/manifests/performance-fixtures.json
@@ -3,6 +3,7 @@
   "schema": "homeboy-rigs/wordpress-performance-fixtures/v1",
   "property": "WordPress/gutenberg",
   "description": "Fixture profiles for Gutenberg API performance runs that exercise editor bootstrap and dynamic rendering REST surfaces.",
+  "full_surface_coverage_manifest": "manifests/full-surface-coverage.json",
   "profiles": [
     {
       "id": "editor-bootstrap-small",

--- a/WordPress/wordpress/manifests/full-surface-coverage.json
+++ b/WordPress/wordpress/manifests/full-surface-coverage.json
@@ -1,0 +1,33 @@
+{
+  "schema": "homeboy-rigs/wordpress-full-surface-coverage/v1",
+  "property": "WordPress/wordpress",
+  "description": "Coverage targets for WordPress core across REST API, database schema, server requests, and browser requests.",
+  "requires_primitives": [
+    "wordpress-rest-route-matrix",
+    "wordpress-rest-request-cases",
+    "wordpress-rest-db-query-profiler",
+    "wordpress-db-inventory",
+    "wordpress-external-http-guardrail",
+    "browser-request-capture"
+  ],
+  "surfaces": {
+    "rest_api": {
+      "manifest": "manifests/rest-route-coverage.json",
+      "budget_manifest": "manifests/rest-route-budgets.json",
+      "coverage_goal": "all_registered_routes_and_generated_safe_cases"
+    },
+    "database": {
+      "coverage_goal": "all_tables_rows_columns_indexes",
+      "inventory_artifact": "homeboy/wordpress-db-inventory/v1",
+      "query_profile_artifact": "homeboy/wordpress-rest-db-query-profile/v1"
+    },
+    "server_requests": {
+      "coverage_goal": "all_outbound_http_hosts_and_blocked_unapproved_requests",
+      "guardrail": "wordpress-external-http-guardrail"
+    },
+    "browser_requests": {
+      "coverage_goal": "all_document_fetch_xhr_websocket_asset_requests_for_editor_and_frontend_flows",
+      "scenarios": ["front_page", "post_editor", "site_editor", "media_library"]
+    }
+  }
+}

--- a/WordPress/wordpress/manifests/performance-fixtures.json
+++ b/WordPress/wordpress/manifests/performance-fixtures.json
@@ -3,6 +3,7 @@
   "schema": "homeboy-rigs/wordpress-performance-fixtures/v1",
   "property": "WordPress/wordpress",
   "description": "Fixture profiles for WordPress core API performance runs that exercise content, editor bootstrap, and diagnostics REST surfaces.",
+  "full_surface_coverage_manifest": "manifests/full-surface-coverage.json",
   "profiles": [
     {
       "id": "content-editor-small",

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.json
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.json
@@ -1,0 +1,32 @@
+{
+  "schema": "homeboy-rigs/wordpress-full-surface-coverage/v1",
+  "property": "woocommerce/woocommerce",
+  "description": "Coverage targets for WooCommerce across Store API, REST API, database schema, server requests, and browser requests.",
+  "requires_primitives": [
+    "wordpress-rest-route-matrix",
+    "wordpress-rest-request-cases",
+    "wordpress-rest-db-query-profiler",
+    "wordpress-db-inventory",
+    "wordpress-external-http-guardrail",
+    "browser-request-capture"
+  ],
+  "surfaces": {
+    "rest_api": {
+      "budget_manifest": "manifests/rest-route-budgets.json",
+      "coverage_goal": "all_wc_v3_wc_store_wc_admin_routes_and_generated_safe_cases"
+    },
+    "database": {
+      "coverage_goal": "all_tables_rows_columns_indexes_after_catalog_checkout_fixture_setup",
+      "inventory_artifact": "homeboy/wordpress-db-inventory/v1",
+      "query_profile_artifact": "homeboy/wordpress-rest-db-query-profile/v1"
+    },
+    "server_requests": {
+      "coverage_goal": "all_webhook_marketplace_payment_tax_shipping_http_hosts_with_unapproved_requests_blocked",
+      "guardrail": "wordpress-external-http-guardrail"
+    },
+    "browser_requests": {
+      "coverage_goal": "all_cart_checkout_product_admin_fetch_xhr_websocket_asset_requests",
+      "scenarios": ["shop", "product", "cart", "checkout", "orders_admin", "products_admin", "analytics_admin"]
+    }
+  }
+}

--- a/woocommerce/woocommerce/manifests/performance-fixtures.json
+++ b/woocommerce/woocommerce/manifests/performance-fixtures.json
@@ -3,6 +3,7 @@
   "schema": "homeboy-rigs/wordpress-performance-fixtures/v1",
   "property": "woocommerce/woocommerce",
   "description": "Fixture profiles for WooCommerce large-merchant performance runs that exercise catalog, cart, checkout, and REST batch surfaces.",
+  "full_surface_coverage_manifest": "manifests/full-surface-coverage.json",
   "profiles": [
     {
       "id": "large-catalog-checkout-small",


### PR DESCRIPTION
## Summary
- Add full-surface coverage manifests for WordPress core, Gutenberg, Jetpack, and WooCommerce.
- Declare REST API, database, server-request, and browser-request coverage goals for each property.
- Reference the newly added DB inventory primitive and explicitly mark browser request capture as a required primitive rather than pretending it exists.

## Testing
- `node scripts/lint-rig-packages.mjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Drafting full-surface coverage manifests and PR preparation under Chris review.
