### PR TITLE
Add Jetpack fuzz coverage rig manifests

### DIFF
--- a/Automattic/jetpack/README.md
+++ b/Automattic/jetpack/README.md
@@ -2,7 +2,7 @@
 
 ## `jetpack-api-route-inventory`
 
-Captures a lightweight inventory of registered Jetpack REST routes without executing API requests. This is an adapter scaffold for applying generic Homeboy Extensions / WP Codebox API performance primitives to Jetpack later.
+Declares the Jetpack fuzz coverage suite for REST/API, module state, admin pages, database/query profiling, options, sync queue behavior, external HTTP guardrails, and browser/admin request coverage. The suite uses generic fuzz workload manifests under `fuzz/`; it does not declare fuzz workloads as bench fallbacks.
 
 Install locally:
 
@@ -10,16 +10,17 @@ Install locally:
 homeboy rig install $HOME/Developer/homeboy-rigs@<branch>/Automattic/jetpack
 ```
 
-Run the route inventory workload:
+Check the rig package:
 
 ```sh
-homeboy bench --rig jetpack-api-route-inventory --scenario jetpack-rest-route-inventory --iterations 1 --shared-state /tmp/jetpack-api-inventory
+homeboy rig check jetpack-api-route-inventory
+homeboy rig check jetpack-browser-coverage
 ```
 
-Run the currently executable full-surface profile. It is intentionally limited to workload-backed REST route inventory until generated REST cases, DB inventory/profiling, external HTTP guardrails, and browser request coverage have concrete workload files:
+Run fuzz workloads only through the fuzz runner surface once available in the target Homeboy install. Do not use `homeboy bench` as a fallback for these coverage manifests.
 
 ```sh
-homeboy bench --rig jetpack-api-route-inventory --profile full-surface --iterations 1 --shared-state /tmp/jetpack-full-surface
+homeboy fuzz --rig jetpack-api-route-inventory --workload jetpack-rest-route-inventory
 ```
 
-The coverage manifest lives at `manifests/rest-route-coverage.json`. It keeps Jetpack-specific route grouping in this rig package so upstream primitives can stay generic.
+The coverage manifests live under `manifests/`, with executable/declarative fuzz workload manifests under `fuzz/`. External HTTP guardrail probes use `.invalid` synthetic hosts and an empty allowlist so no real external service calls are expected.

--- a/Automattic/jetpack/bench/jetpack-external-http-guardrail.php
+++ b/Automattic/jetpack/bench/jetpack-external-http-guardrail.php
@@ -11,14 +11,14 @@ return function (): array {
 		array(
 			'type'             => 'external-http-guardrail',
 			'action'           => 'install',
-			'allowlistDomains' => array( 'public-api.wordpress.com' ),
+			'allowlistDomains' => array(),
 			'blockNetwork'     => true,
 			'metric-prefix'    => 'jetpack_external_http_guardrail_install',
 		)
 	);
 
-	wp_remote_get( 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.com?guardrail=1' );
-	wp_remote_post( 'https://jetpack.wordpress.com/guardrail-probe', array( 'body' => array( 'event' => 'synthetic' ) ) );
+	wp_remote_get( 'https://jetpack-homeboy-guardrail.invalid/rest/v1.1/sites/example.wordpress.com?guardrail=1' );
+	wp_remote_post( 'https://jetpack-homeboy-guardrail.invalid/guardrail-probe', array( 'body' => array( 'event' => 'synthetic' ) ) );
 
 	$payload = wp_codebox_bench_run_external_http_guardrail_step(
 		array(
@@ -31,10 +31,10 @@ return function (): array {
 	$payload['metadata'] = array_merge(
 		$payload['metadata'] ?? array(),
 		array(
-			'runner'         => 'wp-codebox',
-			'workload'       => 'jetpack-external-http-guardrail',
-			'coverage_shape' => 'Jetpack connection and service API external HTTP guardrail probes',
-		)
-	);
+				'runner'         => 'wp-codebox',
+				'workload'       => 'jetpack-external-http-guardrail',
+				'coverage_shape' => 'Jetpack connection and service API external HTTP guardrail probes with all synthetic network requests blocked',
+			)
+		);
 	return $payload;
 };

--- a/Automattic/jetpack/fuzz/db-inventory.json
+++ b/Automattic/jetpack/fuzz/db-inventory.json
@@ -1,0 +1,17 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "db-inventory",
+  "label": "Jetpack database inventory",
+  "safety_class": "read_only",
+  "surface_ids": ["wordpress-database", "jetpack-database"],
+  "operations": ["table-inventory", "column-index-inventory"],
+  "case_budget": 1,
+  "duration_budget_seconds": 300,
+  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "workload_path": "${package.root}/bench/db-inventory.workload.json", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report" },
+  "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
+  "workload": { "runner": "wp-codebox", "type": "json", "path": "${package.root}/bench/db-inventory.workload.json", "entry": "db-inventory" },
+  "cases": [{ "case_id": "db-inventory:default", "surface_ids": ["wordpress-database", "jetpack-database"], "operations": ["table-inventory", "column-index-inventory"], "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }], "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/db-inventory.workload.json", "type=json"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=db_inventory"] }] }, "artifacts": [{ "name": "db_inventory", "path": "db-inventory/db_inventory.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }], "metadata": { "safety_class": "read_only" } }],
+  "limits": { "max_cases": 1, "max_duration_seconds": 300 },
+  "coverage": { "surface_ids": ["wordpress-database", "jetpack-database"], "operations": ["table-inventory", "column-index-inventory"] },
+  "artifacts": { "expected": [{ "name": "db_inventory", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/Automattic/jetpack/fuzz/generated-rest-request-cases.json
+++ b/Automattic/jetpack/fuzz/generated-rest-request-cases.json
@@ -1,0 +1,17 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "generated-rest-request-cases",
+  "label": "Generated Jetpack REST request cases",
+  "safety_class": "read_only",
+  "surface_ids": ["jetpack-rest-routes"],
+  "operations": ["generated-rest-case-plan", "request-case-execution"],
+  "case_budget": 80,
+  "duration_budget_seconds": 600,
+  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "workload_path": "${package.root}/bench/generated-rest-request-cases.workload.json", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report" },
+  "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
+  "workload": { "runner": "wp-codebox", "type": "json", "path": "${package.root}/bench/generated-rest-request-cases.workload.json", "entry": "generated-rest-request-cases" },
+  "cases": [{ "case_id": "generated-rest-request-cases:default", "surface_ids": ["jetpack-rest-routes"], "operations": ["generated-rest-case-plan", "request-case-execution"], "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }], "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/generated-rest-request-cases.workload.json", "type=json"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=rest_request_cases"] }] }, "artifacts": [{ "name": "rest_request_cases", "path": "generated-rest-request-cases/rest_request_cases.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }], "metadata": { "safety_class": "read_only" } }],
+  "limits": { "max_cases": 80, "max_duration_seconds": 600 },
+  "coverage": { "surface_ids": ["jetpack-rest-routes"], "operations": ["generated-rest-case-plan", "request-case-execution"] },
+  "artifacts": { "expected": [{ "name": "rest_request_cases", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/Automattic/jetpack/fuzz/jetpack-admin-page-coverage.json
+++ b/Automattic/jetpack/fuzz/jetpack-admin-page-coverage.json
@@ -1,0 +1,17 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "jetpack-admin-page-coverage",
+  "label": "Jetpack admin page coverage",
+  "safety_class": "read_only",
+  "surface_ids": ["jetpack-admin-pages", "wordpress-admin-pages"],
+  "operations": ["admin-page-discovery", "permission-boundary-classification", "query-attribution"],
+  "case_budget": 40,
+  "duration_budget_seconds": 600,
+  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report" },
+  "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
+  "workload": { "runner": "wp-codebox", "type": "generic", "entry": "wordpress-admin-page-coverage" },
+  "cases": [{ "case_id": "jetpack-admin-page-coverage:default", "surface_ids": ["jetpack-admin-pages", "wordpress-admin-pages"], "operations": ["admin-page-discovery", "permission-boundary-classification", "query-attribution"], "inputs": { "roles": ["administrator"], "include_menu_slugs": ["jetpack", "jetpack#/dashboard", "jetpack_modules", "jetpack#/settings"], "safe_methods": ["GET"], "skip_url_patterns": ["action=delete", "action=install", "action=update", "_wpnonce="] }, "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }], "action": [{ "command": "wordpress.fuzz-admin-pages", "args": ["safe_methods=GET", "max_pages=40"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=admin_page_coverage"] }] }, "artifacts": [{ "name": "admin_page_coverage", "path": "jetpack-admin-page-coverage/admin_page_coverage.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }], "metadata": { "safety_class": "read_only" } }],
+  "limits": { "max_cases": 40, "max_duration_seconds": 600 },
+  "coverage": { "surface_ids": ["jetpack-admin-pages", "wordpress-admin-pages"], "operations": ["admin-page-discovery", "permission-boundary-classification", "query-attribution"] },
+  "artifacts": { "expected": [{ "name": "admin_page_coverage", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/Automattic/jetpack/fuzz/jetpack-external-http-guardrail.json
+++ b/Automattic/jetpack/fuzz/jetpack-external-http-guardrail.json
@@ -1,0 +1,18 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "jetpack-external-http-guardrail",
+  "label": "Jetpack external HTTP guardrail",
+  "safety_class": "read_only",
+  "surface_ids": ["jetpack-external-http", "jetpack-connection", "jetpack-sync"],
+  "operations": ["external-http-blocklist-probe", "network-side-effect-classification"],
+  "case_budget": 1,
+  "duration_budget_seconds": 300,
+  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "workload_path": "${package.root}/bench/jetpack-external-http-guardrail.php", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report", "network_policy": "block_all_synthetic_external_requests" },
+  "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
+  "workload": { "runner": "wp-codebox", "type": "php", "path": "${package.root}/bench/jetpack-external-http-guardrail.php", "entry": "jetpack-external-http-guardrail" },
+  "network_guardrail": { "block_network": true, "allowlist_domains": [], "probe_hosts": ["jetpack-homeboy-guardrail.invalid"], "real_external_service_calls_allowed": false },
+  "cases": [{ "case_id": "jetpack-external-http-guardrail:default", "surface_ids": ["jetpack-external-http", "jetpack-connection", "jetpack-sync"], "operations": ["external-http-blocklist-probe", "network-side-effect-classification"], "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }, { "command": "wordpress.ensure-external-http-guardrail", "args": ["allowlist=", "block_network=true"] }], "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/jetpack-external-http-guardrail.php", "type=php"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=external_http_guardrail"] }] }, "artifacts": [{ "name": "external_http_guardrail", "path": "jetpack-external-http-guardrail/external_http_guardrail.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }], "metadata": { "safety_class": "read_only" } }],
+  "limits": { "max_cases": 1, "max_duration_seconds": 300 },
+  "coverage": { "surface_ids": ["jetpack-external-http", "jetpack-connection", "jetpack-sync"], "operations": ["external-http-blocklist-probe", "network-side-effect-classification"] },
+  "artifacts": { "expected": [{ "name": "external_http_guardrail", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/Automattic/jetpack/fuzz/jetpack-module-state-matrix.json
+++ b/Automattic/jetpack/fuzz/jetpack-module-state-matrix.json
@@ -1,0 +1,17 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "jetpack-module-state-matrix",
+  "label": "Jetpack module state matrix",
+  "safety_class": "isolated_mutation",
+  "surface_ids": ["jetpack-modules", "jetpack-settings"],
+  "operations": ["module-discovery", "module-activate-deactivate", "settings-state-classification"],
+  "case_budget": 80,
+  "duration_budget_seconds": 900,
+  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report" },
+  "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
+  "workload": { "runner": "wp-codebox", "type": "generic", "entry": "wordpress-plugin-module-state-matrix" },
+  "cases": [{ "case_id": "jetpack-module-state-matrix:default", "surface_ids": ["jetpack-modules", "jetpack-settings"], "operations": ["module-discovery", "module-activate-deactivate", "settings-state-classification"], "inputs": { "module_allowlist": ["stats", "publicize", "related-posts", "markdown", "shortcodes", "widget-visibility"], "synthetic_connection": false, "external_dispatch": false }, "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }], "action": [{ "command": "wordpress.fuzz-plugin-module-state", "args": ["external_dispatch=false", "synthetic_connection=false"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=module_state_matrix"] }] }, "artifacts": [{ "name": "module_state_matrix", "path": "jetpack-module-state-matrix/module_state_matrix.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }], "metadata": { "safety_class": "isolated_mutation" } }],
+  "limits": { "max_cases": 80, "max_duration_seconds": 900 },
+  "coverage": { "surface_ids": ["jetpack-modules", "jetpack-settings"], "operations": ["module-discovery", "module-activate-deactivate", "settings-state-classification"] },
+  "artifacts": { "expected": [{ "name": "module_state_matrix", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/Automattic/jetpack/fuzz/jetpack-options-matrix.json
+++ b/Automattic/jetpack/fuzz/jetpack-options-matrix.json
@@ -1,0 +1,17 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "jetpack-options-matrix",
+  "label": "Jetpack options matrix",
+  "safety_class": "isolated_mutation",
+  "surface_ids": ["jetpack-options", "wordpress-options"],
+  "operations": ["option-default-read", "option-update-rollback", "serialization-boundary-classification"],
+  "case_budget": 120,
+  "duration_budget_seconds": 900,
+  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report" },
+  "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
+  "workload": { "runner": "wp-codebox", "type": "generic", "entry": "wordpress-plugin-option-matrix" },
+  "cases": [{ "case_id": "jetpack-options-matrix:default", "surface_ids": ["jetpack-options", "wordpress-options"], "operations": ["option-default-read", "option-update-rollback", "serialization-boundary-classification"], "inputs": { "option_prefixes": ["jetpack_", "jetpack_%", "jpsq_"], "secret_placeholders_only": true, "restore_original_values": true }, "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }], "action": [{ "command": "wordpress.fuzz-plugin-options", "args": ["secret_placeholders_only=true", "restore_original_values=true"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=options_matrix"] }] }, "artifacts": [{ "name": "options_matrix", "path": "jetpack-options-matrix/options_matrix.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }], "metadata": { "safety_class": "isolated_mutation" } }],
+  "limits": { "max_cases": 120, "max_duration_seconds": 900 },
+  "coverage": { "surface_ids": ["jetpack-options", "wordpress-options"], "operations": ["option-default-read", "option-update-rollback", "serialization-boundary-classification"] },
+  "artifacts": { "expected": [{ "name": "options_matrix", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/Automattic/jetpack/fuzz/jetpack-rest-route-inventory.json
+++ b/Automattic/jetpack/fuzz/jetpack-rest-route-inventory.json
@@ -1,0 +1,36 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "jetpack-rest-route-inventory",
+  "label": "Jetpack REST route inventory",
+  "safety_class": "read_only",
+  "surface_ids": ["jetpack-rest-routes", "wordpress-rest-api"],
+  "operations": ["route-discovery", "permission-boundary-classification"],
+  "case_budget": 1,
+  "duration_budget_seconds": 300,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/jetpack-rest-route-inventory.php",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
+  "workload": { "runner": "wp-codebox", "type": "php", "path": "${package.root}/bench/jetpack-rest-route-inventory.php", "entry": "jetpack-rest-route-inventory" },
+  "cases": [
+    {
+      "case_id": "jetpack-rest-route-inventory:default",
+      "surface_ids": ["jetpack-rest-routes", "wordpress-rest-api"],
+      "operations": ["route-discovery", "permission-boundary-classification"],
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }],
+        "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/jetpack-rest-route-inventory.php", "type=php"] }],
+        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=route_inventory"] }]
+      },
+      "artifacts": [{ "name": "route_inventory", "path": "jetpack-rest-route-inventory/route_inventory.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }],
+      "metadata": { "safety_class": "read_only" }
+    }
+  ],
+  "limits": { "max_cases": 1, "max_duration_seconds": 300 },
+  "coverage": { "surface_ids": ["jetpack-rest-routes", "wordpress-rest-api"], "operations": ["route-discovery", "permission-boundary-classification"] },
+  "artifacts": { "expected": [{ "name": "route_inventory", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/Automattic/jetpack/fuzz/jetpack-sync-queue-coverage.json
+++ b/Automattic/jetpack/fuzz/jetpack-sync-queue-coverage.json
@@ -1,0 +1,17 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "jetpack-sync-queue-coverage",
+  "label": "Jetpack sync queue coverage",
+  "safety_class": "isolated_mutation",
+  "surface_ids": ["jetpack-sync", "wordpress-cron", "wordpress-options"],
+  "operations": ["sync-queue-discovery", "action-serialization", "retry-boundary-classification"],
+  "case_budget": 80,
+  "duration_budget_seconds": 900,
+  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report" },
+  "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
+  "workload": { "runner": "wp-codebox", "type": "generic", "entry": "wordpress-plugin-sync-queue-coverage" },
+  "cases": [{ "case_id": "jetpack-sync-queue-coverage:default", "surface_ids": ["jetpack-sync", "wordpress-cron", "wordpress-options"], "operations": ["sync-queue-discovery", "action-serialization", "retry-boundary-classification"], "inputs": { "remote_dispatch": false, "synthetic_actions": ["post_save", "option_update", "comment_status", "module_toggle"], "force_http_guardrail": true }, "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }, { "command": "wordpress.ensure-external-http-guardrail", "args": ["allowlist=", "block_network=true"] }], "action": [{ "command": "wordpress.fuzz-plugin-sync-queue", "args": ["remote_dispatch=false", "force_http_guardrail=true"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=sync_queue_coverage"] }] }, "artifacts": [{ "name": "sync_queue_coverage", "path": "jetpack-sync-queue-coverage/sync_queue_coverage.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }], "metadata": { "safety_class": "isolated_mutation" } }],
+  "limits": { "max_cases": 80, "max_duration_seconds": 900 },
+  "coverage": { "surface_ids": ["jetpack-sync", "wordpress-cron", "wordpress-options"], "operations": ["sync-queue-discovery", "action-serialization", "retry-boundary-classification"] },
+  "artifacts": { "expected": [{ "name": "sync_queue_coverage", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/Automattic/jetpack/fuzz/rest-db-query-profile.json
+++ b/Automattic/jetpack/fuzz/rest-db-query-profile.json
@@ -1,0 +1,17 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "rest-db-query-profile",
+  "label": "Jetpack REST DB query profile",
+  "safety_class": "read_only",
+  "surface_ids": ["jetpack-rest-routes", "wordpress-database"],
+  "operations": ["request-case-query-profile", "query-attribution"],
+  "case_budget": 50,
+  "duration_budget_seconds": 600,
+  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "workload_path": "${package.root}/bench/rest-db-query-profile.workload.json", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report" },
+  "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
+  "workload": { "runner": "wp-codebox", "type": "json", "path": "${package.root}/bench/rest-db-query-profile.workload.json", "entry": "rest-db-query-profile" },
+  "cases": [{ "case_id": "rest-db-query-profile:default", "surface_ids": ["jetpack-rest-routes", "wordpress-database"], "operations": ["request-case-query-profile", "query-attribution"], "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }], "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/rest-db-query-profile.workload.json", "type=json"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=rest_db_query_profile"] }] }, "artifacts": [{ "name": "rest_db_query_profile", "path": "rest-db-query-profile/rest_db_query_profile.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }], "metadata": { "safety_class": "read_only" } }],
+  "limits": { "max_cases": 50, "max_duration_seconds": 600 },
+  "coverage": { "surface_ids": ["jetpack-rest-routes", "wordpress-database"], "operations": ["request-case-query-profile", "query-attribution"] },
+  "artifacts": { "expected": [{ "name": "rest_db_query_profile", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/Automattic/jetpack/manifests/full-surface-coverage.json
+++ b/Automattic/jetpack/manifests/full-surface-coverage.json
@@ -8,7 +8,11 @@
     "wordpress-rest-db-query-profiler",
     "wordpress-db-inventory",
     "wordpress-external-http-guardrail",
-    "browser-request-coverage"
+    "browser-request-coverage",
+    "wordpress-authenticated-admin-page-coverage",
+    "wordpress-plugin-option-matrix",
+    "wordpress-plugin-module-state-matrix",
+    "wordpress-plugin-sync-queue-coverage"
   ],
   "surfaces": {
     "rest_api": {
@@ -23,7 +27,9 @@
     },
     "server_requests": {
       "coverage_goal": "all_connection_wpcom_sync_and_module_http_hosts_with_unapproved_requests_blocked",
-      "guardrail": "wordpress-external-http-guardrail"
+      "guardrail": "wordpress-external-http-guardrail",
+      "guardrail_manifest": "fuzz/jetpack-external-http-guardrail.json",
+      "network_policy": "block_all_synthetic_external_requests"
     },
     "browser_requests": {
       "coverage_goal": "all_wp_admin_jetpack_screen_fetch_xhr_websocket_asset_requests",
@@ -31,14 +37,131 @@
       "trace_workload": "bench/jetpack-browser-coverage.trace.mjs",
       "rig": "rigs/jetpack-browser-coverage/rig.json",
       "scenarios": ["dashboard", "connection", "modules", "settings"]
+    },
+    "authenticated_admin_pages": {
+      "coverage_goal": "bounded_safe_wp_admin_jetpack_menu_submenu_get_pages_as_admin",
+      "coverage_artifact": "homeboy/wordpress-admin-page-coverage/v1",
+      "workload": "fuzz/jetpack-admin-page-coverage.json",
+      "rig": "rigs/jetpack-api-route-inventory/rig.json"
+    },
+    "options": {
+      "coverage_goal": "bounded Jetpack option read/write/default shape coverage for isolated fixture options",
+      "workload": "fuzz/jetpack-options-matrix.json",
+      "rig": "rigs/jetpack-api-route-inventory/rig.json"
+    },
+    "modules": {
+      "coverage_goal": "bounded Jetpack module activate/deactivate/settings state matrix in an isolated runner",
+      "workload": "fuzz/jetpack-module-state-matrix.json",
+      "rig": "rigs/jetpack-api-route-inventory/rig.json"
+    },
+    "sync": {
+      "coverage_goal": "bounded Jetpack sync queue/action serialization coverage without WordPress.com credentials",
+      "workload": "fuzz/jetpack-sync-queue-coverage.json",
+      "rig": "rigs/jetpack-api-route-inventory/rig.json"
     }
   },
   "coverage_profiles": {
     "full-surface": {
       "rest_api": ["jetpack-rest-route-inventory", "generated-rest-request-cases"],
-      "database": ["db-inventory", "rest-db-query-profiler"],
-      "server_requests": ["external-http-guardrail"],
+      "database": ["db-inventory", "rest-db-query-profile"],
+      "server_requests": ["jetpack-external-http-guardrail"],
+      "authenticated_admin_pages": ["jetpack-admin-page-coverage"],
+      "options": ["jetpack-options-matrix"],
+      "modules": ["jetpack-module-state-matrix"],
+      "sync": ["jetpack-sync-queue-coverage"],
       "browser_requests": ["dashboard", "connection", "modules", "settings"]
+    }
+  },
+  "workloads": {
+    "jetpack-rest-route-inventory": {
+      "surface": "rest_api",
+      "coverage_shape": "registered Jetpack and WPCOM REST route inventory with permission-boundary classification",
+      "safety": {
+        "classification": "read_only_inventory",
+        "notes": ["Inspects the local REST route registry", "Does not execute route handlers"]
+      },
+      "artifact_expectations": { "required": ["metrics", "route_inventory json artifact"], "optional": ["namespace counts"] }
+    },
+    "generated-rest-request-cases": {
+      "surface": "rest_api",
+      "coverage_shape": "generated safe Jetpack REST request cases for site, connection, modules, settings, and WPCOM publicize routes",
+      "safety": {
+        "classification": "bounded_authenticated_read",
+        "notes": ["Uses explicit local GET request cases", "Does not require WordPress.com OAuth credentials"]
+      },
+      "artifact_expectations": { "required": ["metadata", "captured REST responses"], "optional": ["request case timing"] }
+    },
+    "rest-db-query-profile": {
+      "surface": "database",
+      "coverage_shape": "DB query profile for safe Jetpack REST request cases",
+      "safety": {
+        "classification": "bounded_authenticated_read",
+        "notes": ["Profiles local REST request cases only", "Captures query counts without external service calls"]
+      },
+      "artifact_expectations": { "required": ["metrics", "query profile json artifact"], "optional": ["query samples"] }
+    },
+    "db-inventory": {
+      "surface": "database",
+      "coverage_shape": "Jetpack fixture database table, row, column, and index inventory",
+      "safety": {
+        "classification": "read_only_inventory",
+        "notes": ["Reads isolated runner database metadata", "Does not mutate production or developer databases"]
+      },
+      "artifact_expectations": { "required": ["metrics", "db inventory json artifact"], "optional": ["table samples"] }
+    },
+    "jetpack-admin-page-coverage": {
+      "surface": "authenticated_admin_pages",
+      "coverage_shape": "bounded authenticated wp-admin Jetpack menu and submenu GET coverage for administrator users",
+      "safety": {
+        "classification": "bounded_authenticated_read",
+        "notes": ["GET-only admin visits with explicit skips for destructive/update/install screens", "Per-role and per-page limits bound request volume"]
+      },
+      "artifact_expectations": { "required": ["metrics", "admin_page_coverage json artifact"], "optional": ["request logs"] }
+    },
+    "jetpack-module-state-matrix": {
+      "surface": "modules",
+      "coverage_shape": "bounded Jetpack module activation, deactivation, dependency, and settings-state matrix",
+      "safety": {
+        "classification": "isolated_fixture_mutation",
+        "notes": ["Mutates only module state in the isolated runner", "Connection-dependent modules are classified instead of calling external services"]
+      },
+      "artifact_expectations": { "required": ["metrics", "module matrix rows"], "optional": ["skipped module reasons"] }
+    },
+    "jetpack-options-matrix": {
+      "surface": "options",
+      "coverage_shape": "bounded Jetpack option defaults, serialization, update, and rollback matrix",
+      "safety": {
+        "classification": "isolated_fixture_mutation",
+        "notes": ["Mutates options only inside the isolated runner database", "Secrets and tokens are represented by synthetic placeholder values"]
+      },
+      "artifact_expectations": { "required": ["metrics", "option matrix rows"], "optional": ["serialization samples"] }
+    },
+    "jetpack-sync-queue-coverage": {
+      "surface": "sync",
+      "coverage_shape": "bounded Jetpack sync queue, action serialization, cron, and retry coverage without remote dispatch",
+      "safety": {
+        "classification": "isolated_fixture_mutation",
+        "notes": ["Exercises local sync queue state only", "Outbound WordPress.com dispatch is blocked by the external HTTP guardrail"]
+      },
+      "artifact_expectations": { "required": ["metrics", "sync queue artifact"], "optional": ["serialized action samples"] }
+    },
+    "jetpack-external-http-guardrail": {
+      "surface": "server_requests",
+      "coverage_shape": "Jetpack connection, sync, module, and WordPress.com API external HTTP guardrail probes with all synthetic requests blocked",
+      "safety": {
+        "classification": "network_guardrail_probe",
+        "notes": ["Installs the external HTTP guardrail before probes run", "Uses .invalid synthetic hosts and an empty allowlist so no real external service calls are expected"]
+      },
+      "artifact_expectations": { "required": ["metrics", "guardrail collection"], "optional": ["captured request samples"] }
+    },
+    "jetpack-browser-coverage": {
+      "surface": "browser_requests",
+      "coverage_shape": "Jetpack dashboard, connection, modules, and settings admin browser request coverage",
+      "safety": {
+        "classification": "browser_fixture_trace",
+        "notes": ["Runs in WP Codebox browser coverage", "No WordPress.com OAuth fixture or live service account is provisioned"]
+      },
+      "artifact_expectations": { "required": ["browser request coverage artifact"], "optional": ["screenshots", "console logs"] }
     }
   }
 }

--- a/Automattic/jetpack/manifests/full-surface-coverage.test.mjs
+++ b/Automattic/jetpack/manifests/full-surface-coverage.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.join(__dirname, '..');
+const fuzzRoot = path.join(packageRoot, 'fuzz');
+
+const manifest = JSON.parse(readFileSync(path.join(__dirname, 'full-surface-coverage.json'), 'utf8'));
+const apiRig = JSON.parse(readFileSync(path.join(packageRoot, 'rigs/jetpack-api-route-inventory/rig.json'), 'utf8'));
+const browserRig = JSON.parse(readFileSync(path.join(packageRoot, 'rigs/jetpack-browser-coverage/rig.json'), 'utf8'));
+
+const expectedSafetyClassifications = new Set([
+  'bounded_authenticated_read',
+  'browser_fixture_trace',
+  'isolated_fixture_mutation',
+  'network_guardrail_probe',
+  'read_only_inventory',
+]);
+
+function workloadIdFromPath(workloadPath) {
+  return path.basename(workloadPath).replace(/\.json$/, '');
+}
+
+test('Jetpack fuzz workloads are declared outside bench profiles', () => {
+  assert.equal(apiRig.bench_workloads, undefined, 'Jetpack fuzz coverage must not use bench_workloads as a fallback');
+  assert.equal(apiRig.bench_profiles, undefined, 'Jetpack fuzz coverage must not use bench_profiles as a fallback');
+
+  const rigWorkloads = new Set(apiRig.fuzz_workloads.wordpress.map((workload) => workloadIdFromPath(workload.path)));
+  const fuzzFiles = new Set(readdirSync(fuzzRoot).filter((file) => file.endsWith('.json')).map((file) => file.replace(/\.json$/, '')));
+
+  assert.deepEqual(rigWorkloads, fuzzFiles);
+});
+
+test('Jetpack fuzz workload manifests carry coverage contract metadata', () => {
+  const workloadIds = new Set([
+    ...apiRig.fuzz_workloads.wordpress.map((workload) => workloadIdFromPath(workload.path)),
+    ...browserRig.trace_profiles['full-surface'],
+  ]);
+  const profile = manifest.coverage_profiles['full-surface'];
+  const profileFuzzIds = new Set(Object.entries(profile)
+    .filter(([surface]) => surface !== 'browser_requests')
+    .flatMap(([, ids]) => ids));
+
+  for (const workloadId of workloadIds) {
+    const metadata = manifest.workloads?.[workloadId];
+    assert.ok(metadata, `${workloadId} is missing manifest.workloads metadata`);
+    assert.equal(typeof metadata.coverage_shape, 'string', `${workloadId} coverage_shape must be a string`);
+    assert.ok(metadata.coverage_shape.length > 24, `${workloadId} coverage_shape should be reviewer-readable`);
+    assert.equal(typeof metadata.surface, 'string', `${workloadId} surface must be a string`);
+    assert.ok(expectedSafetyClassifications.has(metadata.safety?.classification), `${workloadId} has unknown safety classification`);
+    assert.ok(Array.isArray(metadata.safety?.notes), `${workloadId} safety notes must be an array`);
+    assert.ok(metadata.safety.notes.length > 0, `${workloadId} needs at least one safety note`);
+    assert.ok(Array.isArray(metadata.artifact_expectations?.required), `${workloadId} required artifact expectations must be an array`);
+    assert.ok(metadata.artifact_expectations.required.length > 0, `${workloadId} needs at least one required artifact expectation`);
+  }
+
+  assert.deepEqual(profileFuzzIds, new Set(apiRig.fuzz_workloads.wordpress.map((workload) => workloadIdFromPath(workload.path))));
+  assert.deepEqual(new Set(profile.browser_requests), new Set(manifest.surfaces.browser_requests.scenarios));
+  assert.deepEqual(new Set(Object.keys(manifest.workloads)), workloadIds);
+});
+
+test('Jetpack external HTTP guardrail blocks synthetic probes', () => {
+  const guardrail = JSON.parse(readFileSync(path.join(fuzzRoot, 'jetpack-external-http-guardrail.json'), 'utf8'));
+
+  assert.equal(guardrail.network_guardrail.block_network, true);
+  assert.deepEqual(guardrail.network_guardrail.allowlist_domains, []);
+  assert.equal(guardrail.network_guardrail.real_external_service_calls_allowed, false);
+  assert.ok(guardrail.network_guardrail.probe_hosts.every((host) => host.endsWith('.invalid')));
+});

--- a/Automattic/jetpack/manifests/performance-fixtures.json
+++ b/Automattic/jetpack/manifests/performance-fixtures.json
@@ -25,6 +25,13 @@
       ],
       "expected_workloads": [
         "jetpack-rest-route-inventory",
+        "generated-rest-request-cases",
+        "rest-db-query-profile",
+        "db-inventory",
+        "jetpack-admin-page-coverage",
+        "jetpack-module-state-matrix",
+        "jetpack-options-matrix",
+        "jetpack-sync-queue-coverage",
         "jetpack-external-http-guardrail"
       ]
     }

--- a/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
+++ b/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
@@ -26,34 +26,20 @@
     "default_component": "jetpack",
     "warmup_iterations": 0
   },
-  "bench_workloads": {
-    "wordpress": [
-      { "path": "${package.root}/bench/jetpack-rest-route-inventory.php" },
-      { "path": "${package.root}/bench/jetpack-external-http-guardrail.php" },
-      { "path": "${package.root}/bench/generated-rest-request-cases.workload.json" },
-      { "path": "${package.root}/bench/rest-db-query-profile.workload.json" },
-      { "path": "${package.root}/bench/db-inventory.workload.json" }
-    ]
+  "fuzz": {
+    "default_component": "jetpack"
   },
-  "bench_profiles": {
-    "smoke": [
-      "jetpack-rest-route-inventory",
-      "jetpack-external-http-guardrail",
-      "generated-rest-request-cases",
-      "rest-db-query-profile",
-      "db-inventory"
-    ],
-    "api-coverage": [
-      "jetpack-rest-route-inventory",
-      "generated-rest-request-cases",
-      "rest-db-query-profile"
-    ],
-    "full-surface": [
-      "jetpack-rest-route-inventory",
-      "generated-rest-request-cases",
-      "jetpack-external-http-guardrail",
-      "rest-db-query-profile",
-      "db-inventory"
+  "fuzz_workloads": {
+    "wordpress": [
+      { "path": "${package.root}/fuzz/jetpack-rest-route-inventory.json" },
+      { "path": "${package.root}/fuzz/generated-rest-request-cases.json" },
+      { "path": "${package.root}/fuzz/rest-db-query-profile.json" },
+      { "path": "${package.root}/fuzz/db-inventory.json" },
+      { "path": "${package.root}/fuzz/jetpack-admin-page-coverage.json" },
+      { "path": "${package.root}/fuzz/jetpack-module-state-matrix.json" },
+      { "path": "${package.root}/fuzz/jetpack-options-matrix.json" },
+      { "path": "${package.root}/fuzz/jetpack-sync-queue-coverage.json" },
+      { "path": "${package.root}/fuzz/jetpack-external-http-guardrail.json" }
     ]
   },
   "pipeline": {


### PR DESCRIPTION
## Summary
- Adds Jetpack fuzz workload manifests for REST/API, admin pages, modules, options, sync, database/query profiling, external HTTP guardrails, and browser coverage contracts.
- Wires the Jetpack API rig through `fuzz_workloads` instead of bench profiles so there is no bench fallback for fuzz coverage.
- Updates external HTTP guardrail probes to use `.invalid` synthetic hosts with an empty allowlist and explicit no-real-external-service-call policy.
- Adds Jetpack manifest validation for fuzz workload wiring, coverage metadata, and HTTP guardrail safety.

## Validation
- `node scripts/lint-rig-packages.mjs`
- `node --test Automattic/jetpack/manifests/full-surface-coverage.test.mjs`

## Not run
- Heavy local tests, benchmarks, and Homeboy bench/trace/fuzz execution were not run.
- `node --test` repo-wide was attempted and hit existing unrelated Studio/Woo test failures: missing `HOMEBOY_NODEJS_WORKLOAD_UTILS` for `Automattic/studio/bench/studio-agent-site-build.test.mjs`, plus stale Woo full-surface bench-profile assumptions.

## Gaps
- Generic fuzz runner execution is declared but not exercised locally.
- Admin/options/modules/sync workloads are manifest contracts for generic fuzz primitives; concrete runner artifacts still need an offloaded run.
- Browser coverage remains in the existing WP Codebox trace rig and was not executed locally.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting Jetpack rig manifests, guardrail wiring, validation tests, and PR text.