### PR TITLE
Wire full-surface coverage benchmark profiles

### DIFF
--- a/Automattic/jetpack/README.md
+++ b/Automattic/jetpack/README.md
@@ -16,4 +16,10 @@ Run the route inventory workload:
 homeboy bench --rig jetpack-api-route-inventory --scenario jetpack-rest-route-inventory --iterations 1 --shared-state /tmp/jetpack-api-inventory
 ```
 
+Run the currently executable full-surface profile. It is intentionally limited to workload-backed REST route inventory until generated REST cases, DB inventory/profiling, external HTTP guardrails, and browser request coverage have concrete workload files:
+
+```sh
+homeboy bench --rig jetpack-api-route-inventory --profile full-surface --iterations 1 --shared-state /tmp/jetpack-full-surface
+```
+
 The coverage manifest lives at `manifests/rest-route-coverage.json`. It keeps Jetpack-specific route grouping in this rig package so upstream primitives can stay generic.

--- a/Automattic/jetpack/bench/db-inventory.workload.json
+++ b/Automattic/jetpack/bench/db-inventory.workload.json
@@ -1,0 +1,18 @@
+{
+  "id": "db-inventory",
+  "source": "config",
+  "run": [
+    {
+      "type": "db-inventory",
+      "metric-prefix": "db_inventory",
+      "include-columns": true,
+      "include-indexes": true
+    }
+  ],
+  "metadata": {
+    "runner": "wp-codebox",
+    "workload": "db-inventory",
+    "coverage_shape": "Jetpack fixture database table, row, column, and index inventory",
+    "manifest": "manifests/full-surface-coverage.json"
+  }
+}

--- a/Automattic/jetpack/bench/generated-rest-request-cases.workload.json
+++ b/Automattic/jetpack/bench/generated-rest-request-cases.workload.json
@@ -1,0 +1,42 @@
+{
+  "id": "generated-rest-request-cases",
+  "source": "config",
+  "rest_request_cases": [
+    {
+      "id": "jetpack-site",
+      "method": "GET",
+      "path": "/jetpack/v4/site",
+      "capture-response": true
+    },
+    {
+      "id": "jetpack-modules",
+      "method": "GET",
+      "path": "/jetpack/v4/modules",
+      "capture-response": true
+    },
+    {
+      "id": "jetpack-settings",
+      "method": "GET",
+      "path": "/jetpack/v4/settings",
+      "capture-response": true
+    },
+    {
+      "id": "jetpack-connection",
+      "method": "GET",
+      "path": "/jetpack/v4/connection",
+      "capture-response": true
+    },
+    {
+      "id": "wpcom-publicize-services",
+      "method": "GET",
+      "path": "/wpcom/v2/publicize/services",
+      "capture-response": true
+    }
+  ],
+  "metadata": {
+    "runner": "wp-codebox",
+    "workload": "generated-rest-request-cases",
+    "coverage_shape": "generated safe Jetpack REST request cases",
+    "manifest": "manifests/rest-route-coverage.json"
+  }
+}

--- a/Automattic/jetpack/bench/jetpack-browser-coverage.trace.mjs
+++ b/Automattic/jetpack/bench/jetpack-browser-coverage.trace.mjs
@@ -1,0 +1,33 @@
+import path from 'node:path';
+
+import { runBrowserCoverageTrace } from '../../../shared/wp-codebox/browser-coverage-trace.mjs';
+
+const componentPath = process.env.HOMEBOY_COMPONENT_PATH;
+const scenarioRoot = new URL( '../browser-scenarios/', import.meta.url ).pathname;
+
+await runBrowserCoverageTrace( {
+	componentId: 'jetpack',
+	scenarioId: 'jetpack-browser-coverage',
+	componentPath,
+	requiredFile: 'jetpack.php',
+	wpVersion: process.env.HOMEBOY_JETPACK_BROWSER_COVERAGE_WP_VERSION || '7.0',
+	blueprintSteps: [
+		{ step: 'activatePlugin', pluginPath: '/wordpress/wp-content/plugins/jetpack/jetpack.php' },
+		{ step: 'login', username: 'admin', password: 'password' },
+	],
+	inputs: {
+		extraPlugins: [
+			{ source: componentPath, slug: 'jetpack', pluginFile: 'jetpack/jetpack.php', activate: true },
+		],
+	},
+	assumptions: [
+		'This workload exercises Jetpack admin routes with the plugin activated in WP Codebox.',
+		'No WordPress.com OAuth fixture is provisioned here; connection-dependent screens are still executable and capture unauthenticated/connection-required request coverage.',
+	],
+	scenarios: [
+		{ id: 'dashboard', stepsFile: path.join( scenarioRoot, 'dashboard.json' ) },
+		{ id: 'connection', stepsFile: path.join( scenarioRoot, 'connection.json' ) },
+		{ id: 'modules', stepsFile: path.join( scenarioRoot, 'modules.json' ) },
+		{ id: 'settings', stepsFile: path.join( scenarioRoot, 'settings.json' ) },
+	],
+} );

--- a/Automattic/jetpack/bench/jetpack-external-http-guardrail.php
+++ b/Automattic/jetpack/bench/jetpack-external-http-guardrail.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Jetpack external HTTP guardrail coverage workload.
+ */
+return function (): array {
+	if ( ! function_exists( 'wp_codebox_bench_run_external_http_guardrail_step' ) ) {
+		throw new RuntimeException( 'WP Codebox external-http-guardrail bench primitive is not available.' );
+	}
+
+	wp_codebox_bench_run_external_http_guardrail_step(
+		array(
+			'type'             => 'external-http-guardrail',
+			'action'           => 'install',
+			'allowlistDomains' => array( 'public-api.wordpress.com' ),
+			'blockNetwork'     => true,
+			'metric-prefix'    => 'jetpack_external_http_guardrail_install',
+		)
+	);
+
+	wp_remote_get( 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.com?guardrail=1' );
+	wp_remote_post( 'https://jetpack.wordpress.com/guardrail-probe', array( 'body' => array( 'event' => 'synthetic' ) ) );
+
+	$payload = wp_codebox_bench_run_external_http_guardrail_step(
+		array(
+			'type'          => 'external-http-guardrail',
+			'action'        => 'collect',
+			'metric-prefix' => 'jetpack_external_http_guardrail',
+			'sampleLimit'   => 20,
+		)
+	);
+	$payload['metadata'] = array_merge(
+		$payload['metadata'] ?? array(),
+		array(
+			'runner'         => 'wp-codebox',
+			'workload'       => 'jetpack-external-http-guardrail',
+			'coverage_shape' => 'Jetpack connection and service API external HTTP guardrail probes',
+		)
+	);
+	return $payload;
+};

--- a/Automattic/jetpack/bench/rest-db-query-profile.workload.json
+++ b/Automattic/jetpack/bench/rest-db-query-profile.workload.json
@@ -1,0 +1,23 @@
+{
+  "id": "rest-db-query-profile",
+  "source": "config",
+  "run": [
+    {
+      "type": "rest-db-query-profiler",
+      "metric-prefix": "rest_db_query_profile",
+      "sampleLimit": 50,
+      "queryLengthLimit": 500,
+      "rest_request_cases": [
+        { "id": "jetpack-site", "method": "GET", "path": "/jetpack/v4/site" },
+        { "id": "jetpack-modules", "method": "GET", "path": "/jetpack/v4/modules" },
+        { "id": "jetpack-settings", "method": "GET", "path": "/jetpack/v4/settings" }
+      ]
+    }
+  ],
+  "metadata": {
+    "runner": "wp-codebox",
+    "workload": "rest-db-query-profile",
+    "coverage_shape": "Jetpack REST request DB query profile",
+    "manifest": "manifests/full-surface-coverage.json"
+  }
+}

--- a/Automattic/jetpack/browser-scenarios/connection.json
+++ b/Automattic/jetpack/browser-scenarios/connection.json
@@ -1,0 +1,5 @@
+[
+  { "kind": "navigate", "url": "/wp-admin/admin.php?page=jetpack#/connection", "waitFor": "load" },
+  { "kind": "waitFor", "selector": "body", "timeout": "30s" },
+  { "kind": "screenshot", "name": "jetpack-connection" }
+]

--- a/Automattic/jetpack/browser-scenarios/dashboard.json
+++ b/Automattic/jetpack/browser-scenarios/dashboard.json
@@ -1,0 +1,5 @@
+[
+  { "kind": "navigate", "url": "/wp-admin/admin.php?page=jetpack", "waitFor": "load" },
+  { "kind": "waitFor", "selector": "body", "timeout": "30s" },
+  { "kind": "screenshot", "name": "jetpack-dashboard" }
+]

--- a/Automattic/jetpack/browser-scenarios/modules.json
+++ b/Automattic/jetpack/browser-scenarios/modules.json
@@ -1,0 +1,5 @@
+[
+  { "kind": "navigate", "url": "/wp-admin/admin.php?page=jetpack_modules", "waitFor": "load" },
+  { "kind": "waitFor", "selector": "body", "timeout": "30s" },
+  { "kind": "screenshot", "name": "jetpack-modules" }
+]

--- a/Automattic/jetpack/browser-scenarios/settings.json
+++ b/Automattic/jetpack/browser-scenarios/settings.json
@@ -1,0 +1,5 @@
+[
+  { "kind": "navigate", "url": "/wp-admin/admin.php?page=jetpack#/settings", "waitFor": "load" },
+  { "kind": "waitFor", "selector": "body", "timeout": "30s" },
+  { "kind": "screenshot", "name": "jetpack-settings" }
+]

--- a/Automattic/jetpack/manifests/full-surface-coverage.json
+++ b/Automattic/jetpack/manifests/full-surface-coverage.json
@@ -28,6 +28,8 @@
     "browser_requests": {
       "coverage_goal": "all_wp_admin_jetpack_screen_fetch_xhr_websocket_asset_requests",
       "coverage_artifact": "wp-codebox/browser-request-coverage/v1",
+      "trace_workload": "bench/jetpack-browser-coverage.trace.mjs",
+      "rig": "rigs/jetpack-browser-coverage/rig.json",
       "scenarios": ["dashboard", "connection", "modules", "settings"]
     }
   },

--- a/Automattic/jetpack/manifests/performance-fixtures.json
+++ b/Automattic/jetpack/manifests/performance-fixtures.json
@@ -24,7 +24,8 @@
         "site-data"
       ],
       "expected_workloads": [
-        "jetpack-rest-route-inventory"
+        "jetpack-rest-route-inventory",
+        "jetpack-external-http-guardrail"
       ]
     }
   ]

--- a/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
+++ b/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
@@ -28,15 +28,32 @@
   },
   "bench_workloads": {
     "wordpress": [
-      { "path": "${package.root}/bench/jetpack-rest-route-inventory.php" }
+      { "path": "${package.root}/bench/jetpack-rest-route-inventory.php" },
+      { "path": "${package.root}/bench/jetpack-external-http-guardrail.php" },
+      { "path": "${package.root}/bench/generated-rest-request-cases.workload.json" },
+      { "path": "${package.root}/bench/rest-db-query-profile.workload.json" },
+      { "path": "${package.root}/bench/db-inventory.workload.json" }
     ]
   },
   "bench_profiles": {
     "smoke": [
-      "jetpack-rest-route-inventory"
+      "jetpack-rest-route-inventory",
+      "jetpack-external-http-guardrail",
+      "generated-rest-request-cases",
+      "rest-db-query-profile",
+      "db-inventory"
     ],
     "api-coverage": [
-      "jetpack-rest-route-inventory"
+      "jetpack-rest-route-inventory",
+      "generated-rest-request-cases",
+      "rest-db-query-profile"
+    ],
+    "full-surface": [
+      "jetpack-rest-route-inventory",
+      "generated-rest-request-cases",
+      "jetpack-external-http-guardrail",
+      "rest-db-query-profile",
+      "db-inventory"
     ]
   },
   "pipeline": {

--- a/Automattic/jetpack/rigs/jetpack-browser-coverage/rig.json
+++ b/Automattic/jetpack/rigs/jetpack-browser-coverage/rig.json
@@ -1,0 +1,59 @@
+{
+  "id": "jetpack-browser-coverage",
+  "description": "WP Codebox browser-actions request coverage for Jetpack dashboard, connection, modules, and settings admin surfaces.",
+  "components": {
+    "jetpack": {
+      "path": "~/Developer/jetpack/projects/plugins/jetpack",
+      "branch": "trunk"
+    }
+  },
+  "resources": {
+    "exclusive": [
+      "jetpack-browser-coverage:${env.HOMEBOY_SETTINGS_JETPACK_BROWSER_COVERAGE_NAMESPACE}"
+    ],
+    "paths": [
+      "${components.jetpack.path}"
+    ]
+  },
+  "trace": {
+    "default_component": "jetpack"
+  },
+  "trace_workloads": {
+    "nodejs": [
+      {
+        "path": "${package.root}/bench/jetpack-browser-coverage.trace.mjs",
+        "check_groups": [],
+        "port_range_size": 1,
+        "trace_default_phase_preset": "browser-request-coverage",
+        "trace_phase_presets": {
+          "browser-request-coverage": [
+            "start:scenario.start",
+            "recipe:wp_codebox.recipe.start",
+            "actions:browser.actions.ready"
+          ]
+        }
+      }
+    ]
+  },
+  "trace_profiles": {
+    "smoke": ["jetpack-browser-coverage"],
+    "full-surface": ["jetpack-browser-coverage"]
+  },
+  "pipeline": {
+    "check": [
+      {
+        "kind": "requirement",
+        "label": "Jetpack plugin checkout exists",
+        "file": "${components.jetpack.path}/jetpack.php",
+        "component": "jetpack",
+        "component_path_contains": "jetpack"
+      },
+      {
+        "kind": "command",
+        "label": "WP Codebox CLI exists",
+        "command": "bash \"${package.root}/../../shared/wp-codebox/check-cli.sh\""
+      }
+    ],
+    "down": []
+  }
+}

--- a/WordPress/gutenberg/README.md
+++ b/WordPress/gutenberg/README.md
@@ -18,6 +18,12 @@ Run the route inventory workload:
 homeboy bench --rig gutenberg-api-route-inventory --scenario gutenberg-rest-route-inventory --iterations 1 --shared-state /tmp/gutenberg-api-inventory
 ```
 
+Run the currently executable full-surface profile. It is intentionally limited to workload-backed REST route inventory until generated REST cases, DB inventory/profiling, external HTTP guardrails, and browser request coverage have concrete workload files:
+
+```sh
+homeboy bench --rig gutenberg-api-route-inventory --profile full-surface --iterations 1 --shared-state /tmp/gutenberg-full-surface
+```
+
 The coverage manifest lives at `manifests/rest-route-coverage.json`. It keeps
 Gutenberg-specific route grouping in this rig package so upstream primitives can
 stay generic.

--- a/WordPress/gutenberg/bench/db-inventory.workload.json
+++ b/WordPress/gutenberg/bench/db-inventory.workload.json
@@ -1,0 +1,18 @@
+{
+  "id": "db-inventory",
+  "source": "config",
+  "run": [
+    {
+      "type": "db-inventory",
+      "metric-prefix": "db_inventory",
+      "include-columns": true,
+      "include-indexes": true
+    }
+  ],
+  "metadata": {
+    "runner": "wp-codebox",
+    "workload": "db-inventory",
+    "coverage_shape": "Gutenberg fixture database table, row, column, and index inventory",
+    "manifest": "manifests/full-surface-coverage.json"
+  }
+}

--- a/WordPress/gutenberg/bench/generated-rest-request-cases.workload.json
+++ b/WordPress/gutenberg/bench/generated-rest-request-cases.workload.json
@@ -1,0 +1,47 @@
+{
+  "id": "generated-rest-request-cases",
+  "source": "config",
+  "rest_request_cases": [
+    {
+      "id": "gutenberg-block-patterns",
+      "method": "GET",
+      "path": "/wp/v2/block-patterns/patterns",
+      "params": { "context": "view" },
+      "capture-response": true
+    },
+    {
+      "id": "gutenberg-block-pattern-categories",
+      "method": "GET",
+      "path": "/wp/v2/block-patterns/categories",
+      "params": { "context": "view" },
+      "capture-response": true
+    },
+    {
+      "id": "gutenberg-block-directory-search",
+      "method": "GET",
+      "path": "/wp/v2/block-directory/search",
+      "params": { "term": "paragraph" },
+      "capture-response": true
+    },
+    {
+      "id": "gutenberg-templates",
+      "method": "GET",
+      "path": "/wp/v2/templates",
+      "params": { "context": "view" },
+      "capture-response": true
+    },
+    {
+      "id": "gutenberg-template-parts",
+      "method": "GET",
+      "path": "/wp/v2/template-parts",
+      "params": { "context": "view" },
+      "capture-response": true
+    }
+  ],
+  "metadata": {
+    "runner": "wp-codebox",
+    "workload": "generated-rest-request-cases",
+    "coverage_shape": "generated safe Gutenberg REST request cases",
+    "manifest": "manifests/rest-route-coverage.json"
+  }
+}

--- a/WordPress/gutenberg/bench/gutenberg-browser-coverage.trace.mjs
+++ b/WordPress/gutenberg/bench/gutenberg-browser-coverage.trace.mjs
@@ -1,0 +1,33 @@
+import path from 'node:path';
+
+import { runBrowserCoverageTrace } from '../../../shared/wp-codebox/browser-coverage-trace.mjs';
+
+const componentPath = process.env.HOMEBOY_COMPONENT_PATH;
+const scenarioRoot = new URL( '../browser-scenarios/', import.meta.url ).pathname;
+
+await runBrowserCoverageTrace( {
+	componentId: 'gutenberg',
+	scenarioId: 'gutenberg-browser-coverage',
+	componentPath,
+	requiredFile: 'gutenberg.php',
+	wpVersion: process.env.HOMEBOY_GUTENBERG_BROWSER_COVERAGE_WP_VERSION || '7.0',
+	blueprintSteps: [
+		{ step: 'activatePlugin', pluginPath: '/wordpress/wp-content/plugins/gutenberg/gutenberg.php' },
+		{ step: 'login', username: 'admin', password: 'password' },
+	],
+	inputs: {
+		extraPlugins: [
+			{ source: componentPath, slug: 'gutenberg', pluginFile: 'gutenberg/gutenberg.php', activate: true },
+		],
+	},
+	assumptions: [
+		'The Gutenberg checkout is mounted as a plugin and activated before browser actions run.',
+		'Editor route coverage uses stable admin URLs and document/body readiness to keep the workload executable across editor UI refactors.',
+	],
+	scenarios: [
+		{ id: 'post_editor', stepsFile: path.join( scenarioRoot, 'post_editor.json' ) },
+		{ id: 'site_editor', stepsFile: path.join( scenarioRoot, 'site_editor.json' ) },
+		{ id: 'template_editor', stepsFile: path.join( scenarioRoot, 'template_editor.json' ) },
+		{ id: 'patterns', stepsFile: path.join( scenarioRoot, 'patterns.json' ) },
+	],
+} );

--- a/WordPress/gutenberg/bench/gutenberg-external-http-guardrail.php
+++ b/WordPress/gutenberg/bench/gutenberg-external-http-guardrail.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Gutenberg external HTTP guardrail coverage workload.
+ */
+return function (): array {
+	if ( ! function_exists( 'wp_codebox_bench_run_external_http_guardrail_step' ) ) {
+		throw new RuntimeException( 'WP Codebox external-http-guardrail bench primitive is not available.' );
+	}
+
+	wp_codebox_bench_run_external_http_guardrail_step(
+		array(
+			'type'             => 'external-http-guardrail',
+			'action'           => 'install',
+			'allowlistDomains' => array( 'api.wordpress.org' ),
+			'blockNetwork'     => true,
+			'metric-prefix'    => 'gutenberg_external_http_guardrail_install',
+		)
+	);
+
+	wp_remote_get( 'https://api.wordpress.org/patterns/1.0/?locale=en_US' );
+	wp_remote_get( 'https://patterns.wordpress.org/guardrail-probe?client=gutenberg' );
+
+	$payload = wp_codebox_bench_run_external_http_guardrail_step(
+		array(
+			'type'          => 'external-http-guardrail',
+			'action'        => 'collect',
+			'metric-prefix' => 'gutenberg_external_http_guardrail',
+			'sampleLimit'   => 20,
+		)
+	);
+	$payload['metadata'] = array_merge(
+		$payload['metadata'] ?? array(),
+		array(
+			'runner'         => 'wp-codebox',
+			'workload'       => 'gutenberg-external-http-guardrail',
+			'coverage_shape' => 'pattern directory and editor library external HTTP guardrail probes',
+		)
+	);
+	return $payload;
+};

--- a/WordPress/gutenberg/bench/rest-db-query-profile.workload.json
+++ b/WordPress/gutenberg/bench/rest-db-query-profile.workload.json
@@ -1,0 +1,23 @@
+{
+  "id": "rest-db-query-profile",
+  "source": "config",
+  "run": [
+    {
+      "type": "rest-db-query-profiler",
+      "metric-prefix": "rest_db_query_profile",
+      "sampleLimit": 50,
+      "queryLengthLimit": 500,
+      "rest_request_cases": [
+        { "id": "gutenberg-block-patterns", "method": "GET", "path": "/wp/v2/block-patterns/patterns", "params": { "context": "view" } },
+        { "id": "gutenberg-block-pattern-categories", "method": "GET", "path": "/wp/v2/block-patterns/categories", "params": { "context": "view" } },
+        { "id": "gutenberg-templates", "method": "GET", "path": "/wp/v2/templates", "params": { "context": "view" } }
+      ]
+    }
+  ],
+  "metadata": {
+    "runner": "wp-codebox",
+    "workload": "rest-db-query-profile",
+    "coverage_shape": "Gutenberg REST request DB query profile",
+    "manifest": "manifests/full-surface-coverage.json"
+  }
+}

--- a/WordPress/gutenberg/browser-scenarios/patterns.json
+++ b/WordPress/gutenberg/browser-scenarios/patterns.json
@@ -1,0 +1,5 @@
+[
+  { "kind": "navigate", "url": "/wp-admin/site-editor.php?p=%2Fpatterns", "waitFor": "load" },
+  { "kind": "waitFor", "selector": "body", "timeout": "30s" },
+  { "kind": "screenshot", "name": "gutenberg-patterns" }
+]

--- a/WordPress/gutenberg/browser-scenarios/post_editor.json
+++ b/WordPress/gutenberg/browser-scenarios/post_editor.json
@@ -1,0 +1,5 @@
+[
+  { "kind": "navigate", "url": "/wp-admin/post-new.php", "waitFor": "load" },
+  { "kind": "waitFor", "selector": "body", "timeout": "30s" },
+  { "kind": "screenshot", "name": "gutenberg-post-editor" }
+]

--- a/WordPress/gutenberg/browser-scenarios/site_editor.json
+++ b/WordPress/gutenberg/browser-scenarios/site_editor.json
@@ -1,0 +1,5 @@
+[
+  { "kind": "navigate", "url": "/wp-admin/site-editor.php", "waitFor": "load" },
+  { "kind": "waitFor", "selector": "body", "timeout": "30s" },
+  { "kind": "screenshot", "name": "gutenberg-site-editor" }
+]

--- a/WordPress/gutenberg/browser-scenarios/template_editor.json
+++ b/WordPress/gutenberg/browser-scenarios/template_editor.json
@@ -1,0 +1,5 @@
+[
+  { "kind": "navigate", "url": "/wp-admin/site-editor.php?postType=wp_template", "waitFor": "load" },
+  { "kind": "waitFor", "selector": "body", "timeout": "30s" },
+  { "kind": "screenshot", "name": "gutenberg-template-editor" }
+]

--- a/WordPress/gutenberg/manifests/full-surface-coverage.json
+++ b/WordPress/gutenberg/manifests/full-surface-coverage.json
@@ -28,6 +28,8 @@
     "browser_requests": {
       "coverage_goal": "all_editor_bootstrap_fetch_xhr_websocket_asset_requests",
       "coverage_artifact": "wp-codebox/browser-request-coverage/v1",
+      "trace_workload": "bench/gutenberg-browser-coverage.trace.mjs",
+      "rig": "rigs/gutenberg-browser-coverage/rig.json",
       "scenarios": ["post_editor", "site_editor", "template_editor", "patterns"]
     }
   },

--- a/WordPress/gutenberg/manifests/performance-fixtures.json
+++ b/WordPress/gutenberg/manifests/performance-fixtures.json
@@ -21,7 +21,8 @@
         "dynamic-rendering"
       ],
       "expected_workloads": [
-        "gutenberg-rest-route-inventory"
+        "gutenberg-rest-route-inventory",
+        "gutenberg-external-http-guardrail"
       ]
     }
   ]

--- a/WordPress/gutenberg/rigs/gutenberg-api-route-inventory/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-api-route-inventory/rig.json
@@ -28,15 +28,32 @@
   },
   "bench_workloads": {
     "wordpress": [
-      { "path": "${package.root}/bench/gutenberg-rest-route-inventory.php" }
+      { "path": "${package.root}/bench/gutenberg-rest-route-inventory.php" },
+      { "path": "${package.root}/bench/gutenberg-external-http-guardrail.php" },
+      { "path": "${package.root}/bench/generated-rest-request-cases.workload.json" },
+      { "path": "${package.root}/bench/rest-db-query-profile.workload.json" },
+      { "path": "${package.root}/bench/db-inventory.workload.json" }
     ]
   },
   "bench_profiles": {
     "smoke": [
-      "gutenberg-rest-route-inventory"
+      "gutenberg-rest-route-inventory",
+      "gutenberg-external-http-guardrail",
+      "generated-rest-request-cases",
+      "rest-db-query-profile",
+      "db-inventory"
     ],
     "api-coverage": [
-      "gutenberg-rest-route-inventory"
+      "gutenberg-rest-route-inventory",
+      "generated-rest-request-cases",
+      "rest-db-query-profile"
+    ],
+    "full-surface": [
+      "gutenberg-rest-route-inventory",
+      "generated-rest-request-cases",
+      "gutenberg-external-http-guardrail",
+      "rest-db-query-profile",
+      "db-inventory"
     ]
   },
   "pipeline": {

--- a/WordPress/gutenberg/rigs/gutenberg-browser-coverage/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-browser-coverage/rig.json
@@ -1,0 +1,59 @@
+{
+  "id": "gutenberg-browser-coverage",
+  "description": "WP Codebox browser-actions request coverage for Gutenberg post editor, site editor, template editor, and patterns surfaces.",
+  "components": {
+    "gutenberg": {
+      "path": "~/Developer/gutenberg",
+      "branch": "trunk"
+    }
+  },
+  "resources": {
+    "exclusive": [
+      "gutenberg-browser-coverage:${env.HOMEBOY_SETTINGS_GUTENBERG_BROWSER_COVERAGE_NAMESPACE}"
+    ],
+    "paths": [
+      "${components.gutenberg.path}"
+    ]
+  },
+  "trace": {
+    "default_component": "gutenberg"
+  },
+  "trace_workloads": {
+    "nodejs": [
+      {
+        "path": "${package.root}/bench/gutenberg-browser-coverage.trace.mjs",
+        "check_groups": [],
+        "port_range_size": 1,
+        "trace_default_phase_preset": "browser-request-coverage",
+        "trace_phase_presets": {
+          "browser-request-coverage": [
+            "start:scenario.start",
+            "recipe:wp_codebox.recipe.start",
+            "actions:browser.actions.ready"
+          ]
+        }
+      }
+    ]
+  },
+  "trace_profiles": {
+    "smoke": ["gutenberg-browser-coverage"],
+    "full-surface": ["gutenberg-browser-coverage"]
+  },
+  "pipeline": {
+    "check": [
+      {
+        "kind": "requirement",
+        "label": "Gutenberg checkout exists",
+        "file": "${components.gutenberg.path}/gutenberg.php",
+        "component": "gutenberg",
+        "component_path_contains": "gutenberg"
+      },
+      {
+        "kind": "command",
+        "label": "WP Codebox CLI exists",
+        "command": "bash \"${package.root}/../../shared/wp-codebox/check-cli.sh\""
+      }
+    ],
+    "down": []
+  }
+}

--- a/WordPress/wordpress/README.md
+++ b/WordPress/wordpress/README.md
@@ -16,4 +16,10 @@ Run the route inventory workload:
 homeboy bench --rig wordpress-core-api-route-inventory --scenario wordpress-core-rest-route-inventory --iterations 1 --shared-state /tmp/wordpress-core-api-inventory
 ```
 
+Run the currently executable full-surface profile. It is intentionally limited to workload-backed REST route inventory until generated REST cases, DB inventory/profiling, external HTTP guardrails, and browser request coverage have concrete workload files:
+
+```sh
+homeboy bench --rig wordpress-core-api-route-inventory --profile full-surface --iterations 1 --shared-state /tmp/wordpress-core-full-surface
+```
+
 The coverage manifest lives at `manifests/rest-route-coverage.json`. It keeps core-specific route grouping in this rig package so upstream primitives can stay generic.

--- a/WordPress/wordpress/bench/db-inventory.workload.json
+++ b/WordPress/wordpress/bench/db-inventory.workload.json
@@ -1,0 +1,18 @@
+{
+  "id": "db-inventory",
+  "source": "config",
+  "run": [
+    {
+      "type": "db-inventory",
+      "metric-prefix": "db_inventory",
+      "include-columns": true,
+      "include-indexes": true
+    }
+  ],
+  "metadata": {
+    "runner": "wp-codebox",
+    "workload": "db-inventory",
+    "coverage_shape": "WordPress database table, row, column, and index inventory",
+    "manifest": "manifests/full-surface-coverage.json"
+  }
+}

--- a/WordPress/wordpress/bench/generated-rest-request-cases.workload.json
+++ b/WordPress/wordpress/bench/generated-rest-request-cases.workload.json
@@ -1,0 +1,47 @@
+{
+  "id": "generated-rest-request-cases",
+  "source": "config",
+  "rest_request_cases": [
+    {
+      "id": "core-posts-list",
+      "method": "GET",
+      "path": "/wp/v2/posts",
+      "params": { "per_page": 1, "context": "view" },
+      "capture-response": true
+    },
+    {
+      "id": "core-pages-list",
+      "method": "GET",
+      "path": "/wp/v2/pages",
+      "params": { "per_page": 1, "context": "view" },
+      "capture-response": true
+    },
+    {
+      "id": "core-types",
+      "method": "GET",
+      "path": "/wp/v2/types",
+      "params": { "context": "view" },
+      "capture-response": true
+    },
+    {
+      "id": "core-taxonomies",
+      "method": "GET",
+      "path": "/wp/v2/taxonomies",
+      "params": { "context": "view" },
+      "capture-response": true
+    },
+    {
+      "id": "core-statuses",
+      "method": "GET",
+      "path": "/wp/v2/statuses",
+      "params": { "context": "view" },
+      "capture-response": true
+    }
+  ],
+  "metadata": {
+    "runner": "wp-codebox",
+    "workload": "generated-rest-request-cases",
+    "coverage_shape": "generated safe WordPress core REST request cases",
+    "manifest": "manifests/rest-route-coverage.json"
+  }
+}

--- a/WordPress/wordpress/bench/rest-db-query-profile.workload.json
+++ b/WordPress/wordpress/bench/rest-db-query-profile.workload.json
@@ -1,0 +1,23 @@
+{
+  "id": "rest-db-query-profile",
+  "source": "config",
+  "run": [
+    {
+      "type": "rest-db-query-profiler",
+      "metric-prefix": "rest_db_query_profile",
+      "sampleLimit": 50,
+      "queryLengthLimit": 500,
+      "rest_request_cases": [
+        { "id": "core-posts-list", "method": "GET", "path": "/wp/v2/posts", "params": { "per_page": 1, "context": "view" } },
+        { "id": "core-pages-list", "method": "GET", "path": "/wp/v2/pages", "params": { "per_page": 1, "context": "view" } },
+        { "id": "core-types", "method": "GET", "path": "/wp/v2/types", "params": { "context": "view" } }
+      ]
+    }
+  ],
+  "metadata": {
+    "runner": "wp-codebox",
+    "workload": "rest-db-query-profile",
+    "coverage_shape": "WordPress core REST request DB query profile",
+    "manifest": "manifests/full-surface-coverage.json"
+  }
+}

--- a/WordPress/wordpress/bench/wordpress-core-browser-coverage.trace.mjs
+++ b/WordPress/wordpress/bench/wordpress-core-browser-coverage.trace.mjs
@@ -1,0 +1,23 @@
+import path from 'node:path';
+
+import { runBrowserCoverageTrace } from '../../../shared/wp-codebox/browser-coverage-trace.mjs';
+
+const scenarioRoot = new URL( '../browser-scenarios/', import.meta.url ).pathname;
+
+await runBrowserCoverageTrace( {
+	componentId: 'wordpress',
+	scenarioId: 'wordpress-core-browser-coverage',
+	componentPath: process.env.HOMEBOY_COMPONENT_PATH,
+	requiredFile: 'src/wp-includes/rest-api.php',
+	wpVersion: process.env.HOMEBOY_WORDPRESS_CORE_BROWSER_COVERAGE_WP_VERSION || '7.0',
+	assumptions: [
+		'WP Codebox Playground supplies the WordPress runtime and logs in as admin through the blueprint login step.',
+		'Admin screen readiness is captured at document/body level so request coverage is produced even if editor-specific selectors change.',
+	],
+	scenarios: [
+		{ id: 'front_page', stepsFile: path.join( scenarioRoot, 'front_page.json' ) },
+		{ id: 'post_editor', stepsFile: path.join( scenarioRoot, 'post_editor.json' ) },
+		{ id: 'site_editor', stepsFile: path.join( scenarioRoot, 'site_editor.json' ) },
+		{ id: 'media_library', stepsFile: path.join( scenarioRoot, 'media_library.json' ) },
+	],
+} );

--- a/WordPress/wordpress/bench/wordpress-core-external-http-guardrail.php
+++ b/WordPress/wordpress/bench/wordpress-core-external-http-guardrail.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * WordPress core external HTTP guardrail coverage workload.
+ */
+return function (): array {
+	if ( ! function_exists( 'wp_codebox_bench_run_external_http_guardrail_step' ) ) {
+		throw new RuntimeException( 'WP Codebox external-http-guardrail bench primitive is not available.' );
+	}
+
+	wp_codebox_bench_run_external_http_guardrail_step(
+		array(
+			'type'             => 'external-http-guardrail',
+			'action'           => 'install',
+			'allowlistDomains' => array( 'api.wordpress.org' ),
+			'blockNetwork'     => true,
+			'metric-prefix'    => 'core_external_http_guardrail_install',
+		)
+	);
+
+	wp_remote_get( 'https://api.wordpress.org/core/version-check/1.7/?channel=stable' );
+	wp_remote_get( 'https://downloads.wordpress.org/release-check/guardrail-probe?token=synthetic' );
+
+	$payload = wp_codebox_bench_run_external_http_guardrail_step(
+		array(
+			'type'          => 'external-http-guardrail',
+			'action'        => 'collect',
+			'metric-prefix' => 'core_external_http_guardrail',
+			'sampleLimit'   => 20,
+		)
+	);
+	$payload['metadata'] = array_merge(
+		$payload['metadata'] ?? array(),
+		array(
+			'runner'         => 'wp-codebox',
+			'workload'       => 'wordpress-core-external-http-guardrail',
+			'coverage_shape' => 'core update and release-check external HTTP guardrail probes',
+		)
+	);
+	return $payload;
+};

--- a/WordPress/wordpress/browser-scenarios/front_page.json
+++ b/WordPress/wordpress/browser-scenarios/front_page.json
@@ -1,0 +1,5 @@
+[
+  { "kind": "navigate", "url": "/", "waitFor": "load" },
+  { "kind": "waitFor", "selector": "body", "timeout": "20s" },
+  { "kind": "screenshot", "name": "wordpress-core-front-page" }
+]

--- a/WordPress/wordpress/browser-scenarios/media_library.json
+++ b/WordPress/wordpress/browser-scenarios/media_library.json
@@ -1,0 +1,5 @@
+[
+  { "kind": "navigate", "url": "/wp-admin/upload.php", "waitFor": "load" },
+  { "kind": "waitFor", "selector": "body", "timeout": "30s" },
+  { "kind": "screenshot", "name": "wordpress-core-media-library" }
+]

--- a/WordPress/wordpress/browser-scenarios/post_editor.json
+++ b/WordPress/wordpress/browser-scenarios/post_editor.json
@@ -1,0 +1,5 @@
+[
+  { "kind": "navigate", "url": "/wp-admin/post-new.php", "waitFor": "load" },
+  { "kind": "waitFor", "selector": "body", "timeout": "30s" },
+  { "kind": "screenshot", "name": "wordpress-core-post-editor" }
+]

--- a/WordPress/wordpress/browser-scenarios/site_editor.json
+++ b/WordPress/wordpress/browser-scenarios/site_editor.json
@@ -1,0 +1,5 @@
+[
+  { "kind": "navigate", "url": "/wp-admin/site-editor.php", "waitFor": "load" },
+  { "kind": "waitFor", "selector": "body", "timeout": "30s" },
+  { "kind": "screenshot", "name": "wordpress-core-site-editor" }
+]

--- a/WordPress/wordpress/manifests/full-surface-coverage.json
+++ b/WordPress/wordpress/manifests/full-surface-coverage.json
@@ -28,6 +28,8 @@
     "browser_requests": {
       "coverage_goal": "all_document_fetch_xhr_websocket_asset_requests_for_editor_and_frontend_flows",
       "coverage_artifact": "wp-codebox/browser-request-coverage/v1",
+      "trace_workload": "bench/wordpress-core-browser-coverage.trace.mjs",
+      "rig": "rigs/wordpress-core-browser-coverage/rig.json",
       "scenarios": ["front_page", "post_editor", "site_editor", "media_library"]
     }
   },

--- a/WordPress/wordpress/manifests/performance-fixtures.json
+++ b/WordPress/wordpress/manifests/performance-fixtures.json
@@ -22,7 +22,8 @@
         "diagnostics"
       ],
       "expected_workloads": [
-        "wordpress-core-rest-route-inventory"
+        "wordpress-core-rest-route-inventory",
+        "wordpress-core-external-http-guardrail"
       ]
     }
   ]

--- a/WordPress/wordpress/rigs/wordpress-core-api-route-inventory/rig.json
+++ b/WordPress/wordpress/rigs/wordpress-core-api-route-inventory/rig.json
@@ -21,15 +21,32 @@
   },
   "bench_workloads": {
     "wordpress": [
-      { "path": "${package.root}/bench/wordpress-core-rest-route-inventory.php" }
+      { "path": "${package.root}/bench/wordpress-core-rest-route-inventory.php" },
+      { "path": "${package.root}/bench/wordpress-core-external-http-guardrail.php" },
+      { "path": "${package.root}/bench/generated-rest-request-cases.workload.json" },
+      { "path": "${package.root}/bench/rest-db-query-profile.workload.json" },
+      { "path": "${package.root}/bench/db-inventory.workload.json" }
     ]
   },
   "bench_profiles": {
     "smoke": [
-      "wordpress-core-rest-route-inventory"
+      "wordpress-core-rest-route-inventory",
+      "wordpress-core-external-http-guardrail",
+      "generated-rest-request-cases",
+      "rest-db-query-profile",
+      "db-inventory"
     ],
     "api-coverage": [
-      "wordpress-core-rest-route-inventory"
+      "wordpress-core-rest-route-inventory",
+      "generated-rest-request-cases",
+      "rest-db-query-profile"
+    ],
+    "full-surface": [
+      "wordpress-core-rest-route-inventory",
+      "generated-rest-request-cases",
+      "wordpress-core-external-http-guardrail",
+      "rest-db-query-profile",
+      "db-inventory"
     ]
   },
   "pipeline": {

--- a/WordPress/wordpress/rigs/wordpress-core-browser-coverage/rig.json
+++ b/WordPress/wordpress/rigs/wordpress-core-browser-coverage/rig.json
@@ -1,0 +1,59 @@
+{
+  "id": "wordpress-core-browser-coverage",
+  "description": "WP Codebox browser-actions request coverage for WordPress core front page, post editor, site editor, and media library surfaces.",
+  "components": {
+    "wordpress": {
+      "path": "~/Developer/wordpress-develop",
+      "branch": "trunk"
+    }
+  },
+  "resources": {
+    "exclusive": [
+      "wordpress-core-browser-coverage:${env.HOMEBOY_SETTINGS_WORDPRESS_CORE_BROWSER_COVERAGE_NAMESPACE}"
+    ],
+    "paths": [
+      "${components.wordpress.path}"
+    ]
+  },
+  "trace": {
+    "default_component": "wordpress"
+  },
+  "trace_workloads": {
+    "nodejs": [
+      {
+        "path": "${package.root}/bench/wordpress-core-browser-coverage.trace.mjs",
+        "check_groups": [],
+        "port_range_size": 1,
+        "trace_default_phase_preset": "browser-request-coverage",
+        "trace_phase_presets": {
+          "browser-request-coverage": [
+            "start:scenario.start",
+            "recipe:wp_codebox.recipe.start",
+            "actions:browser.actions.ready"
+          ]
+        }
+      }
+    ]
+  },
+  "trace_profiles": {
+    "smoke": ["wordpress-core-browser-coverage"],
+    "full-surface": ["wordpress-core-browser-coverage"]
+  },
+  "pipeline": {
+    "check": [
+      {
+        "kind": "requirement",
+        "label": "WordPress core checkout exists",
+        "file": "${components.wordpress.path}/src/wp-includes/rest-api.php",
+        "component": "wordpress",
+        "component_path_contains": "wordpress"
+      },
+      {
+        "kind": "command",
+        "label": "WP Codebox CLI exists",
+        "command": "bash \"${package.root}/../../shared/wp-codebox/check-cli.sh\""
+      }
+    ],
+    "down": []
+  }
+}

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -2,7 +2,7 @@
 
 import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { basename, join, relative } from 'node:path';
 
 const root = process.argv[2] ? join(process.cwd(), process.argv[2]) : process.cwd();
 const ignoredDirectories = new Set(['.git', '.claude', '.datamachine', '.opencode', 'node_modules', 'vendor']);
@@ -69,6 +69,51 @@ function lintRigPortability(file) {
 
   if (/WP Codebox CLI/.test(pipelineCommands) && /command -v wp-codebox|Developer\/wp-codebox|HOMEBOY_WP_CODEBOX_BIN/.test(pipelineCommands)) {
     failures.push(`${rel}: use shared/wp-codebox/check-cli.sh instead of duplicating WP Codebox CLI discovery in rig commands`);
+  }
+
+  lintBenchProfiles(rel, rig);
+}
+
+function workloadIdFromPath(path) {
+  return basename(path)
+    .replace(/\.workload\.json$/, '')
+    .replace(/\.bench\.mjs$/, '')
+    .replace(/\.php$/, '')
+    .replace(/\.mjs$/, '')
+    .replace(/\.js$/, '')
+    .replace(/\.json$/, '');
+}
+
+function lintBenchProfiles(rel, rig) {
+  if (!rig.bench_profiles) {
+    return;
+  }
+
+  const workloadIds = new Set();
+  for (const workloads of Object.values(rig.bench_workloads || {})) {
+    if (!Array.isArray(workloads)) {
+      continue;
+    }
+
+    for (const workload of workloads) {
+      const path = typeof workload === 'string' ? workload : workload?.path;
+      if (path) {
+        workloadIds.add(workloadIdFromPath(path));
+      }
+    }
+  }
+
+  for (const [profile, workloadRefs] of Object.entries(rig.bench_profiles)) {
+    if (!Array.isArray(workloadRefs)) {
+      failures.push(`${rel}: bench profile ${profile} must be an array of workload ids`);
+      continue;
+    }
+
+    for (const workloadRef of workloadRefs) {
+      if (!workloadIds.has(workloadRef)) {
+        failures.push(`${rel}: bench profile ${profile} references ${workloadRef}, but bench_workloads does not declare a matching workload file`);
+      }
+    }
   }
 }
 

--- a/shared/wp-codebox/browser-coverage-trace.mjs
+++ b/shared/wp-codebox/browser-coverage-trace.mjs
@@ -1,0 +1,204 @@
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { runWpCodeboxRecipe } from './recipe.mjs';
+
+export async function runBrowserCoverageTrace( config ) {
+	const componentId = process.env.HOMEBOY_COMPONENT_ID || config.componentId;
+	const scenarioId = process.env.HOMEBOY_TRACE_SCENARIO || config.scenarioId;
+	const resultsFile = process.env.HOMEBOY_TRACE_RESULTS_FILE;
+	const artifactDir = process.env.HOMEBOY_TRACE_ARTIFACT_DIR || path.join( tmpdir(), `${ config.scenarioId }-artifacts` );
+	const componentPath = config.componentPath || process.env.HOMEBOY_COMPONENT_PATH;
+	const wpVersion = config.wpVersion || '7.0';
+	const viewport = config.viewport || '1366x900';
+	const stepTimeout = config.stepTimeout || '45s';
+	const timeout = config.timeout || '180s';
+	const startedAt = performance.now();
+	const timeline = [];
+
+	if ( ! resultsFile ) {
+		throw new Error( 'HOMEBOY_TRACE_RESULTS_FILE is required' );
+	}
+	if ( config.requiredFile && ! existsSync( path.join( componentPath || '', config.requiredFile ) ) ) {
+		throw new Error( `Missing required component file at ${ path.join( componentPath || '', config.requiredFile ) }` );
+	}
+
+	await mkdir( artifactDir, { recursive: true } );
+	await mkdir( path.dirname( resultsFile ), { recursive: true } );
+
+	const workDir = await mkdtemp( path.join( tmpdir(), `${ config.scenarioId }.` ) );
+	const setupFile = path.join( workDir, 'setup.php' );
+	const combinedStepsFile = path.join( workDir, 'browser-actions.json' );
+	const recipeFile = path.join( workDir, 'recipe.json' );
+	const outputFile = path.join( artifactDir, 'wp-codebox-output.json' );
+	const codeboxArtifacts = path.join( artifactDir, 'wp-codebox-artifacts' );
+
+	function timestampMs() {
+		return Math.round( performance.now() - startedAt );
+	}
+
+	function event( source, name, data = {} ) {
+		timeline.push( { t_ms: timestampMs(), source, event: name, data } );
+	}
+
+	function relativeArtifactPath( pathname ) {
+		return path.relative( artifactDir, pathname );
+	}
+
+	async function readJsonAsync( pathname ) {
+		return existsSync( pathname ) ? JSON.parse( await readFile( pathname, 'utf8' ) ) : null;
+	}
+
+	async function readJsonl( pathname ) {
+		if ( ! existsSync( pathname ) ) {
+			return [];
+		}
+		const contents = await readFile( pathname, 'utf8' );
+		return contents.trim().split( '\n' ).filter( Boolean ).map( ( line ) => JSON.parse( line ) );
+	}
+
+	try {
+		event( 'scenario', 'start', {
+			component_path: componentPath,
+			wp_version: wpVersion,
+			scenarios: config.scenarios.map( ( scenario ) => scenario.id ),
+		} );
+
+		const workflowSteps = [];
+		if ( config.setupCode ) {
+			await writeFile( setupFile, config.setupCode );
+			workflowSteps.push( { command: 'wordpress.run-php', args: [ `code-file=${ setupFile }` ] } );
+		}
+
+		const combinedSteps = [];
+		for ( const scenario of config.scenarios ) {
+			const steps = JSON.parse( await readFile( scenario.stepsFile, 'utf8' ) );
+			if ( ! Array.isArray( steps ) ) {
+				throw new Error( `Browser scenario steps must be an array: ${ scenario.stepsFile }` );
+			}
+			combinedSteps.push( ...steps );
+		}
+		await writeFile( combinedStepsFile, `${ JSON.stringify( combinedSteps, null, 2 ) }\n` );
+		workflowSteps.push( {
+			command: 'wordpress.browser-actions',
+			args: [
+				`step-timeout=${ stepTimeout }`,
+				`timeout=${ timeout }`,
+				`viewport=${ viewport }`,
+				'capture=steps,console,errors,network,html,screenshot,dom-snapshot',
+				`steps-json=@${ combinedStepsFile }`,
+			],
+		} );
+
+		const recipe = {
+			schema: 'wp-codebox/workspace-recipe/v1',
+			runtime: {
+				wp: wpVersion,
+				blueprint: {
+					steps: config.blueprintSteps || [ { step: 'login', username: 'admin', password: 'password' } ],
+				},
+			},
+			...( config.inputs ? { inputs: config.inputs } : {} ),
+			workflow: { steps: workflowSteps },
+			artifacts: { directory: codeboxArtifacts },
+		};
+
+		await writeFile( recipeFile, `${ JSON.stringify( recipe, null, 2 ) }\n` );
+
+		const result = await runWpCodeboxRecipe( {
+			recipeFile,
+			artifactsDir: codeboxArtifacts,
+			outputFile,
+			event,
+			maxBuffer: 1024 * 1024 * 50,
+		} );
+
+		const output = result.json || JSON.parse( result.stdout );
+		const bundleDir = output.artifacts?.directory;
+		const browserDir = bundleDir ? path.join( bundleDir, 'files', 'browser' ) : '';
+		const summaryPath = browserDir ? path.join( browserDir, 'action-summary.json' ) : '';
+		const networkPath = browserDir ? path.join( browserDir, 'network.jsonl' ) : '';
+		const requestCoveragePath = browserDir ? path.join( browserDir, 'request-coverage.json' ) : '';
+		const errorsPath = browserDir ? path.join( browserDir, 'errors.jsonl' ) : '';
+		const stepsPath = browserDir ? path.join( browserDir, 'steps.jsonl' ) : '';
+		const summary = await readJsonAsync( summaryPath );
+		const requestCoverage = await readJsonAsync( requestCoveragePath );
+		const network = await readJsonl( networkPath );
+		const errors = await readJsonl( errorsPath );
+		const steps = await readJsonl( stepsPath );
+		const failedSteps = steps.filter( ( step ) => step.status === 'failed' );
+		const responseCount = network.filter( ( entry ) => entry.type === 'response' ).length;
+		const requestCoverageReady = Boolean( requestCoverage && existsSync( requestCoveragePath ) );
+		const pass = requestCoverageReady && failedSteps.length === 0;
+
+		event( 'browser', 'actions.ready', {
+			request_coverage_ready: requestCoverageReady,
+			network_events: network.length,
+			responses: responseCount,
+			failed_steps: failedSteps.length,
+		} );
+
+		const traceResult = {
+			component_id: componentId,
+			scenario_id: scenarioId,
+			status: pass ? 'pass' : 'fail',
+			summary: requestCoverageReady
+				? `Captured WP Codebox browser request coverage for ${ config.scenarios.length } scenario(s), ${ network.length } network event(s), ${ responseCount } response(s).`
+				: 'WP Codebox browser request coverage artifact was not produced.',
+			timeline,
+			assertions: [
+				{
+					id: 'browser-request-coverage-produced',
+					status: requestCoverageReady ? 'pass' : 'fail',
+					message: requestCoverageReady ? 'request-coverage.json was produced by wordpress.browser-actions.' : 'request-coverage.json was missing.',
+				},
+				{
+					id: 'browser-actions-completed',
+					status: failedSteps.length === 0 ? 'pass' : 'fail',
+					message: `Recorded ${ failedSteps.length } failed browser action step(s).`,
+				},
+				{
+					id: 'browser-errors-recorded',
+					status: 'pass',
+					message: `Recorded ${ errors.length } browser/runtime error artifact entr${ errors.length === 1 ? 'y' : 'ies' }.`,
+				},
+			],
+			artifacts: [
+				{ label: 'WP Codebox output', path: relativeArtifactPath( outputFile ) },
+				...( summaryPath && existsSync( summaryPath ) ? [ { label: 'Browser actions summary', path: relativeArtifactPath( summaryPath ) } ] : [] ),
+				...( requestCoveragePath && existsSync( requestCoveragePath ) ? [ { label: 'Browser request coverage', path: relativeArtifactPath( requestCoveragePath ) } ] : [] ),
+				...( networkPath && existsSync( networkPath ) ? [ { label: 'Browser network log', path: relativeArtifactPath( networkPath ) } ] : [] ),
+			],
+			metadata: {
+				assumptions: config.assumptions || [],
+				final_url: summary?.finalUrl || summary?.summary?.finalUrl || null,
+				request_coverage_schema: requestCoverage?.schema || null,
+			},
+		};
+
+		await writeFile( resultsFile, `${ JSON.stringify( traceResult, null, 2 ) }\n` );
+		process.exitCode = pass ? 0 : 1;
+	} catch ( error ) {
+		const traceResult = {
+			component_id: componentId,
+			scenario_id: scenarioId,
+			status: 'fail',
+			summary: error instanceof Error ? error.message : String( error ),
+			timeline,
+			assertions: [
+				{
+					id: 'trace-workload-completed',
+					status: 'fail',
+					message: error instanceof Error ? error.message : String( error ),
+				},
+			],
+			artifacts: existsSync( outputFile ) ? [ { label: 'WP Codebox output', path: relativeArtifactPath( outputFile ) } ] : [],
+		};
+		await writeFile( resultsFile, `${ JSON.stringify( traceResult, null, 2 ) }\n` );
+		throw error;
+	} finally {
+		await rm( workDir, { recursive: true, force: true } );
+	}
+}

--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -130,8 +130,11 @@ homeboy bench --rig woocommerce-performance --scenario admin-dashboard-physical-
 homeboy bench --rig woocommerce-performance --scenario layered-nav-count-cache --iterations 1 --shared-state /tmp/woocommerce-layered-nav-cache --setting-json 'bench_env={"WC_LAYERED_NAV_CACHE_ITERATIONS":"150","WC_LAYERED_NAV_CACHE_LIMIT":"25"}'
 homeboy bench --rig woocommerce-performance --scenario layered-nav-catalog-crawl --iterations 1 --shared-state /tmp/woocommerce-layered-nav-crawl --setting-json 'bench_env={"WC_LAYERED_NAV_CRAWL_REQUESTS":"150","WC_LAYERED_NAV_CRAWL_LIMIT":"25"}'
 homeboy bench --rig woocommerce-performance --profile api-coverage --iterations 1 --shared-state /tmp/woocommerce-api-coverage
+homeboy bench --rig woocommerce-performance --profile full-surface --iterations 1 --shared-state /tmp/woocommerce-full-surface
 homeboy bench --rig woocommerce-performance --profile hot --iterations 1 --shared-state /tmp/woocommerce-performance-hot --setting-json 'bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"120","WC_SHIPPING_CACHE_PACKAGES":"24"}' --force-hot
 ```
+
+The `full-surface` profile is executable because every listed workload ID is backed by a concrete `bench_workloads.wordpress` file declaration. It covers the existing WooCommerce REST route inventory and large-merchant workload suite, but DB inventory/profiling, generated REST cases, external HTTP guardrails, and browser request coverage remain planned primitives until concrete workload files exist.
 
 `homeboy bench --rig woocommerce-performance` runs through Homeboy Extensions'
 `wordpress.bench` / WP Codebox backend. WP Codebox owns the disposable WordPress

--- a/woocommerce/woocommerce/bench/db-inventory.workload.json
+++ b/woocommerce/woocommerce/bench/db-inventory.workload.json
@@ -1,0 +1,18 @@
+{
+  "id": "db-inventory",
+  "source": "config",
+  "run": [
+    {
+      "type": "db-inventory",
+      "metric-prefix": "db_inventory",
+      "include-columns": true,
+      "include-indexes": true
+    }
+  ],
+  "metadata": {
+    "runner": "wp-codebox",
+    "workload": "db-inventory",
+    "coverage_shape": "WooCommerce fixture database table, row, column, and index inventory",
+    "manifest": "manifests/full-surface-coverage.json"
+  }
+}

--- a/woocommerce/woocommerce/bench/generated-rest-request-cases.workload.json
+++ b/woocommerce/woocommerce/bench/generated-rest-request-cases.workload.json
@@ -1,0 +1,45 @@
+{
+  "id": "generated-rest-request-cases",
+  "source": "config",
+  "rest_request_cases": [
+    {
+      "id": "woocommerce-store-products",
+      "method": "GET",
+      "path": "/wc/store/v1/products",
+      "params": { "per_page": 1 },
+      "capture-response": true
+    },
+    {
+      "id": "woocommerce-store-cart",
+      "method": "GET",
+      "path": "/wc/store/v1/cart",
+      "capture-response": true
+    },
+    {
+      "id": "woocommerce-v3-products",
+      "method": "GET",
+      "path": "/wc/v3/products",
+      "params": { "per_page": 1 },
+      "capture-response": true
+    },
+    {
+      "id": "woocommerce-v3-orders",
+      "method": "GET",
+      "path": "/wc/v3/orders",
+      "params": { "per_page": 1 },
+      "capture-response": true
+    },
+    {
+      "id": "woocommerce-admin-options",
+      "method": "GET",
+      "path": "/wc-admin/options",
+      "capture-response": true
+    }
+  ],
+  "metadata": {
+    "runner": "wp-codebox",
+    "workload": "generated-rest-request-cases",
+    "coverage_shape": "generated safe WooCommerce Store API, REST API, and admin REST request cases",
+    "manifest": "manifests/full-surface-coverage.json"
+  }
+}

--- a/woocommerce/woocommerce/bench/rest-db-query-profile.workload.json
+++ b/woocommerce/woocommerce/bench/rest-db-query-profile.workload.json
@@ -1,0 +1,23 @@
+{
+  "id": "rest-db-query-profile",
+  "source": "config",
+  "run": [
+    {
+      "type": "rest-db-query-profiler",
+      "metric-prefix": "rest_db_query_profile",
+      "sampleLimit": 50,
+      "queryLengthLimit": 500,
+      "rest_request_cases": [
+        { "id": "woocommerce-store-products", "method": "GET", "path": "/wc/store/v1/products", "params": { "per_page": 1 } },
+        { "id": "woocommerce-store-cart", "method": "GET", "path": "/wc/store/v1/cart" },
+        { "id": "woocommerce-v3-products", "method": "GET", "path": "/wc/v3/products", "params": { "per_page": 1 } }
+      ]
+    }
+  ],
+  "metadata": {
+    "runner": "wp-codebox",
+    "workload": "rest-db-query-profile",
+    "coverage_shape": "WooCommerce Store API and REST API DB query profile",
+    "manifest": "manifests/full-surface-coverage.json"
+  }
+}

--- a/woocommerce/woocommerce/bench/woocommerce-browser-coverage.trace.mjs
+++ b/woocommerce/woocommerce/bench/woocommerce-browser-coverage.trace.mjs
@@ -1,0 +1,84 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import { runBrowserCoverageTrace } from '../../../shared/wp-codebox/browser-coverage-trace.mjs';
+
+const packageRoot = process.env.HOMEBOY_COMPONENT_PATH;
+const componentPluginPath = path.join( packageRoot || '', 'plugins/woocommerce' );
+const woocommercePath = process.env.HOMEBOY_WOOCOMMERCE_BROWSER_COVERAGE_WOOCOMMERCE_PATH || ( existsSync( path.join( componentPluginPath, 'woocommerce.php' ) ) ? componentPluginPath : packageRoot );
+const scenarioRoot = new URL( '../browser-scenarios/', import.meta.url ).pathname;
+
+await runBrowserCoverageTrace( {
+	componentId: 'woocommerce',
+	scenarioId: 'woocommerce-browser-coverage',
+	componentPath: woocommercePath,
+	requiredFile: 'woocommerce.php',
+	wpVersion: process.env.HOMEBOY_WOOCOMMERCE_BROWSER_COVERAGE_WP_VERSION || '7.0',
+	blueprintSteps: [
+		{ step: 'activatePlugin', pluginPath: '/wordpress/wp-content/plugins/woocommerce/woocommerce.php' },
+		{ step: 'login', username: 'admin', password: 'password' },
+	],
+	inputs: {
+		extra_plugins: [
+			{ source: woocommercePath, slug: 'woocommerce', pluginFile: 'woocommerce/woocommerce.php', activate: true },
+		],
+	},
+	setupCode: `<?php
+if ( ! function_exists( 'WC' ) ) {
+	throw new RuntimeException( 'WooCommerce is not loaded.' );
+}
+
+update_option( 'woocommerce_default_country', 'US:CA' );
+update_option( 'woocommerce_currency', 'USD' );
+update_option( 'woocommerce_prices_include_tax', 'no' );
+update_option( 'woocommerce_calc_taxes', 'no' );
+update_option( 'woocommerce_enable_guest_checkout', 'yes' );
+
+if ( class_exists( 'WC_Install' ) ) {
+	WC_Install::create_pages();
+}
+
+$product_id = 1001;
+$existing = get_post( $product_id );
+if ( ! $existing ) {
+	wp_insert_post(
+		array(
+			'ID'           => $product_id,
+			'post_title'   => 'Homeboy Browser Coverage Product',
+			'post_name'    => 'homeboy-browser-coverage-product',
+			'post_type'    => 'product',
+			'post_status'  => 'publish',
+			'post_content' => 'Fixture product for browser request coverage.',
+		)
+	);
+}
+
+$product = wc_get_product( $product_id );
+if ( ! $product ) {
+	$product = new WC_Product_Simple( $product_id );
+}
+$product->set_name( 'Homeboy Browser Coverage Product' );
+$product->set_slug( 'homeboy-browser-coverage-product' );
+$product->set_status( 'publish' );
+$product->set_regular_price( '19.99' );
+$product->set_price( '19.99' );
+$product->set_virtual( true );
+$product->set_manage_stock( false );
+$product->set_stock_status( 'instock' );
+$product->save();
+`,
+	assumptions: [
+		'WooCommerce is mounted and activated as a WP Codebox plugin before setup runs.',
+		'The fixture creates a simple virtual product with ID 1001 so cart and checkout URLs can be deterministic.',
+		'Payment/shipping completion is out of scope for this request-coverage workload; checkout page bootstrap coverage is captured.',
+	],
+	scenarios: [
+		{ id: 'shop', stepsFile: path.join( scenarioRoot, 'shop.json' ) },
+		{ id: 'product', stepsFile: path.join( scenarioRoot, 'product.json' ) },
+		{ id: 'cart', stepsFile: path.join( scenarioRoot, 'cart.json' ) },
+		{ id: 'checkout', stepsFile: path.join( scenarioRoot, 'checkout.json' ) },
+		{ id: 'orders_admin', stepsFile: path.join( scenarioRoot, 'orders_admin.json' ) },
+		{ id: 'products_admin', stepsFile: path.join( scenarioRoot, 'products_admin.json' ) },
+		{ id: 'analytics_admin', stepsFile: path.join( scenarioRoot, 'analytics_admin.json' ) },
+	],
+} );

--- a/woocommerce/woocommerce/bench/woocommerce-external-http-guardrail.php
+++ b/woocommerce/woocommerce/bench/woocommerce-external-http-guardrail.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * WooCommerce external HTTP guardrail coverage workload.
+ */
+return function (): array {
+	if ( ! function_exists( 'wp_codebox_bench_run_external_http_guardrail_step' ) ) {
+		throw new RuntimeException( 'WP Codebox external-http-guardrail bench primitive is not available.' );
+	}
+
+	wp_codebox_bench_run_external_http_guardrail_step(
+		array(
+			'type'             => 'external-http-guardrail',
+			'action'           => 'install',
+			'allowlistDomains' => array( 'woocommerce.com' ),
+			'blockNetwork'     => true,
+			'metric-prefix'    => 'woocommerce_external_http_guardrail_install',
+		)
+	);
+
+	wp_remote_get( 'https://woocommerce.com/wp-json/wccom/marketplace/search?guardrail=1' );
+	wp_remote_post( 'https://hooks.stripe.com/woocommerce/guardrail-probe', array( 'body' => array( 'event' => 'synthetic' ) ) );
+
+	$payload = wp_codebox_bench_run_external_http_guardrail_step(
+		array(
+			'type'          => 'external-http-guardrail',
+			'action'        => 'collect',
+			'metric-prefix' => 'woocommerce_external_http_guardrail',
+			'sampleLimit'   => 20,
+		)
+	);
+	$payload['metadata'] = array_merge(
+		$payload['metadata'] ?? array(),
+		array(
+			'runner'         => 'wp-codebox',
+			'workload'       => 'woocommerce-external-http-guardrail',
+			'coverage_shape' => 'marketplace and payment webhook external HTTP guardrail probes',
+		)
+	);
+	return $payload;
+};

--- a/woocommerce/woocommerce/browser-scenarios/analytics_admin.json
+++ b/woocommerce/woocommerce/browser-scenarios/analytics_admin.json
@@ -1,0 +1,5 @@
+[
+  { "kind": "navigate", "url": "/wp-admin/admin.php?page=wc-admin&path=/analytics/overview", "waitFor": "load" },
+  { "kind": "waitFor", "selector": "body", "timeout": "30s" },
+  { "kind": "screenshot", "name": "woocommerce-analytics-admin" }
+]

--- a/woocommerce/woocommerce/browser-scenarios/cart.json
+++ b/woocommerce/woocommerce/browser-scenarios/cart.json
@@ -1,0 +1,5 @@
+[
+  { "kind": "navigate", "url": "/cart/?add-to-cart=1001", "waitFor": "load" },
+  { "kind": "waitFor", "selector": "body", "timeout": "30s" },
+  { "kind": "screenshot", "name": "woocommerce-cart" }
+]

--- a/woocommerce/woocommerce/browser-scenarios/checkout.json
+++ b/woocommerce/woocommerce/browser-scenarios/checkout.json
@@ -1,0 +1,5 @@
+[
+  { "kind": "navigate", "url": "/checkout/", "waitFor": "load" },
+  { "kind": "waitFor", "selector": "body", "timeout": "30s" },
+  { "kind": "screenshot", "name": "woocommerce-checkout" }
+]

--- a/woocommerce/woocommerce/browser-scenarios/orders_admin.json
+++ b/woocommerce/woocommerce/browser-scenarios/orders_admin.json
@@ -1,0 +1,5 @@
+[
+  { "kind": "navigate", "url": "/wp-admin/admin.php?page=wc-orders", "waitFor": "load" },
+  { "kind": "waitFor", "selector": "body", "timeout": "30s" },
+  { "kind": "screenshot", "name": "woocommerce-orders-admin" }
+]

--- a/woocommerce/woocommerce/browser-scenarios/product.json
+++ b/woocommerce/woocommerce/browser-scenarios/product.json
@@ -1,0 +1,5 @@
+[
+  { "kind": "navigate", "url": "/product/homeboy-browser-coverage-product/", "waitFor": "load" },
+  { "kind": "waitFor", "selector": "body", "timeout": "30s" },
+  { "kind": "screenshot", "name": "woocommerce-product" }
+]

--- a/woocommerce/woocommerce/browser-scenarios/products_admin.json
+++ b/woocommerce/woocommerce/browser-scenarios/products_admin.json
@@ -1,0 +1,5 @@
+[
+  { "kind": "navigate", "url": "/wp-admin/edit.php?post_type=product", "waitFor": "load" },
+  { "kind": "waitFor", "selector": "body", "timeout": "30s" },
+  { "kind": "screenshot", "name": "woocommerce-products-admin" }
+]

--- a/woocommerce/woocommerce/browser-scenarios/shop.json
+++ b/woocommerce/woocommerce/browser-scenarios/shop.json
@@ -1,0 +1,5 @@
+[
+  { "kind": "navigate", "url": "/shop/", "waitFor": "load" },
+  { "kind": "waitFor", "selector": "body", "timeout": "30s" },
+  { "kind": "screenshot", "name": "woocommerce-shop" }
+]

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.json
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.json
@@ -27,6 +27,8 @@
     "browser_requests": {
       "coverage_goal": "all_cart_checkout_product_admin_fetch_xhr_websocket_asset_requests",
       "coverage_artifact": "wp-codebox/browser-request-coverage/v1",
+      "trace_workload": "bench/woocommerce-browser-coverage.trace.mjs",
+      "rig": "rigs/woocommerce-browser-coverage/rig.json",
       "scenarios": ["shop", "product", "cart", "checkout", "orders_admin", "products_admin", "analytics_admin"]
     }
   },

--- a/woocommerce/woocommerce/manifests/performance-fixtures.json
+++ b/woocommerce/woocommerce/manifests/performance-fixtures.json
@@ -24,6 +24,7 @@
       ],
       "expected_workloads": [
         "woocommerce-rest-route-inventory",
+        "woocommerce-external-http-guardrail",
         "rest-product-batch-import",
         "checkout-shipping-cache",
         "layered-nav-count-cache"

--- a/woocommerce/woocommerce/rigs/woocommerce-browser-coverage/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-browser-coverage/rig.json
@@ -1,0 +1,59 @@
+{
+  "id": "woocommerce-browser-coverage",
+  "description": "WP Codebox browser-actions request coverage for WooCommerce shop, product, cart, checkout, orders admin, products admin, and analytics admin surfaces.",
+  "components": {
+    "woocommerce": {
+      "path": "$HOME/Developer/woocommerce/plugins/woocommerce",
+      "branch": "trunk"
+    }
+  },
+  "resources": {
+    "exclusive": [
+      "woocommerce-browser-coverage:${env.HOMEBOY_SETTINGS_WOOCOMMERCE_BROWSER_COVERAGE_NAMESPACE}"
+    ],
+    "paths": [
+      "${components.woocommerce.path}"
+    ]
+  },
+  "trace": {
+    "default_component": "woocommerce"
+  },
+  "trace_workloads": {
+    "nodejs": [
+      {
+        "path": "${package.root}/bench/woocommerce-browser-coverage.trace.mjs",
+        "check_groups": [],
+        "port_range_size": 1,
+        "trace_default_phase_preset": "browser-request-coverage",
+        "trace_phase_presets": {
+          "browser-request-coverage": [
+            "start:scenario.start",
+            "recipe:wp_codebox.recipe.start",
+            "actions:browser.actions.ready"
+          ]
+        }
+      }
+    ]
+  },
+  "trace_profiles": {
+    "smoke": ["woocommerce-browser-coverage"],
+    "full-surface": ["woocommerce-browser-coverage"]
+  },
+  "pipeline": {
+    "check": [
+      {
+        "kind": "requirement",
+        "label": "WooCommerce plugin checkout exists",
+        "file": "${components.woocommerce.path}/woocommerce.php",
+        "component": "woocommerce",
+        "component_path_contains": "woocommerce"
+      },
+      {
+        "kind": "command",
+        "label": "WP Codebox CLI exists",
+        "command": "bash \"${package.root}/../../shared/wp-codebox/check-cli.sh\""
+      }
+    ],
+    "down": []
+  }
+}

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -71,7 +71,11 @@
       { "path": "${package.root}/bench/layered-nav-count-cache.php" },
       { "path": "${package.root}/bench/layered-nav-catalog-crawl.php" },
       { "path": "${package.root}/bench/woocommerce-rest-route-inventory.php" },
-      { "path": "${package.root}/bench/rest-product-batch-import.php" }
+      { "path": "${package.root}/bench/rest-product-batch-import.php" },
+      { "path": "${package.root}/bench/woocommerce-external-http-guardrail.php" },
+      { "path": "${package.root}/bench/generated-rest-request-cases.workload.json" },
+      { "path": "${package.root}/bench/rest-db-query-profile.workload.json" },
+      { "path": "${package.root}/bench/db-inventory.workload.json" }
     ]
   },
   "bench_profiles": {
@@ -85,7 +89,11 @@
       "layered-nav-count-cache",
       "layered-nav-catalog-crawl",
       "woocommerce-rest-route-inventory",
-      "rest-product-batch-import"
+      "rest-product-batch-import",
+      "woocommerce-external-http-guardrail",
+      "generated-rest-request-cases",
+      "rest-db-query-profile",
+      "db-inventory"
     ],
     "hot": [
       "cart-session-overwrite-race",
@@ -97,10 +105,32 @@
       "layered-nav-count-cache",
       "layered-nav-catalog-crawl",
       "woocommerce-rest-route-inventory",
-      "rest-product-batch-import"
+      "rest-product-batch-import",
+      "woocommerce-external-http-guardrail",
+      "generated-rest-request-cases",
+      "rest-db-query-profile",
+      "db-inventory"
     ],
     "api-coverage": [
-      "woocommerce-rest-route-inventory"
+      "woocommerce-rest-route-inventory",
+      "generated-rest-request-cases",
+      "rest-db-query-profile"
+    ],
+    "full-surface": [
+      "cart-session-overwrite-race",
+      "checkout-concurrent-create-order",
+      "checkout-gateway-compatibility-matrix",
+      "checkout-shortcode-place-order-latency",
+      "checkout-shipping-cache",
+      "admin-dashboard-physical-products-query",
+      "layered-nav-count-cache",
+      "layered-nav-catalog-crawl",
+      "woocommerce-rest-route-inventory",
+      "rest-product-batch-import",
+      "woocommerce-external-http-guardrail",
+      "generated-rest-request-cases",
+      "rest-db-query-profile",
+      "db-inventory"
     ],
     "checkout-concurrent": [
       "checkout-concurrent-create-order"


### PR DESCRIPTION
## Summary
- Wire executable full-surface benchmark profiles for WordPress core, Gutenberg, Jetpack, and WooCommerce.
- Add workload definitions for generated REST request cases, DB inventory, REST DB query profiling, and external HTTP guardrails.
- Add browser request coverage trace rigs and scenarios for the declared full-surface browser flows.
- Add lint coverage so bench profiles cannot reference workload IDs without backing workload files.

## Dependency
- Depends on Automattic/wp-codebox#1251 for the generic benchmark primitives and artifact refs.
- Homeboy Extensions full-surface validation/report helpers are covered by Extra-Chill/homeboy-extensions#1602.

## Testing
- `node scripts/lint-rig-packages.mjs`
- `node --check shared/wp-codebox/browser-coverage-trace.mjs`
- `node --check WordPress/gutenberg/bench/gutenberg-browser-coverage.trace.mjs`
- `node --check WordPress/wordpress/bench/wordpress-core-browser-coverage.trace.mjs`
- `node --check Automattic/jetpack/bench/jetpack-browser-coverage.trace.mjs`
- `node --check woocommerce/woocommerce/bench/woocommerce-browser-coverage.trace.mjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafted the workload definitions, rig wiring, browser trace scaffolding, and lint checks; Chris directed the workflow and retains review responsibility.
