### PR TITLE
feat(woocommerce): migrate coverage workloads to fuzz

### DIFF
--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -35,9 +35,9 @@ homeboy rig check woocommerce-performance
 
 ## Runner Prerequisites
 
-The rig mounts the selected WooCommerce checkout into the disposable WP Codebox
-WordPress runtime. Pass `homeboy bench --path /absolute/path/to/plugins/woocommerce`
-when validating a specific WooCommerce worktree.
+The rig mounts the selected WooCommerce checkout into disposable WP Codebox
+WordPress runtimes. Pass `--path /absolute/path/to/plugins/woocommerce` when
+validating a specific WooCommerce worktree.
 
 The checkout gateway compatibility matrix defaults to the `core_only` profile
 set so BACS, Cheque, and COD controls can run even when real gateway plugin
@@ -45,7 +45,7 @@ materialization is unavailable. Select the focused Stripe profile set when the
 runner can prepare WooCommerce Stripe Gateway:
 
 ```bash
-homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 \
+homeboy fuzz run --rig woocommerce-performance --workload checkout-gateway-compatibility-matrix --run-id wc-gateway-stripe --seed 1 --max-duration 15m \
   --setting-json 'bench_env={"WC_CHECKOUT_GATEWAY_MATRIX_PROFILE_SET":"stripe"}' \
   --setting-json 'validation_dependencies=["woocommerce-gateway-stripe"]'
 ```
@@ -57,7 +57,7 @@ lowest-level escape hatch for comma-separated profile ids or gateway ids.
 Homeboy Extensions resolves that dependency through the runner dependency
 contract, prepares a runnable artifact when the source checkout needs Composer
 materialization, mounts the prepared plugin into WP Codebox, and attaches
-`prepared_dependencies` provenance to the final bench results. The workload
+`prepared_dependencies` provenance to the final fuzz results. The workload
 artifact reports the runtime side of that same contract: configured dependency,
 source path when explicitly provided, git revision when visible, prepared artifact
 path when exported, mounted plugin directory, plugin version, and status. If the
@@ -73,7 +73,7 @@ Codebox recipe mounting for Stripe product-page traces:
 {"source":"/path/to/woocommerce-gateway-stripe","slug":"woocommerce-gateway-stripe","pluginFile":"woocommerce-gateway-stripe/woocommerce-gateway-stripe.php","activate":true}
 ```
 
-The gateway matrix is a WordPress bench workload, so it consumes the same
+The gateway matrix is a WordPress fuzz workload, so it consumes the same
 slug/entrypoint/runtime metadata through Homeboy Extensions' WordPress dependency
 contract instead of building a second Stripe-specific mount path in this rig.
 
@@ -82,7 +82,7 @@ adding them to `validation_dependencies` or by overriding `wp_codebox_extra_plug
 and the matching artifact path env values:
 
 ```bash
-homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 \
+homeboy fuzz run --rig woocommerce-performance --workload checkout-gateway-compatibility-matrix --run-id wc-gateway-mounted-plugins --seed 1 --max-duration 15m \
   --setting-json 'wp_codebox_extra_plugins=[{"source":"/path/to/woocommerce-paypal-payments","slug":"woocommerce-paypal-payments","pluginFile":"woocommerce-paypal-payments/woocommerce-paypal-payments.php","activate":false},{"source":"/path/to/woocommerce-payments","slug":"woocommerce-payments","pluginFile":"woocommerce-payments/woocommerce-payments.php","activate":false}]' \
   --setting-json 'bench_env={"WC_CHECKOUT_GATEWAY_MATRIX_PAYPAL_PAYMENTS_PATH":"/path/to/woocommerce-paypal-payments","WC_CHECKOUT_GATEWAY_MATRIX_WOOPAYMENTS_PATH":"/path/to/woocommerce-payments"}'
 ```
@@ -119,39 +119,50 @@ homeboy rig check woocommerce-performance
   `assets/client/admin/wp-admin-scripts/command-palette.asset.php` is missing.
 - It does not modify WooCommerce source files or switch branches.
 
-Admin coverage and full-surface runs require built WooCommerce admin JS outputs.
-`homeboy rig check woocommerce-performance` fails before benchmark execution when
+Admin coverage fuzz runs require built WooCommerce admin JS outputs.
+`homeboy rig check woocommerce-performance` fails before fuzz execution when
 `assets/client/admin/wp-admin-scripts/*.asset.php` registries or
 `vendor/automattic/jetpack-connection/dist/jetpack-connection.js` are missing.
 
 Equivalent manual prep, when needed for debugging, should run from the selected
 WooCommerce plugin directory.
 
+## Fuzz Commands
+
+```bash
+homeboy rig up woocommerce-performance
+homeboy fuzz list --rig woocommerce-performance
+homeboy fuzz run --rig woocommerce-performance --workload checkout-concurrent-create-order --run-id wc-checkout-atomicity --seed 1 --max-duration 10m
+homeboy fuzz run --rig woocommerce-performance --workload checkout-shipping-cache --run-id wc-shipping-cache --seed 1 --max-duration 15m
+homeboy fuzz run --rig woocommerce-performance --workload admin-page-coverage --run-id wc-admin-coverage --seed 1 --max-duration 15m
+homeboy fuzz run --rig woocommerce-performance --workload generated-rest-request-cases --run-id wc-rest-generated-cases --seed 1 --max-duration 20m
+```
+
+`homeboy fuzz --rig woocommerce-performance` resolves the rig's WooCommerce
+component and `fuzz_workloads.wordpress` declarations. Fuzz workloads are not
+registered through `bench_workloads`, so there is no legacy bench fallback path
+for checkout atomicity, shipping cache guardrails, layered-nav cache coverage,
+admin coverage, REST coverage, DB inventory, or external HTTP guardrails.
+
 ## Benchmark Commands
 
 ```bash
 homeboy rig up woocommerce-performance
-homeboy bench --rig woocommerce-performance --scenario checkout-concurrent-create-order --iterations 1 --shared-state /tmp/woocommerce-concurrent-checkout
-homeboy bench --rig woocommerce-performance --scenario checkout-gateway-compatibility-matrix --iterations 1 --shared-state /tmp/woocommerce-gateway-matrix
-homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-bench
 homeboy bench --rig woocommerce-performance --scenario checkout-shortcode-place-order-latency --iterations 1 --shared-state /tmp/woocommerce-shortcode-checkout
 homeboy bench --rig woocommerce-performance --scenario admin-dashboard-physical-products-query --iterations 1 --shared-state /tmp/woocommerce-admin-dashboard-products --setting-json 'bench_env={"WC_ADMIN_DASHBOARD_PRODUCTS":"500","WC_ADMIN_DASHBOARD_TERMS":"20"}'
-homeboy bench --rig woocommerce-performance --scenario layered-nav-count-cache --iterations 1 --shared-state /tmp/woocommerce-layered-nav-cache --setting-json 'bench_env={"WC_LAYERED_NAV_CACHE_ITERATIONS":"150","WC_LAYERED_NAV_CACHE_LIMIT":"25"}'
-homeboy bench --rig woocommerce-performance --scenario layered-nav-catalog-crawl --iterations 1 --shared-state /tmp/woocommerce-layered-nav-crawl --setting-json 'bench_env={"WC_LAYERED_NAV_CRAWL_REQUESTS":"150","WC_LAYERED_NAV_CRAWL_LIMIT":"25"}'
-homeboy bench --rig woocommerce-performance --scenario admin-page-coverage --iterations 1 --shared-state /tmp/woocommerce-admin-page-coverage
-homeboy bench --rig woocommerce-performance --profile api-coverage --iterations 1 --shared-state /tmp/woocommerce-api-coverage
-homeboy bench --rig woocommerce-performance --profile full-surface --iterations 1 --shared-state /tmp/woocommerce-full-surface
-homeboy bench --rig woocommerce-performance --profile hot --iterations 1 --shared-state /tmp/woocommerce-performance-hot --setting-json 'bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"120","WC_SHIPPING_CACHE_PACKAGES":"24"}' --force-hot
+homeboy bench --rig woocommerce-performance --scenario rest-product-batch-import --iterations 1 --shared-state /tmp/woocommerce-rest-product-batch-import
+homeboy bench --rig woocommerce-performance --profile hot --iterations 1 --shared-state /tmp/woocommerce-performance-hot --force-hot
 ```
 
-The `full-surface` profile is executable because every listed workload ID is backed by a concrete `bench_workloads.wordpress` file declaration. It covers the existing WooCommerce REST route inventory, bounded authenticated admin page coverage, DB inventory/profiling, generated REST cases, external HTTP guardrails, and the large-merchant workload suite. Browser request coverage remains a separate trace rig until it can run as a concrete WordPress bench workload.
+The `hot` bench profile now contains only true performance workloads. Full-surface
+coverage moved to fuzz workload declarations.
 
 `homeboy bench --rig woocommerce-performance` runs through Homeboy Extensions'
 `wordpress.bench` / WP Codebox backend. WP Codebox owns the disposable WordPress
 runtime, mounts WooCommerce as the runtime plugin, mounts the rig's PHP workload
 into `tests/bench/`, and returns the normalized Homeboy `BenchResults` envelope.
 
-## Current Workloads
+## Current Fuzz Workloads
 
 - `checkout-concurrent-create-order` calls public `WC_Checkout::create_order()`
   twice against the same cart to report duplicate-order behavior, then records
@@ -180,12 +191,6 @@ into `tests/bench/`, and returns the normalized Homeboy `BenchResults` envelope.
   packages, and measures cold, warm, totals-only churn, and address-rehashed
   shipping calculation passes through WooCommerce's checkout/cart shipping cache
   path.
-- `checkout-shortcode-place-order-latency` seeds a shortcode checkout page,
-  roughly 150 products, 125 variations, and historical CPT orders with HPOS
-  disabled, then drives `WC()->checkout()->process_checkout()` for COD and a
-  synthetic successful gateway while capturing checkout POST timing, order
-  creation timing, query counts, Action Scheduler deltas, and raw JSON evidence
-  for the slow place-order report in homeboy-rigs issue #223.
 - `checkout-concurrent-create-order` seeds one WooCommerce cart/session, then
   fires simultaneous `/?wc-ajax=checkout` POSTs with the same session cookie to
   distinguish true request races from sequential `create_order()` retry fixes.
@@ -196,12 +201,6 @@ into `tests/bench/`, and returns the normalized Homeboy `BenchResults` envelope.
   across many unique layered-nav count query hashes to measure growth of the
   single `wc_layered_nav_counts_*` taxonomy transient reported in WooCommerce
   issue #17355.
-- `admin-dashboard-physical-products-query` seeds configurable simple products
-  and product categories with deterministic `_virtual` metadata, sets the
-  WooCommerce onboarding state, exercises
-  `Shipping::has_physical_products()` plus the dashboard setup-widget PHP path,
-  and records whether the reported physical-products SQL appears on the tested
-  WooCommerce branch.
 - `layered-nav-catalog-crawl` uses real `filter_*` request combinations and
   renders the layered-nav widget list path for each request shape, measuring
   the same transient growth through a crawler/catalog-traffic-shaped path.
@@ -218,6 +217,23 @@ into `tests/bench/`, and returns the normalized Homeboy `BenchResults` envelope.
   Codebox HTTP runtime. It records HTTP status, redirects when visible, request
   timing, PHP notices/errors observed by a temporary runtime-only MU plugin, DB
   query counts and query shapes when available, and explicit skipped reasons.
+
+## Current Bench Workloads
+
+- `checkout-shortcode-place-order-latency` seeds a shortcode checkout page,
+  roughly 150 products, 125 variations, and historical CPT orders with HPOS
+  disabled, then drives `WC()->checkout()->process_checkout()` for COD and a
+  synthetic successful gateway while capturing checkout POST timing, order
+  creation timing, query counts, Action Scheduler deltas, and raw JSON evidence
+  for the slow place-order report in homeboy-rigs issue #223.
+- `admin-dashboard-physical-products-query` seeds configurable simple products
+  and product categories with deterministic `_virtual` metadata, sets the
+  WooCommerce onboarding state, exercises
+  `Shipping::has_physical_products()` plus the dashboard setup-widget PHP path,
+  and records whether the reported physical-products SQL appears on the tested
+  WooCommerce branch.
+- `rest-product-batch-import` measures WooCommerce REST product batch import
+  throughput and related query behavior for generated catalog shapes.
 
 ## Metrics
 
@@ -271,13 +287,13 @@ The first slice reports:
 
 See `docs/checkout-shipping-cache.md` for workload details and current TODOs.
 
-For baseline/candidate duplicate-checkout comparisons, run the focused profile
-against each WooCommerce checkout and keep the shared-state artifacts attached
-to the WooCommerce tracker or PR:
+For baseline/candidate duplicate-checkout comparisons, run the focused fuzz
+workload against each WooCommerce checkout and keep the artifacts attached to the
+WooCommerce tracker or PR:
 
 ```bash
-homeboy bench --rig woocommerce-performance --profile checkout-concurrent --iterations 1 --shared-state /tmp/wc-checkout-baseline
-homeboy bench --rig woocommerce-performance --profile checkout-concurrent --iterations 1 --shared-state /tmp/wc-checkout-candidate
+homeboy fuzz run --rig woocommerce-performance --workload checkout-concurrent-create-order --run-id wc-checkout-baseline --seed 1 --max-duration 10m
+homeboy fuzz run --rig woocommerce-performance --workload checkout-concurrent-create-order --run-id wc-checkout-candidate --seed 1 --max-duration 10m
 ```
 
 Use `bench_env.WC_CONCURRENT_CHECKOUT_REQUESTS`,
@@ -292,7 +308,7 @@ comments without inventing missing baseline/candidate numbers:
 
 ```bash
 node woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs \
-  --input /tmp/woocommerce-performance-bench
+  --input /tmp/woocommerce-shipping-cache-artifacts
 ```
 
 The report separates timing evidence from shipping-rate call-count evidence and

--- a/woocommerce/woocommerce/docs/checkout-pr-evidence-matrix.md
+++ b/woocommerce/woocommerce/docs/checkout-pr-evidence-matrix.md
@@ -94,20 +94,21 @@ Run these rows for both the old PR shape and the revised WooCommerce candidate.
 ```bash
 homeboy rig up woocommerce-performance
 
-homeboy bench --rig woocommerce-performance \
-  --scenario checkout-gateway-compatibility-matrix \
-  --iterations 1 \
-  --shared-state /tmp/woocommerce-checkout-pr-65588-old-shape \
-  --setting-json 'bench_env={"WC_CHECKOUT_GATEWAY_MATRIX_PROFILES":"core_bacs,core_cheque,core_cod"}'
+homeboy fuzz run --rig woocommerce-performance \
+  --workload checkout-gateway-compatibility-matrix \
+  --run-id woocommerce-checkout-pr-65588-old-shape-gateway \
+  --seed 1 \
+  --max-duration 15m
 
-homeboy bench --rig woocommerce-performance \
-  --scenario checkout-concurrent-create-order \
-  --iterations 1 \
-  --shared-state /tmp/woocommerce-checkout-pr-65588-old-shape
+homeboy fuzz run --rig woocommerce-performance \
+  --workload checkout-concurrent-create-order \
+  --run-id woocommerce-checkout-pr-65588-old-shape-concurrent \
+  --seed 1 \
+  --max-duration 10m
 ```
 
-Repeat with the revised candidate checked out and
-`--shared-state /tmp/woocommerce-checkout-pr-65588-revised-candidate`.
+Repeat with the revised candidate checked out and candidate-specific `--run-id`
+values.
 
 ## Expected Interpretation
 

--- a/woocommerce/woocommerce/docs/checkout-shipping-cache-matrix-report.md
+++ b/woocommerce/woocommerce/docs/checkout-shipping-cache-matrix-report.md
@@ -1,8 +1,8 @@
 # Checkout Shipping Cache Matrix Report
 
-This is the report shell for WooCommerce shipping-cache evidence packages. It is
-safe to paste into WooCommerce PR comments after replacing planned rows with real
-baseline/candidate artifacts.
+This is the report shell for WooCommerce shipping-cache fuzz evidence packages.
+It is safe to paste into WooCommerce PR comments after replacing planned rows
+with real baseline/candidate artifacts.
 
 Generate the current report shape locally:
 
@@ -16,11 +16,11 @@ script only renders that data plus optional workload artifacts. This keeps the
 Woo-specific matrix shape close to the future Homeboy core evidence-matrix
 primitive without depending on unreleased core.
 
-Generate from one shared-state directory:
+Generate from one exported artifact directory:
 
 ```bash
 node woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs \
-  --input /tmp/woocommerce-performance-bench
+  --input /tmp/woocommerce-shipping-cache-artifacts
 ```
 
 Generate baseline/candidate deltas when Homeboy comparison/export artifacts are
@@ -38,16 +38,16 @@ node woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs \
 homeboy rig up woocommerce-performance
 homeboy rig check woocommerce-performance
 
-homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-40x1 --setting-json 'bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"40","WC_SHIPPING_CACHE_PACKAGES":"1","WC_SHIPPING_CACHE_TOTAL_CHURN_RUNS":"3"}'
-homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-40x8 --setting-json 'bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"40","WC_SHIPPING_CACHE_PACKAGES":"8","WC_SHIPPING_CACHE_TOTAL_CHURN_RUNS":"3"}'
-homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-200x8 --setting-json 'bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"200","WC_SHIPPING_CACHE_PACKAGES":"8","WC_SHIPPING_CACHE_TOTAL_CHURN_RUNS":"5"}' --force-hot
-homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-200x40 --setting-json 'bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"200","WC_SHIPPING_CACHE_PACKAGES":"40","WC_SHIPPING_CACHE_TOTAL_CHURN_RUNS":"5"}' --force-hot
-homeboy bench --rig woocommerce-performance --scenario checkout-shipping-cache --iterations 1 --shared-state /tmp/woocommerce-performance-1000x40 --setting-json 'bench_env={"WC_SHIPPING_CACHE_CART_ITEMS":"1000","WC_SHIPPING_CACHE_PACKAGES":"40","WC_SHIPPING_CACHE_TOTAL_CHURN_RUNS":"5"}' --force-hot
+homeboy fuzz run --rig woocommerce-performance --workload checkout-shipping-cache --run-id woocommerce-shipping-cache-40x1 --seed 1 --max-duration 15m
+homeboy fuzz run --rig woocommerce-performance --workload checkout-shipping-cache --run-id woocommerce-shipping-cache-40x8 --seed 1 --max-duration 15m
+homeboy fuzz run --rig woocommerce-performance --workload checkout-shipping-cache --run-id woocommerce-shipping-cache-200x8 --seed 1 --max-duration 15m
+homeboy fuzz run --rig woocommerce-performance --workload checkout-shipping-cache --run-id woocommerce-shipping-cache-200x40 --seed 1 --max-duration 15m
+homeboy fuzz run --rig woocommerce-performance --workload checkout-shipping-cache --run-id woocommerce-shipping-cache-1000x40 --seed 1 --max-duration 15m
 ```
 
 ## Dependency Blockers
 
 - Extra-Chill/homeboy#3516 is needed before this report can consume canonical
-  Homeboy baseline/candidate exports instead of local shared-state directories.
+  Homeboy baseline/candidate exports directly from the run corpus.
 - Extra-Chill/homeboy-extensions#1089 added deterministic expensive shipping
   method fixture support for the matrix dimension.

--- a/woocommerce/woocommerce/fuzz/admin-page-coverage.json
+++ b/woocommerce/woocommerce/fuzz/admin-page-coverage.json
@@ -1,0 +1,17 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "admin-page-coverage",
+  "label": "WooCommerce admin page coverage",
+  "safety_class": "read_only",
+  "surface_ids": ["woocommerce-admin-pages", "wordpress-admin-pages"],
+  "operations": ["admin-page-discovery", "permission-boundary-classification", "query-attribution"],
+  "case_budget": 80,
+  "duration_budget_seconds": 900,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/admin-page-coverage.php",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  }
+}

--- a/woocommerce/woocommerce/fuzz/cart-session-overwrite-race.json
+++ b/woocommerce/woocommerce/fuzz/cart-session-overwrite-race.json
@@ -1,0 +1,17 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "cart-session-overwrite-race",
+  "label": "Cart session overwrite race",
+  "safety_class": "isolated_mutation",
+  "surface_ids": ["woocommerce-cart-session"],
+  "operations": ["session-write-race", "cart-hash-guardrail"],
+  "case_budget": 1,
+  "duration_budget_seconds": 300,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/cart-session-overwrite-race.php",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  }
+}

--- a/woocommerce/woocommerce/fuzz/checkout-concurrent-create-order.json
+++ b/woocommerce/woocommerce/fuzz/checkout-concurrent-create-order.json
@@ -1,0 +1,22 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "checkout-concurrent-create-order",
+  "label": "Checkout create_order atomicity",
+  "safety_class": "isolated_mutation",
+  "surface_ids": ["woocommerce-checkout-create-order", "woocommerce-ajax-checkout"],
+  "operations": ["duplicate-order-repro", "concurrent-checkout-post", "session-side-effect-guardrails"],
+  "case_budget": 10,
+  "duration_budget_seconds": 600,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/checkout-concurrent-create-order.php",
+    "issues": [
+      "https://github.com/woocommerce/woocommerce/issues/62659",
+      "https://github.com/chubes4/homeboy-rigs/issues/253",
+      "https://github.com/chubes4/homeboy-rigs/issues/254"
+    ],
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  }
+}

--- a/woocommerce/woocommerce/fuzz/checkout-gateway-compatibility-matrix.json
+++ b/woocommerce/woocommerce/fuzz/checkout-gateway-compatibility-matrix.json
@@ -1,0 +1,17 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "checkout-gateway-compatibility-matrix",
+  "label": "Checkout gateway compatibility matrix",
+  "safety_class": "isolated_mutation",
+  "surface_ids": ["woocommerce-checkout-payment-gateways", "woocommerce-checkout-create-order"],
+  "operations": ["gateway-profile-matrix", "idempotency-repro", "dependency-readiness-classification"],
+  "case_budget": 12,
+  "duration_budget_seconds": 900,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/checkout-gateway-compatibility-matrix.php",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  }
+}

--- a/woocommerce/woocommerce/fuzz/checkout-shipping-cache.json
+++ b/woocommerce/woocommerce/fuzz/checkout-shipping-cache.json
@@ -1,0 +1,28 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "checkout-shipping-cache",
+  "label": "Checkout shipping cache guardrails",
+  "safety_class": "isolated_mutation",
+  "surface_ids": ["woocommerce-cart-shipping-packages", "woocommerce-shipping-rate-cache"],
+  "operations": ["package-shape-matrix", "cache-key-churn", "real-input-rehash"],
+  "case_budget": 40,
+  "duration_budget_seconds": 900,
+  "thresholds": [
+    {
+      "schema": "homeboy/fuzz-threshold/v1",
+      "id": "shipping-cache-max-failure-rate",
+      "metric": "failure_rate",
+      "operator": "less_than_or_equal",
+      "value": 0,
+      "unit": "ratio",
+      "safety_class": "isolated_mutation"
+    }
+  ],
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/checkout-shipping-cache.php",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  }
+}

--- a/woocommerce/woocommerce/fuzz/db-inventory.json
+++ b/woocommerce/woocommerce/fuzz/db-inventory.json
@@ -1,0 +1,17 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "db-inventory",
+  "label": "WooCommerce database inventory",
+  "safety_class": "read_only",
+  "surface_ids": ["woocommerce-database-tables", "wordpress-database-tables"],
+  "operations": ["table-inventory", "index-inventory"],
+  "case_budget": 1,
+  "duration_budget_seconds": 300,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/db-inventory.workload.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  }
+}

--- a/woocommerce/woocommerce/fuzz/generated-rest-request-cases.json
+++ b/woocommerce/woocommerce/fuzz/generated-rest-request-cases.json
@@ -1,0 +1,17 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "generated-rest-request-cases",
+  "label": "Generated WooCommerce REST request cases",
+  "safety_class": "isolated_mutation",
+  "surface_ids": ["woocommerce-rest-routes"],
+  "operations": ["generated-rest-case-plan", "request-case-execution"],
+  "case_budget": 200,
+  "duration_budget_seconds": 1200,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/generated-rest-request-cases.workload.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  }
+}

--- a/woocommerce/woocommerce/fuzz/layered-nav-catalog-crawl.json
+++ b/woocommerce/woocommerce/fuzz/layered-nav-catalog-crawl.json
@@ -1,0 +1,17 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "layered-nav-catalog-crawl",
+  "label": "Layered nav catalog crawl cache cap",
+  "safety_class": "isolated_mutation",
+  "surface_ids": ["woocommerce-layered-nav-widget", "woocommerce-product-archive"],
+  "operations": ["facet-url-crawl", "transient-entry-cap-guardrail"],
+  "case_budget": 25,
+  "duration_budget_seconds": 900,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/layered-nav-catalog-crawl.php",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  }
+}

--- a/woocommerce/woocommerce/fuzz/layered-nav-count-cache.json
+++ b/woocommerce/woocommerce/fuzz/layered-nav-count-cache.json
@@ -1,0 +1,17 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "layered-nav-count-cache",
+  "label": "Layered nav count cache cap",
+  "safety_class": "isolated_mutation",
+  "surface_ids": ["woocommerce-layered-nav-count-cache"],
+  "operations": ["taxonomy-filter-count-cache", "transient-entry-cap-guardrail"],
+  "case_budget": 25,
+  "duration_budget_seconds": 600,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/layered-nav-count-cache.php",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  }
+}

--- a/woocommerce/woocommerce/fuzz/rest-db-query-profile.json
+++ b/woocommerce/woocommerce/fuzz/rest-db-query-profile.json
@@ -1,0 +1,17 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "rest-db-query-profile",
+  "label": "REST DB query profile coverage",
+  "safety_class": "read_only",
+  "surface_ids": ["woocommerce-rest-routes", "wordpress-database-queries"],
+  "operations": ["rest-query-profile", "query-shape-attribution"],
+  "case_budget": 80,
+  "duration_budget_seconds": 900,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/rest-db-query-profile.workload.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  }
+}

--- a/woocommerce/woocommerce/fuzz/woocommerce-external-http-guardrail.json
+++ b/woocommerce/woocommerce/fuzz/woocommerce-external-http-guardrail.json
@@ -1,0 +1,17 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "woocommerce-external-http-guardrail",
+  "label": "WooCommerce external HTTP guardrail",
+  "safety_class": "read_only",
+  "surface_ids": ["woocommerce-external-http"],
+  "operations": ["external-http-blocklist-probe", "network-side-effect-classification"],
+  "case_budget": 1,
+  "duration_budget_seconds": 300,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/woocommerce-external-http-guardrail.php",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  }
+}

--- a/woocommerce/woocommerce/fuzz/woocommerce-rest-route-inventory.json
+++ b/woocommerce/woocommerce/fuzz/woocommerce-rest-route-inventory.json
@@ -1,0 +1,17 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "woocommerce-rest-route-inventory",
+  "label": "WooCommerce REST route inventory",
+  "safety_class": "read_only",
+  "surface_ids": ["woocommerce-rest-routes", "wordpress-rest-api"],
+  "operations": ["route-discovery", "permission-boundary-classification"],
+  "case_budget": 1,
+  "duration_budget_seconds": 300,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/woocommerce-rest-route-inventory.php",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  }
+}

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -1,6 +1,6 @@
 {
   "id": "woocommerce-performance",
-  "description": "WooCommerce large-merchant performance rig. Uses the WordPress/WP Codebox bench runtime for checkout and shipping cache workloads tied to concrete WooCommerce performance issues.",
+  "description": "WooCommerce large-merchant performance and fuzz rig. Uses WordPress/WP Codebox runtimes for performance benchmarks plus declared fuzz workloads tied to concrete WooCommerce issues and coverage surfaces.",
   "components": {
     "woocommerce": {
       "path": "~/Developer/woocommerce/plugins/woocommerce",
@@ -61,82 +61,42 @@
     "default_component": "woocommerce",
     "warmup_iterations": 0
   },
+  "fuzz": {
+    "default_component": "woocommerce"
+  },
   "bench_workloads": {
     "wordpress": [
-      { "path": "${package.root}/bench/cart-session-overwrite-race.php" },
-      { "path": "${package.root}/bench/checkout-concurrent-create-order.php" },
-      { "path": "${package.root}/bench/checkout-gateway-compatibility-matrix.php" },
       { "path": "${package.root}/bench/checkout-shortcode-place-order-latency.php" },
-      { "path": "${package.root}/bench/checkout-shipping-cache.php" },
       { "path": "${package.root}/bench/admin-dashboard-physical-products-query.php" },
-      { "path": "${package.root}/bench/layered-nav-count-cache.php" },
-      { "path": "${package.root}/bench/layered-nav-catalog-crawl.php" },
-      { "path": "${package.root}/bench/admin-page-coverage.php" },
-      { "path": "${package.root}/bench/woocommerce-rest-route-inventory.php" },
-      { "path": "${package.root}/bench/rest-product-batch-import.php" },
-      { "path": "${package.root}/bench/woocommerce-external-http-guardrail.php" },
-      { "path": "${package.root}/bench/generated-rest-request-cases.workload.json" },
-      { "path": "${package.root}/bench/rest-db-query-profile.workload.json" },
-      { "path": "${package.root}/bench/db-inventory.workload.json" }
+      { "path": "${package.root}/bench/rest-product-batch-import.php" }
+    ]
+  },
+  "fuzz_workloads": {
+    "wordpress": [
+      { "path": "${package.root}/fuzz/cart-session-overwrite-race.json" },
+      { "path": "${package.root}/fuzz/checkout-concurrent-create-order.json" },
+      { "path": "${package.root}/fuzz/checkout-gateway-compatibility-matrix.json" },
+      { "path": "${package.root}/fuzz/checkout-shipping-cache.json" },
+      { "path": "${package.root}/fuzz/admin-page-coverage.json" },
+      { "path": "${package.root}/fuzz/layered-nav-count-cache.json" },
+      { "path": "${package.root}/fuzz/layered-nav-catalog-crawl.json" },
+      { "path": "${package.root}/fuzz/woocommerce-rest-route-inventory.json" },
+      { "path": "${package.root}/fuzz/generated-rest-request-cases.json" },
+      { "path": "${package.root}/fuzz/rest-db-query-profile.json" },
+      { "path": "${package.root}/fuzz/db-inventory.json" },
+      { "path": "${package.root}/fuzz/woocommerce-external-http-guardrail.json" }
     ]
   },
   "bench_profiles": {
     "smoke": [
-      "cart-session-overwrite-race",
-      "checkout-concurrent-create-order",
-      "checkout-gateway-compatibility-matrix",
       "checkout-shortcode-place-order-latency",
-      "checkout-shipping-cache",
       "admin-dashboard-physical-products-query",
-      "layered-nav-count-cache",
-      "layered-nav-catalog-crawl",
-      "woocommerce-rest-route-inventory",
-      "rest-product-batch-import",
-      "woocommerce-external-http-guardrail",
-      "generated-rest-request-cases",
-      "rest-db-query-profile",
-      "db-inventory"
+      "rest-product-batch-import"
     ],
     "hot": [
-      "cart-session-overwrite-race",
-      "checkout-concurrent-create-order",
-      "checkout-gateway-compatibility-matrix",
       "checkout-shortcode-place-order-latency",
-      "checkout-shipping-cache",
       "admin-dashboard-physical-products-query",
-      "layered-nav-count-cache",
-      "layered-nav-catalog-crawl",
-      "woocommerce-rest-route-inventory",
-      "rest-product-batch-import",
-      "woocommerce-external-http-guardrail",
-      "generated-rest-request-cases",
-      "rest-db-query-profile",
-      "db-inventory"
-    ],
-    "api-coverage": [
-      "woocommerce-rest-route-inventory",
-      "generated-rest-request-cases",
-      "rest-db-query-profile"
-    ],
-    "full-surface": [
-      "cart-session-overwrite-race",
-      "checkout-concurrent-create-order",
-      "checkout-gateway-compatibility-matrix",
-      "checkout-shortcode-place-order-latency",
-      "checkout-shipping-cache",
-      "admin-dashboard-physical-products-query",
-      "layered-nav-count-cache",
-      "layered-nav-catalog-crawl",
-      "admin-page-coverage",
-      "woocommerce-rest-route-inventory",
-      "rest-product-batch-import",
-      "woocommerce-external-http-guardrail",
-      "generated-rest-request-cases",
-      "rest-db-query-profile",
-      "db-inventory"
-    ],
-    "checkout-concurrent": [
-      "checkout-concurrent-create-order"
+      "rest-product-batch-import"
     ]
   },
   "pipeline": {
@@ -187,7 +147,7 @@
         "kind": "command",
         "label": "WooCommerce admin assets are built",
         "command": "bash \"${package.root}/tools/check-admin-assets.sh\" \"${components.woocommerce.path}\"",
-        "remediation": "Use a packaged WooCommerce plugin checkout or build the WooCommerce admin assets before running admin-page-coverage/full-surface benchmarks."
+        "remediation": "Use a packaged WooCommerce plugin checkout or build the WooCommerce admin assets before running admin-page-coverage fuzz workloads."
       }
     ],
     "up": [


### PR DESCRIPTION
## Summary
- migrate WooCommerce coverage/guardrail workloads from `bench_workloads` to declarative `fuzz_workloads`
- add 12 `homeboy/fuzz-workload/v1` manifests for checkout, shipping cache, layered nav, admin, REST, DB, and external HTTP guardrail surfaces
- remove migrated workload IDs from bench profiles so there is no legacy bench fallback path
- update docs and commands to use `homeboy fuzz run --rig woocommerce-performance`

## Dependency
- Depends on Extra-Chill/homeboy#5655 for `homeboy fuzz --rig` and `fuzz_workloads` support.

## Verification
- Parsed `woocommerce-performance/rig.json` plus all fuzz manifests with Node.
- Validated 12 fuzz manifests are declared by the rig and do not appear in `bench_workloads` or `bench_profiles`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Migrating rig declarations/docs, drafting fuzz workload manifests, and running structural validation.
