### PR TITLE
Expand Woo shipping cache package coverage

### DIFF
--- a/woocommerce/woocommerce/bench/checkout-shipping-cache.php
+++ b/woocommerce/woocommerce/bench/checkout-shipping-cache.php
@@ -29,6 +29,10 @@ return function (): array {
 
 	$cart_items       = max( 1, min( 1000, (int) ( getenv( 'WC_SHIPPING_CACHE_CART_ITEMS' ) ?: 40 ) ) );
 	$packages         = max( 1, min( $cart_items, (int) ( getenv( 'WC_SHIPPING_CACHE_PACKAGES' ) ?: 8 ) ) );
+	$package_shape    = getenv( 'WC_SHIPPING_CACHE_PACKAGE_SHAPE' ) ?: 'balanced';
+	if ( ! in_array( $package_shape, array( 'balanced', 'mixed_destination' ), true ) ) {
+		$package_shape = 'balanced';
+	}
 	$warm_runs        = max( 1, min( 100, (int) ( getenv( 'WC_SHIPPING_CACHE_WARM_RUNS' ) ?: 5 ) ) );
 	$total_churn_runs = max( 1, min( 100, (int) ( getenv( 'WC_SHIPPING_CACHE_TOTAL_CHURN_RUNS' ) ?: 3 ) ) );
 	$rehash_runs      = max( 1, min( 100, (int) ( getenv( 'WC_SHIPPING_CACHE_REHASH_RUNS' ) ?: 3 ) ) );
@@ -162,7 +166,7 @@ return function (): array {
 		'field' => '',
 		'step'  => 0,
 	);
-	$split_packages = static function ( array $cart_packages ) use ( $packages, &$current_phase, $synthetic_unknown_key, $flat_rate_instance_id ): array {
+	$split_packages = static function ( array $cart_packages ) use ( $packages, $package_shape, &$current_phase, $synthetic_unknown_key, $flat_rate_instance_id ): array {
 		$base_package = $cart_packages[0] ?? array();
 		$contents     = array_values( $base_package['contents'] ?? array() );
 		if ( empty( $contents ) ) {
@@ -184,6 +188,11 @@ return function (): array {
 			$package['homeboy_package_index']  = $index;
 			$package['subtotal']               = (float) array_sum( wp_list_pluck( $package['contents'], 'line_subtotal' ) );
 			$package['total']                  = (float) array_sum( wp_list_pluck( $package['contents'], 'line_total' ) );
+			if ( 'mixed_destination' === $package_shape ) {
+				$package['destination']['postcode'] = '941' . str_pad( (string) ( 10 + $index ), 2, '0', STR_PAD_LEFT );
+				$package['destination']['address']  = ( 100 + $index ) . ' Performance Way';
+				$package['destination']['address_1'] = ( 100 + $index ) . ' Performance Way';
+			}
 
 			switch ( $current_phase['field'] ) {
 				case 'subtotal':
@@ -394,6 +403,7 @@ return function (): array {
 		'success_rate'                         => 1,
 		'cart_items'                           => $cart_items,
 		'configured_package_target'            => $packages,
+		'package_shape'                        => $package_shape,
 		'actual_package_count'                 => (int) $cold_row['package_count'],
 		'shipping_rate_count'                  => (int) $cold_row['rate_count'],
 		'warm_runs'                            => $warm_runs,
@@ -460,6 +470,7 @@ return function (): array {
 			'issues'                     => $issues,
 			'zone_id'                    => $zone->get_id(),
 			'product_seed'               => 'simple-physical',
+			'package_shape'              => $package_shape,
 		),
 		'artifacts' => $artifact_path ? array( 'raw_result' => array( 'path' => $artifact_path, 'kind' => 'json' ) ) : array(),
 	);

--- a/woocommerce/woocommerce/bench/checkout-shipping-cache.test.mjs
+++ b/woocommerce/woocommerce/bench/checkout-shipping-cache.test.mjs
@@ -6,6 +6,7 @@ import path from 'node:path';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const workload = readFileSync(path.join(__dirname, 'checkout-shipping-cache.php'), 'utf8');
+const performanceRig = JSON.parse(readFileSync(path.join(__dirname, '../rigs/woocommerce-performance/rig.json'), 'utf8'));
 
 function caseBody(name) {
   const match = workload.match(new RegExp(`case '${name}':[\\s\\S]*?\\n\\s*break;`));
@@ -24,4 +25,12 @@ test('package_index churn does not mutate the rig-only helper key', () => {
 test('unknown package key guardrail still uses the synthetic key', () => {
   assert.match(caseBody('unknown_package_key'), /\$package\[ \$synthetic_unknown_key \]/);
   assert.doesNotMatch(workload, /woocommerce_shipping_package_hash_ignored_fields/);
+});
+
+test('performance rig enables mixed destination package shape without adding runs', () => {
+  const benchEnv = performanceRig.components.woocommerce.extensions.wordpress.bench_env;
+  assert.equal(benchEnv.WC_SHIPPING_CACHE_PACKAGE_SHAPE, 'mixed_destination');
+  assert.match(workload, /WC_SHIPPING_CACHE_PACKAGE_SHAPE/);
+  assert.match(workload, /array\( 'balanced', 'mixed_destination' \)/);
+  assert.match(workload, /'package_shape'\s*=>\s*\$package_shape/);
 });

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -18,6 +18,7 @@
             "WC_CHECKOUT_GATEWAY_MATRIX_WOOPAYMENTS_PATH": "",
             "WC_SHIPPING_CACHE_CART_ITEMS": "40",
             "WC_SHIPPING_CACHE_PACKAGES": "8",
+            "WC_SHIPPING_CACHE_PACKAGE_SHAPE": "mixed_destination",
             "WC_SHIPPING_CACHE_WARM_RUNS": "5",
             "WC_SHIPPING_CACHE_TOTAL_CHURN_RUNS": "3",
             "WC_SHIPPING_CACHE_REHASH_RUNS": "3",


### PR DESCRIPTION
## Summary
- Add a bounded `WC_SHIPPING_CACHE_PACKAGE_SHAPE` fixture dimension to the Woo checkout shipping-cache workload.
- Enable `mixed_destination` in the `woocommerce-performance` rig so the existing shipping-cache run covers distinct per-package destination hash inputs without increasing run count.
- Extend the existing checkout shipping-cache Node test to lock the rig env/workload declaration together.

## Verification
- `node --test "woocommerce/woocommerce/bench/checkout-shipping-cache.test.mjs" "woocommerce/woocommerce/bench/admin-page-coverage.test.mjs"`
- `node "scripts/lint-rig-packages.mjs"`
- Targeted Lab attempt: `homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --warmup 0 --runner homeboy-lab --run-id woo-checkout-shipping-mixed-destination` did not reach the workload because `woocommerce-performance` `bench_prepare` failed while building Woo admin assets on the runner with a Wireit lock `ECOMPROMISED`. Persisted run: `runner-exec-homeboy-lab-fa3d763a-2061-4964-adad-30a0cd45e20c`.
- A second targeted Lab retry was accidentally triggered while creating this PR body and also failed before workload execution. Persisted run: `runner-exec-homeboy-lab-34c588ad-a154-4e06-b961-b48222815360`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Inspecting the Woo checkout/shipping rig coverage, implementing the bounded fixture dimension, updating tests, and drafting this PR.