### PR TITLE
fix(woocommerce): skip admin permission boundary coverage

### DIFF
--- a/woocommerce/woocommerce/bench/admin-page-coverage.php
+++ b/woocommerce/woocommerce/bench/admin-page-coverage.php
@@ -168,10 +168,11 @@ add_action( "shutdown", function () {
 		}
 		$url = $normalize_admin_url( $page );
 		$candidates[ $url ] = array(
-			'label'  => isset( $item[0] ) ? wp_strip_all_tags( (string) $item[0] ) : '',
-			'source' => $source,
-			'page'   => $page,
-			'url'    => $url,
+			'label'      => isset( $item[0] ) ? wp_strip_all_tags( (string) $item[0] ) : '',
+			'capability' => isset( $item[1] ) ? (string) $item[1] : '',
+			'source'     => $source,
+			'page'       => $page,
+			'url'        => $url,
 		);
 	};
 	foreach ( $menu as $item ) {
@@ -224,16 +225,22 @@ add_action( "shutdown", function () {
 				$visits[] = array_merge( $target, array( 'role' => $role, 'status' => 'error', 'error' => $response->get_error_message(), 'elapsed_ms' => $elapsed ) );
 				continue;
 			}
-			$visits[] = array_merge(
+			$status_code = (int) wp_remote_retrieve_response_code( $response );
+			$visit       = array_merge(
 				$target,
 				array(
 					'role'        => $role,
 					'status'      => 'visited',
-					'status_code' => wp_remote_retrieve_response_code( $response ),
+					'status_code' => $status_code,
 					'final_url'   => wp_remote_retrieve_header( $response, 'x-redirect-by' ) ? wp_remote_retrieve_header( $response, 'location' ) : '',
 					'elapsed_ms'  => $elapsed,
 				)
 			);
+			if ( 403 === $status_code && 'shop_manager' === $role && isset( $target['capability'] ) && '' !== $target['capability'] && ! user_can( (int) $role_data['user_id'], (string) $target['capability'] ) ) {
+				$visit['status'] = 'skipped';
+				$visit['reasons'] = array( 'permission_boundary' );
+			}
+			$visits[] = $visit;
 		}
 	}
 
@@ -245,10 +252,12 @@ add_action( "shutdown", function () {
 	delete_option( $log_option );
 	delete_option( $log_option . '_expected' );
 
-	$status_counts = array_count_values( array_map( static fn( array $visit ): string => (string) $visit['status'], $visits ) );
-	$http_errors   = array_filter( $visits, static fn( array $visit ): bool => isset( $visit['status_code'] ) && (int) $visit['status_code'] >= 400 );
-	$php_errors    = 0;
-	$query_counts  = array();
+	$status_counts              = array_count_values( array_map( static fn( array $visit ): string => (string) $visit['status'], $visits ) );
+	$measured_visits            = array_filter( $visits, static fn( array $visit ): bool => 'skipped' !== (string) $visit['status'] );
+	$http_errors                = array_filter( $measured_visits, static fn( array $visit ): bool => isset( $visit['status_code'] ) && (int) $visit['status_code'] >= 400 );
+	$permission_boundary_skips  = array_filter( $visits, static fn( array $visit ): bool => 'skipped' === (string) $visit['status'] && in_array( 'permission_boundary', (array) ( $visit['reasons'] ?? array() ), true ) );
+	$php_errors                 = 0;
+	$query_counts               = array();
 	foreach ( $request_logs as $record ) {
 		$php_errors += count( (array) ( $record['php_errors'] ?? array() ) );
 		if ( isset( $record['query_count'] ) ) {
@@ -257,12 +266,13 @@ add_action( "shutdown", function () {
 	}
 
 	$summary = array(
-		'success_rate'              => count( $visits ) > 0 ? ( count( $visits ) - count( $http_errors ) - ( $status_counts['error'] ?? 0 ) ) / count( $visits ) : 0,
+		'success_rate'              => count( $measured_visits ) > 0 ? ( count( $measured_visits ) - count( $http_errors ) - ( $status_counts['error'] ?? 0 ) ) / count( $measured_visits ) : 0,
 		'total_elapsed_ms'          => ( microtime( true ) - $started ) * 1000,
 		'enumerated_admin_url_count' => count( $candidates ),
 		'visited_admin_url_count'    => count( $targets ),
 		'total_visit_count'          => count( $visits ),
 		'skipped_unsafe_count'       => count( $skipped ),
+		'skipped_permission_count'   => count( $permission_boundary_skips ),
 		'http_error_count'           => count( $http_errors ),
 		'request_error_count'        => $status_counts['error'] ?? 0,
 		'php_error_notice_count'     => $php_errors,

--- a/woocommerce/woocommerce/bench/admin-page-coverage.test.mjs
+++ b/woocommerce/woocommerce/bench/admin-page-coverage.test.mjs
@@ -13,6 +13,21 @@ const browserCoverageRig = JSON.parse(readFileSync(path.join(__dirname, '../rigs
 const manifest = JSON.parse(readFileSync(path.join(__dirname, '../manifests/full-surface-coverage.json'), 'utf8'));
 const adminAssetsCheck = path.join(__dirname, '../tools/check-admin-assets.sh');
 
+const summarizeArtifactVisits = (visits) => {
+  const measuredVisits = visits.filter((visit) => visit.status !== 'skipped');
+  const httpErrors = measuredVisits.filter((visit) => Number(visit.status_code) >= 400);
+  const requestErrors = measuredVisits.filter((visit) => visit.status === 'error');
+  const permissionBoundarySkips = visits.filter(
+    (visit) => visit.status === 'skipped' && visit.reasons?.includes('permission_boundary')
+  );
+
+  return {
+    success_rate: measuredVisits.length > 0 ? (measuredVisits.length - httpErrors.length - requestErrors.length) / measuredVisits.length : 0,
+    http_error_count: httpErrors.length,
+    skipped_permission_count: permissionBoundarySkips.length,
+  };
+};
+
 test('admin page coverage is bounded and skips unsafe admin actions', () => {
   assert.match(workload, /WC_ADMIN_PAGE_COVERAGE_LIMIT/);
   assert.match(workload, /min\( 100,/);
@@ -51,4 +66,44 @@ test('admin coverage rigs fail preflight when WooCommerce admin assets are missi
   writeFileSync(path.join(woocommercePath, 'assets/client/admin/wp-admin-scripts/index.asset.php'), '<?php return array();');
   const ready = spawnSync('bash', [adminAssetsCheck, woocommercePath], { encoding: 'utf8' });
   assert.equal(ready.status, 0);
+});
+
+test('admin page coverage treats expected shop-manager 403s as permission-boundary skips', () => {
+  assert.match(workload, /permission_boundary/);
+  assert.match(workload, /skipped_permission_count/);
+  assert.match(workload, /user_can\( \(int\) \$role_data\['user_id'\], \(string\) \$target\['capability'\] \)/);
+
+  const permissionBoundaryOnly = summarizeArtifactVisits([
+    {
+      role: 'shop_manager',
+      status: 'visited',
+      status_code: 200,
+      page: 'admin.php?page=wc-admin',
+    },
+    {
+      role: 'shop_manager',
+      status: 'skipped',
+      status_code: 403,
+      reasons: ['permission_boundary'],
+      capability: 'manage_options',
+      page: 'options-general.php',
+    },
+  ]);
+
+  assert.equal(permissionBoundaryOnly.success_rate, 1);
+  assert.equal(permissionBoundaryOnly.http_error_count, 0);
+  assert.equal(permissionBoundaryOnly.skipped_permission_count, 1);
+
+  const trueFailure = summarizeArtifactVisits([
+    {
+      role: 'shop_manager',
+      status: 'visited',
+      status_code: 500,
+      page: 'admin.php?page=wc-admin',
+    },
+  ]);
+
+  assert.equal(trueFailure.success_rate, 0);
+  assert.equal(trueFailure.http_error_count, 1);
+  assert.equal(trueFailure.skipped_permission_count, 0);
 });


### PR DESCRIPTION
## Summary
- Classify expected shop-manager 403s for admin menu pages whose declared capability the role lacks as skipped permission-boundary visits.
- Exclude permission-boundary skips from success-rate and HTTP-error metrics while preserving real failures such as 500s, request errors, fatals, and unexpected 403s.
- Add an artifact-level test covering skipped permission-boundary 403s and preserved 500 failures.

## Verification
- `node --test "woocommerce/woocommerce/bench/admin-page-coverage.test.mjs"` - passed
- `node "scripts/lint-rig-packages.mjs"` - passed
- Targeted lab benchmark attempted through Homeboy lab offload; remote run failed during `woocommerce-performance` `bench_prepare` before workload execution because the offloaded rigs snapshot had no root `composer.json`. Persisted run: `runner-exec-homeboy-lab-fd92e6d4-3ebc-484f-98cd-c3423660a0a9`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the Woo admin coverage classification change, updating tests, and running verification.