### PR TITLE
Wire full surface coverage profiles

### DIFF
--- a/Automattic/jetpack/manifests/full-surface-coverage.json
+++ b/Automattic/jetpack/manifests/full-surface-coverage.json
@@ -8,7 +8,7 @@
     "wordpress-rest-db-query-profiler",
     "wordpress-db-inventory",
     "wordpress-external-http-guardrail",
-    "browser-request-capture"
+    "browser-request-coverage"
   ],
   "surfaces": {
     "rest_api": {
@@ -27,7 +27,16 @@
     },
     "browser_requests": {
       "coverage_goal": "all_wp_admin_jetpack_screen_fetch_xhr_websocket_asset_requests",
+      "coverage_artifact": "wp-codebox/browser-request-coverage/v1",
       "scenarios": ["dashboard", "connection", "modules", "settings"]
+    }
+  },
+  "coverage_profiles": {
+    "full-surface": {
+      "rest_api": ["jetpack-rest-route-inventory", "generated-rest-request-cases"],
+      "database": ["db-inventory", "rest-db-query-profiler"],
+      "server_requests": ["external-http-guardrail"],
+      "browser_requests": ["dashboard", "connection", "modules", "settings"]
     }
   }
 }

--- a/WordPress/gutenberg/manifests/full-surface-coverage.json
+++ b/WordPress/gutenberg/manifests/full-surface-coverage.json
@@ -8,7 +8,7 @@
     "wordpress-rest-db-query-profiler",
     "wordpress-db-inventory",
     "wordpress-external-http-guardrail",
-    "browser-request-capture"
+    "browser-request-coverage"
   ],
   "surfaces": {
     "rest_api": {
@@ -27,7 +27,16 @@
     },
     "browser_requests": {
       "coverage_goal": "all_editor_bootstrap_fetch_xhr_websocket_asset_requests",
+      "coverage_artifact": "wp-codebox/browser-request-coverage/v1",
       "scenarios": ["post_editor", "site_editor", "template_editor", "patterns"]
+    }
+  },
+  "coverage_profiles": {
+    "full-surface": {
+      "rest_api": ["gutenberg-rest-route-inventory", "generated-rest-request-cases"],
+      "database": ["db-inventory", "rest-db-query-profiler"],
+      "server_requests": ["external-http-guardrail"],
+      "browser_requests": ["post_editor", "site_editor", "template_editor", "patterns"]
     }
   }
 }

--- a/WordPress/wordpress/manifests/full-surface-coverage.json
+++ b/WordPress/wordpress/manifests/full-surface-coverage.json
@@ -8,7 +8,7 @@
     "wordpress-rest-db-query-profiler",
     "wordpress-db-inventory",
     "wordpress-external-http-guardrail",
-    "browser-request-capture"
+    "browser-request-coverage"
   ],
   "surfaces": {
     "rest_api": {
@@ -27,7 +27,16 @@
     },
     "browser_requests": {
       "coverage_goal": "all_document_fetch_xhr_websocket_asset_requests_for_editor_and_frontend_flows",
+      "coverage_artifact": "wp-codebox/browser-request-coverage/v1",
       "scenarios": ["front_page", "post_editor", "site_editor", "media_library"]
+    }
+  },
+  "coverage_profiles": {
+    "full-surface": {
+      "rest_api": ["wordpress-core-rest-route-inventory", "generated-rest-request-cases"],
+      "database": ["db-inventory", "rest-db-query-profiler"],
+      "server_requests": ["external-http-guardrail"],
+      "browser_requests": ["front_page", "post_editor", "site_editor", "media_library"]
     }
   }
 }

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.json
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.json
@@ -8,7 +8,7 @@
     "wordpress-rest-db-query-profiler",
     "wordpress-db-inventory",
     "wordpress-external-http-guardrail",
-    "browser-request-capture"
+    "browser-request-coverage"
   ],
   "surfaces": {
     "rest_api": {
@@ -26,7 +26,16 @@
     },
     "browser_requests": {
       "coverage_goal": "all_cart_checkout_product_admin_fetch_xhr_websocket_asset_requests",
+      "coverage_artifact": "wp-codebox/browser-request-coverage/v1",
       "scenarios": ["shop", "product", "cart", "checkout", "orders_admin", "products_admin", "analytics_admin"]
+    }
+  },
+  "coverage_profiles": {
+    "full-surface": {
+      "rest_api": ["woocommerce-rest-route-inventory", "generated-rest-request-cases"],
+      "database": ["db-inventory", "rest-db-query-profiler"],
+      "server_requests": ["external-http-guardrail"],
+      "browser_requests": ["shop", "product", "cart", "checkout", "orders_admin", "products_admin", "analytics_admin"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Wire full-surface coverage profiles across WordPress core, Gutenberg, Jetpack, and WooCommerce.
- Connect REST, generated REST cases, DB inventory, REST DB query profiling, server HTTP guardrails, and browser request coverage artifacts into one profile per property.
- Replace the earlier placeholder browser requirement with the concrete `browser-request-coverage` primitive.

## Testing
- `node scripts/lint-rig-packages.mjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (openai/gpt-5.5)
- **Used for:** Wiring full-surface coverage profiles and PR preparation under Chris review.
