### PR TITLE
Add Gutenberg fuzz coverage manifests

### DIFF
--- a/WordPress/gutenberg/README.md
+++ b/WordPress/gutenberg/README.md
@@ -30,18 +30,12 @@ stay generic.
 
 ## `gutenberg` fuzzer profile
 
-`manifests/fuzzer-profile.json` defines a rig-owned Gutenberg fuzzer profile analogous to the Woo full-surface shape. It composes REST route coverage, `wp-admin` and editor page coverage, block editor load/action probes, DB query/profile hooks, external HTTP guardrails, and coverage-gap reporting without moving Gutenberg-specific knowledge into Homeboy core or Homeboy Extensions.
+`manifests/fuzzer-profile.json` defines a rig-owned Gutenberg fuzzer profile analogous to the Woo full-surface shape. It composes REST route coverage, `wp-admin` and editor page coverage, block editor load/action probes, Site Editor probes, block rendering, DB query/profile hooks, external HTTP guardrails, and coverage-gap reporting without moving Gutenberg-specific knowledge into Homeboy core or Homeboy Extensions.
 
-Run the bench-side fuzzer profile:
-
-```sh
-homeboy bench --rig gutenberg-api-route-inventory --profile fuzzer --iterations 1 --shared-state /tmp/gutenberg-fuzzer-bench
-```
-
-Run the browser/editor trace side:
+Run the fuzzer manifests through the WordPress extension runner:
 
 ```sh
-homeboy trace --rig gutenberg-browser-coverage --profile fuzzer
+homeboy fuzz --rig gutenberg-api-route-inventory --runner wordpress --shared-state /tmp/gutenberg-fuzzer
 ```
 
 See `docs/fuzzer-profile.md` for the gap-report contract and current limits.

--- a/WordPress/gutenberg/docs/fuzzer-profile.md
+++ b/WordPress/gutenberg/docs/fuzzer-profile.md
@@ -1,16 +1,17 @@
 # Gutenberg Fuzzer Profile
 
-This scaffold keeps Gutenberg-specific coverage knowledge inside `homeboy-rigs/WordPress/gutenberg`. Homeboy core and Homeboy Extensions only need to run declared bench/trace workloads and preserve their artifacts.
+This scaffold keeps Gutenberg-specific coverage knowledge inside `homeboy-rigs/WordPress/gutenberg`. Homeboy core and Homeboy Extensions only need to run declared fuzz workloads through the existing WordPress runner and preserve their artifacts.
 
 ## Coverage Shape
 
 The `fuzzer` profile composes the same surface classes as the Woo full-surface rig:
 
-- REST route coverage through `gutenberg-rest-route-inventory` and `generated-rest-request-cases`.
-- `wp-admin` and editor page coverage through `gutenberg-browser-coverage` scenarios for post editor, Site Editor, template editor, and patterns.
+- REST route coverage through `gutenberg-rest-route-fuzz` and `gutenberg-rest-request-cases-fuzz`.
+- `wp-admin` and editor page coverage through `block-editor-browser-coverage` and `site-editor-browser-coverage` manifests that point at the rig-owned browser scenarios for post editor, Site Editor, template editor, and patterns.
+- Dynamic block rendering coverage through `block-rendering-coverage` request cases.
 - Block editor load/action probes through the browser action scenario files in `browser-scenarios/`.
-- DB inventory and REST query profiling through `db-inventory` and `rest-db-query-profile`.
-- External HTTP guardrails through `gutenberg-external-http-guardrail`.
+- DB inventory and REST query profiling through `gutenberg-db-inventory-fuzz` and `gutenberg-rest-db-query-profile-fuzz`.
+- External HTTP guardrails through `gutenberg-external-http-guardrail-fuzz`.
 - Coverage-gap reporting shape in `manifests/fuzzer-profile.json` and `manifests/full-surface-coverage.json`.
 
 ## Commands
@@ -23,26 +24,20 @@ homeboy rig check gutenberg-api-route-inventory
 homeboy rig check gutenberg-browser-coverage
 ```
 
-Run the bench-side fuzzer profile:
+Run the fuzzer manifests through the WordPress extension runner:
 
 ```sh
-homeboy bench --rig gutenberg-api-route-inventory --profile fuzzer --iterations 1 --shared-state /tmp/gutenberg-fuzzer-bench
-```
-
-Run the browser/editor trace side:
-
-```sh
-homeboy trace --rig gutenberg-browser-coverage --profile fuzzer
+homeboy fuzz --rig gutenberg-api-route-inventory --runner wordpress --shared-state /tmp/gutenberg-fuzzer
 ```
 
 ## Gap Report Contract
 
-A consumer can produce `homeboy-rigs/gutenberg-fuzzer-coverage-gap/v1` from the artifacts emitted by those two commands. The report should include:
+A consumer can produce `homeboy-rigs/gutenberg-fuzzer-coverage-gap/v1` from the artifacts emitted by the fuzz runner. The report should include:
 
 - REST routes from `manifests/rest-route-coverage.json` that were registered but do not have generated safe request cases.
 - Target browser scenarios from `manifests/full-surface-coverage.json` that did not produce browser request coverage.
 - Covered REST routes without DB query profiles or with query counts/durations over `manifests/rest-route-budgets.json`.
-- Unapproved outbound hosts observed by `gutenberg-external-http-guardrail`.
+- Unapproved outbound hosts observed by `gutenberg-external-http-guardrail-fuzz`.
 - Fixture or primitive gaps that prevent a surface from being interpreted as covered.
 
 ## Current Limits

--- a/WordPress/gutenberg/fuzz/block-editor-browser-coverage.json
+++ b/WordPress/gutenberg/fuzz/block-editor-browser-coverage.json
@@ -1,0 +1,41 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "block-editor-browser-coverage",
+  "label": "Gutenberg block editor browser coverage",
+  "safety_class": "isolated_mutation",
+  "surface_ids": ["gutenberg-block-editor", "wordpress-admin-pages", "browser-requests"],
+  "operations": ["editor-page-load", "block-editor-action-probe", "browser-request-coverage"],
+  "case_budget": 24,
+  "duration_budget_seconds": 900,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/gutenberg-browser-coverage.trace.mjs",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": { "type": "wordpress-plugin", "slug": "gutenberg", "component": "gutenberg" },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "trace",
+    "path": "${package.root}/bench/gutenberg-browser-coverage.trace.mjs",
+    "entry": "post_editor"
+  },
+  "cases": [
+    {
+      "case_id": "block-editor-browser-coverage:default",
+      "surface_ids": ["gutenberg-block-editor", "wordpress-admin-pages", "browser-requests"],
+      "operations": ["editor-page-load", "block-editor-action-probe", "browser-request-coverage"],
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=gutenberg/gutenberg.php"] }],
+        "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/gutenberg-browser-coverage.trace.mjs", "type=trace", "scenario=post_editor"] }],
+        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=block_editor_browser_coverage"] }]
+      },
+      "artifacts": [{ "name": "block_editor_browser_coverage", "path": "block-editor-browser-coverage/browser_request_coverage.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }],
+      "metadata": { "safety_class": "isolated_mutation" }
+    }
+  ],
+  "limits": { "max_cases": 24, "max_duration_seconds": 900 },
+  "coverage": { "surface_ids": ["gutenberg-block-editor", "wordpress-admin-pages", "browser-requests"], "operations": ["editor-page-load", "block-editor-action-probe", "browser-request-coverage"] },
+  "artifacts": { "expected": [{ "name": "block_editor_browser_coverage", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/WordPress/gutenberg/fuzz/block-rendering-coverage.json
+++ b/WordPress/gutenberg/fuzz/block-rendering-coverage.json
@@ -1,0 +1,41 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "block-rendering-coverage",
+  "label": "Gutenberg dynamic block rendering coverage",
+  "safety_class": "isolated_mutation",
+  "surface_ids": ["gutenberg-block-renderer", "wordpress-rest-api", "wordpress-server-rendered-blocks"],
+  "operations": ["block-renderer-route-cases", "server-rendered-block-coverage"],
+  "case_budget": 80,
+  "duration_budget_seconds": 900,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/generated-rest-request-cases.workload.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": { "type": "wordpress-plugin", "slug": "gutenberg", "component": "gutenberg" },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "json",
+    "path": "${package.root}/bench/generated-rest-request-cases.workload.json",
+    "entry": "block-rendering-coverage"
+  },
+  "cases": [
+    {
+      "case_id": "block-rendering-coverage:default",
+      "surface_ids": ["gutenberg-block-renderer", "wordpress-rest-api", "wordpress-server-rendered-blocks"],
+      "operations": ["block-renderer-route-cases", "server-rendered-block-coverage"],
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=gutenberg/gutenberg.php"] }],
+        "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/generated-rest-request-cases.workload.json", "type=json", "surface=gutenberg-block-renderer"] }],
+        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=block_rendering_coverage"] }]
+      },
+      "artifacts": [{ "name": "block_rendering_coverage", "path": "block-rendering-coverage/rest_request_cases.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }],
+      "metadata": { "safety_class": "isolated_mutation" }
+    }
+  ],
+  "limits": { "max_cases": 80, "max_duration_seconds": 900 },
+  "coverage": { "surface_ids": ["gutenberg-block-renderer", "wordpress-rest-api", "wordpress-server-rendered-blocks"], "operations": ["block-renderer-route-cases", "server-rendered-block-coverage"] },
+  "artifacts": { "expected": [{ "name": "block_rendering_coverage", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/WordPress/gutenberg/fuzz/gutenberg-db-inventory-fuzz.json
+++ b/WordPress/gutenberg/fuzz/gutenberg-db-inventory-fuzz.json
@@ -1,0 +1,36 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "gutenberg-db-inventory-fuzz",
+  "label": "Gutenberg database inventory coverage",
+  "safety_class": "read_only",
+  "surface_ids": ["wordpress-database", "gutenberg-fixture-state"],
+  "operations": ["database-inventory", "fixture-state-classification"],
+  "case_budget": 20,
+  "duration_budget_seconds": 300,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/db-inventory.workload.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": { "type": "wordpress-plugin", "slug": "gutenberg", "component": "gutenberg" },
+  "workload": { "runner": "wp-codebox", "type": "json", "path": "${package.root}/bench/db-inventory.workload.json", "entry": "db-inventory" },
+  "cases": [
+    {
+      "case_id": "gutenberg-db-inventory-fuzz:default",
+      "surface_ids": ["wordpress-database", "gutenberg-fixture-state"],
+      "operations": ["database-inventory", "fixture-state-classification"],
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=gutenberg/gutenberg.php"] }],
+        "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/db-inventory.workload.json", "type=json"] }],
+        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=db_inventory"] }]
+      },
+      "artifacts": [{ "name": "db_inventory", "path": "db-inventory/db_inventory.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }],
+      "metadata": { "safety_class": "read_only" }
+    }
+  ],
+  "limits": { "max_cases": 20, "max_duration_seconds": 300 },
+  "coverage": { "surface_ids": ["wordpress-database", "gutenberg-fixture-state"], "operations": ["database-inventory", "fixture-state-classification"] },
+  "artifacts": { "expected": [{ "name": "db_inventory", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/WordPress/gutenberg/fuzz/gutenberg-external-http-guardrail-fuzz.json
+++ b/WordPress/gutenberg/fuzz/gutenberg-external-http-guardrail-fuzz.json
@@ -1,0 +1,36 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "gutenberg-external-http-guardrail-fuzz",
+  "label": "Gutenberg external HTTP guardrail coverage",
+  "safety_class": "read_only",
+  "surface_ids": ["gutenberg-api", "wordpress-http-api", "performance-guardrails"],
+  "operations": ["external-http-host-inventory", "unapproved-host-blocking"],
+  "case_budget": 30,
+  "duration_budget_seconds": 300,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/gutenberg-external-http-guardrail.php",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": { "type": "wordpress-plugin", "slug": "gutenberg", "component": "gutenberg" },
+  "workload": { "runner": "wp-codebox", "type": "php", "path": "${package.root}/bench/gutenberg-external-http-guardrail.php", "entry": "gutenberg-external-http-guardrail" },
+  "cases": [
+    {
+      "case_id": "gutenberg-external-http-guardrail-fuzz:default",
+      "surface_ids": ["gutenberg-api", "wordpress-http-api", "performance-guardrails"],
+      "operations": ["external-http-host-inventory", "unapproved-host-blocking"],
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=gutenberg/gutenberg.php"] }],
+        "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/gutenberg-external-http-guardrail.php", "type=php"] }],
+        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=external_http_guardrail"] }]
+      },
+      "artifacts": [{ "name": "external_http_guardrail", "path": "gutenberg-external-http-guardrail/external_http_guardrail.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }],
+      "metadata": { "safety_class": "read_only" }
+    }
+  ],
+  "limits": { "max_cases": 30, "max_duration_seconds": 300 },
+  "coverage": { "surface_ids": ["gutenberg-api", "wordpress-http-api", "performance-guardrails"], "operations": ["external-http-host-inventory", "unapproved-host-blocking"] },
+  "artifacts": { "expected": [{ "name": "external_http_guardrail", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/WordPress/gutenberg/fuzz/gutenberg-rest-db-query-profile-fuzz.json
+++ b/WordPress/gutenberg/fuzz/gutenberg-rest-db-query-profile-fuzz.json
@@ -1,0 +1,36 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "gutenberg-rest-db-query-profile-fuzz",
+  "label": "Gutenberg REST database query profile coverage",
+  "safety_class": "read_only",
+  "surface_ids": ["gutenberg-rest-routes", "wordpress-database-queries"],
+  "operations": ["rest-query-profile", "query-shape-attribution"],
+  "case_budget": 80,
+  "duration_budget_seconds": 900,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/rest-db-query-profile.workload.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": { "type": "wordpress-plugin", "slug": "gutenberg", "component": "gutenberg" },
+  "workload": { "runner": "wp-codebox", "type": "json", "path": "${package.root}/bench/rest-db-query-profile.workload.json", "entry": "rest-db-query-profile" },
+  "cases": [
+    {
+      "case_id": "gutenberg-rest-db-query-profile-fuzz:default",
+      "surface_ids": ["gutenberg-rest-routes", "wordpress-database-queries"],
+      "operations": ["rest-query-profile", "query-shape-attribution"],
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=gutenberg/gutenberg.php"] }],
+        "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/rest-db-query-profile.workload.json", "type=json"] }],
+        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=rest_db_query_profile"] }]
+      },
+      "artifacts": [{ "name": "rest_db_query_profile", "path": "rest-db-query-profile/rest_db_query_profile.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }],
+      "metadata": { "safety_class": "read_only" }
+    }
+  ],
+  "limits": { "max_cases": 80, "max_duration_seconds": 900 },
+  "coverage": { "surface_ids": ["gutenberg-rest-routes", "wordpress-database-queries"], "operations": ["rest-query-profile", "query-shape-attribution"] },
+  "artifacts": { "expected": [{ "name": "rest_db_query_profile", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/WordPress/gutenberg/fuzz/gutenberg-rest-request-cases-fuzz.json
+++ b/WordPress/gutenberg/fuzz/gutenberg-rest-request-cases-fuzz.json
@@ -1,0 +1,41 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "gutenberg-rest-request-cases-fuzz",
+  "label": "Generated Gutenberg REST request cases",
+  "safety_class": "isolated_mutation",
+  "surface_ids": ["gutenberg-rest-routes", "wordpress-rest-api"],
+  "operations": ["generated-rest-case-plan", "request-case-execution"],
+  "case_budget": 120,
+  "duration_budget_seconds": 900,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/generated-rest-request-cases.workload.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": { "type": "wordpress-plugin", "slug": "gutenberg", "component": "gutenberg" },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "json",
+    "path": "${package.root}/bench/generated-rest-request-cases.workload.json",
+    "entry": "generated-rest-request-cases"
+  },
+  "cases": [
+    {
+      "case_id": "gutenberg-rest-request-cases-fuzz:default",
+      "surface_ids": ["gutenberg-rest-routes", "wordpress-rest-api"],
+      "operations": ["generated-rest-case-plan", "request-case-execution"],
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=gutenberg/gutenberg.php"] }],
+        "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/generated-rest-request-cases.workload.json", "type=json"] }],
+        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=rest_request_cases"] }]
+      },
+      "artifacts": [{ "name": "rest_request_cases", "path": "generated-rest-request-cases/rest_request_cases.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }],
+      "metadata": { "safety_class": "isolated_mutation" }
+    }
+  ],
+  "limits": { "max_cases": 120, "max_duration_seconds": 900 },
+  "coverage": { "surface_ids": ["gutenberg-rest-routes", "wordpress-rest-api"], "operations": ["generated-rest-case-plan", "request-case-execution"] },
+  "artifacts": { "expected": [{ "name": "rest_request_cases", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/WordPress/gutenberg/fuzz/gutenberg-rest-route-fuzz.json
+++ b/WordPress/gutenberg/fuzz/gutenberg-rest-route-fuzz.json
@@ -1,0 +1,41 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "gutenberg-rest-route-fuzz",
+  "label": "Gutenberg REST route inventory coverage",
+  "safety_class": "read_only",
+  "surface_ids": ["gutenberg-rest-routes", "wordpress-rest-api"],
+  "operations": ["rest-route-discovery", "route-group-classification"],
+  "case_budget": 40,
+  "duration_budget_seconds": 300,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/gutenberg-rest-route-inventory.php",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": { "type": "wordpress-plugin", "slug": "gutenberg", "component": "gutenberg" },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "php",
+    "path": "${package.root}/bench/gutenberg-rest-route-inventory.php",
+    "entry": "gutenberg-rest-route-inventory"
+  },
+  "cases": [
+    {
+      "case_id": "gutenberg-rest-route-fuzz:default",
+      "surface_ids": ["gutenberg-rest-routes", "wordpress-rest-api"],
+      "operations": ["rest-route-discovery", "route-group-classification"],
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=gutenberg/gutenberg.php"] }],
+        "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/gutenberg-rest-route-inventory.php", "type=php"] }],
+        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=rest_route_inventory"] }]
+      },
+      "artifacts": [{ "name": "rest_route_inventory", "path": "gutenberg-rest-route-inventory/rest_route_inventory.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }],
+      "metadata": { "safety_class": "read_only" }
+    }
+  ],
+  "limits": { "max_cases": 40, "max_duration_seconds": 300 },
+  "coverage": { "surface_ids": ["gutenberg-rest-routes", "wordpress-rest-api"], "operations": ["rest-route-discovery", "route-group-classification"] },
+  "artifacts": { "expected": [{ "name": "rest_route_inventory", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/WordPress/gutenberg/fuzz/site-editor-browser-coverage.json
+++ b/WordPress/gutenberg/fuzz/site-editor-browser-coverage.json
@@ -1,0 +1,41 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "site-editor-browser-coverage",
+  "label": "Gutenberg site editor browser coverage",
+  "safety_class": "isolated_mutation",
+  "surface_ids": ["gutenberg-site-editor", "wordpress-admin-pages", "browser-requests"],
+  "operations": ["site-editor-page-load", "template-editor-action-probe", "browser-request-coverage"],
+  "case_budget": 24,
+  "duration_budget_seconds": 900,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/gutenberg-browser-coverage.trace.mjs",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": { "type": "wordpress-plugin", "slug": "gutenberg", "component": "gutenberg" },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "trace",
+    "path": "${package.root}/bench/gutenberg-browser-coverage.trace.mjs",
+    "entry": "site_editor"
+  },
+  "cases": [
+    {
+      "case_id": "site-editor-browser-coverage:default",
+      "surface_ids": ["gutenberg-site-editor", "wordpress-admin-pages", "browser-requests"],
+      "operations": ["site-editor-page-load", "template-editor-action-probe", "browser-request-coverage"],
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=gutenberg/gutenberg.php"] }],
+        "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/gutenberg-browser-coverage.trace.mjs", "type=trace", "scenario=site_editor"] }],
+        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=site_editor_browser_coverage"] }]
+      },
+      "artifacts": [{ "name": "site_editor_browser_coverage", "path": "site-editor-browser-coverage/browser_request_coverage.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }],
+      "metadata": { "safety_class": "isolated_mutation" }
+    }
+  ],
+  "limits": { "max_cases": 24, "max_duration_seconds": 900 },
+  "coverage": { "surface_ids": ["gutenberg-site-editor", "wordpress-admin-pages", "browser-requests"], "operations": ["site-editor-page-load", "template-editor-action-probe", "browser-request-coverage"] },
+  "artifacts": { "expected": [{ "name": "site_editor_browser_coverage", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/WordPress/gutenberg/manifests/full-surface-coverage.json
+++ b/WordPress/gutenberg/manifests/full-surface-coverage.json
@@ -28,7 +28,7 @@
     "browser_requests": {
       "coverage_goal": "all_editor_bootstrap_fetch_xhr_websocket_asset_requests",
       "coverage_artifact": "wp-codebox/browser-request-coverage/v1",
-      "trace_workload": "bench/gutenberg-browser-coverage.trace.mjs",
+      "fuzz_workloads": ["block-editor-browser-coverage", "site-editor-browser-coverage"],
       "rig": "rigs/gutenberg-browser-coverage/rig.json",
       "scenarios": ["post_editor", "site_editor", "template_editor", "patterns"]
     }
@@ -52,10 +52,11 @@
   },
   "coverage_profiles": {
     "fuzzer": {
-      "rest_api": ["gutenberg-rest-route-inventory", "generated-rest-request-cases"],
-      "database": ["db-inventory", "rest-db-query-profile"],
-      "server_requests": ["gutenberg-external-http-guardrail"],
-      "browser_requests": ["post_editor", "site_editor", "template_editor", "patterns"]
+      "rest_api": ["gutenberg-rest-route-fuzz", "gutenberg-rest-request-cases-fuzz"],
+      "database": ["gutenberg-db-inventory-fuzz", "gutenberg-rest-db-query-profile-fuzz"],
+      "server_requests": ["gutenberg-external-http-guardrail-fuzz"],
+      "browser_requests": ["block-editor-browser-coverage", "site-editor-browser-coverage"],
+      "block_rendering": ["block-rendering-coverage"]
     },
     "full-surface": {
       "rest_api": ["gutenberg-rest-route-inventory", "generated-rest-request-cases"],

--- a/WordPress/gutenberg/manifests/fuzzer-profile.json
+++ b/WordPress/gutenberg/manifests/fuzzer-profile.json
@@ -9,20 +9,27 @@
     "fixtures": "manifests/performance-fixtures.json"
   },
   "execution": {
-    "bench_rig": "gutenberg-api-route-inventory",
-    "bench_profile": "fuzzer",
-    "trace_rig": "gutenberg-browser-coverage",
-    "trace_profile": "fuzzer"
+    "fuzz_rig": "gutenberg-api-route-inventory",
+    "fuzz_workloads": [
+      "gutenberg-rest-route-fuzz",
+      "gutenberg-rest-request-cases-fuzz",
+      "block-editor-browser-coverage",
+      "site-editor-browser-coverage",
+      "block-rendering-coverage",
+      "gutenberg-db-inventory-fuzz",
+      "gutenberg-rest-db-query-profile-fuzz",
+      "gutenberg-external-http-guardrail-fuzz"
+    ]
   },
   "surfaces": {
     "rest_route_coverage": {
-      "workloads": ["gutenberg-rest-route-inventory", "generated-rest-request-cases"],
+      "workloads": ["gutenberg-rest-route-fuzz", "gutenberg-rest-request-cases-fuzz"],
       "target_manifest": "manifests/rest-route-coverage.json",
       "gap_rule": "Report registered Gutenberg-facing routes that do not have generated safe request cases."
     },
     "wp_admin_editor_pages": {
-      "trace_workload": "bench/gutenberg-browser-coverage.trace.mjs",
-      "scenarios": ["post_editor", "site_editor", "template_editor", "patterns"],
+      "fuzz_workloads": ["block-editor-browser-coverage", "site-editor-browser-coverage"],
+      "scenario_sources": ["browser-scenarios/post_editor.json", "browser-scenarios/site_editor.json", "browser-scenarios/template_editor.json", "browser-scenarios/patterns.json"],
       "gap_rule": "Report target scenarios missing browser request coverage artifacts or failing readiness steps."
     },
     "block_editor_load_action_probes": {
@@ -36,12 +43,12 @@
       "gap_rule": "Report editor screens that load but produce failed browser actions, browser errors, or no request coverage."
     },
     "db_query_profile_hooks": {
-      "workloads": ["db-inventory", "rest-db-query-profile"],
+      "workloads": ["gutenberg-db-inventory-fuzz", "gutenberg-rest-db-query-profile-fuzz"],
       "budget_manifest": "manifests/rest-route-budgets.json",
       "gap_rule": "Report covered routes without query profiles and query profiles that exceed Gutenberg route budgets."
     },
     "server_request_guardrails": {
-      "workloads": ["gutenberg-external-http-guardrail"],
+      "workloads": ["gutenberg-external-http-guardrail-fuzz"],
       "allowed_hosts": ["api.wordpress.org"],
       "gap_rule": "Report unapproved outbound hosts touched by Gutenberg editor/library probes."
     }

--- a/WordPress/gutenberg/rigs/gutenberg-api-route-inventory/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-api-route-inventory/rig.json
@@ -26,6 +26,9 @@
     "default_component": "gutenberg",
     "warmup_iterations": 0
   },
+  "fuzz": {
+    "default_component": "gutenberg"
+  },
   "bench_workloads": {
     "wordpress": [
       { "path": "${package.root}/bench/gutenberg-rest-route-inventory.php" },
@@ -33,6 +36,18 @@
       { "path": "${package.root}/bench/generated-rest-request-cases.workload.json" },
       { "path": "${package.root}/bench/rest-db-query-profile.workload.json" },
       { "path": "${package.root}/bench/db-inventory.workload.json" }
+    ]
+  },
+  "fuzz_workloads": {
+    "wordpress": [
+      { "path": "${package.root}/fuzz/gutenberg-rest-route-fuzz.json" },
+      { "path": "${package.root}/fuzz/gutenberg-rest-request-cases-fuzz.json" },
+      { "path": "${package.root}/fuzz/block-editor-browser-coverage.json" },
+      { "path": "${package.root}/fuzz/site-editor-browser-coverage.json" },
+      { "path": "${package.root}/fuzz/block-rendering-coverage.json" },
+      { "path": "${package.root}/fuzz/gutenberg-db-inventory-fuzz.json" },
+      { "path": "${package.root}/fuzz/gutenberg-rest-db-query-profile-fuzz.json" },
+      { "path": "${package.root}/fuzz/gutenberg-external-http-guardrail-fuzz.json" }
     ]
   },
   "bench_profiles": {
@@ -47,13 +62,6 @@
       "gutenberg-rest-route-inventory",
       "generated-rest-request-cases",
       "rest-db-query-profile"
-    ],
-    "fuzzer": [
-      "gutenberg-rest-route-inventory",
-      "generated-rest-request-cases",
-      "gutenberg-external-http-guardrail",
-      "rest-db-query-profile",
-      "db-inventory"
     ],
     "full-surface": [
       "gutenberg-rest-route-inventory",

--- a/WordPress/gutenberg/tools/validate-fuzz-manifests.mjs
+++ b/WordPress/gutenberg/tools/validate-fuzz-manifests.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.join(__dirname, '..');
+const fuzzDir = path.join(packageRoot, 'fuzz');
+const rig = JSON.parse(readFileSync(path.join(packageRoot, 'rigs/gutenberg-api-route-inventory/rig.json'), 'utf8'));
+
+const fuzzManifests = readdirSync(fuzzDir)
+  .filter((file) => file.endsWith('.json'))
+  .sort()
+  .map((file) => ({
+    file,
+    path: path.join(fuzzDir, file),
+    manifest: JSON.parse(readFileSync(path.join(fuzzDir, file), 'utf8')),
+  }));
+
+assert.equal(fuzzManifests.length, 8, 'expected 8 Gutenberg fuzz manifests');
+
+const declaredFuzzIds = new Set(
+  (rig.fuzz_workloads?.wordpress || []).map((entry) => path.basename(entry.path, '.json'))
+);
+const benchWorkloadIds = new Set(
+  Object.values(rig.bench_workloads || {})
+    .flat()
+    .map((entry) => path.basename(entry.path, path.extname(entry.path)))
+);
+const benchProfileIds = new Set(Object.values(rig.bench_profiles || {}).flat());
+
+const requiredSurfaces = new Set([
+  'gutenberg-rest-routes',
+  'gutenberg-block-editor',
+  'gutenberg-site-editor',
+  'gutenberg-block-renderer',
+  'wordpress-admin-pages',
+  'wordpress-database',
+  'wordpress-database-queries',
+  'performance-guardrails',
+]);
+const coveredSurfaces = new Set();
+
+for (const { file, manifest } of fuzzManifests) {
+  assert.equal(manifest.schema, 'homeboy/fuzz-workload/v1', `${file} schema mismatch`);
+  assert.equal(typeof manifest.id, 'string', `${file} requires id`);
+  assert.ok(declaredFuzzIds.has(manifest.id), `${manifest.id} is not declared in rig fuzz_workloads.wordpress`);
+  assert.ok(!benchWorkloadIds.has(manifest.id), `${manifest.id} must not appear in bench_workloads`);
+  assert.ok(!benchProfileIds.has(manifest.id), `${manifest.id} must not appear in bench_profiles`);
+
+  assert.equal(manifest.target?.type, 'wordpress-plugin', `${manifest.id} target.type mismatch`);
+  assert.equal(manifest.target?.slug, 'gutenberg', `${manifest.id} target.slug mismatch`);
+  assert.equal(manifest.workload?.runner, 'wp-codebox', `${manifest.id} workload.runner mismatch`);
+  assert.equal(manifest.workload?.path, manifest.metadata?.workload_path, `${manifest.id} workload path must match metadata`);
+  assert.ok(['php', 'json', 'trace'].includes(manifest.workload?.type), `${manifest.id} workload.type must be php, json, or trace`);
+  assert.deepEqual(manifest.coverage?.surface_ids, manifest.surface_ids, `${manifest.id} coverage surface ids drifted`);
+  assert.deepEqual(manifest.coverage?.operations, manifest.operations, `${manifest.id} coverage operations drifted`);
+  assert.equal(manifest.limits?.max_cases, manifest.case_budget, `${manifest.id} max_cases must match case_budget`);
+  assert.equal(manifest.limits?.max_duration_seconds, manifest.duration_budget_seconds, `${manifest.id} max_duration_seconds must match duration_budget_seconds`);
+
+  assert.equal(manifest.cases?.length, 1, `${manifest.id} requires one default runner case`);
+  const [runnerCase] = manifest.cases;
+  assert.equal(runnerCase.case_id, `${manifest.id}:default`, `${manifest.id} default case id mismatch`);
+  assert.deepEqual(runnerCase.surface_ids, manifest.surface_ids, `${manifest.id} case surface ids drifted`);
+  assert.deepEqual(runnerCase.operations, manifest.operations, `${manifest.id} case operations drifted`);
+  assert.ok(Array.isArray(runnerCase.phases?.action), `${manifest.id} requires action phase`);
+  assert.ok(runnerCase.phases.action.length > 0, `${manifest.id} requires at least one action step`);
+  assert.ok(Array.isArray(runnerCase.artifacts), `${manifest.id} requires case artifacts`);
+  assert.ok(Array.isArray(manifest.artifacts?.expected), `${manifest.id} requires expected artifacts`);
+
+  for (const surfaceId of manifest.surface_ids || []) {
+    coveredSurfaces.add(surfaceId);
+  }
+}
+
+for (const surfaceId of requiredSurfaces) {
+  assert.ok(coveredSurfaces.has(surfaceId), `missing Gutenberg fuzz surface ${surfaceId}`);
+}
+
+console.log(`validated ${fuzzManifests.length} Gutenberg fuzz manifests; no fuzz IDs are present in bench_workloads or bench_profiles`);

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -10,6 +10,7 @@ const phpFiles = [];
 const rigFiles = [];
 const jsonFiles = [];
 const portableSourceFiles = [];
+const fuzzManifestValidators = [];
 const failures = [];
 const studioModelRigGenerator = join(root, 'scripts/generate-studio-agent-model-rigs.mjs');
 const personalPathPrefix = '/Users/' + 'chubes/';
@@ -43,6 +44,10 @@ function walk(directory) {
 
     if (entry.isFile() && /\.(json|mjs|js)$/.test(entry.name)) {
       portableSourceFiles.push(join(directory, entry.name));
+    }
+
+    if (entry.isFile() && entry.name === 'validate-fuzz-manifests.mjs') {
+      fuzzManifestValidators.push(join(directory, entry.name));
     }
   }
 }
@@ -249,6 +254,16 @@ function lintGeneratedStudioModelRigs() {
   }
 }
 
+function lintFuzzManifestValidators() {
+  for (const validator of fuzzManifestValidators) {
+    const result = spawnSync('node', [validator], { encoding: 'utf8' });
+    if (result.status !== 0) {
+      const output = `${result.stdout || ''}${result.stderr || ''}`.trim();
+      failures.push(`${relative(root, validator)} failed${output ? `: ${output}` : ''}`);
+    }
+  }
+}
+
 walk(root);
 
 const wordpressPluginFuzzWorkloadIdsByPackageRoot = collectWordPressPluginFuzzWorkloadIds();
@@ -256,6 +271,7 @@ const wordpressPluginFuzzWorkloadIdsByPackageRoot = collectWordPressPluginFuzzWo
 rigFiles.forEach((file) => lintRigPortability(file, wordpressPluginFuzzWorkloadIdsByPackageRoot));
 portableSourceFiles.forEach(lintPortableSource);
 lintGeneratedStudioModelRigs();
+lintFuzzManifestValidators();
 
 reportFailures();
 


### PR DESCRIPTION
## Summary
- Add Gutenberg fuzz workload manifests for REST/API coverage, block editor, Site Editor, block rendering, database inventory, REST query profiling, and external HTTP/performance guardrails.
- Wire the manifests into `gutenberg-api-route-inventory` via `fuzz_workloads` while keeping fuzz IDs out of `bench_workloads`/`bench_profiles` so there is no bench fallback.
- Add Gutenberg fuzz manifest validation and run package lint validators from the shared lint script.
- Update Gutenberg coverage docs/manifests to describe the fuzz-runner path.

## Validation
- `node WordPress/gutenberg/tools/validate-fuzz-manifests.mjs`
- `node scripts/lint-rig-packages.mjs`
- `git diff --check`

Heavy local fuzz/bench runs were not executed.

## Gaps
- The manifests reuse existing WP Codebox workload entrypoints; deeper Gutenberg-specific action generation can expand `browser-scenarios/` after the first artifact bundle shows high-value editor paths.
- Coverage-gap report generation is declared as a contract, not implemented as a separate reducer in this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the Gutenberg fuzz manifest suite, validation script, lint wiring, and PR text.
