### PR TITLE
Recover Gutenberg API DB Lab cell contract

### DIFF
--- a/WordPress/gutenberg/README.md
+++ b/WordPress/gutenberg/README.md
@@ -40,6 +40,8 @@ homeboy fuzz --rig gutenberg-api-route-inventory --runner wordpress --shared-sta
 
 See `docs/fuzzer-profile.md` for the gap-report contract and current limits.
 
+`manifests/api-db-lab-cell.json` recovers the Gutenberg 1 API/DB Lab cell as a coverage contract. It pins REST namespace coverage, role permission-boundary expectations, DB query attribution fields, option/postmeta state attribution, entity fixtures, and the proof artifact sections required before this surface can be marked P.
+
 Current D/E-only fuzz workload additions:
 
 - `gutenberg-hooks-options-inventory` declares hook, option, postmeta, template/pattern, cron/state, transient, and editor-state inventory so remote-cache pressure is visible in the same artifact. It is not P until a fuzz run emits the runtime-state artifact.

--- a/WordPress/gutenberg/docs/fuzzer-profile.md
+++ b/WordPress/gutenberg/docs/fuzzer-profile.md
@@ -13,6 +13,7 @@ The `fuzzer` profile composes the same surface classes as the Woo full-surface r
 - DB inventory and REST query profiling through `gutenberg-db-inventory-fuzz` and `gutenberg-rest-db-query-profile-fuzz`.
 - Hook, option, postmeta, template/pattern, cron, transient, and editor-state inventory through `gutenberg-hooks-options-inventory`.
 - Editor, Site Editor, block-rendering, pattern-preview, notes-unsaved-attachment, and external HTTP performance summaries through `gutenberg-editor-performance-observation`.
+- Gutenberg 1 API/DB Lab cell recovery through `manifests/api-db-lab-cell.json`: REST namespaces, role permission boundaries, query/table attribution, option/postmeta state, entity fixtures, and required proof artifact sections.
 - External HTTP guardrails through `gutenberg-external-http-guardrail-fuzz`.
 - Coverage-gap reporting shape in `manifests/fuzzer-profile.json` and `manifests/full-surface-coverage.json`.
 
@@ -41,6 +42,7 @@ A consumer can produce `homeboy-rigs/gutenberg-fuzzer-coverage-gap/v1` from the 
 - Covered REST routes without DB query profiles or with query counts/durations over `manifests/rest-route-budgets.json`.
 - Missing hook, option, postmeta, template, pattern, cron, transient, or editor-state inventory sections.
 - Missing editor, Site Editor, block-rendering, pattern-preview, notes-unsaved-attachment, or external HTTP performance summary sections.
+- REST namespaces without generated cases, routes without role permission-boundary cases, queries without table/key attribution, and entities without state artifacts from the Gutenberg 1 API/DB Lab cell contract.
 - Unapproved outbound hosts observed by `gutenberg-external-http-guardrail-fuzz`.
 - Fixture or primitive gaps that prevent a surface from being interpreted as covered.
 

--- a/WordPress/gutenberg/manifests/api-db-lab-cell.json
+++ b/WordPress/gutenberg/manifests/api-db-lab-cell.json
@@ -1,0 +1,103 @@
+{
+  "schema": "homeboy-rigs/gutenberg-api-db-lab-cell/v1",
+  "id": "gutenberg-api-db-lab-cell",
+  "property": "WordPress/gutenberg",
+  "description": "Recovered Gutenberg 1 Lab cell contract for REST namespace coverage, permission boundaries, DB/query attribution, option/postmeta state, entity fixtures, and proof artifacts.",
+  "rest_namespaces": [
+    {
+      "namespace": "wp/v2",
+      "route_prefixes": [
+        "/wp/v2/block-directory",
+        "/wp/v2/block-patterns",
+        "/wp/v2/block-renderer",
+        "/wp/v2/global-styles",
+        "/wp/v2/navigation",
+        "/wp/v2/templates",
+        "/wp/v2/template-parts"
+      ]
+    },
+    {
+      "namespace": "__experimental",
+      "route_prefixes": ["/__experimental"]
+    }
+  ],
+  "permission_boundaries": [
+    {
+      "role": "anonymous",
+      "expectations": ["public read routes remain available", "editor-only routes return rest_forbidden or rest_cannot_view"]
+    },
+    {
+      "role": "subscriber",
+      "expectations": ["read-only editor data stays bounded", "mutation routes remain denied"]
+    },
+    {
+      "role": "editor",
+      "expectations": ["template, pattern, navigation, and global-style reads execute with query attribution", "mutations require nonce/capability evidence"]
+    },
+    {
+      "role": "administrator",
+      "expectations": ["privileged routes execute inside isolated fixtures", "capability-sensitive responses record status and auth context"]
+    }
+  ],
+  "db_query_attribution": {
+    "artifact_schema": "homeboy/wordpress-rest-db-query-profile/v1",
+    "required_fields": [
+      "route",
+      "namespace",
+      "method",
+      "role",
+      "status",
+      "query_count",
+      "query_time_ms",
+      "tables_touched",
+      "option_keys",
+      "postmeta_keys",
+      "slowest_queries",
+      "duplicate_query_groups"
+    ],
+    "required_tables": ["posts", "postmeta", "options", "terms", "term_taxonomy", "term_relationships"],
+    "budget_manifest": "manifests/rest-route-budgets.json"
+  },
+  "state_attribution": {
+    "options": ["gutenberg experiments", "editor settings", "global styles", "block directory cache", "pattern directory cache"],
+    "postmeta": ["template state", "template part state", "global styles revisions", "navigation state", "autosave or attachment editor state"],
+    "required_artifact_sections": ["options", "postmeta", "transients", "autoload_pressure", "mutation_deltas"]
+  },
+  "entity_fixtures": [
+    "post",
+    "page",
+    "wp_template",
+    "wp_template_part",
+    "wp_global_styles",
+    "wp_navigation",
+    "attachment",
+    "reusable_block",
+    "pattern_directory_result",
+    "block_directory_result"
+  ],
+  "proof_artifacts": [
+    {
+      "name": "rest_namespace_permission_matrix",
+      "schema": "homeboy/gutenberg-rest-permission-matrix/v1",
+      "required_sections": ["namespaces", "routes", "roles", "statuses", "denials", "allowed_mutations"]
+    },
+    {
+      "name": "rest_db_query_profile",
+      "schema": "homeboy/wordpress-rest-db-query-profile/v1",
+      "required_sections": ["routes", "query_counts", "tables_touched", "option_keys", "postmeta_keys", "slowest_queries", "duplicate_query_groups", "budget_regressions"]
+    },
+    {
+      "name": "entity_state_attribution",
+      "schema": "homeboy/gutenberg-entity-state-attribution/v1",
+      "required_sections": ["entities", "options", "postmeta", "transients", "mutation_deltas"]
+    }
+  ],
+  "coverage_gap_sections": [
+    "rest_namespaces_without_cases",
+    "routes_without_permission_boundary_cases",
+    "covered_routes_without_db_query_attribution",
+    "queries_without_table_or_key_attribution",
+    "entities_without_state_artifacts",
+    "proof_artifacts_missing_required_sections"
+  ]
+}

--- a/WordPress/gutenberg/manifests/full-surface-coverage.json
+++ b/WordPress/gutenberg/manifests/full-surface-coverage.json
@@ -18,6 +18,7 @@
     },
     "database": {
       "coverage_goal": "all_tables_rows_columns_indexes_after_editor_fixture_setup",
+      "lab_cell_contract": "manifests/api-db-lab-cell.json",
       "inventory_artifact": "homeboy/wordpress-db-inventory/v1",
       "query_profile_artifact": "homeboy/wordpress-rest-db-query-profile/v1"
     },

--- a/WordPress/gutenberg/manifests/fuzzer-profile.json
+++ b/WordPress/gutenberg/manifests/fuzzer-profile.json
@@ -4,6 +4,7 @@
   "description": "Rig-owned Gutenberg fuzzer profile analogous to Woo full-surface coverage. It composes REST route coverage, wp-admin/editor page coverage, block editor load/action probes, DB query/profile hooks, external HTTP guardrails, and coverage-gap reporting without adding Gutenberg-specific logic to Homeboy core or Homeboy Extensions.",
   "source_manifests": {
     "full_surface": "manifests/full-surface-coverage.json",
+    "api_db_lab_cell": "manifests/api-db-lab-cell.json",
     "rest_routes": "manifests/rest-route-coverage.json",
     "rest_budgets": "manifests/rest-route-budgets.json",
     "fixtures": "manifests/performance-fixtures.json"
@@ -47,6 +48,7 @@
     "db_query_profile_hooks": {
       "workloads": ["gutenberg-db-inventory-fuzz", "gutenberg-rest-db-query-profile-fuzz"],
       "budget_manifest": "manifests/rest-route-budgets.json",
+      "lab_cell_contract": "manifests/api-db-lab-cell.json",
       "profile_contract": {
         "artifact_schema": "homeboy/wordpress-rest-db-query-profile/v1",
         "required_route_classes": ["editor-rest", "block-directory", "patterns", "global-styles", "block-renderer"],
@@ -133,6 +135,9 @@
       "covered_routes_without_query_profiles",
       "missing_runtime_state_inventory_sections",
       "missing_performance_observation_sections",
+      "routes_without_permission_boundary_cases",
+      "queries_without_table_or_key_attribution",
+      "entities_without_state_artifacts",
       "budget_regressions",
       "unapproved_external_hosts",
       "unexpected_allowed_external_hosts",

--- a/WordPress/gutenberg/tools/validate-fuzz-manifests.mjs
+++ b/WordPress/gutenberg/tools/validate-fuzz-manifests.mjs
@@ -25,6 +25,7 @@ const fuzzManifests = readdirSync(fuzzDir)
 assert.equal(fuzzManifests.length, declaredFuzzIds.size, 'expected one manifest per declared Gutenberg fuzz workload');
 
 const fuzzerProfile = JSON.parse(readFileSync(path.join(packageRoot, 'manifests/fuzzer-profile.json'), 'utf8'));
+const apiDbLabCell = JSON.parse(readFileSync(path.join(packageRoot, 'manifests/api-db-lab-cell.json'), 'utf8'));
 const benchWorkloadIds = new Set(
   Object.values(rig.bench_workloads || {})
     .flat()
@@ -128,6 +129,27 @@ for (const [name, summary] of Object.entries(fuzzerProfile.artifact_summaries ||
   assert.equal(summary.semantic_key, 'fuzz.report', `${name} artifact summary semantic key mismatch`);
   assert.ok(Array.isArray(summary.required_sections), `${name} artifact summary requires sections`);
   assert.ok(summary.required_sections.length > 0, `${name} artifact summary has no required sections`);
+}
+
+assert.equal(apiDbLabCell.schema, 'homeboy-rigs/gutenberg-api-db-lab-cell/v1', 'Gutenberg API/DB Lab cell schema mismatch');
+assert.ok(apiDbLabCell.rest_namespaces.some((entry) => entry.namespace === 'wp/v2'), 'API/DB Lab cell must cover wp/v2 routes');
+assert.ok(apiDbLabCell.rest_namespaces.some((entry) => entry.namespace === '__experimental'), 'API/DB Lab cell must cover __experimental routes');
+for (const role of ['anonymous', 'subscriber', 'editor', 'administrator']) {
+  assert.ok(apiDbLabCell.permission_boundaries.some((entry) => entry.role === role), `API/DB Lab cell missing ${role} permission boundary`);
+}
+for (const field of ['namespace', 'role', 'tables_touched', 'option_keys', 'postmeta_keys']) {
+  assert.ok(apiDbLabCell.db_query_attribution.required_fields.includes(field), `API/DB Lab cell missing DB attribution field ${field}`);
+}
+for (const section of ['options', 'postmeta', 'transients', 'mutation_deltas']) {
+  assert.ok(apiDbLabCell.state_attribution.required_artifact_sections.includes(section), `API/DB Lab cell missing state attribution section ${section}`);
+}
+for (const entity of ['wp_template', 'wp_template_part', 'wp_global_styles', 'wp_navigation', 'attachment']) {
+  assert.ok(apiDbLabCell.entity_fixtures.includes(entity), `API/DB Lab cell missing entity fixture ${entity}`);
+}
+for (const artifact of ['rest_namespace_permission_matrix', 'rest_db_query_profile', 'entity_state_attribution']) {
+  const proofArtifact = apiDbLabCell.proof_artifacts.find((entry) => entry.name === artifact);
+  assert.ok(proofArtifact, `API/DB Lab cell missing proof artifact ${artifact}`);
+  assert.ok(proofArtifact.required_sections.length > 0, `API/DB Lab cell proof artifact ${artifact} requires sections`);
 }
 
 console.log(`validated ${fuzzManifests.length} Gutenberg fuzz manifests; no fuzz IDs are present in bench_workloads or bench_profiles`);


### PR DESCRIPTION
## Summary
- Recover the missing Gutenberg 1 API/DB Lab cell as an additive rig-owned coverage contract.
- Pin REST namespace, permission-boundary, DB/query attribution, option/postmeta, entity fixture, and proof artifact expectations.
- Wire the contract into the Gutenberg fuzzer/full-surface manifests, docs, and manifest validation.

## Verification
- `node WordPress/gutenberg/tools/validate-fuzz-manifests.mjs`
- `git diff --check`
- `node scripts/lint-rig-packages.mjs .`
- No local benchmarks or fuzz runs were executed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Inspecting merged/open Gutenberg coverage PRs, recovering the missing Lab cell contract, updating validation/docs, and running focused non-benchmark verification.