### PR TITLE
Improve Woo generated REST coverage expectations

### DIFF
--- a/woocommerce/woocommerce/bench/generated-rest-request-cases.workload.json
+++ b/woocommerce/woocommerce/bench/generated-rest-request-cases.workload.json
@@ -13,39 +13,171 @@
       "method": "GET",
       "path": "/wc/store/v1/products",
       "params": { "per_page": 1 },
-      "capture-response": true
+      "capture-response": true,
+      "metadata": {
+        "surface": "store_api",
+        "expected_statuses": [200],
+        "expected_outcome": "public_read_success"
+      }
+    },
+    {
+      "id": "woocommerce-store-product-categories",
+      "method": "GET",
+      "path": "/wc/store/v1/products/categories",
+      "params": { "per_page": 1 },
+      "capture-response": true,
+      "metadata": {
+        "surface": "store_api",
+        "expected_statuses": [200],
+        "expected_outcome": "public_read_success"
+      }
+    },
+    {
+      "id": "woocommerce-store-product-tags",
+      "method": "GET",
+      "path": "/wc/store/v1/products/tags",
+      "params": { "per_page": 1 },
+      "capture-response": true,
+      "metadata": {
+        "surface": "store_api",
+        "expected_statuses": [200],
+        "expected_outcome": "public_read_success"
+      }
+    },
+    {
+      "id": "woocommerce-store-product-attributes",
+      "method": "GET",
+      "path": "/wc/store/v1/products/attributes",
+      "capture-response": true,
+      "metadata": {
+        "surface": "store_api",
+        "expected_statuses": [200],
+        "expected_outcome": "public_read_success"
+      }
+    },
+    {
+      "id": "woocommerce-store-product-reviews",
+      "method": "GET",
+      "path": "/wc/store/v1/products/reviews",
+      "params": { "per_page": 1 },
+      "capture-response": true,
+      "metadata": {
+        "surface": "store_api",
+        "expected_statuses": [200],
+        "expected_outcome": "public_read_success"
+      }
+    },
+    {
+      "id": "woocommerce-store-product-collection-data",
+      "method": "GET",
+      "path": "/wc/store/v1/products/collection-data",
+      "capture-response": true,
+      "metadata": {
+        "surface": "store_api",
+        "expected_statuses": [200],
+        "expected_outcome": "public_read_success"
+      }
     },
     {
       "id": "woocommerce-store-cart",
       "method": "GET",
       "path": "/wc/store/v1/cart",
-      "capture-response": true
+      "capture-response": true,
+      "metadata": {
+        "surface": "store_api",
+        "expected_statuses": [200],
+        "expected_outcome": "public_session_read_success"
+      }
+    },
+    {
+      "id": "woocommerce-store-checkout",
+      "method": "GET",
+      "path": "/wc/store/v1/checkout",
+      "capture-response": true,
+      "metadata": {
+        "surface": "store_api",
+        "expected_statuses": [200],
+        "expected_outcome": "public_session_read_success"
+      }
     },
     {
       "id": "woocommerce-v3-products",
       "method": "GET",
       "path": "/wc/v3/products",
       "params": { "per_page": 1 },
-      "capture-response": true
+      "capture-response": true,
+      "metadata": {
+        "surface": "wc_rest_api",
+        "expected_statuses": [401, 403],
+        "expected_outcome": "auth_boundary"
+      }
     },
     {
       "id": "woocommerce-v3-orders",
       "method": "GET",
       "path": "/wc/v3/orders",
       "params": { "per_page": 1 },
-      "capture-response": true
+      "capture-response": true,
+      "metadata": {
+        "surface": "wc_rest_api",
+        "expected_statuses": [401, 403],
+        "expected_outcome": "auth_boundary"
+      }
+    },
+    {
+      "id": "woocommerce-v3-payment-gateways",
+      "method": "GET",
+      "path": "/wc/v3/payment_gateways",
+      "capture-response": true,
+      "metadata": {
+        "surface": "wc_rest_api",
+        "expected_statuses": [401, 403],
+        "expected_outcome": "auth_boundary"
+      }
+    },
+    {
+      "id": "woocommerce-v3-reports",
+      "method": "GET",
+      "path": "/wc/v3/reports",
+      "capture-response": true,
+      "metadata": {
+        "surface": "wc_rest_api",
+        "expected_statuses": [401, 403],
+        "expected_outcome": "auth_boundary"
+      }
+    },
+    {
+      "id": "woocommerce-v3-system-status",
+      "method": "GET",
+      "path": "/wc/v3/system_status",
+      "capture-response": true,
+      "metadata": {
+        "surface": "wc_rest_api",
+        "expected_statuses": [401, 403],
+        "expected_outcome": "auth_boundary"
+      }
     },
     {
       "id": "woocommerce-admin-options",
       "method": "GET",
       "path": "/wc-admin/options",
-      "capture-response": true
+      "capture-response": true,
+      "metadata": {
+        "surface": "wc_admin_api",
+        "expected_statuses": [401, 403],
+        "expected_outcome": "auth_boundary"
+      }
     }
   ],
   "metadata": {
     "runner": "wp-codebox",
     "workload": "generated-rest-request-cases",
-    "coverage_shape": "generated safe WooCommerce Store API, REST API, and admin REST request cases",
+    "coverage_shape": "generated safe WooCommerce Store API public reads plus REST/admin auth-boundary request cases",
+    "status_contract": {
+      "public_read_success": "Expected 200 for read-only Store API catalog routes.",
+      "public_session_read_success": "Expected 200 for read-only Store API cart/checkout session routes.",
+      "auth_boundary": "Expected 401 or 403 for credentialed Woo REST/admin routes when the workload has no API credentials. Other statuses indicate a route, bootstrap, or permission regression."
+    },
     "manifest": "manifests/full-surface-coverage.json"
   }
 }

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.json
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.json
@@ -14,7 +14,17 @@
   "surfaces": {
     "rest_api": {
       "budget_manifest": "manifests/rest-route-budgets.json",
-      "coverage_goal": "all_wc_v3_wc_store_wc_admin_routes_and_generated_safe_cases"
+      "coverage_goal": "all_wc_v3_wc_store_wc_admin_routes_and_generated_safe_cases",
+      "generated_request_cases": {
+        "workload": "bench/generated-rest-request-cases.workload.json",
+        "status_contract": {
+          "public_read_success": "Store API catalog GET cases should return 200.",
+          "public_session_read_success": "Store API cart/checkout GET cases should return 200 without credentials.",
+          "auth_boundary": "Woo REST and wc-admin GET cases intentionally run without credentials and should return 401 or 403; 2xx, 404, or 5xx statuses are actionable coverage failures."
+        },
+        "safe_methods": ["GET"],
+        "surfaces": ["store_api", "wc_rest_api", "wc_admin_api"]
+      }
     },
     "database": {
       "coverage_goal": "all_tables_rows_columns_indexes_after_catalog_checkout_fixture_setup",


### PR DESCRIPTION
## Summary
- Expand Woo generated REST request cases with additional read-only Store API coverage.
- Add representative Woo REST and wc-admin GET auth-boundary cases.
- Document per-case expected status classes in workload metadata and the full-surface manifest.

## Verification
- Parsed edited JSON files with Node.
- Ran `node --test "woocommerce/woocommerce/bench/admin-page-coverage.test.mjs" "woocommerce/woocommerce/bench/checkout-shipping-cache.test.mjs"`.
- Ran `node "scripts/lint-rig-packages.mjs"`.
- Attempted targeted lab run: `homeboy bench --rig woocommerce-performance --scenario generated-rest-request-cases --iterations 1 --warmup 0 --ignore-default-baseline`. It offloaded to `homeboy-lab` but failed in rig `bench_prepare` before the workload executed due to runner-side Woo admin asset prep/lockfile issues.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Inspecting the rig workload/manifest, drafting the JSON coverage updates, running verification commands, and preparing this PR.