### PR TITLE
Add WordPress Core fuzz coverage rig

### DIFF
--- a/WordPress/wordpress-develop/README.md
+++ b/WordPress/wordpress-develop/README.md
@@ -1,0 +1,34 @@
+# WordPress Core Fuzz Coverage Rigs
+
+## `wordpress-core-fuzz-coverage`
+
+Declares a WordPress Core coverage/fuzz suite for `WordPress/wordpress-develop` using generic `homeboy/fuzz-workload/v1` manifests. The package keeps WordPress-specific surface knowledge in `homeboy-rigs`; Homeboy core only needs to understand the generic fuzz workload contract.
+
+Install locally:
+
+```sh
+homeboy rig install $HOME/Developer/homeboy-rigs@<branch>/WordPress/wordpress-develop
+```
+
+Validate the rig package without running workloads:
+
+```sh
+homeboy rig check wordpress-core-fuzz-coverage
+node scripts/lint-rig-packages.mjs WordPress/wordpress-develop
+```
+
+The suite intentionally declares `fuzz_workloads` and `fuzz_profiles` only. It does not register `bench_workloads` or `bench_profiles`, so there is no benchmark fallback path.
+
+## Coverage Shape
+
+The `fuzzer` profile groups these manifests:
+
+- `fuzz/rest-api.json` covers REST route inventory and representative safe request cases.
+- `fuzz/db-inventory-query-profile.json` covers database inventory and REST/query attribution.
+- `fuzz/admin-page-coverage.json` covers core admin page discovery and browser-visible admin readiness.
+- `fuzz/hooks-cron-options.json` covers hooks, scheduled events, autoloaded options, transients, and rewrite state.
+- `fuzz/content-types-taxonomies.json` covers post types, post statuses, taxonomies, terms, and permalink surfaces.
+- `fuzz/media-users.json` covers attachment/media metadata, REST media endpoints, users, roles, and capabilities.
+- `fuzz/performance-surfaces.json` covers representative bootstrap, REST, admin, editor, cron, media, and query surfaces as performance observation targets.
+
+Supporting manifests live in `manifests/` and define the intended coverage gap report shape. The manifests are declarative until Homeboy Extensions exposes a first-class fuzz runner for these generic WordPress primitives.

--- a/WordPress/wordpress-develop/fuzz/admin-page-coverage.json
+++ b/WordPress/wordpress-develop/fuzz/admin-page-coverage.json
@@ -1,0 +1,29 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "admin-page-coverage",
+  "label": "WordPress Core admin page coverage",
+  "safety_class": "read_only",
+  "surface_ids": ["wordpress-core-admin-pages"],
+  "operations": ["admin-page-discovery", "browser-readiness", "permission-boundary-classification", "query-attribution"],
+  "case_budget": 90,
+  "duration_budget_seconds": 1200,
+  "metadata": { "kind": "wordpress-core-fuzz", "wordpress_runner": "wp-codebox", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report" },
+  "target": { "type": "wordpress-core", "component": "wordpress-develop" },
+  "cases": [
+    {
+      "case_id": "admin-page-coverage:core-menu-pages",
+      "surface_ids": ["wordpress-core-admin-pages"],
+      "operations": ["admin-page-discovery", "browser-readiness", "permission-boundary-classification", "query-attribution"],
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-core-fixture", "args": ["administrator=1", "editor=1", "posts=10", "media=3"] }],
+        "action": [{ "command": "wordpress.run-declarative-fuzz", "args": ["surface=admin_pages", "paths=/wp-admin/index.php,/wp-admin/edit.php,/wp-admin/post-new.php,/wp-admin/upload.php,/wp-admin/themes.php,/wp-admin/plugins.php,/wp-admin/users.php,/wp-admin/options-general.php,/wp-admin/site-editor.php"] }],
+        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=admin_page_coverage"] }]
+      },
+      "artifacts": [{ "name": "admin_page_coverage", "path": "admin-page-coverage/admin_page_coverage.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }],
+      "metadata": { "safety_class": "read_only" }
+    }
+  ],
+  "limits": { "max_cases": 90, "max_duration_seconds": 1200 },
+  "coverage": { "surface_ids": ["wordpress-core-admin-pages"], "operations": ["admin-page-discovery", "browser-readiness", "permission-boundary-classification", "query-attribution"] },
+  "artifacts": { "expected": [{ "name": "admin_page_coverage", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/WordPress/wordpress-develop/fuzz/content-types-taxonomies.json
+++ b/WordPress/wordpress-develop/fuzz/content-types-taxonomies.json
@@ -1,0 +1,29 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "content-types-taxonomies",
+  "label": "WordPress Core post type, status, taxonomy, term, and permalink coverage",
+  "safety_class": "isolated_mutation",
+  "surface_ids": ["wordpress-core-post-types", "wordpress-core-taxonomies", "wordpress-core-permalinks"],
+  "operations": ["post-type-inventory", "post-status-inventory", "taxonomy-inventory", "term-fixture-matrix", "permalink-resolution"],
+  "case_budget": 160,
+  "duration_budget_seconds": 1200,
+  "metadata": { "kind": "wordpress-core-fuzz", "wordpress_runner": "wp-codebox", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report" },
+  "target": { "type": "wordpress-core", "component": "wordpress-develop" },
+  "cases": [
+    {
+      "case_id": "content-types-taxonomies:registration-and-resolution",
+      "surface_ids": ["wordpress-core-post-types", "wordpress-core-taxonomies", "wordpress-core-permalinks"],
+      "operations": ["post-type-inventory", "post-status-inventory", "taxonomy-inventory", "term-fixture-matrix", "permalink-resolution"],
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-core-fixture", "args": ["posts=25", "pages=8", "terms=12", "menus=2", "permalinks=plain,postname"] }],
+        "action": [{ "command": "wordpress.run-declarative-fuzz", "args": ["surface=content_registration"] }],
+        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=content_types_taxonomies"] }]
+      },
+      "artifacts": [{ "name": "content_types_taxonomies", "path": "content-types-taxonomies/content_types_taxonomies.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }],
+      "metadata": { "safety_class": "isolated_mutation" }
+    }
+  ],
+  "limits": { "max_cases": 160, "max_duration_seconds": 1200 },
+  "coverage": { "surface_ids": ["wordpress-core-post-types", "wordpress-core-taxonomies", "wordpress-core-permalinks"], "operations": ["post-type-inventory", "post-status-inventory", "taxonomy-inventory", "term-fixture-matrix", "permalink-resolution"] },
+  "artifacts": { "expected": [{ "name": "content_types_taxonomies", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/WordPress/wordpress-develop/fuzz/db-inventory-query-profile.json
+++ b/WordPress/wordpress-develop/fuzz/db-inventory-query-profile.json
@@ -1,0 +1,29 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "db-inventory-query-profile",
+  "label": "WordPress Core DB inventory and query profile",
+  "safety_class": "read_only",
+  "surface_ids": ["wordpress-core-database", "wordpress-core-rest-routes"],
+  "operations": ["db-inventory", "rest-query-profile", "query-shape-attribution"],
+  "case_budget": 100,
+  "duration_budget_seconds": 900,
+  "metadata": { "kind": "wordpress-core-fuzz", "wordpress_runner": "wp-codebox", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report" },
+  "target": { "type": "wordpress-core", "component": "wordpress-develop" },
+  "cases": [
+    {
+      "case_id": "db-inventory-query-profile:core-tables-and-rest-cases",
+      "surface_ids": ["wordpress-core-database", "wordpress-core-rest-routes"],
+      "operations": ["db-inventory", "rest-query-profile", "query-shape-attribution"],
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-core-fixture", "args": ["posts=20", "comments=20", "media=5", "terms=8"] }],
+        "action": [{ "command": "wordpress.run-declarative-fuzz", "args": ["surface=database", "rest_cases=${package.root}/manifests/rest-route-coverage.json"] }],
+        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=db_inventory_query_profile"] }]
+      },
+      "artifacts": [{ "name": "db_inventory_query_profile", "path": "db-inventory-query-profile/db_inventory_query_profile.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }],
+      "metadata": { "safety_class": "read_only" }
+    }
+  ],
+  "limits": { "max_cases": 100, "max_duration_seconds": 900 },
+  "coverage": { "surface_ids": ["wordpress-core-database", "wordpress-core-rest-routes"], "operations": ["db-inventory", "rest-query-profile", "query-shape-attribution"] },
+  "artifacts": { "expected": [{ "name": "db_inventory_query_profile", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/WordPress/wordpress-develop/fuzz/hooks-cron-options.json
+++ b/WordPress/wordpress-develop/fuzz/hooks-cron-options.json
@@ -1,0 +1,29 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "hooks-cron-options",
+  "label": "WordPress Core hooks, cron, options, transients, and rewrite coverage",
+  "safety_class": "read_only",
+  "surface_ids": ["wordpress-core-hooks", "wordpress-core-cron", "wordpress-core-options", "wordpress-core-rewrites"],
+  "operations": ["hook-inventory", "cron-inventory", "option-inventory", "transient-inventory", "rewrite-rule-inventory"],
+  "case_budget": 120,
+  "duration_budget_seconds": 900,
+  "metadata": { "kind": "wordpress-core-fuzz", "wordpress_runner": "wp-codebox", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report" },
+  "target": { "type": "wordpress-core", "component": "wordpress-develop" },
+  "cases": [
+    {
+      "case_id": "hooks-cron-options:runtime-state-inventory",
+      "surface_ids": ["wordpress-core-hooks", "wordpress-core-cron", "wordpress-core-options", "wordpress-core-rewrites"],
+      "operations": ["hook-inventory", "cron-inventory", "option-inventory", "transient-inventory", "rewrite-rule-inventory"],
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-core-fixture", "args": ["cron=default", "permalinks=postname", "transients=core-safe"] }],
+        "action": [{ "command": "wordpress.run-declarative-fuzz", "args": ["surface=runtime_state"] }],
+        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=hooks_cron_options"] }]
+      },
+      "artifacts": [{ "name": "hooks_cron_options", "path": "hooks-cron-options/hooks_cron_options.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }],
+      "metadata": { "safety_class": "read_only" }
+    }
+  ],
+  "limits": { "max_cases": 120, "max_duration_seconds": 900 },
+  "coverage": { "surface_ids": ["wordpress-core-hooks", "wordpress-core-cron", "wordpress-core-options", "wordpress-core-rewrites"], "operations": ["hook-inventory", "cron-inventory", "option-inventory", "transient-inventory", "rewrite-rule-inventory"] },
+  "artifacts": { "expected": [{ "name": "hooks_cron_options", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/WordPress/wordpress-develop/fuzz/media-users.json
+++ b/WordPress/wordpress-develop/fuzz/media-users.json
@@ -1,0 +1,29 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "media-users",
+  "label": "WordPress Core media, users, roles, and capabilities coverage",
+  "safety_class": "isolated_mutation",
+  "surface_ids": ["wordpress-core-media", "wordpress-core-users", "wordpress-core-roles-capabilities"],
+  "operations": ["attachment-fixture-matrix", "image-metadata-inventory", "user-role-inventory", "capability-boundary-classification", "rest-permission-checks"],
+  "case_budget": 140,
+  "duration_budget_seconds": 1200,
+  "metadata": { "kind": "wordpress-core-fuzz", "wordpress_runner": "wp-codebox", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report" },
+  "target": { "type": "wordpress-core", "component": "wordpress-develop" },
+  "cases": [
+    {
+      "case_id": "media-users:permissions-and-metadata",
+      "surface_ids": ["wordpress-core-media", "wordpress-core-users", "wordpress-core-roles-capabilities"],
+      "operations": ["attachment-fixture-matrix", "image-metadata-inventory", "user-role-inventory", "capability-boundary-classification", "rest-permission-checks"],
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-core-fixture", "args": ["media=8", "users=administrator,editor,author,contributor,subscriber", "posts=10"] }],
+        "action": [{ "command": "wordpress.run-declarative-fuzz", "args": ["surface=media_users"] }],
+        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=media_users"] }]
+      },
+      "artifacts": [{ "name": "media_users", "path": "media-users/media_users.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }],
+      "metadata": { "safety_class": "isolated_mutation" }
+    }
+  ],
+  "limits": { "max_cases": 140, "max_duration_seconds": 1200 },
+  "coverage": { "surface_ids": ["wordpress-core-media", "wordpress-core-users", "wordpress-core-roles-capabilities"], "operations": ["attachment-fixture-matrix", "image-metadata-inventory", "user-role-inventory", "capability-boundary-classification", "rest-permission-checks"] },
+  "artifacts": { "expected": [{ "name": "media_users", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/WordPress/wordpress-develop/fuzz/performance-surfaces.json
+++ b/WordPress/wordpress-develop/fuzz/performance-surfaces.json
@@ -1,0 +1,35 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "performance-surfaces",
+  "label": "WordPress Core representative performance surfaces",
+  "safety_class": "read_only",
+  "surface_ids": ["wordpress-core-performance"],
+  "operations": ["performance-surface-inventory", "request-timing-observation", "query-count-observation", "asset-request-observation"],
+  "case_budget": 80,
+  "duration_budget_seconds": 1200,
+  "metadata": {
+    "kind": "wordpress-core-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "coverage_manifest": "${package.root}/manifests/performance-surfaces.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": { "type": "wordpress-core", "component": "wordpress-develop" },
+  "cases": [
+    {
+      "case_id": "performance-surfaces:representative-observations",
+      "surface_ids": ["wordpress-core-performance"],
+      "operations": ["performance-surface-inventory", "request-timing-observation", "query-count-observation", "asset-request-observation"],
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-core-fixture", "args": ["theme=twentytwentyfive", "posts=20", "media=8", "menus=2"] }],
+        "action": [{ "command": "wordpress.run-declarative-fuzz", "args": ["manifest=${package.root}/manifests/performance-surfaces.json", "surface=performance"] }],
+        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=performance_surfaces"] }]
+      },
+      "artifacts": [{ "name": "performance_surfaces", "path": "performance-surfaces/performance_surfaces.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }],
+      "metadata": { "safety_class": "read_only" }
+    }
+  ],
+  "limits": { "max_cases": 80, "max_duration_seconds": 1200 },
+  "coverage": { "surface_ids": ["wordpress-core-performance"], "operations": ["performance-surface-inventory", "request-timing-observation", "query-count-observation", "asset-request-observation"] },
+  "artifacts": { "expected": [{ "name": "performance_surfaces", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/WordPress/wordpress-develop/fuzz/rest-api.json
+++ b/WordPress/wordpress-develop/fuzz/rest-api.json
@@ -1,0 +1,35 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "rest-api",
+  "label": "WordPress Core REST API coverage",
+  "safety_class": "mixed_read_isolated_mutation",
+  "surface_ids": ["wordpress-core-rest-routes"],
+  "operations": ["rest-route-inventory", "generated-rest-case-plan", "request-case-execution", "permission-boundary-classification"],
+  "case_budget": 250,
+  "duration_budget_seconds": 1200,
+  "metadata": {
+    "kind": "wordpress-core-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "coverage_manifest": "${package.root}/manifests/rest-route-coverage.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report"
+  },
+  "target": { "type": "wordpress-core", "component": "wordpress-develop" },
+  "cases": [
+    {
+      "case_id": "rest-api:inventory-and-safe-cases",
+      "surface_ids": ["wordpress-core-rest-routes"],
+      "operations": ["rest-route-inventory", "generated-rest-case-plan", "request-case-execution"],
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-core-fixture", "args": ["posts=5", "pages=3", "media=2", "users=2", "terms=4"] }],
+        "action": [{ "command": "wordpress.run-declarative-fuzz", "args": ["manifest=${package.root}/manifests/rest-route-coverage.json", "surface=rest_api"] }],
+        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=rest_api_coverage"] }]
+      },
+      "artifacts": [{ "name": "rest_api_coverage", "path": "rest-api/rest_api_coverage.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }],
+      "metadata": { "safety_class": "mixed_read_isolated_mutation" }
+    }
+  ],
+  "limits": { "max_cases": 250, "max_duration_seconds": 1200 },
+  "coverage": { "surface_ids": ["wordpress-core-rest-routes"], "operations": ["rest-route-inventory", "generated-rest-case-plan", "request-case-execution", "permission-boundary-classification"] },
+  "artifacts": { "expected": [{ "name": "rest_api_coverage", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+}

--- a/WordPress/wordpress-develop/manifests/full-surface-coverage.json
+++ b/WordPress/wordpress-develop/manifests/full-surface-coverage.json
@@ -1,0 +1,35 @@
+{
+  "schema": "homeboy-rigs/wordpress-core-full-surface-coverage/v1",
+  "property": "WordPress/wordpress-develop",
+  "description": "Coverage targets for WordPress Core fuzzing across API, database, admin, runtime registration, content, media, users, and performance surfaces.",
+  "requires_primitives": [
+    "wordpress-rest-route-matrix",
+    "wordpress-rest-request-cases",
+    "wordpress-rest-db-query-profiler",
+    "wordpress-db-inventory",
+    "wordpress-admin-page-coverage",
+    "wordpress-hook-inventory",
+    "wordpress-cron-inventory",
+    "wordpress-option-inventory",
+    "wordpress-content-registration-inventory",
+    "wordpress-media-user-permission-coverage",
+    "wordpress-performance-observation"
+  ],
+  "coverage_profiles": {
+    "smoke": ["rest-api", "db-inventory-query-profile", "admin-page-coverage"],
+    "fuzzer": ["rest-api", "db-inventory-query-profile", "admin-page-coverage", "hooks-cron-options", "content-types-taxonomies", "media-users", "performance-surfaces"],
+    "full-surface": ["rest-api", "db-inventory-query-profile", "admin-page-coverage", "hooks-cron-options", "content-types-taxonomies", "media-users", "performance-surfaces"]
+  },
+  "coverage_gap_reporting": {
+    "report_shape": "homeboy-rigs/wordpress-core-fuzzer-coverage-gap/v1",
+    "compare": {
+      "rest_api": "registered core REST routes minus generated safe request cases",
+      "database": "core table inventory plus query profiles per covered REST case",
+      "admin_pages": "manifest admin pages minus captured readiness and query attribution artifacts",
+      "runtime_state": "registered hooks, cron events, rewrite rules, autoloaded options, and transients minus inventory rows",
+      "content": "registered post types, statuses, taxonomies, terms, and permalink structures minus inventory rows",
+      "media_users": "attachment, user, role, and capability surfaces minus permission coverage rows",
+      "performance": "declared representative performance surfaces minus observation artifacts"
+    }
+  }
+}

--- a/WordPress/wordpress-develop/manifests/fuzzer-profile.json
+++ b/WordPress/wordpress-develop/manifests/fuzzer-profile.json
@@ -1,0 +1,37 @@
+{
+  "schema": "homeboy-rigs/wordpress-core-fuzzer-profile/v1",
+  "property": "WordPress/wordpress-develop",
+  "description": "Rig-owned WordPress Core fuzzer profile covering REST, database inventory/query shape, wp-admin pages, hooks, cron, options, content registration, taxonomies, media, users, and representative performance surfaces without adding WordPress assumptions to Homeboy core.",
+  "source_manifests": {
+    "full_surface": "manifests/full-surface-coverage.json",
+    "rest_routes": "manifests/rest-route-coverage.json",
+    "performance_surfaces": "manifests/performance-surfaces.json"
+  },
+  "execution": {
+    "rig": "wordpress-core-fuzz-coverage",
+    "profiles": ["smoke", "fuzzer", "full-surface"],
+    "runner_contract": "homeboy/fuzz-workload/v1"
+  },
+  "coverage_gap_report": {
+    "schema": "homeboy-rigs/wordpress-core-fuzzer-coverage-gap/v1",
+    "inputs": [
+      "REST route inventory and request case artifacts",
+      "DB inventory and REST query profile artifacts",
+      "admin page coverage artifacts",
+      "hook, cron, option, transient, and rewrite artifacts",
+      "post type, post status, taxonomy, term, and permalink artifacts",
+      "media, user, role, and capability artifacts",
+      "performance observation artifacts"
+    ],
+    "sections": [
+      "rest_routes_without_cases",
+      "registered_surfaces_without_inventory_rows",
+      "admin_pages_without_browser_readiness",
+      "autoloaded_options_and_cron_outliers",
+      "content_registration_gaps",
+      "media_and_user_permission_gaps",
+      "performance_surfaces_without_observations",
+      "open_runner_primitive_gaps"
+    ]
+  }
+}

--- a/WordPress/wordpress-develop/manifests/performance-surfaces.json
+++ b/WordPress/wordpress-develop/manifests/performance-surfaces.json
@@ -1,0 +1,14 @@
+{
+  "schema": "homeboy-rigs/wordpress-core-performance-surfaces/v1",
+  "property": "WordPress/wordpress-develop",
+  "surfaces": [
+    { "id": "front-page-bootstrap", "kind": "frontend", "paths": ["/"], "signals": ["ttfb", "query_count", "object_cache_groups", "enqueued_assets"] },
+    { "id": "rest-posts-list", "kind": "rest", "paths": ["/wp-json/wp/v2/posts?per_page=5"], "signals": ["ttfb", "query_count", "response_bytes"] },
+    { "id": "admin-dashboard", "kind": "admin", "paths": ["/wp-admin/index.php"], "signals": ["ready_time", "query_count", "admin_notices", "requests"] },
+    { "id": "post-editor", "kind": "editor", "paths": ["/wp-admin/post-new.php"], "signals": ["ready_time", "rest_preloads", "editor_assets", "long_tasks"] },
+    { "id": "site-editor", "kind": "editor", "paths": ["/wp-admin/site-editor.php"], "signals": ["ready_time", "rest_preloads", "editor_assets", "long_tasks"] },
+    { "id": "media-library-grid", "kind": "admin", "paths": ["/wp-admin/upload.php?mode=grid"], "signals": ["ready_time", "rest_requests", "image_metadata_queries"] },
+    { "id": "cron-spawn", "kind": "server", "paths": ["wp-cron.php"], "signals": ["scheduled_event_count", "spawn_time", "lock_state"] },
+    { "id": "options-autoload", "kind": "database", "paths": ["wp_options"], "signals": ["autoload_count", "autoload_bytes", "largest_options"] }
+  ]
+}

--- a/WordPress/wordpress-develop/manifests/rest-route-coverage.json
+++ b/WordPress/wordpress-develop/manifests/rest-route-coverage.json
@@ -1,0 +1,25 @@
+{
+  "schema": "homeboy-rigs/wordpress-core-rest-route-coverage/v1",
+  "property": "WordPress/wordpress-develop",
+  "route_groups": [
+    { "id": "posts", "namespace": "wp/v2", "patterns": ["/wp/v2/posts", "/wp/v2/pages", "/wp/v2/search"] },
+    { "id": "taxonomies", "namespace": "wp/v2", "patterns": ["/wp/v2/categories", "/wp/v2/tags", "/wp/v2/taxonomies", "/wp/v2/types", "/wp/v2/statuses"] },
+    { "id": "media", "namespace": "wp/v2", "patterns": ["/wp/v2/media"] },
+    { "id": "users", "namespace": "wp/v2", "patterns": ["/wp/v2/users", "/wp/v2/users/me"] },
+    { "id": "settings", "namespace": "wp/v2", "patterns": ["/wp/v2/settings"] },
+    { "id": "blocks", "namespace": "wp/v2", "patterns": ["/wp/v2/blocks", "/wp/v2/block-types", "/wp/v2/block-patterns/*", "/wp/v2/templates", "/wp/v2/template-parts", "/wp/v2/navigation"] },
+    { "id": "site-health", "namespace": "wp-site-health/v1", "patterns": ["/wp-site-health/v1/*"] },
+    { "id": "menus", "namespace": "wp/v2", "patterns": ["/wp/v2/menus", "/wp/v2/menu-items", "/wp/v2/menu-locations"] }
+  ],
+  "safe_request_cases": [
+    { "id": "posts-list", "method": "GET", "path": "/wp/v2/posts", "params": { "context": "view", "per_page": 5 } },
+    { "id": "pages-list", "method": "GET", "path": "/wp/v2/pages", "params": { "context": "view", "per_page": 5 } },
+    { "id": "media-list", "method": "GET", "path": "/wp/v2/media", "params": { "context": "view", "per_page": 5 } },
+    { "id": "users-me-edit", "method": "GET", "path": "/wp/v2/users/me", "params": { "context": "edit" } },
+    { "id": "settings-edit", "method": "GET", "path": "/wp/v2/settings", "params": { "context": "edit" } },
+    { "id": "taxonomies-view", "method": "GET", "path": "/wp/v2/taxonomies", "params": { "context": "view" } },
+    { "id": "types-view", "method": "GET", "path": "/wp/v2/types", "params": { "context": "view" } },
+    { "id": "block-types-edit", "method": "GET", "path": "/wp/v2/block-types", "params": { "context": "edit" } },
+    { "id": "search-post", "method": "GET", "path": "/wp/v2/search", "params": { "search": "hello", "type": "post", "per_page": 5 } }
+  ]
+}

--- a/WordPress/wordpress-develop/rigs/wordpress-core-fuzz-coverage/rig.json
+++ b/WordPress/wordpress-develop/rigs/wordpress-core-fuzz-coverage/rig.json
@@ -1,0 +1,70 @@
+{
+  "id": "wordpress-core-fuzz-coverage",
+  "description": "WordPress Core coverage/fuzz rig suite using generic Homeboy fuzz workload manifests and no bench fallback.",
+  "components": {
+    "wordpress-develop": {
+      "path": "~/Developer/wordpress-develop",
+      "branch": "trunk",
+      "extensions": {
+        "wordpress": {
+          "wp_codebox_wordpress_version": "latest",
+          "wp_codebox_source_root": "~/Developer/wordpress-develop",
+          "wp_codebox_source_subpath": "src"
+        }
+      }
+    }
+  },
+  "resources": {
+    "exclusive": [
+      "wordpress-core-fuzz-coverage:${env.HOMEBOY_SETTINGS_WORDPRESS_CORE_FUZZ_NAMESPACE}"
+    ],
+    "paths": [
+      "${components.wordpress-develop.path}"
+    ]
+  },
+  "fuzz": {
+    "default_component": "wordpress-develop",
+    "schema": "homeboy/fuzz-workload/v1",
+    "manifest": "${package.root}/manifests/fuzzer-profile.json"
+  },
+  "fuzz_workloads": {
+    "wordpress": [
+      { "path": "${package.root}/fuzz/rest-api.json" },
+      { "path": "${package.root}/fuzz/db-inventory-query-profile.json" },
+      { "path": "${package.root}/fuzz/admin-page-coverage.json" },
+      { "path": "${package.root}/fuzz/hooks-cron-options.json" },
+      { "path": "${package.root}/fuzz/content-types-taxonomies.json" },
+      { "path": "${package.root}/fuzz/media-users.json" },
+      { "path": "${package.root}/fuzz/performance-surfaces.json" }
+    ]
+  },
+  "fuzz_profiles": {
+    "smoke": [
+      "rest-api",
+      "db-inventory-query-profile",
+      "admin-page-coverage"
+    ],
+    "fuzzer": [
+      "rest-api",
+      "db-inventory-query-profile",
+      "admin-page-coverage",
+      "hooks-cron-options",
+      "content-types-taxonomies",
+      "media-users",
+      "performance-surfaces"
+    ],
+    "full-surface": [
+      "rest-api",
+      "db-inventory-query-profile",
+      "admin-page-coverage",
+      "hooks-cron-options",
+      "content-types-taxonomies",
+      "media-users",
+      "performance-surfaces"
+    ]
+  },
+  "pipeline": {
+    "check": [],
+    "down": []
+  }
+}

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -9,6 +9,7 @@ const ignoredDirectories = new Set(['.git', '.claude', '.datamachine', '.opencod
 const phpFiles = [];
 const rigFiles = [];
 const jsonFiles = [];
+const fuzzWorkloadFiles = [];
 const portableSourceFiles = [];
 const failures = [];
 const studioModelRigGenerator = join(root, 'scripts/generate-studio-agent-model-rigs.mjs');
@@ -39,6 +40,10 @@ function walk(directory) {
 
     if (entry.isFile() && entry.name.endsWith('.json')) {
       jsonFiles.push(join(directory, entry.name));
+
+      if (directory.split('/').includes('fuzz')) {
+        fuzzWorkloadFiles.push(join(directory, entry.name));
+      }
     }
 
     if (entry.isFile() && /\.(json|mjs|js)$/.test(entry.name)) {
@@ -77,6 +82,10 @@ function lintRigPortability(file, fuzzWorkloadIdsByPackageRoot) {
   }
 
   lintBenchProfiles(rel, file, rig, fuzzWorkloadIdsByPackageRoot);
+
+  if (rel === 'WordPress/wordpress-develop/rigs/wordpress-core-fuzz-coverage/rig.json' && (rig.bench_profiles || rig.bench_workloads)) {
+    failures.push(`${rel}: WordPress Core fuzz coverage must declare fuzz_workloads/fuzz_profiles only; do not add bench fallback`);
+  }
 }
 
 function packageRootForRig(file) {
@@ -208,6 +217,52 @@ function lintPortableSource(file) {
   }
 }
 
+function lintFuzzWorkload(file) {
+  const rel = relative(root, file);
+  let workload;
+
+  try {
+    workload = JSON.parse(readFileSync(file, 'utf8'));
+  } catch (error) {
+    failures.push(`${rel}: invalid JSON: ${error.message}`);
+    return;
+  }
+
+  if (workload.schema !== 'homeboy/fuzz-workload/v1') {
+    failures.push(`${rel}: fuzz workload schema must be homeboy/fuzz-workload/v1`);
+  }
+
+  for (const field of ['id', 'label', 'safety_class']) {
+    if (typeof workload[field] !== 'string' || workload[field].length === 0) {
+      failures.push(`${rel}: fuzz workload must define non-empty string field ${field}`);
+    }
+  }
+
+  for (const field of ['surface_ids', 'operations', 'cases']) {
+    if (!Array.isArray(workload[field]) || workload[field].length === 0) {
+      failures.push(`${rel}: fuzz workload must define non-empty array field ${field}`);
+    }
+  }
+
+  if (!workload.target || typeof workload.target.type !== 'string') {
+    failures.push(`${rel}: fuzz workload must define target.type`);
+  }
+
+  if (!workload.metadata || typeof workload.metadata.kind !== 'string') {
+    failures.push(`${rel}: fuzz workload must define metadata.kind`);
+  }
+
+  if (workload.limits) {
+    if (!Number.isInteger(workload.limits.max_cases) || workload.limits.max_cases < 1) {
+      failures.push(`${rel}: limits.max_cases must be a positive integer`);
+    }
+
+    if (!Number.isInteger(workload.limits.max_duration_seconds) || workload.limits.max_duration_seconds < 1) {
+      failures.push(`${rel}: limits.max_duration_seconds must be a positive integer`);
+    }
+  }
+}
+
 function lintPhp(file) {
   const result = spawnSync('php', ['-l', file], { encoding: 'utf8' });
   if (result.status !== 0) {
@@ -254,6 +309,7 @@ walk(root);
 const wordpressPluginFuzzWorkloadIdsByPackageRoot = collectWordPressPluginFuzzWorkloadIds();
 
 rigFiles.forEach((file) => lintRigPortability(file, wordpressPluginFuzzWorkloadIdsByPackageRoot));
+fuzzWorkloadFiles.forEach(lintFuzzWorkload);
 portableSourceFiles.forEach(lintPortableSource);
 lintGeneratedStudioModelRigs();
 
@@ -271,4 +327,5 @@ reportFailures();
 console.log('Rig package lint passed.');
 console.log(`- PHP syntax: ${phpFiles.length} file(s)`);
 console.log(`- rig portability: ${rigFiles.length} rig(s)`);
+console.log(`- fuzz workloads: ${fuzzWorkloadFiles.length} workload(s)`);
 console.log(`- portable source paths: ${portableSourceFiles.length} file(s)`);


### PR DESCRIPTION
## Summary
- Add a WordPress Core rig package under `WordPress/wordpress-develop` for generic `homeboy/fuzz-workload/v1` coverage manifests.
- Declare fuzz workloads for REST API, DB inventory/query profile, admin page coverage, hooks/cron/options/rewrites, post types/taxonomies/permalinks, media/users/capabilities, and representative performance surfaces.
- Add lightweight lint coverage for generic fuzz workload manifests and a guard that prevents the WordPress Core fuzz rig from adding `bench_*` fallback declarations.

## Verification
- `node scripts/lint-rig-packages.mjs WordPress/wordpress-develop`
- `homeboy rig install /Users/chubes/Developer/homeboy-rigs@feat-wordpress-core-fuzz-coverage/WordPress/wordpress-develop`
- `homeboy rig --force-hot --allow-local-hot check wordpress-core-fuzz-coverage`
- `node scripts/lint-rig-packages.mjs`

No benchmarks were run.

## Remaining gaps
- The manifests are declarative until Homeboy Extensions exposes a first-class generic fuzz runner for the declared WordPress primitives.
- Runtime execution still needs a caller-supplied WordPress Core checkout/path; the package check does not assume one exists locally.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the rig package, fuzz workload manifests, lint updates, validation commands, and PR description.