### PR TITLE
Require Woo admin assets before coverage runs

### DIFF
--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -111,9 +111,18 @@ homeboy rig check woocommerce-performance
 
 - It runs `composer install --no-interaction --no-progress` only when
   `vendor/autoload_packages.php` is missing.
+- It uses the same Composer install prep when
+  `vendor/automattic/jetpack-connection/dist/jetpack-connection.js` is missing.
 - It runs `php bin/generate-feature-config.php` only when
   `includes/react-admin/feature-config.php` is missing.
+- It runs `pnpm --filter @woocommerce/plugin-woocommerce build:admin` only when
+  `assets/client/admin/wp-admin-scripts/command-palette.asset.php` is missing.
 - It does not modify WooCommerce source files or switch branches.
+
+Admin coverage and full-surface runs require built WooCommerce admin JS outputs.
+`homeboy rig check woocommerce-performance` fails before benchmark execution when
+`assets/client/admin/wp-admin-scripts/*.asset.php` registries or
+`vendor/automattic/jetpack-connection/dist/jetpack-connection.js` are missing.
 
 Equivalent manual prep, when needed for debugging, should run from the selected
 WooCommerce plugin directory.

--- a/woocommerce/woocommerce/bench/admin-page-coverage.php
+++ b/woocommerce/woocommerce/bench/admin-page-coverage.php
@@ -23,6 +23,17 @@ return function (): array {
 		WC()->init();
 	}
 
+	$admin_asset_registries = array_merge(
+		glob( WP_PLUGIN_DIR . '/woocommerce/assets/client/admin/wp-admin-scripts/*.asset.php' ) ?: array(),
+		glob( WP_PLUGIN_DIR . '/woocommerce/assets/client/admin/wp-admin-scripts/*.min.asset.php' ) ?: array()
+	);
+	if ( empty( $admin_asset_registries ) ) {
+		throw new RuntimeException( 'WooCommerce admin asset registries are missing; build WooCommerce admin assets before running admin page coverage.' );
+	}
+	if ( ! is_readable( WP_PLUGIN_DIR . '/woocommerce/vendor/automattic/jetpack-connection/dist/jetpack-connection.js' ) ) {
+		throw new RuntimeException( 'WooCommerce Jetpack connection build output is missing; install/build WooCommerce dependencies before running admin page coverage.' );
+	}
+
 	$run_id     = 'woocommerce-admin-page-coverage-' . getmypid() . '-' . time();
 	$token      = wp_generate_password( 24, false, false );
 	$limit      = max( 1, min( 100, (int) ( getenv( 'WC_ADMIN_PAGE_COVERAGE_LIMIT' ) ?: 50 ) ) );

--- a/woocommerce/woocommerce/bench/admin-page-coverage.test.mjs
+++ b/woocommerce/woocommerce/bench/admin-page-coverage.test.mjs
@@ -1,17 +1,23 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import { spawnSync } from 'node:child_process';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const workload = readFileSync(path.join(__dirname, 'admin-page-coverage.php'), 'utf8');
 const rig = JSON.parse(readFileSync(path.join(__dirname, '../rigs/woocommerce-performance/rig.json'), 'utf8'));
+const browserCoverageRig = JSON.parse(readFileSync(path.join(__dirname, '../rigs/woocommerce-browser-coverage/rig.json'), 'utf8'));
 const manifest = JSON.parse(readFileSync(path.join(__dirname, '../manifests/full-surface-coverage.json'), 'utf8'));
+const adminAssetsCheck = path.join(__dirname, '../tools/check-admin-assets.sh');
 
 test('admin page coverage is bounded and skips unsafe admin actions', () => {
   assert.match(workload, /WC_ADMIN_PAGE_COVERAGE_LIMIT/);
   assert.match(workload, /min\( 100,/);
+  assert.match(workload, /admin asset registries are missing/);
+  assert.match(workload, /jetpack-connection\/dist\/jetpack-connection\.js/);
   assert.match(workload, /post-new\.php/);
   assert.match(workload, /plugin-install\.php/);
   assert.match(workload, /unsafe_query_arg_/);
@@ -25,4 +31,31 @@ test('admin page coverage is wired into executable full-surface profile', () => 
   );
   assert.ok(rig.bench_profiles['full-surface'].includes('admin-page-coverage'));
   assert.deepEqual(manifest.coverage_profiles['full-surface'].authenticated_admin_pages, ['admin-page-coverage']);
+});
+
+test('admin coverage rigs fail preflight when WooCommerce admin assets are missing', () => {
+  assert.ok(
+    rig.pipeline.check.some((entry) => entry.command?.includes('tools/check-admin-assets.sh')),
+    'expected woocommerce-performance admin asset preflight'
+  );
+  assert.ok(
+    browserCoverageRig.pipeline.check.some((entry) => entry.command?.includes('tools/check-admin-assets.sh')),
+    'expected woocommerce-browser-coverage admin asset preflight'
+  );
+
+  const woocommercePath = mkdtempSync(path.join(tmpdir(), 'homeboy-woo-assets-'));
+  const missing = spawnSync('bash', [adminAssetsCheck, woocommercePath], { encoding: 'utf8' });
+  assert.equal(missing.status, 1);
+  assert.match(missing.stderr, /admin asset registries are missing/);
+
+  mkdirSync(path.join(woocommercePath, 'assets/client/admin/wp-admin-scripts'), { recursive: true });
+  writeFileSync(path.join(woocommercePath, 'assets/client/admin/wp-admin-scripts/index.asset.php'), '<?php return array();');
+  const missingJetpack = spawnSync('bash', [adminAssetsCheck, woocommercePath], { encoding: 'utf8' });
+  assert.equal(missingJetpack.status, 1);
+  assert.match(missingJetpack.stderr, /Jetpack connection build output is missing/);
+
+  mkdirSync(path.join(woocommercePath, 'vendor/automattic/jetpack-connection/dist'), { recursive: true });
+  writeFileSync(path.join(woocommercePath, 'vendor/automattic/jetpack-connection/dist/jetpack-connection.js'), '/* built */');
+  const ready = spawnSync('bash', [adminAssetsCheck, woocommercePath], { encoding: 'utf8' });
+  assert.equal(ready.status, 0);
 });

--- a/woocommerce/woocommerce/rigs/woocommerce-browser-coverage/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-browser-coverage/rig.json
@@ -52,6 +52,12 @@
         "kind": "command",
         "label": "WP Codebox CLI exists",
         "command": "bash \"${package.root}/../../shared/wp-codebox/check-cli.sh\""
+      },
+      {
+        "kind": "command",
+        "label": "WooCommerce admin assets are built",
+        "command": "bash \"${package.root}/tools/check-admin-assets.sh\" \"${components.woocommerce.path}\"",
+        "remediation": "Use a packaged WooCommerce plugin checkout or build the WooCommerce admin assets before running woocommerce-browser-coverage."
       }
     ],
     "down": []

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -173,6 +173,28 @@
         "prepare_command": "woocommerce_component_source=\"${components.woocommerce.path}\"; php \"$woocommerce_component_source/bin/generate-feature-config.php\"; woocommerce_plugin_source=\"$woocommerce_component_source\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\" ]; then woocommerce_plugin_source=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\" ]; then woocommerce_plugin_source=\"$woocommerce_plugin_source/$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\"; fi; fi; if [ \"$woocommerce_plugin_source\" != \"$woocommerce_component_source\" ]; then php \"$woocommerce_plugin_source/bin/generate-feature-config.php\"; fi",
         "prepare_phases": ["up", "bench_prepare"],
         "remediation": "Ensure PHP is available, then run: homeboy rig up woocommerce-performance"
+      },
+      {
+        "kind": "requirement",
+        "label": "WooCommerce Jetpack connection package asset exists or can be prepared",
+        "file": "${components.woocommerce.path}/vendor/automattic/jetpack-connection/dist/jetpack-connection.js",
+        "prepare_command": "woocommerce_component_source=\"${components.woocommerce.path}\"; woocommerce_plugin_source=\"$woocommerce_component_source\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\" ]; then woocommerce_plugin_source=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\" ]; then woocommerce_plugin_source=\"$woocommerce_plugin_source/$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\"; fi; fi; XDEBUG_MODE=off composer --working-dir=\"$woocommerce_plugin_source\" install --no-interaction --no-progress",
+        "prepare_phases": ["up", "bench_prepare"],
+        "remediation": "Run: homeboy rig up woocommerce-performance. The WooCommerce checkout must include Composer package assets before WP Codebox benchmarks start."
+      },
+      {
+        "kind": "requirement",
+        "label": "WooCommerce admin script asset registry exists or can be built",
+        "file": "${components.woocommerce.path}/assets/client/admin/wp-admin-scripts/command-palette.asset.php",
+        "prepare_command": "woocommerce_component_source=\"${components.woocommerce.path}\"; woocommerce_source_root=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -z \"$woocommerce_source_root\" ]; then woocommerce_source_root=$(cd \"$woocommerce_component_source/../..\" && pwd); fi; cd \"$woocommerce_source_root\" || exit 1; if [ ! -d node_modules ]; then pnpm install --frozen-lockfile; fi; pnpm --filter @woocommerce/plugin-woocommerce build:admin",
+        "prepare_phases": ["up", "bench_prepare"],
+        "remediation": "Install pnpm dependencies and build Woo admin assets, or run: homeboy rig up woocommerce-performance"
+      },
+      {
+        "kind": "command",
+        "label": "WooCommerce admin assets are built",
+        "command": "bash \"${package.root}/tools/check-admin-assets.sh\" \"${components.woocommerce.path}\"",
+        "remediation": "Use a packaged WooCommerce plugin checkout or build the WooCommerce admin assets before running admin-page-coverage/full-surface benchmarks."
       }
     ],
     "up": [
@@ -191,6 +213,22 @@
         "prepare_command": "woocommerce_component_source=\"${components.woocommerce.path}\"; php \"$woocommerce_component_source/bin/generate-feature-config.php\"; woocommerce_plugin_source=\"$woocommerce_component_source\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\" ]; then woocommerce_plugin_source=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\" ]; then woocommerce_plugin_source=\"$woocommerce_plugin_source/$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\"; fi; fi; if [ \"$woocommerce_plugin_source\" != \"$woocommerce_component_source\" ]; then php \"$woocommerce_plugin_source/bin/generate-feature-config.php\"; fi",
         "prepare_phases": ["up"],
         "remediation": "Ensure PHP is available, then run: homeboy rig up woocommerce-performance"
+      },
+      {
+        "kind": "requirement",
+        "label": "Prepare WooCommerce Jetpack connection package asset when missing",
+        "file": "${components.woocommerce.path}/vendor/automattic/jetpack-connection/dist/jetpack-connection.js",
+        "prepare_command": "woocommerce_component_source=\"${components.woocommerce.path}\"; woocommerce_plugin_source=\"$woocommerce_component_source\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\" ]; then woocommerce_plugin_source=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\" ]; then woocommerce_plugin_source=\"$woocommerce_plugin_source/$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\"; fi; fi; XDEBUG_MODE=off composer --working-dir=\"$woocommerce_plugin_source\" install --no-interaction --no-progress",
+        "prepare_phases": ["up"],
+        "remediation": "Run: homeboy rig up woocommerce-performance. The WooCommerce checkout must include Composer package assets before WP Codebox benchmarks start."
+      },
+      {
+        "kind": "requirement",
+        "label": "Build WooCommerce admin script asset registry when missing",
+        "file": "${components.woocommerce.path}/assets/client/admin/wp-admin-scripts/command-palette.asset.php",
+        "prepare_command": "woocommerce_component_source=\"${components.woocommerce.path}\"; woocommerce_source_root=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -z \"$woocommerce_source_root\" ]; then woocommerce_source_root=$(cd \"$woocommerce_component_source/../..\" && pwd); fi; cd \"$woocommerce_source_root\" || exit 1; if [ ! -d node_modules ]; then pnpm install --frozen-lockfile; fi; pnpm --filter @woocommerce/plugin-woocommerce build:admin",
+        "prepare_phases": ["up"],
+        "remediation": "Install pnpm dependencies and build Woo admin assets, or run: homeboy rig up woocommerce-performance"
       }
     ],
     "bench_prepare": [
@@ -209,6 +247,22 @@
         "prepare_command": "woocommerce_component_source=\"${components.woocommerce.path}\"; php \"$woocommerce_component_source/bin/generate-feature-config.php\"; woocommerce_plugin_source=\"$woocommerce_component_source\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\" ]; then woocommerce_plugin_source=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\" ]; then woocommerce_plugin_source=\"$woocommerce_plugin_source/$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\"; fi; fi; if [ \"$woocommerce_plugin_source\" != \"$woocommerce_component_source\" ]; then php \"$woocommerce_plugin_source/bin/generate-feature-config.php\"; fi",
         "prepare_phases": ["bench_prepare"],
         "remediation": "Ensure PHP is available, then run: homeboy rig up woocommerce-performance"
+      },
+      {
+        "kind": "requirement",
+        "label": "Prepare WooCommerce Jetpack connection package asset when missing",
+        "file": "${components.woocommerce.path}/vendor/automattic/jetpack-connection/dist/jetpack-connection.js",
+        "prepare_command": "woocommerce_component_source=\"${components.woocommerce.path}\"; woocommerce_plugin_source=\"$woocommerce_component_source\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\" ]; then woocommerce_plugin_source=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\" ]; then woocommerce_plugin_source=\"$woocommerce_plugin_source/$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\"; fi; fi; XDEBUG_MODE=off composer --working-dir=\"$woocommerce_plugin_source\" install --no-interaction --no-progress",
+        "prepare_phases": ["bench_prepare"],
+        "remediation": "Run: homeboy rig up woocommerce-performance. The WooCommerce checkout must include Composer package assets before WP Codebox benchmarks start."
+      },
+      {
+        "kind": "requirement",
+        "label": "Build WooCommerce admin script asset registry when missing",
+        "file": "${components.woocommerce.path}/assets/client/admin/wp-admin-scripts/command-palette.asset.php",
+        "prepare_command": "woocommerce_component_source=\"${components.woocommerce.path}\"; woocommerce_source_root=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -z \"$woocommerce_source_root\" ]; then woocommerce_source_root=$(cd \"$woocommerce_component_source/../..\" && pwd); fi; cd \"$woocommerce_source_root\" || exit 1; if [ ! -d node_modules ]; then pnpm install --frozen-lockfile; fi; pnpm --filter @woocommerce/plugin-woocommerce build:admin",
+        "prepare_phases": ["bench_prepare"],
+        "remediation": "Install pnpm dependencies and build Woo admin assets, or run: homeboy rig up woocommerce-performance"
       }
     ],
     "down": []

--- a/woocommerce/woocommerce/tools/check-admin-assets.sh
+++ b/woocommerce/woocommerce/tools/check-admin-assets.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+woocommerce_path="${1:-}"
+
+if [ -z "$woocommerce_path" ]; then
+	printf '%s\n' 'Usage: check-admin-assets.sh /path/to/plugins/woocommerce' >&2
+	exit 2
+fi
+
+admin_scripts_dir="$woocommerce_path/assets/client/admin/wp-admin-scripts"
+jetpack_connection_js="$woocommerce_path/vendor/automattic/jetpack-connection/dist/jetpack-connection.js"
+
+has_registry=0
+for registry in "$admin_scripts_dir"/*.asset.php "$admin_scripts_dir"/*.min.asset.php; do
+	if [ -r "$registry" ]; then
+		has_registry=1
+		break
+	fi
+done
+
+if [ "$has_registry" -ne 1 ]; then
+	printf '%s\n' "WooCommerce admin asset registries are missing from $admin_scripts_dir" >&2
+	printf '%s\n' 'Use a packaged WooCommerce plugin checkout or build the WooCommerce admin assets before running admin coverage/full-surface rigs.' >&2
+	exit 1
+fi
+
+if [ ! -r "$jetpack_connection_js" ]; then
+	printf '%s\n' "WooCommerce Jetpack connection build output is missing: $jetpack_connection_js" >&2
+	printf '%s\n' 'Install/build WooCommerce dependencies before running admin coverage/full-surface rigs.' >&2
+	exit 1
+fi


### PR DESCRIPTION
## Summary
- Add a WooCommerce admin asset readiness check used by admin coverage/full-surface rigs.
- Prepare missing Composer-packaged JS assets and Woo admin script registries during `up` / `bench_prepare` when possible.
- Fail `admin-page-coverage` before crawling admin pages if required built assets are still missing.

## Why
The latest Woo full-surface run `b0fb25a0-8588-436c-930d-78f875708809` produced misleading admin timing data because the sandbox Woo checkout was not admin-build-ready:

- `admin-page-coverage` had `success_rate=0`.
- Admin page visits returned `47` HTTP `500`s and `15` HTTP `403`s.
- The fatal path was `WooCommerce/src/Internal/Admin/WCAdminAssets.php:144` with `Could not find asset registry for wp-admin-scripts`.
- The run also reported missing `vendor/automattic/jetpack-connection/dist/jetpack-connection.js`.

Those failures should be setup/readiness failures, not latency evidence.

## Testing
- `node --test "woocommerce/woocommerce/bench/admin-page-coverage.test.mjs"`
- `node "scripts/lint-rig-packages.mjs"`
- Lab verification note: `homeboy rig check --runner homeboy-lab --allow-dirty-lab-workspace woocommerce-performance` still used the runner's installed rig source rather than this branch until reinstall; attempted branch reinstall exposed a Homeboy source-path mapping papercut for nested rig packages. The package-level lint/test above verifies this branch's rig spec and guard script.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Woo admin asset readiness failure, drafting the rig readiness/prep changes, adding tests, and running verification.
