### PR TITLE
Improve Woo admin coverage summaries

### DIFF
--- a/woocommerce/woocommerce/bench/admin-page-coverage.php
+++ b/woocommerce/woocommerce/bench/admin-page-coverage.php
@@ -245,16 +245,64 @@ add_action( "shutdown", function () {
 	delete_option( $log_option );
 	delete_option( $log_option . '_expected' );
 
-	$status_counts = array_count_values( array_map( static fn( array $visit ): string => (string) $visit['status'], $visits ) );
-	$http_errors   = array_filter( $visits, static fn( array $visit ): bool => isset( $visit['status_code'] ) && (int) $visit['status_code'] >= 400 );
-	$php_errors    = 0;
-	$query_counts  = array();
+	$status_counts         = array_count_values( array_map( static fn( array $visit ): string => (string) $visit['status'], $visits ) );
+	$http_errors           = array_filter( $visits, static fn( array $visit ): bool => isset( $visit['status_code'] ) && (int) $visit['status_code'] >= 400 );
+	$status_code_counts    = array_count_values( array_map( 'strval', array_filter( array_column( $visits, 'status_code' ), 'is_numeric' ) ) );
+	$php_errors            = 0;
+	$query_counts          = array();
+	$top_query_count_pages = array();
+	$php_error_summaries   = array();
+	$php_fatal_summaries   = array();
 	foreach ( $request_logs as $record ) {
-		$php_errors += count( (array) ( $record['php_errors'] ?? array() ) );
+		foreach ( (array) ( $record['php_errors'] ?? array() ) as $error ) {
+			$php_errors++;
+			$php_error_summaries[] = array(
+				'path'     => (string) ( $record['path'] ?? '' ),
+				'severity' => (int) ( $error['severity'] ?? 0 ),
+				'message'  => (string) ( $error['message'] ?? '' ),
+				'file'     => (string) ( $error['file'] ?? '' ),
+				'line'     => (int) ( $error['line'] ?? 0 ),
+			);
+		}
+		$last_error = (array) ( $record['last_error'] ?? array() );
+		if ( $last_error && in_array( (int) ( $last_error['type'] ?? 0 ), array( E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR ), true ) ) {
+			$php_fatal_summaries[] = array(
+				'path'    => (string) ( $record['path'] ?? '' ),
+				'type'    => (int) ( $last_error['type'] ?? 0 ),
+				'message' => (string) ( $last_error['message'] ?? '' ),
+				'file'    => isset( $last_error['file'] ) ? basename( (string) $last_error['file'] ) : '',
+				'line'    => (int) ( $last_error['line'] ?? 0 ),
+			);
+		}
 		if ( isset( $record['query_count'] ) ) {
-			$query_counts[] = (int) $record['query_count'];
+			$query_count             = (int) $record['query_count'];
+			$query_counts[]          = $query_count;
+			$top_query_count_pages[] = array(
+				'path'            => (string) ( $record['path'] ?? '' ),
+				'query_count'     => $query_count,
+				'elapsed_ms'      => isset( $record['elapsed_ms'] ) ? (float) $record['elapsed_ms'] : null,
+				'php_error_count' => count( (array) ( $record['php_errors'] ?? array() ) ),
+			);
 		}
 	}
+	$top_slow_visited_pages = array_map(
+		static fn( array $visit ): array => array(
+			'label'      => (string) ( $visit['label'] ?? '' ),
+			'page'       => (string) ( $visit['page'] ?? '' ),
+			'role'       => (string) ( $visit['role'] ?? '' ),
+			'status'     => (string) ( $visit['status'] ?? '' ),
+			'elapsed_ms' => isset( $visit['elapsed_ms'] ) ? (float) $visit['elapsed_ms'] : null,
+		),
+		$visits
+	);
+	usort( $top_slow_visited_pages, static fn( array $left, array $right ): int => ( $right['elapsed_ms'] ?? 0 ) <=> ( $left['elapsed_ms'] ?? 0 ) );
+	usort( $top_query_count_pages, static fn( array $left, array $right ): int => $right['query_count'] <=> $left['query_count'] );
+	$permission_skip_count = count(
+		array_filter(
+			$skipped,
+			static fn( array $skip ): bool => (bool) preg_grep( '/permission|capabilit|forbidden|unauthor/i', (array) ( $skip['reasons'] ?? array() ) )
+		)
+	);
 
 	$summary = array(
 		'success_rate'              => count( $visits ) > 0 ? ( count( $visits ) - count( $http_errors ) - ( $status_counts['error'] ?? 0 ) ) / count( $visits ) : 0,
@@ -268,6 +316,12 @@ add_action( "shutdown", function () {
 		'php_error_notice_count'     => $php_errors,
 		'max_query_count'            => $query_counts ? max( $query_counts ) : null,
 		'avg_query_count'            => $query_counts ? array_sum( $query_counts ) / count( $query_counts ) : null,
+		'top_slow_visited_pages'     => array_slice( $top_slow_visited_pages, 0, 5 ),
+		'top_query_count_pages'      => array_slice( $top_query_count_pages, 0, 5 ),
+		'status_code_counts'         => $status_code_counts,
+		'permission_skip_count'      => $permission_skip_count,
+		'php_error_summaries'        => array_slice( $php_error_summaries, 0, 10 ),
+		'php_fatal_summaries'        => array_slice( $php_fatal_summaries, 0, 10 ),
 	);
 
 	$artifact_path = '';

--- a/woocommerce/woocommerce/bench/admin-page-coverage.test.mjs
+++ b/woocommerce/woocommerce/bench/admin-page-coverage.test.mjs
@@ -52,3 +52,28 @@ test('admin coverage rigs fail preflight when WooCommerce admin assets are missi
   const ready = spawnSync('bash', [adminAssetsCheck, woocommercePath], { encoding: 'utf8' });
   assert.equal(ready.status, 0);
 });
+
+test('admin page coverage artifact includes additive bottleneck summaries', () => {
+  for (const rawField of ['visits', 'request_logs']) {
+    assert.match(workload, new RegExp(`'${rawField}'\\s*=>\\s*\\$${rawField}`));
+  }
+
+  for (const summaryField of [
+    'top_slow_visited_pages',
+    'top_query_count_pages',
+    'status_code_counts',
+    'permission_skip_count',
+    'php_error_summaries',
+    'php_fatal_summaries',
+  ]) {
+    assert.match(workload, new RegExp(`'${summaryField}'\\s*=>`));
+  }
+
+  assert.match(workload, /label'\s*=>\s*\(string\) \( \$visit\['label'\]/);
+  assert.match(workload, /page'\s*=>\s*\(string\) \( \$visit\['page'\]/);
+  assert.match(workload, /role'\s*=>\s*\(string\) \( \$visit\['role'\]/);
+  assert.match(workload, /status'\s*=>\s*\(string\) \( \$visit\['status'\]/);
+  assert.match(workload, /elapsed_ms'\s*=>\s*isset\( \$visit\['elapsed_ms'\] \)/);
+  assert.match(workload, /usort\( \$top_slow_visited_pages/);
+  assert.match(workload, /usort\( \$top_query_count_pages/);
+});


### PR DESCRIPTION
## Summary
- Add concise Woo admin coverage summary fields for slow visited pages, query-heavy request logs, status-code counts, permission skips, and PHP error/fatal summaries.
- Keep raw visits and request_logs intact while extending the existing metrics payload.
- Update admin-page coverage tests for the additive artifact summary fields.

## Verification
- node --test "woocommerce/woocommerce/bench/admin-page-coverage.test.mjs"
- node "scripts/lint-rig-packages.mjs"

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing additive coverage summary fields, updating tests, and running verification.