### PR TITLE
Allow Studio timing matrix to use system browser

### DIFF
--- a/Automattic/studio/bench/studio-page-timing-matrix.bench.mjs
+++ b/Automattic/studio/bench/studio-page-timing-matrix.bench.mjs
@@ -99,6 +99,11 @@ function configuredPaths() {
   return normalizeConfiguredPaths(raw.split(/[,\n]/).map((value) => value.trim()).filter(Boolean));
 }
 
+function browserLaunchOptions() {
+  const executablePath = setting('studio_browser_executable_path') || process.env.STUDIO_BROWSER_EXECUTABLE_PATH || '';
+  return executablePath ? { executablePath } : {};
+}
+
 function normalizeConfiguredPaths(values) {
   return {
     paths: values.filter((value) => value !== 'admin-menu'),
@@ -286,6 +291,7 @@ export default async function studioPageTimingMatrixBench() {
       trace: true,
       screenshot: true,
       waitForNetworkIdle: false,
+      launchOptions: browserLaunchOptions(),
       action: async ({ page, mark }) => {
         await page.goto(status.autoLoginUrl, { waitUntil: 'domcontentloaded', timeout: 120000 });
         await page.waitForLoadState('networkidle', { timeout: 120000 }).catch(() => {});


### PR DESCRIPTION
## Summary
- Allow the Studio page timing matrix bench to pass a Playwright browser executable path through `STUDIO_BROWSER_EXECUTABLE_PATH` or `studio_browser_executable_path`.
- Keep the default behavior unchanged when no executable override is provided.

## Why
- The Homeboy Lab runner currently has system Chrome installed but Playwright managed Chromium install fails on its reported `ubuntu26.04-x64` platform.
- This lets the Studio admin perf rig continue collecting browser timing evidence on that runner without changing the shared browser helper.

## Validation
- `node --check Automattic/studio/bench/studio-page-timing-matrix.bench.mjs`
- Offloaded single-path run with `STUDIO_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome` and `STUDIO_PAGE_TIMING_PATHS=/wp-admin/themes.php`: `homeboy runs show 6661f350-03e3-4fe1-bf3c-bf4f30ea2dd7`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Lab Playwright browser issue, drafting the small benchmark rig change, and preparing this PR.