### PR TITLE
feat(woocommerce): declare fuzz runner inputs

### DIFF
--- a/woocommerce/woocommerce/fuzz/admin-page-coverage.json
+++ b/woocommerce/woocommerce/fuzz/admin-page-coverage.json
@@ -3,8 +3,15 @@
   "id": "admin-page-coverage",
   "label": "WooCommerce admin page coverage",
   "safety_class": "read_only",
-  "surface_ids": ["woocommerce-admin-pages", "wordpress-admin-pages"],
-  "operations": ["admin-page-discovery", "permission-boundary-classification", "query-attribution"],
+  "surface_ids": [
+    "woocommerce-admin-pages",
+    "wordpress-admin-pages"
+  ],
+  "operations": [
+    "admin-page-discovery",
+    "permission-boundary-classification",
+    "query-attribution"
+  ],
   "case_budget": 80,
   "duration_budget_seconds": 900,
   "metadata": {
@@ -13,5 +20,95 @@
     "workload_path": "${package.root}/bench/admin-page-coverage.php",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "php",
+    "path": "${package.root}/bench/admin-page-coverage.php",
+    "entry": "admin-page-coverage"
+  },
+  "cases": [
+    {
+      "case_id": "admin-page-coverage:default",
+      "surface_ids": [
+        "woocommerce-admin-pages",
+        "wordpress-admin-pages"
+      ],
+      "operations": [
+        "admin-page-discovery",
+        "permission-boundary-classification",
+        "query-attribution"
+      ],
+      "phases": {
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=woocommerce/woocommerce.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.run-workload",
+            "args": [
+              "path=${package.root}/bench/admin-page-coverage.php",
+              "type=php"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=admin_page_coverage"
+            ]
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "admin_page_coverage",
+          "path": "admin-page-coverage/admin_page_coverage.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "read_only"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 80,
+    "max_duration_seconds": 900
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-admin-pages",
+      "wordpress-admin-pages"
+    ],
+    "operations": [
+      "admin-page-discovery",
+      "permission-boundary-classification",
+      "query-attribution"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "admin_page_coverage",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": false
+      }
+    ]
   }
 }

--- a/woocommerce/woocommerce/fuzz/cart-session-overwrite-race.json
+++ b/woocommerce/woocommerce/fuzz/cart-session-overwrite-race.json
@@ -3,8 +3,13 @@
   "id": "cart-session-overwrite-race",
   "label": "Cart session overwrite race",
   "safety_class": "isolated_mutation",
-  "surface_ids": ["woocommerce-cart-session"],
-  "operations": ["session-write-race", "cart-hash-guardrail"],
+  "surface_ids": [
+    "woocommerce-cart-session"
+  ],
+  "operations": [
+    "session-write-race",
+    "cart-hash-guardrail"
+  ],
   "case_budget": 1,
   "duration_budget_seconds": 300,
   "metadata": {
@@ -13,5 +18,91 @@
     "workload_path": "${package.root}/bench/cart-session-overwrite-race.php",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "php",
+    "path": "${package.root}/bench/cart-session-overwrite-race.php",
+    "entry": "cart-session-overwrite-race"
+  },
+  "cases": [
+    {
+      "case_id": "cart-session-overwrite-race:default",
+      "surface_ids": [
+        "woocommerce-cart-session"
+      ],
+      "operations": [
+        "session-write-race",
+        "cart-hash-guardrail"
+      ],
+      "phases": {
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=woocommerce/woocommerce.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.run-workload",
+            "args": [
+              "path=${package.root}/bench/cart-session-overwrite-race.php",
+              "type=php"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=raw_result"
+            ]
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "raw_result",
+          "path": "cart-session-overwrite-race/raw_result.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "isolated_mutation"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 1,
+    "max_duration_seconds": 300
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-cart-session"
+    ],
+    "operations": [
+      "session-write-race",
+      "cart-hash-guardrail"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "raw_result",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": false
+      }
+    ]
   }
 }

--- a/woocommerce/woocommerce/fuzz/checkout-concurrent-create-order.json
+++ b/woocommerce/woocommerce/fuzz/checkout-concurrent-create-order.json
@@ -3,8 +3,15 @@
   "id": "checkout-concurrent-create-order",
   "label": "Checkout create_order atomicity",
   "safety_class": "isolated_mutation",
-  "surface_ids": ["woocommerce-checkout-create-order", "woocommerce-ajax-checkout"],
-  "operations": ["duplicate-order-repro", "concurrent-checkout-post", "session-side-effect-guardrails"],
+  "surface_ids": [
+    "woocommerce-checkout-create-order",
+    "woocommerce-ajax-checkout"
+  ],
+  "operations": [
+    "duplicate-order-repro",
+    "concurrent-checkout-post",
+    "session-side-effect-guardrails"
+  ],
   "case_budget": 10,
   "duration_budget_seconds": 600,
   "metadata": {
@@ -18,5 +25,95 @@
     ],
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "php",
+    "path": "${package.root}/bench/checkout-concurrent-create-order.php",
+    "entry": "checkout-concurrent-create-order"
+  },
+  "cases": [
+    {
+      "case_id": "checkout-concurrent-create-order:default",
+      "surface_ids": [
+        "woocommerce-checkout-create-order",
+        "woocommerce-ajax-checkout"
+      ],
+      "operations": [
+        "duplicate-order-repro",
+        "concurrent-checkout-post",
+        "session-side-effect-guardrails"
+      ],
+      "phases": {
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=woocommerce/woocommerce.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.run-workload",
+            "args": [
+              "path=${package.root}/bench/checkout-concurrent-create-order.php",
+              "type=php"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=raw_result"
+            ]
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "raw_result",
+          "path": "checkout-concurrent-create-order/raw_result.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "isolated_mutation"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 10,
+    "max_duration_seconds": 600
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-checkout-create-order",
+      "woocommerce-ajax-checkout"
+    ],
+    "operations": [
+      "duplicate-order-repro",
+      "concurrent-checkout-post",
+      "session-side-effect-guardrails"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "raw_result",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": false
+      }
+    ]
   }
 }

--- a/woocommerce/woocommerce/fuzz/checkout-gateway-compatibility-matrix.json
+++ b/woocommerce/woocommerce/fuzz/checkout-gateway-compatibility-matrix.json
@@ -3,8 +3,15 @@
   "id": "checkout-gateway-compatibility-matrix",
   "label": "Checkout gateway compatibility matrix",
   "safety_class": "isolated_mutation",
-  "surface_ids": ["woocommerce-checkout-payment-gateways", "woocommerce-checkout-create-order"],
-  "operations": ["gateway-profile-matrix", "idempotency-repro", "dependency-readiness-classification"],
+  "surface_ids": [
+    "woocommerce-checkout-payment-gateways",
+    "woocommerce-checkout-create-order"
+  ],
+  "operations": [
+    "gateway-profile-matrix",
+    "idempotency-repro",
+    "dependency-readiness-classification"
+  ],
   "case_budget": 12,
   "duration_budget_seconds": 900,
   "metadata": {
@@ -13,5 +20,95 @@
     "workload_path": "${package.root}/bench/checkout-gateway-compatibility-matrix.php",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "php",
+    "path": "${package.root}/bench/checkout-gateway-compatibility-matrix.php",
+    "entry": "checkout-gateway-compatibility-matrix"
+  },
+  "cases": [
+    {
+      "case_id": "checkout-gateway-compatibility-matrix:default",
+      "surface_ids": [
+        "woocommerce-checkout-payment-gateways",
+        "woocommerce-checkout-create-order"
+      ],
+      "operations": [
+        "gateway-profile-matrix",
+        "idempotency-repro",
+        "dependency-readiness-classification"
+      ],
+      "phases": {
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=woocommerce/woocommerce.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.run-workload",
+            "args": [
+              "path=${package.root}/bench/checkout-gateway-compatibility-matrix.php",
+              "type=php"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=gateway_matrix"
+            ]
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "gateway_matrix",
+          "path": "checkout-gateway-compatibility-matrix/gateway_matrix.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "isolated_mutation"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 12,
+    "max_duration_seconds": 900
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-checkout-payment-gateways",
+      "woocommerce-checkout-create-order"
+    ],
+    "operations": [
+      "gateway-profile-matrix",
+      "idempotency-repro",
+      "dependency-readiness-classification"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "gateway_matrix",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": false
+      }
+    ]
   }
 }

--- a/woocommerce/woocommerce/fuzz/checkout-shipping-cache.json
+++ b/woocommerce/woocommerce/fuzz/checkout-shipping-cache.json
@@ -3,8 +3,15 @@
   "id": "checkout-shipping-cache",
   "label": "Checkout shipping cache guardrails",
   "safety_class": "isolated_mutation",
-  "surface_ids": ["woocommerce-cart-shipping-packages", "woocommerce-shipping-rate-cache"],
-  "operations": ["package-shape-matrix", "cache-key-churn", "real-input-rehash"],
+  "surface_ids": [
+    "woocommerce-cart-shipping-packages",
+    "woocommerce-shipping-rate-cache"
+  ],
+  "operations": [
+    "package-shape-matrix",
+    "cache-key-churn",
+    "real-input-rehash"
+  ],
   "case_budget": 40,
   "duration_budget_seconds": 900,
   "thresholds": [
@@ -24,5 +31,95 @@
     "workload_path": "${package.root}/bench/checkout-shipping-cache.php",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "php",
+    "path": "${package.root}/bench/checkout-shipping-cache.php",
+    "entry": "checkout-shipping-cache"
+  },
+  "cases": [
+    {
+      "case_id": "checkout-shipping-cache:default",
+      "surface_ids": [
+        "woocommerce-cart-shipping-packages",
+        "woocommerce-shipping-rate-cache"
+      ],
+      "operations": [
+        "package-shape-matrix",
+        "cache-key-churn",
+        "real-input-rehash"
+      ],
+      "phases": {
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=woocommerce/woocommerce.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.run-workload",
+            "args": [
+              "path=${package.root}/bench/checkout-shipping-cache.php",
+              "type=php"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=raw_result"
+            ]
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "raw_result",
+          "path": "checkout-shipping-cache/raw_result.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "isolated_mutation"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 40,
+    "max_duration_seconds": 900
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-cart-shipping-packages",
+      "woocommerce-shipping-rate-cache"
+    ],
+    "operations": [
+      "package-shape-matrix",
+      "cache-key-churn",
+      "real-input-rehash"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "raw_result",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": false
+      }
+    ]
   }
 }

--- a/woocommerce/woocommerce/fuzz/db-inventory.json
+++ b/woocommerce/woocommerce/fuzz/db-inventory.json
@@ -3,8 +3,14 @@
   "id": "db-inventory",
   "label": "WooCommerce database inventory",
   "safety_class": "read_only",
-  "surface_ids": ["woocommerce-database-tables", "wordpress-database-tables"],
-  "operations": ["table-inventory", "index-inventory"],
+  "surface_ids": [
+    "woocommerce-database-tables",
+    "wordpress-database-tables"
+  ],
+  "operations": [
+    "table-inventory",
+    "index-inventory"
+  ],
   "case_budget": 1,
   "duration_budget_seconds": 300,
   "metadata": {
@@ -13,5 +19,93 @@
     "workload_path": "${package.root}/bench/db-inventory.workload.json",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "json",
+    "path": "${package.root}/bench/db-inventory.workload.json",
+    "entry": "db-inventory"
+  },
+  "cases": [
+    {
+      "case_id": "db-inventory:default",
+      "surface_ids": [
+        "woocommerce-database-tables",
+        "wordpress-database-tables"
+      ],
+      "operations": [
+        "table-inventory",
+        "index-inventory"
+      ],
+      "phases": {
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=woocommerce/woocommerce.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.run-workload",
+            "args": [
+              "path=${package.root}/bench/db-inventory.workload.json",
+              "type=json"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=db_inventory"
+            ]
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "db_inventory",
+          "path": "db-inventory/db_inventory.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "read_only"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 1,
+    "max_duration_seconds": 300
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-database-tables",
+      "wordpress-database-tables"
+    ],
+    "operations": [
+      "table-inventory",
+      "index-inventory"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "db_inventory",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": false
+      }
+    ]
   }
 }

--- a/woocommerce/woocommerce/fuzz/generated-rest-request-cases.json
+++ b/woocommerce/woocommerce/fuzz/generated-rest-request-cases.json
@@ -3,8 +3,13 @@
   "id": "generated-rest-request-cases",
   "label": "Generated WooCommerce REST request cases",
   "safety_class": "isolated_mutation",
-  "surface_ids": ["woocommerce-rest-routes"],
-  "operations": ["generated-rest-case-plan", "request-case-execution"],
+  "surface_ids": [
+    "woocommerce-rest-routes"
+  ],
+  "operations": [
+    "generated-rest-case-plan",
+    "request-case-execution"
+  ],
   "case_budget": 200,
   "duration_budget_seconds": 1200,
   "metadata": {
@@ -13,5 +18,91 @@
     "workload_path": "${package.root}/bench/generated-rest-request-cases.workload.json",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "json",
+    "path": "${package.root}/bench/generated-rest-request-cases.workload.json",
+    "entry": "generated-rest-request-cases"
+  },
+  "cases": [
+    {
+      "case_id": "generated-rest-request-cases:default",
+      "surface_ids": [
+        "woocommerce-rest-routes"
+      ],
+      "operations": [
+        "generated-rest-case-plan",
+        "request-case-execution"
+      ],
+      "phases": {
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=woocommerce/woocommerce.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.run-workload",
+            "args": [
+              "path=${package.root}/bench/generated-rest-request-cases.workload.json",
+              "type=json"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=rest_request_cases"
+            ]
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "rest_request_cases",
+          "path": "generated-rest-request-cases/rest_request_cases.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "isolated_mutation"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 200,
+    "max_duration_seconds": 1200
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-rest-routes"
+    ],
+    "operations": [
+      "generated-rest-case-plan",
+      "request-case-execution"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "rest_request_cases",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": false
+      }
+    ]
   }
 }

--- a/woocommerce/woocommerce/fuzz/layered-nav-catalog-crawl.json
+++ b/woocommerce/woocommerce/fuzz/layered-nav-catalog-crawl.json
@@ -3,8 +3,14 @@
   "id": "layered-nav-catalog-crawl",
   "label": "Layered nav catalog crawl cache cap",
   "safety_class": "isolated_mutation",
-  "surface_ids": ["woocommerce-layered-nav-widget", "woocommerce-product-archive"],
-  "operations": ["facet-url-crawl", "transient-entry-cap-guardrail"],
+  "surface_ids": [
+    "woocommerce-layered-nav-widget",
+    "woocommerce-product-archive"
+  ],
+  "operations": [
+    "facet-url-crawl",
+    "transient-entry-cap-guardrail"
+  ],
   "case_budget": 25,
   "duration_budget_seconds": 900,
   "metadata": {
@@ -13,5 +19,93 @@
     "workload_path": "${package.root}/bench/layered-nav-catalog-crawl.php",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "php",
+    "path": "${package.root}/bench/layered-nav-catalog-crawl.php",
+    "entry": "layered-nav-catalog-crawl"
+  },
+  "cases": [
+    {
+      "case_id": "layered-nav-catalog-crawl:default",
+      "surface_ids": [
+        "woocommerce-layered-nav-widget",
+        "woocommerce-product-archive"
+      ],
+      "operations": [
+        "facet-url-crawl",
+        "transient-entry-cap-guardrail"
+      ],
+      "phases": {
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=woocommerce/woocommerce.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.run-workload",
+            "args": [
+              "path=${package.root}/bench/layered-nav-catalog-crawl.php",
+              "type=php"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=raw_result"
+            ]
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "raw_result",
+          "path": "layered-nav-catalog-crawl/raw_result.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "isolated_mutation"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 25,
+    "max_duration_seconds": 900
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-layered-nav-widget",
+      "woocommerce-product-archive"
+    ],
+    "operations": [
+      "facet-url-crawl",
+      "transient-entry-cap-guardrail"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "raw_result",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": false
+      }
+    ]
   }
 }

--- a/woocommerce/woocommerce/fuzz/layered-nav-count-cache.json
+++ b/woocommerce/woocommerce/fuzz/layered-nav-count-cache.json
@@ -3,8 +3,13 @@
   "id": "layered-nav-count-cache",
   "label": "Layered nav count cache cap",
   "safety_class": "isolated_mutation",
-  "surface_ids": ["woocommerce-layered-nav-count-cache"],
-  "operations": ["taxonomy-filter-count-cache", "transient-entry-cap-guardrail"],
+  "surface_ids": [
+    "woocommerce-layered-nav-count-cache"
+  ],
+  "operations": [
+    "taxonomy-filter-count-cache",
+    "transient-entry-cap-guardrail"
+  ],
   "case_budget": 25,
   "duration_budget_seconds": 600,
   "metadata": {
@@ -13,5 +18,91 @@
     "workload_path": "${package.root}/bench/layered-nav-count-cache.php",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "php",
+    "path": "${package.root}/bench/layered-nav-count-cache.php",
+    "entry": "layered-nav-count-cache"
+  },
+  "cases": [
+    {
+      "case_id": "layered-nav-count-cache:default",
+      "surface_ids": [
+        "woocommerce-layered-nav-count-cache"
+      ],
+      "operations": [
+        "taxonomy-filter-count-cache",
+        "transient-entry-cap-guardrail"
+      ],
+      "phases": {
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=woocommerce/woocommerce.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.run-workload",
+            "args": [
+              "path=${package.root}/bench/layered-nav-count-cache.php",
+              "type=php"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=raw_result"
+            ]
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "raw_result",
+          "path": "layered-nav-count-cache/raw_result.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "isolated_mutation"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 25,
+    "max_duration_seconds": 600
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-layered-nav-count-cache"
+    ],
+    "operations": [
+      "taxonomy-filter-count-cache",
+      "transient-entry-cap-guardrail"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "raw_result",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": false
+      }
+    ]
   }
 }

--- a/woocommerce/woocommerce/fuzz/rest-db-query-profile.json
+++ b/woocommerce/woocommerce/fuzz/rest-db-query-profile.json
@@ -3,8 +3,14 @@
   "id": "rest-db-query-profile",
   "label": "REST DB query profile coverage",
   "safety_class": "read_only",
-  "surface_ids": ["woocommerce-rest-routes", "wordpress-database-queries"],
-  "operations": ["rest-query-profile", "query-shape-attribution"],
+  "surface_ids": [
+    "woocommerce-rest-routes",
+    "wordpress-database-queries"
+  ],
+  "operations": [
+    "rest-query-profile",
+    "query-shape-attribution"
+  ],
   "case_budget": 80,
   "duration_budget_seconds": 900,
   "metadata": {
@@ -13,5 +19,93 @@
     "workload_path": "${package.root}/bench/rest-db-query-profile.workload.json",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "json",
+    "path": "${package.root}/bench/rest-db-query-profile.workload.json",
+    "entry": "rest-db-query-profile"
+  },
+  "cases": [
+    {
+      "case_id": "rest-db-query-profile:default",
+      "surface_ids": [
+        "woocommerce-rest-routes",
+        "wordpress-database-queries"
+      ],
+      "operations": [
+        "rest-query-profile",
+        "query-shape-attribution"
+      ],
+      "phases": {
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=woocommerce/woocommerce.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.run-workload",
+            "args": [
+              "path=${package.root}/bench/rest-db-query-profile.workload.json",
+              "type=json"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=rest_db_query_profile"
+            ]
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "rest_db_query_profile",
+          "path": "rest-db-query-profile/rest_db_query_profile.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "read_only"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 80,
+    "max_duration_seconds": 900
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-rest-routes",
+      "wordpress-database-queries"
+    ],
+    "operations": [
+      "rest-query-profile",
+      "query-shape-attribution"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "rest_db_query_profile",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": false
+      }
+    ]
   }
 }

--- a/woocommerce/woocommerce/fuzz/woocommerce-external-http-guardrail.json
+++ b/woocommerce/woocommerce/fuzz/woocommerce-external-http-guardrail.json
@@ -3,8 +3,13 @@
   "id": "woocommerce-external-http-guardrail",
   "label": "WooCommerce external HTTP guardrail",
   "safety_class": "read_only",
-  "surface_ids": ["woocommerce-external-http"],
-  "operations": ["external-http-blocklist-probe", "network-side-effect-classification"],
+  "surface_ids": [
+    "woocommerce-external-http"
+  ],
+  "operations": [
+    "external-http-blocklist-probe",
+    "network-side-effect-classification"
+  ],
   "case_budget": 1,
   "duration_budget_seconds": 300,
   "metadata": {
@@ -13,5 +18,91 @@
     "workload_path": "${package.root}/bench/woocommerce-external-http-guardrail.php",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "php",
+    "path": "${package.root}/bench/woocommerce-external-http-guardrail.php",
+    "entry": "woocommerce-external-http-guardrail"
+  },
+  "cases": [
+    {
+      "case_id": "woocommerce-external-http-guardrail:default",
+      "surface_ids": [
+        "woocommerce-external-http"
+      ],
+      "operations": [
+        "external-http-blocklist-probe",
+        "network-side-effect-classification"
+      ],
+      "phases": {
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=woocommerce/woocommerce.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.run-workload",
+            "args": [
+              "path=${package.root}/bench/woocommerce-external-http-guardrail.php",
+              "type=php"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=external_http_guardrail"
+            ]
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "external_http_guardrail",
+          "path": "woocommerce-external-http-guardrail/external_http_guardrail.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "read_only"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 1,
+    "max_duration_seconds": 300
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-external-http"
+    ],
+    "operations": [
+      "external-http-blocklist-probe",
+      "network-side-effect-classification"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "external_http_guardrail",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": false
+      }
+    ]
   }
 }

--- a/woocommerce/woocommerce/fuzz/woocommerce-rest-route-inventory.json
+++ b/woocommerce/woocommerce/fuzz/woocommerce-rest-route-inventory.json
@@ -3,8 +3,14 @@
   "id": "woocommerce-rest-route-inventory",
   "label": "WooCommerce REST route inventory",
   "safety_class": "read_only",
-  "surface_ids": ["woocommerce-rest-routes", "wordpress-rest-api"],
-  "operations": ["route-discovery", "permission-boundary-classification"],
+  "surface_ids": [
+    "woocommerce-rest-routes",
+    "wordpress-rest-api"
+  ],
+  "operations": [
+    "route-discovery",
+    "permission-boundary-classification"
+  ],
   "case_budget": 1,
   "duration_budget_seconds": 300,
   "metadata": {
@@ -13,5 +19,93 @@
     "workload_path": "${package.root}/bench/woocommerce-rest-route-inventory.php",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "php",
+    "path": "${package.root}/bench/woocommerce-rest-route-inventory.php",
+    "entry": "woocommerce-rest-route-inventory"
+  },
+  "cases": [
+    {
+      "case_id": "woocommerce-rest-route-inventory:default",
+      "surface_ids": [
+        "woocommerce-rest-routes",
+        "wordpress-rest-api"
+      ],
+      "operations": [
+        "route-discovery",
+        "permission-boundary-classification"
+      ],
+      "phases": {
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=woocommerce/woocommerce.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.run-workload",
+            "args": [
+              "path=${package.root}/bench/woocommerce-rest-route-inventory.php",
+              "type=php"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=route_inventory"
+            ]
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "route_inventory",
+          "path": "woocommerce-rest-route-inventory/route_inventory.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "read_only"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 1,
+    "max_duration_seconds": 300
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-rest-routes",
+      "wordpress-rest-api"
+    ],
+    "operations": [
+      "route-discovery",
+      "permission-boundary-classification"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "route_inventory",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": false
+      }
+    ]
   }
 }

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.join(__dirname, '..');
+const fuzzDir = path.join(packageRoot, 'fuzz');
+const rig = JSON.parse(readFileSync(path.join(packageRoot, 'rigs/woocommerce-performance/rig.json'), 'utf8'));
+
+const fuzzManifests = readdirSync(fuzzDir)
+  .filter((file) => file.endsWith('.json'))
+  .sort()
+  .map((file) => ({
+    file,
+    path: path.join(fuzzDir, file),
+    manifest: JSON.parse(readFileSync(path.join(fuzzDir, file), 'utf8')),
+  }));
+
+assert.equal(fuzzManifests.length, 12, 'expected 12 WooCommerce fuzz manifests');
+
+const declaredFuzzIds = new Set(
+  (rig.fuzz_workloads?.wordpress || []).map((entry) => path.basename(entry.path, '.json'))
+);
+const benchWorkloadIds = new Set(
+  Object.values(rig.bench_workloads || {})
+    .flat()
+    .map((entry) => path.basename(entry.path, path.extname(entry.path)))
+);
+const benchProfileIds = new Set(Object.values(rig.bench_profiles || {}).flat());
+
+for (const { file, manifest } of fuzzManifests) {
+  assert.equal(manifest.schema, 'homeboy/fuzz-workload/v1', `${file} schema mismatch`);
+  assert.equal(typeof manifest.id, 'string', `${file} requires id`);
+  assert.ok(declaredFuzzIds.has(manifest.id), `${manifest.id} is not declared in rig fuzz_workloads.wordpress`);
+  assert.ok(!benchWorkloadIds.has(manifest.id), `${manifest.id} must not appear in bench_workloads`);
+  assert.ok(!benchProfileIds.has(manifest.id), `${manifest.id} must not appear in bench_profiles`);
+
+  assert.equal(manifest.target?.type, 'wordpress-plugin', `${manifest.id} target.type mismatch`);
+  assert.equal(manifest.target?.slug, 'woocommerce', `${manifest.id} target.slug mismatch`);
+  assert.equal(manifest.workload?.runner, 'wp-codebox', `${manifest.id} workload.runner mismatch`);
+  assert.equal(manifest.workload?.path, manifest.metadata?.workload_path, `${manifest.id} workload path must match metadata`);
+  assert.ok(['php', 'json'].includes(manifest.workload?.type), `${manifest.id} workload.type must be php or json`);
+  assert.deepEqual(manifest.coverage?.surface_ids, manifest.surface_ids, `${manifest.id} coverage surface ids drifted`);
+  assert.deepEqual(manifest.coverage?.operations, manifest.operations, `${manifest.id} coverage operations drifted`);
+  assert.equal(manifest.limits?.max_cases, manifest.case_budget, `${manifest.id} max_cases must match case_budget`);
+  assert.equal(manifest.limits?.max_duration_seconds, manifest.duration_budget_seconds, `${manifest.id} max_duration_seconds must match duration_budget_seconds`);
+
+  assert.equal(manifest.cases?.length, 1, `${manifest.id} requires one default runner case`);
+  const [runnerCase] = manifest.cases;
+  assert.equal(runnerCase.case_id, `${manifest.id}:default`, `${manifest.id} default case id mismatch`);
+  assert.deepEqual(runnerCase.surface_ids, manifest.surface_ids, `${manifest.id} case surface ids drifted`);
+  assert.deepEqual(runnerCase.operations, manifest.operations, `${manifest.id} case operations drifted`);
+  assert.ok(Array.isArray(runnerCase.phases?.action), `${manifest.id} requires action phase`);
+  assert.ok(runnerCase.phases.action.length > 0, `${manifest.id} requires at least one action step`);
+  assert.ok(Array.isArray(runnerCase.artifacts), `${manifest.id} requires case artifacts`);
+  assert.ok(Array.isArray(manifest.artifacts?.expected), `${manifest.id} requires expected artifacts`);
+}
+
+console.log(`validated ${fuzzManifests.length} WooCommerce fuzz manifests; no migrated fuzz IDs are present in bench_workloads or bench_profiles`);


### PR DESCRIPTION
## Summary
- add concrete WP Codebox runner inputs to the 12 WooCommerce fuzz manifests introduced after #373
- declare target, workload path/type, default case ids, setup/action/assert phases, limits, coverage surfaces/operations, and expected fuzz artifacts in homeboy-rigs
- add a lightweight validator that parses all Woo fuzz manifests and verifies migrated fuzz ids are absent from `bench_workloads` and `bench_profiles`

## Validation
- `node --check woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs`
- `node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs`

Result:

```text
validated 12 WooCommerce fuzz manifests; no migrated fuzz IDs are present in bench_workloads or bench_profiles
```

No local benchmarks were run.

## Dependencies
- Builds on merged `chubes4/homeboy-rigs#373` for the initial Woo fuzz manifest migration.
- Requires merged `Extra-Chill/homeboy#5655` for `homeboy fuzz --rig` and `fuzz_workloads` support.
- Aligns with merged `Extra-Chill/homeboy-extensions#1633` and `Extra-Chill/homeboy-extensions#1638` for generic WP Codebox fuzz-run/fuzz-plan inputs.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Updating Woo fuzz manifests, adding the structural validator, running validation, and drafting this PR description.
