### PR TITLE
Validate Woo fuzz coverage wiring

### DIFF
--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -132,10 +132,18 @@ WooCommerce plugin directory.
 ```bash
 homeboy rig up woocommerce-performance
 homeboy fuzz list --rig woocommerce-performance
+homeboy fuzz run --rig woocommerce-performance --workload cart-session-overwrite-race --run-id wc-cart-session-overwrite-race --seed 1 --max-duration 10m
 homeboy fuzz run --rig woocommerce-performance --workload checkout-concurrent-create-order --run-id wc-checkout-atomicity --seed 1 --max-duration 10m
+homeboy fuzz run --rig woocommerce-performance --workload checkout-gateway-compatibility-matrix --run-id wc-gateway-matrix --seed 1 --max-duration 15m
 homeboy fuzz run --rig woocommerce-performance --workload checkout-shipping-cache --run-id wc-shipping-cache --seed 1 --max-duration 15m
+homeboy fuzz run --rig woocommerce-performance --workload layered-nav-count-cache --run-id wc-layered-nav-count-cache --seed 1 --max-duration 15m
+homeboy fuzz run --rig woocommerce-performance --workload layered-nav-catalog-crawl --run-id wc-layered-nav-catalog-crawl --seed 1 --max-duration 15m
 homeboy fuzz run --rig woocommerce-performance --workload admin-page-coverage --run-id wc-admin-coverage --seed 1 --max-duration 15m
+homeboy fuzz run --rig woocommerce-performance --workload woocommerce-rest-route-inventory --run-id wc-rest-route-inventory --seed 1 --max-duration 10m
 homeboy fuzz run --rig woocommerce-performance --workload generated-rest-request-cases --run-id wc-rest-generated-cases --seed 1 --max-duration 20m
+homeboy fuzz run --rig woocommerce-performance --workload rest-db-query-profile --run-id wc-rest-db-query-profile --seed 1 --max-duration 20m
+homeboy fuzz run --rig woocommerce-performance --workload db-inventory --run-id wc-db-inventory --seed 1 --max-duration 10m
+homeboy fuzz run --rig woocommerce-performance --workload woocommerce-external-http-guardrail --run-id wc-external-http-guardrail --seed 1 --max-duration 10m
 ```
 
 `homeboy fuzz --rig woocommerce-performance` resolves the rig's WooCommerce
@@ -143,6 +151,13 @@ component and `fuzz_workloads.wordpress` declarations. Fuzz workloads are not
 registered through `bench_workloads`, so there is no legacy bench fallback path
 for checkout atomicity, shipping cache guardrails, layered-nav cache coverage,
 admin coverage, REST coverage, DB inventory, or external HTTP guardrails.
+
+The declared full-surface fuzz proof is API/DB/admin/server coverage plus the
+issue-focused checkout/catalog workloads above. Browser request coverage remains
+the separate `woocommerce-browser-coverage` trace profile, and performance timing
+remains in `bench_workloads`. Use Homeboy Lab for heavy `homeboy fuzz run` proof
+when the runner has a `homeboy` binary that exposes the `fuzz` command; do not
+substitute `homeboy bench` for missing fuzz support.
 
 ## Benchmark Commands
 

--- a/woocommerce/woocommerce/bench/admin-page-coverage.test.mjs
+++ b/woocommerce/woocommerce/bench/admin-page-coverage.test.mjs
@@ -55,10 +55,13 @@ test('admin page coverage reports summarized query attribution without dropping 
 
 test('admin page coverage is wired into executable full-surface profile', () => {
   assert.ok(
-    rig.bench_workloads.wordpress.some((entry) => entry.path.includes('bench/admin-page-coverage.php')),
-    'expected workload declaration'
+    rig.fuzz_workloads.wordpress.some((entry) => entry.path.includes('fuzz/admin-page-coverage.json')),
+    'expected fuzz workload declaration'
   );
-  assert.ok(rig.bench_profiles['full-surface'].includes('admin-page-coverage'));
+  assert.ok(
+    !Object.values(rig.bench_workloads).flat().some((entry) => entry.path.includes('admin-page-coverage')),
+    'admin page coverage must not use bench fallback'
+  );
   assert.deepEqual(manifest.coverage_profiles['full-surface'].authenticated_admin_pages, ['admin-page-coverage']);
 });
 

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -11,6 +11,14 @@ const manifest = JSON.parse(readFileSync(path.join(__dirname, 'full-surface-cove
 const performanceRig = JSON.parse(readFileSync(path.join(packageRoot, 'rigs/woocommerce-performance/rig.json'), 'utf8'));
 const browserRig = JSON.parse(readFileSync(path.join(packageRoot, 'rigs/woocommerce-browser-coverage/rig.json'), 'utf8'));
 
+const workloadIdFromPath = (workloadPath) => path.basename(workloadPath, path.extname(workloadPath));
+
+const executableCoverageWorkloadIds = () => new Set([
+  ...Object.values(performanceRig.bench_workloads?.wordpress || {}).flat().map((entry) => workloadIdFromPath(entry.path)),
+  ...(performanceRig.fuzz_workloads?.wordpress || []).map((entry) => workloadIdFromPath(entry.path)),
+  ...browserRig.trace_profiles['full-surface'],
+]);
+
 const expectedSafetyClassifications = new Set([
   'bounded_admin_fixture_mutation',
   'bounded_authenticated_read',
@@ -22,10 +30,7 @@ const expectedSafetyClassifications = new Set([
 ]);
 
 test('full-surface executable workloads have coverage contract metadata', () => {
-  const workloadIds = new Set([
-    ...performanceRig.bench_profiles['full-surface'],
-    ...browserRig.trace_profiles['full-surface'],
-  ]);
+  const workloadIds = executableCoverageWorkloadIds();
 
   assert.ok(workloadIds.size > 0, 'expected executable full-surface workload ids');
 
@@ -44,10 +49,7 @@ test('full-surface executable workloads have coverage contract metadata', () => 
 });
 
 test('manifest workload metadata stays scoped to full-surface workload ids', () => {
-  const workloadIds = new Set([
-    ...performanceRig.bench_profiles['full-surface'],
-    ...browserRig.trace_profiles['full-surface'],
-  ]);
+  const workloadIds = executableCoverageWorkloadIds();
 
   assert.deepEqual(new Set(Object.keys(manifest.workloads)), workloadIds);
 });

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -8,6 +8,22 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
 const fuzzDir = path.join(packageRoot, 'fuzz');
 const rig = JSON.parse(readFileSync(path.join(packageRoot, 'rigs/woocommerce-performance/rig.json'), 'utf8'));
+const coverageManifest = JSON.parse(readFileSync(path.join(packageRoot, 'manifests/full-surface-coverage.json'), 'utf8'));
+
+const expectedFuzzIds = new Set([
+  'admin-page-coverage',
+  'cart-session-overwrite-race',
+  'checkout-concurrent-create-order',
+  'checkout-gateway-compatibility-matrix',
+  'checkout-shipping-cache',
+  'db-inventory',
+  'generated-rest-request-cases',
+  'layered-nav-catalog-crawl',
+  'layered-nav-count-cache',
+  'rest-db-query-profile',
+  'woocommerce-external-http-guardrail',
+  'woocommerce-rest-route-inventory',
+]);
 
 const fuzzManifests = readdirSync(fuzzDir)
   .filter((file) => file.endsWith('.json'))
@@ -29,6 +45,21 @@ const benchWorkloadIds = new Set(
     .map((entry) => path.basename(entry.path, path.extname(entry.path)))
 );
 const benchProfileIds = new Set(Object.values(rig.bench_profiles || {}).flat());
+const actualFuzzIds = new Set(fuzzManifests.map(({ manifest }) => manifest.id));
+
+assert.deepEqual(actualFuzzIds, expectedFuzzIds, 'WooCommerce fuzz manifest ids drifted');
+assert.deepEqual(declaredFuzzIds, expectedFuzzIds, 'rig fuzz_workloads.wordpress ids drifted');
+
+const fullSurfaceFuzzIds = new Set([
+  ...coverageManifest.coverage_profiles['full-surface'].rest_api,
+  ...coverageManifest.coverage_profiles['full-surface'].database,
+  ...coverageManifest.coverage_profiles['full-surface'].server_requests,
+  ...coverageManifest.coverage_profiles['full-surface'].authenticated_admin_pages,
+]);
+
+for (const workloadId of fullSurfaceFuzzIds) {
+  assert.ok(declaredFuzzIds.has(workloadId), `${workloadId} full-surface coverage is not backed by a fuzz workload`);
+}
 
 for (const { file, manifest } of fuzzManifests) {
   assert.equal(manifest.schema, 'homeboy/fuzz-workload/v1', `${file} schema mismatch`);


### PR DESCRIPTION
## Summary
- update Woo full-surface structural tests to derive executable coverage from bench, fuzz, and browser trace declarations after the fuzz migration
- assert admin page coverage is wired as a fuzz workload and cannot fall back through bench workloads
- strengthen the Woo fuzz manifest validator so the 12 expected fuzz IDs and full-surface API/DB/admin/server coverage wiring cannot drift
- document the full set of Woo fuzz-only run commands and the Homeboy Lab proof requirement when a homeboy fuzz binary is available

## Validation
- `node --test woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs woocommerce/woocommerce/bench/admin-page-coverage.test.mjs`
- `node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs`
- `node scripts/lint-rig-packages.mjs`

## Proof limits
- No local `homeboy fuzz run` was executed. The installed local `homeboy` binary does not expose the `fuzz` subcommand; `homeboy fuzz --help` returns `unrecognized subcommand 'fuzz'`.
- No `homeboy bench` fallback proof was used.
- Heavy fuzz proof still needs a Homeboy Lab run once a clean `homeboy fuzz` binary/source path is available.
- While creating this PR, an earlier shell-quoted PR body accidentally invoked command substitutions before `gh` received the body. That produced a failed remote no-workload `homeboy bench` invocation through Homeboy Lab, persisted as `runner-exec-homeboy-lab-415131fa-8f02-4171-ad7c-c9127fee949f`. It was not used as proof.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Inspecting merged Woo fuzz PRs, updating validation/docs, running lightweight local checks, and drafting this PR description.
