### PR TITLE
Improve Woo admin query attribution artifacts

### DIFF
--- a/woocommerce/woocommerce/bench/admin-page-coverage.php
+++ b/woocommerce/woocommerce/bench/admin-page-coverage.php
@@ -241,6 +241,72 @@ add_action( "shutdown", function () {
 	if ( ! is_array( $request_logs ) ) {
 		$request_logs = array();
 	}
+
+	$normalize_query_shape = static function ( string $query ): string {
+		$query = preg_replace( '#/\*.*?\*/#s', ' ', $query );
+		$query = preg_replace( "/'(?:''|[^'])*'/", '?', (string) $query );
+		$query = preg_replace( '/"(?:""|[^"])*"/', '?', (string) $query );
+		$query = preg_replace( '/\b0x[0-9a-f]+\b/i', '?', (string) $query );
+		$query = preg_replace( '/\b\d+(?:\.\d+)?\b/', '?', (string) $query );
+		$query = preg_replace( '/\s+/', ' ', (string) $query );
+		return strtolower( trim( (string) $query ) );
+	};
+
+	$query_family = static function ( string $query_shape ): string {
+		$shape = str_replace( '`', '', strtolower( $query_shape ) );
+		if ( preg_match( '/^select\b.*?\bfrom\s+([a-z0-9_]+)/', $shape, $matches ) ) {
+			return 'select:' . $matches[1];
+		}
+		if ( preg_match( '/^(insert|replace)\s+into\s+([a-z0-9_]+)/', $shape, $matches ) ) {
+			return $matches[1] . ':' . $matches[2];
+		}
+		if ( preg_match( '/^update\s+([a-z0-9_]+)/', $shape, $matches ) ) {
+			return 'update:' . $matches[1];
+		}
+		if ( preg_match( '/^delete\s+from\s+([a-z0-9_]+)/', $shape, $matches ) ) {
+			return 'delete:' . $matches[1];
+		}
+		if ( preg_match( '/^([a-z]+)/', $shape, $matches ) ) {
+			return $matches[1] . ':other';
+		}
+		return 'unknown:other';
+	};
+
+	$top_counts = static function ( array $counts, string $field, int $limit = 10 ): array {
+		arsort( $counts );
+		$rows = array();
+		foreach ( $counts as $value => $count ) {
+			$rows[] = array( $field => (string) $value, 'count' => (int) $count );
+			if ( count( $rows ) >= $limit ) {
+				break;
+			}
+		}
+		return $rows;
+	};
+
+	$query_shape_counts  = array();
+	$query_family_counts = array();
+	$query_sample_count  = 0;
+	foreach ( $request_logs as $record ) {
+		foreach ( (array) ( $record['query_shapes'] ?? array() ) as $query ) {
+			$shape = $normalize_query_shape( (string) $query );
+			if ( '' === $shape ) {
+				continue;
+			}
+			$family = $query_family( $shape );
+			$query_shape_counts[ $shape ]  = ( $query_shape_counts[ $shape ] ?? 0 ) + 1;
+			$query_family_counts[ $family ] = ( $query_family_counts[ $family ] ?? 0 ) + 1;
+			++$query_sample_count;
+		}
+	}
+	$query_attribution = array(
+		'schema'                   => 'homeboy-rigs/woocommerce-admin-query-attribution/v1',
+		'sample_source'            => 'request_logs.query_shapes',
+		'sample_limit_per_request' => 25,
+		'sample_count'             => $query_sample_count,
+		'top_query_shapes'         => $top_counts( $query_shape_counts, 'shape' ),
+		'top_query_families'       => $top_counts( $query_family_counts, 'family' ),
+	);
 	@unlink( $mu_plugin );
 	delete_option( $log_option );
 	delete_option( $log_option . '_expected' );
@@ -268,6 +334,9 @@ add_action( "shutdown", function () {
 		'php_error_notice_count'     => $php_errors,
 		'max_query_count'            => $query_counts ? max( $query_counts ) : null,
 		'avg_query_count'            => $query_counts ? array_sum( $query_counts ) / count( $query_counts ) : null,
+		'query_shape_sample_count'   => $query_attribution['sample_count'],
+		'top_query_shapes'           => $query_attribution['top_query_shapes'],
+		'top_query_families'         => $query_attribution['top_query_families'],
 	);
 
 	$artifact_path = '';
@@ -287,6 +356,7 @@ add_action( "shutdown", function () {
 					'visits'              => $visits,
 					'skipped'             => $skipped,
 					'request_logs'        => $request_logs,
+					'query_attribution'  => $query_attribution,
 					'metrics'             => $summary,
 				),
 				JSON_PRETTY_PRINT

--- a/woocommerce/woocommerce/bench/admin-page-coverage.php
+++ b/woocommerce/woocommerce/bench/admin-page-coverage.php
@@ -335,6 +335,10 @@ add_action( "shutdown", function () {
 		'max_query_count'            => $query_counts ? max( $query_counts ) : null,
 		'avg_query_count'            => $query_counts ? array_sum( $query_counts ) / count( $query_counts ) : null,
 		'query_shape_sample_count'   => $query_attribution['sample_count'],
+		'distinct_query_shape_count'  => count( $query_shape_counts ),
+		'distinct_query_family_count' => count( $query_family_counts ),
+		'top_query_shape_count'      => isset( $query_attribution['top_query_shapes'][0]['count'] ) ? $query_attribution['top_query_shapes'][0]['count'] : 0,
+		'top_query_family_count'     => isset( $query_attribution['top_query_families'][0]['count'] ) ? $query_attribution['top_query_families'][0]['count'] : 0,
 		'top_query_shapes'           => $query_attribution['top_query_shapes'],
 		'top_query_families'         => $query_attribution['top_query_families'],
 	);
@@ -372,6 +376,7 @@ add_action( "shutdown", function () {
 			'coverage_shape' => 'bounded authenticated wp-admin and Woo admin menu/submenu GET coverage',
 			'roles'          => array_keys( $roles ),
 			'limit'          => $limit,
+			'query_attribution' => $query_attribution,
 		),
 		'artifacts' => $artifact_path ? array( 'admin_page_coverage' => array( 'path' => $artifact_path, 'kind' => 'json' ) ) : array(),
 	);

--- a/woocommerce/woocommerce/bench/admin-page-coverage.test.mjs
+++ b/woocommerce/woocommerce/bench/admin-page-coverage.test.mjs
@@ -23,6 +23,19 @@ test('admin page coverage is bounded and skips unsafe admin actions', () => {
   assert.match(workload, /setup_or_onboarding_screen/);
 });
 
+test('admin page coverage reports summarized query attribution without dropping raw logs', () => {
+  assert.match(workload, /'request_logs'\s*=>\s*\$request_logs/);
+  assert.match(workload, /homeboy-rigs\/woocommerce-admin-query-attribution\/v1/);
+  assert.match(workload, /'sample_source'\s*=>\s*'request_logs\.query_shapes'/);
+  assert.match(workload, /'sample_limit_per_request'\s*=>\s*25/);
+  assert.match(workload, /'query_shape_sample_count'\s*=>\s*\$query_attribution\['sample_count'\]/);
+  assert.match(workload, /'top_query_shapes'\s*=>\s*\$query_attribution\['top_query_shapes'\]/);
+  assert.match(workload, /'top_query_families'\s*=>\s*\$query_attribution\['top_query_families'\]/);
+  assert.match(workload, /'query_attribution'\s*=>\s*\$query_attribution/);
+  assert.ok(workload.includes("preg_replace( '/\\b\\d+(?:\\.\\d+)?\\b/', '?'"));
+  assert.match(workload, /return 'select:' \. \$matches\[1\]/);
+});
+
 test('admin page coverage is wired into executable full-surface profile', () => {
   assert.ok(
     rig.bench_workloads.wordpress.some((entry) => entry.path.includes('bench/admin-page-coverage.php')),

--- a/woocommerce/woocommerce/bench/admin-page-coverage.test.mjs
+++ b/woocommerce/woocommerce/bench/admin-page-coverage.test.mjs
@@ -29,6 +29,8 @@ test('admin page coverage reports summarized query attribution without dropping 
   assert.match(workload, /'sample_source'\s*=>\s*'request_logs\.query_shapes'/);
   assert.match(workload, /'sample_limit_per_request'\s*=>\s*25/);
   assert.match(workload, /'query_shape_sample_count'\s*=>\s*\$query_attribution\['sample_count'\]/);
+  assert.match(workload, /'distinct_query_shape_count'\s*=>\s*count\( \$query_shape_counts \)/);
+  assert.match(workload, /'top_query_shape_count'\s*=>\s*isset\( \$query_attribution\['top_query_shapes'\]\[0\]\['count'\] \)/);
   assert.match(workload, /'top_query_shapes'\s*=>\s*\$query_attribution\['top_query_shapes'\]/);
   assert.match(workload, /'top_query_families'\s*=>\s*\$query_attribution\['top_query_families'\]/);
   assert.match(workload, /'query_attribution'\s*=>\s*\$query_attribution/);


### PR DESCRIPTION
## Summary
- Add normalized query-shape and query-family attribution summaries to Woo admin-page coverage.
- Preserve raw request query samples in request_logs while adding query_attribution to the JSON artifact.
- Expose numeric query attribution counters in metrics for persisted bench consumers.

## Verification
- node --test "woocommerce/woocommerce/bench/admin-page-coverage.test.mjs"
- node "scripts/lint-rig-packages.mjs"
- Offloaded lab attempted: homeboy bench --rig woocommerce-performance --scenario admin-page-coverage --iterations 1 --runner homeboy-lab --ignore-default-baseline --json. The run passed, but Homeboy materialized the runner's existing Woo rig workload copy instead of this branch's changed workload (workload sha256 mismatch), so it is not counted as proof of the new fields.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the query attribution summary fields, updating focused tests, running verification, and drafting this PR.