### PR TITLE
Add Studio admin perf rig

### DIFF
--- a/Automattic/studio/rigs/studio-admin-perf/rig.json
+++ b/Automattic/studio/rigs/studio-admin-perf/rig.json
@@ -1,0 +1,68 @@
+{
+  "id": "studio-admin-perf",
+  "description": "Focused Studio admin performance rig for WordPress admin page and REST latency evidence without the wordpress-playground component dependency.",
+  "components": {
+    "studio": {
+      "path": "~/Developer/studio",
+      "branch": "dev/combined-fixes",
+      "extensions": {
+        "nodejs": {
+          "settings": {
+            "studio_bench_variant": "admin-perf"
+          }
+        }
+      }
+    }
+  },
+  "bench": {
+    "default_component": "studio"
+  },
+  "bench_workloads": {
+    "nodejs": [
+      {
+        "path": "${package.root}/bench/studio-admin-theme-page.bench.mjs"
+      },
+      {
+        "path": "${package.root}/bench/studio-admin-theme-page-browser.bench.mjs"
+      },
+      {
+        "path": "${package.root}/bench/studio-dashboard-browser.bench.mjs"
+      },
+      {
+        "path": "${package.root}/bench/studio-page-timing-matrix.bench.mjs"
+      },
+      {
+        "path": "${package.root}/bench/studio-rest-latency-diagnostics.bench.mjs"
+      }
+    ]
+  },
+  "pipeline": {
+    "check": [
+      {
+        "kind": "check",
+        "label": "admin theme page bench exists",
+        "file": "${package.root}/bench/studio-admin-theme-page.bench.mjs"
+      },
+      {
+        "kind": "check",
+        "label": "admin theme page browser bench exists",
+        "file": "${package.root}/bench/studio-admin-theme-page-browser.bench.mjs"
+      },
+      {
+        "kind": "check",
+        "label": "dashboard browser bench exists",
+        "file": "${package.root}/bench/studio-dashboard-browser.bench.mjs"
+      },
+      {
+        "kind": "check",
+        "label": "page timing matrix bench exists",
+        "file": "${package.root}/bench/studio-page-timing-matrix.bench.mjs"
+      },
+      {
+        "kind": "check",
+        "label": "REST latency diagnostics bench exists",
+        "file": "${package.root}/bench/studio-rest-latency-diagnostics.bench.mjs"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add a focused `studio-admin-perf` rig under the Studio rig package.
- Depend only on the Studio component, with no wordpress-playground component, tarball service, symlink, or cross-repo pipeline.
- Register admin performance benchmark workloads, including REST latency diagnostics because it targets admin/editor REST routes without adding component coupling.
- Add a check pipeline that verifies the selected benchmark files exist.

## Validation
- `node -e "JSON.parse(require('fs').readFileSync('Automattic/studio/rigs/studio-admin-perf/rig.json','utf8')); console.log('valid json')"` passed.
- `homeboy rig list` ran, but the active local Homeboy registry was linked to the existing checkout, so it did not discover the new isolated PR worktree rig.
- `homeboy rig install <studio rig package> --id studio-admin-perf` initially caught shorthand workload entries as invalid for the current schema; the rig was updated to workload objects.
- A subsequent `homeboy rig install <studio rig package> --id studio-admin-perf` was blocked by a pre-existing local Homeboy registry stack-spec IO error before installing the rig, so `homeboy rig show studio-admin-perf` and `homeboy bench list --rig studio-admin-perf` could not be completed locally.
- No benchmarks were run locally.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the rig file, running non-hot validation commands, and drafting this PR description.
