### PR TITLE
Test generic fuzz workload manifest lint

### DIFF
--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -2,9 +2,9 @@
 
 import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { basename, dirname, join, relative } from 'node:path';
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 
-const root = process.argv[2] ? join(process.cwd(), process.argv[2]) : process.cwd();
+const root = process.argv[2] ? resolve(process.cwd(), process.argv[2]) : process.cwd();
 const ignoredDirectories = new Set(['.git', '.claude', '.datamachine', '.opencode', 'node_modules', 'vendor']);
 const phpFiles = [];
 const rigFiles = [];
@@ -47,7 +47,7 @@ function walk(directory) {
   }
 }
 
-function lintRigPortability(file, fuzzWorkloadIdsByPackageRoot) {
+function lintRigPortability(file, fuzzWorkloadsByPackageRoot) {
   const rel = relative(root, file);
   const contents = readFileSync(file, 'utf8');
   let rig;
@@ -76,7 +76,8 @@ function lintRigPortability(file, fuzzWorkloadIdsByPackageRoot) {
     failures.push(`${rel}: use shared/wp-codebox/check-cli.sh instead of duplicating WP Codebox CLI discovery in rig commands`);
   }
 
-  lintBenchProfiles(rel, file, rig, fuzzWorkloadIdsByPackageRoot);
+  lintFuzzWorkloads(rel, file, rig, fuzzWorkloadsByPackageRoot);
+  lintBenchProfiles(rel, file, rig, fuzzWorkloadsByPackageRoot);
 }
 
 function packageRootForRig(file) {
@@ -111,16 +112,21 @@ function workloadIdFromPath(path) {
     .replace(/\.json$/, '');
 }
 
-function addSetValue(map, key, value) {
-  if (!map.has(key)) {
-    map.set(key, new Set());
+function resolvePackagePath(path, packageRoot) {
+  if (typeof path !== 'string' || !path) {
+    return null;
   }
 
-  map.get(key).add(value);
+  const expandedPath = path.replaceAll('${package.root}', packageRoot);
+  if (expandedPath.includes('${')) {
+    return null;
+  }
+
+  return isAbsolute(expandedPath) ? expandedPath : resolve(packageRoot, expandedPath);
 }
 
-function collectWordPressPluginFuzzWorkloadIds() {
-  const fuzzWorkloadIdsByPackageRoot = new Map();
+function collectFuzzWorkloads() {
+  const fuzzWorkloadsByPackageRoot = new Map();
 
   for (const file of jsonFiles) {
     const packageRoot = packageRootForFuzzWorkload(file);
@@ -135,25 +141,129 @@ function collectWordPressPluginFuzzWorkloadIds() {
       continue;
     }
 
-    if (workload.schema !== 'homeboy/fuzz-workload/v1' || workload.metadata?.kind !== 'wordpress-plugin-fuzz') {
+    if (workload.schema !== 'homeboy/fuzz-workload/v1') {
       continue;
     }
 
-    addSetValue(fuzzWorkloadIdsByPackageRoot, packageRoot, workloadIdFromPath(file));
+    const workloadIds = new Set([workloadIdFromPath(file)]);
     if (typeof workload.id === 'string' && workload.id) {
-      addSetValue(fuzzWorkloadIdsByPackageRoot, packageRoot, workload.id);
+      workloadIds.add(workload.id);
+    }
+
+    if (!fuzzWorkloadsByPackageRoot.has(packageRoot)) {
+      fuzzWorkloadsByPackageRoot.set(packageRoot, new Map());
+    }
+
+    const packageWorkloads = fuzzWorkloadsByPackageRoot.get(packageRoot);
+    for (const workloadId of workloadIds) {
+      packageWorkloads.set(workloadId, { file, workload });
     }
   }
 
-  return fuzzWorkloadIdsByPackageRoot;
+  return fuzzWorkloadsByPackageRoot;
 }
 
-function lintBenchProfiles(rel, file, rig, fuzzWorkloadIdsByPackageRoot) {
+function validateFuzzWorkloadShape(rel, workload, context, packageRoot) {
+  if (workload.schema !== 'homeboy/fuzz-workload/v1') {
+    failures.push(`${rel}: ${context} must use schema homeboy/fuzz-workload/v1`);
+  }
+
+  for (const field of ['id', 'label', 'safety_class']) {
+    if (typeof workload[field] !== 'string' || workload[field].trim() === '') {
+      failures.push(`${rel}: ${context} must declare a non-empty string ${field}`);
+    }
+  }
+
+  if (!workload.metadata || typeof workload.metadata !== 'object' || Array.isArray(workload.metadata)) {
+    failures.push(`${rel}: ${context} must declare metadata`);
+  }
+
+  if (!workload.target || typeof workload.target !== 'object' || Array.isArray(workload.target)) {
+    failures.push(`${rel}: ${context} must declare target`);
+  }
+
+  if (!workload.workload || typeof workload.workload !== 'object' || Array.isArray(workload.workload)) {
+    failures.push(`${rel}: ${context} must declare workload`);
+  } else if (typeof workload.workload.path !== 'string' || workload.workload.path.trim() === '') {
+    failures.push(`${rel}: ${context} workload must declare a non-empty string path`);
+  } else {
+    const workloadPath = resolvePackagePath(workload.workload.path, packageRoot);
+    if (!workloadPath) {
+      failures.push(`${rel}: ${context} workload path must be resolvable`);
+    } else if (!existsSync(workloadPath)) {
+      failures.push(`${rel}: ${context} workload path ${relative(root, workloadPath)} does not exist`);
+    }
+  }
+
+  if (!Array.isArray(workload.cases) || workload.cases.length === 0) {
+    failures.push(`${rel}: ${context} must declare at least one case`);
+  }
+}
+
+function fuzzWorkloadId(workload, path) {
+  return typeof workload.id === 'string' && workload.id ? workload.id : workloadIdFromPath(path);
+}
+
+function lintFuzzWorkloads(rel, file, rig, fuzzWorkloadsByPackageRoot) {
+  if (!rig.fuzz_workloads) {
+    return;
+  }
+
+  const packageRoot = packageRootForRig(file);
+  const packageWorkloads = fuzzWorkloadsByPackageRoot.get(packageRoot) || new Map();
+  const rigWorkloadIds = new Map();
+
+  for (const [runner, workloads] of Object.entries(rig.fuzz_workloads)) {
+    if (!Array.isArray(workloads)) {
+      failures.push(`${rel}: fuzz_workloads ${runner} must be an array of workload declarations`);
+      continue;
+    }
+
+    for (const declaration of workloads) {
+      const declarationPath = typeof declaration === 'string' ? declaration : declaration?.path;
+      const resolvedPath = resolvePackagePath(declarationPath, packageRoot);
+      if (!resolvedPath) {
+        failures.push(`${rel}: fuzz_workloads ${runner} declaration must use a resolvable path`);
+        continue;
+      }
+
+      const declarationRel = relative(root, resolvedPath);
+      if (!existsSync(resolvedPath)) {
+        failures.push(`${rel}: fuzz_workloads ${runner} declares missing file ${declarationRel}`);
+        continue;
+      }
+
+      let workload;
+      try {
+        workload = JSON.parse(readFileSync(resolvedPath, 'utf8'));
+      } catch (error) {
+        failures.push(`${rel}: fuzz_workloads ${runner} declares invalid JSON file ${declarationRel}: ${error.message}`);
+        continue;
+      }
+
+      validateFuzzWorkloadShape(rel, workload, `fuzz workload ${declarationRel}`, packageRoot);
+
+      const workloadId = fuzzWorkloadId(workload, resolvedPath);
+      const packageWorkload = packageWorkloads.get(workloadId);
+      if (!packageWorkload || packageWorkload.file !== resolvedPath) {
+        failures.push(`${rel}: fuzz_workloads ${runner} declares ${declarationRel}, but fuzz workload id ${workloadId} is not unique within this package`);
+      }
+
+      if (rigWorkloadIds.has(workloadId)) {
+        failures.push(`${rel}: fuzz workload id ${workloadId} is declared more than once in this rig`);
+      } else {
+        rigWorkloadIds.set(workloadId, declarationRel);
+      }
+    }
+  }
+}
+
+function lintBenchProfiles(rel, file, rig, fuzzWorkloadsByPackageRoot) {
   if (!rig.bench_profiles && !rig.bench_workloads) {
     return;
   }
 
-  const fuzzWorkloadIds = fuzzWorkloadIdsByPackageRoot.get(packageRootForRig(file)) || new Set();
+  const fuzzWorkloadIds = new Set((fuzzWorkloadsByPackageRoot.get(packageRootForRig(file)) || new Map()).keys());
   const workloadIds = new Set();
   for (const workloads of Object.values(rig.bench_workloads || {})) {
     if (!Array.isArray(workloads)) {
@@ -167,7 +277,7 @@ function lintBenchProfiles(rel, file, rig, fuzzWorkloadIdsByPackageRoot) {
         workloadIds.add(workloadId);
 
         if (fuzzWorkloadIds.has(workloadId)) {
-          failures.push(`${rel}: bench_workloads declares ${workloadId}, but that id belongs to a WordPress plugin fuzz workload in this package`);
+          failures.push(`${rel}: bench_workloads declares ${workloadId}, but that id belongs to a fuzz workload in this package`);
         }
       }
     }
@@ -185,7 +295,7 @@ function lintBenchProfiles(rel, file, rig, fuzzWorkloadIdsByPackageRoot) {
 
     for (const workloadRef of workloadRefs) {
       if (fuzzWorkloadIds.has(workloadRef)) {
-        failures.push(`${rel}: bench profile ${profile} references ${workloadRef}, but that id belongs to a WordPress plugin fuzz workload in this package`);
+        failures.push(`${rel}: bench profile ${profile} references ${workloadRef}, but that id belongs to a fuzz workload in this package`);
       }
 
       if (!workloadIds.has(workloadRef)) {
@@ -251,9 +361,9 @@ function lintGeneratedStudioModelRigs() {
 
 walk(root);
 
-const wordpressPluginFuzzWorkloadIdsByPackageRoot = collectWordPressPluginFuzzWorkloadIds();
+const fuzzWorkloadsByPackageRoot = collectFuzzWorkloads();
 
-rigFiles.forEach((file) => lintRigPortability(file, wordpressPluginFuzzWorkloadIdsByPackageRoot));
+rigFiles.forEach((file) => lintRigPortability(file, fuzzWorkloadsByPackageRoot));
 portableSourceFiles.forEach(lintPortableSource);
 lintGeneratedStudioModelRigs();
 

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const script = new URL('./lint-rig-packages.mjs', import.meta.url).pathname;
+
+function writeJson(path, value) {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function createRigPackage({ rig = {}, fuzzWorkloads = {}, benchWorkloads = {}, benchProfiles = {} } = {}) {
+  const directory = mkdtempSync(join(tmpdir(), 'homeboy-rigs-lint-'));
+  const packageRoot = join(directory, 'Vendor', 'product');
+  const rigRoot = join(packageRoot, 'rigs', 'generic-rig');
+  const fuzzRoot = join(packageRoot, 'fuzz');
+  const benchRoot = join(packageRoot, 'bench');
+
+  mkdirSync(rigRoot, { recursive: true });
+  mkdirSync(fuzzRoot, { recursive: true });
+  mkdirSync(benchRoot, { recursive: true });
+  writeJson(join(benchRoot, 'generic.workload.json'), { id: 'generic' });
+
+  for (const [name, workload] of Object.entries(fuzzWorkloads)) {
+    writeJson(join(fuzzRoot, `${name}.json`), workload);
+  }
+
+  writeJson(join(rigRoot, 'rig.json'), {
+    id: 'generic-rig',
+    description: 'Generic lint fixture rig.',
+    fuzz_workloads: {
+      generic: [
+        { path: '${package.root}/fuzz/generic-fuzz.json' },
+      ],
+    },
+    bench_workloads: benchWorkloads,
+    bench_profiles: benchProfiles,
+    ...rig,
+  });
+
+  return directory;
+}
+
+function fuzzWorkload(overrides = {}) {
+  return {
+    schema: 'homeboy/fuzz-workload/v1',
+    id: 'generic-fuzz',
+    label: 'Generic fuzz workload',
+    safety_class: 'read_only',
+    metadata: { kind: 'generic-fuzz' },
+    target: { type: 'generic' },
+    workload: {
+      runner: 'generic',
+      type: 'json',
+      path: '${package.root}/bench/generic.workload.json',
+    },
+    cases: [
+      { case_id: 'generic-fuzz:default' },
+    ],
+    ...overrides,
+  };
+}
+
+function runLint(directory) {
+  return spawnSync(process.execPath, [script, directory], { encoding: 'utf8' });
+}
+
+test('accepts generic declared fuzz workloads', () => {
+  const directory = createRigPackage({
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+  });
+
+  const result = runLint(directory);
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+});
+
+test('rejects missing declared fuzz workload files', () => {
+  const directory = createRigPackage();
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /declares missing file/);
+});
+
+test('rejects invalid declared fuzz workload shapes', () => {
+  const directory = createRigPackage({
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload({ schema: 'wrong', label: '' }),
+    },
+  });
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /must use schema homeboy\/fuzz-workload\/v1/);
+  assert.match(result.stderr, /must declare a non-empty string label/);
+});
+
+test('rejects missing fuzz workload backing files', () => {
+  const directory = createRigPackage({
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload({
+        workload: {
+          runner: 'generic',
+          type: 'json',
+          path: '${package.root}/bench/missing.workload.json',
+        },
+      }),
+    },
+  });
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /workload path .*missing\.workload\.json does not exist/);
+});
+
+test('rejects duplicate declared fuzz workload ids per rig', () => {
+  const directory = createRigPackage({
+    rig: {
+      fuzz_workloads: {
+        generic: [
+          { path: '${package.root}/fuzz/generic-fuzz.json' },
+          { path: '${package.root}/fuzz/generic-fuzz-copy.json' },
+        ],
+      },
+    },
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+      'generic-fuzz-copy': fuzzWorkload(),
+    },
+  });
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /fuzz workload id generic-fuzz is declared more than once in this rig/);
+});
+
+test('rejects fuzz ids in bench workloads and profiles', () => {
+  const directory = createRigPackage({
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+    benchWorkloads: {
+      generic: [
+        { path: '${package.root}/bench/generic-fuzz.php' },
+      ],
+    },
+    benchProfiles: {
+      smoke: ['generic-fuzz'],
+    },
+  });
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /bench_workloads declares generic-fuzz, but that id belongs to a fuzz workload/);
+  assert.match(result.stderr, /bench profile smoke references generic-fuzz, but that id belongs to a fuzz workload/);
+});


### PR DESCRIPTION
## Summary
- Generalize fuzz workload linting from WordPress-plugin-specific IDs to any package-local `homeboy/fuzz-workload/v1` manifest.
- Validate rig-declared `fuzz_workloads` paths, manifest schema, required fields, backing `workload.path` files, duplicate fuzz IDs per rig, and fuzz IDs leaking into `bench_workloads` / `bench_profiles`.
- Add focused Node tests covering generic valid declarations and regression failures.

## Validation
- `node --test scripts/lint-rig-packages.test.mjs`
- `node scripts/lint-rig-packages.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing generic lint validation, adding focused tests, and drafting this PR description.