### PR TITLE
Align fuzz rigs with Homeboy safety contract

### DIFF
--- a/Automattic/jetpack/README.md
+++ b/Automattic/jetpack/README.md
@@ -17,11 +17,14 @@ homeboy rig check jetpack-api-route-inventory
 homeboy rig check jetpack-browser-coverage
 ```
 
-Run fuzz workloads only through the fuzz runner surface once available in the target Homeboy install. Do not use `homeboy bench` as a fallback for these coverage manifests.
+Run fuzz workloads only through the generic fuzz command in target Homeboy installs that expose it. Do not use `homeboy bench` as a fallback for these coverage manifests.
 
 ```sh
-homeboy fuzz --rig jetpack-api-route-inventory --workload jetpack-rest-route-inventory
+homeboy fuzz list --rig jetpack-api-route-inventory
+homeboy fuzz run --rig jetpack-api-route-inventory --workload jetpack-rest-route-inventory --run-id jetpack-rest-route-inventory --seed 1 --max-duration 10m
 ```
+
+Use offloaded Lab runners for proof campaigns. Listing workloads confirms declarations only; P status requires persisted `homeboy fuzz run` artifacts.
 
 The coverage manifests live under `manifests/`, with executable/declarative fuzz workload manifests under `fuzz/`. REST cases declare permission classifications for public, local-authenticated, administrator, connected-site, and WP.com-dependent boundaries. DB inventory declares Jetpack table prefixes plus module/options state. External HTTP guardrail probes block `.invalid` synthetic hosts, declare `public-api.wordpress.com` as the WP.com allowlisted boundary, and still disallow real external service calls in the fixture.
 

--- a/Automattic/jetpack/fuzz/jetpack-module-option-table-inventory.json
+++ b/Automattic/jetpack/fuzz/jetpack-module-option-table-inventory.json
@@ -2,7 +2,7 @@
   "schema": "homeboy/fuzz-workload/v1",
   "id": "jetpack-module-option-table-inventory",
   "label": "Jetpack module option and table inventory",
-  "safety_class": "read_only_inventory",
+  "safety_class": "read_only",
   "surface_ids": ["jetpack-modules", "jetpack-options", "jetpack-tables", "wordpress-options"],
   "operations": ["module-option-inventory", "module-table-inventory", "autoload-classification", "serialized-value-boundary-classification"],
   "case_budget": 80,
@@ -38,7 +38,7 @@
         "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=module_option_table_inventory"] }]
       },
       "artifacts": [{ "name": "module_option_table_inventory", "path": "jetpack-module-option-table-inventory/module_option_table_inventory.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }],
-      "metadata": { "safety_class": "read_only_inventory" }
+      "metadata": { "safety_class": "read_only" }
     }
   ],
   "limits": { "max_cases": 80, "max_duration_seconds": 600 },

--- a/WordPress/gutenberg/README.md
+++ b/WordPress/gutenberg/README.md
@@ -32,11 +32,14 @@ stay generic.
 
 `manifests/fuzzer-profile.json` defines a rig-owned Gutenberg fuzzer profile analogous to the Woo full-surface shape. It composes REST route coverage, safe `wp-admin` and editor page enumeration, block editor load/action probes, Site Editor probes, block rendering, frontend rendering/request coverage, DB query/profile hooks, hook/option/postmeta/runtime-state inventory, editor performance observation summaries, external HTTP guardrails, and coverage-gap reporting without moving Gutenberg-specific knowledge into Homeboy core or Homeboy Extensions.
 
-Run the fuzzer manifests through the WordPress extension runner:
+Inspect and run fuzzer manifests through Homeboy's generic fuzz command:
 
 ```sh
-homeboy fuzz --rig gutenberg-api-route-inventory --runner wordpress --shared-state /tmp/gutenberg-fuzzer
+homeboy fuzz list --rig gutenberg-api-route-inventory
+homeboy fuzz run --rig gutenberg-api-route-inventory --workload gutenberg-rest-route-fuzz --run-id gutenberg-rest-route-fuzz --seed 1 --max-duration 10m
 ```
+
+Use an offloaded Lab runner for heavy proof campaigns. A `homeboy fuzz list` result is only a declaration check; P status requires persisted `homeboy fuzz run` evidence and artifacts.
 
 See `docs/fuzzer-profile.md` for the gap-report contract and current limits.
 

--- a/WordPress/gutenberg/docs/fuzzer-profile.md
+++ b/WordPress/gutenberg/docs/fuzzer-profile.md
@@ -29,11 +29,14 @@ homeboy rig check gutenberg-api-route-inventory
 homeboy rig check gutenberg-browser-coverage
 ```
 
-Run the fuzzer manifests through the WordPress extension runner:
+Inspect and run fuzzer manifests through Homeboy's generic fuzz command:
 
 ```sh
-homeboy fuzz --rig gutenberg-api-route-inventory --runner wordpress --shared-state /tmp/gutenberg-fuzzer
+homeboy fuzz list --rig gutenberg-api-route-inventory
+homeboy fuzz run --rig gutenberg-api-route-inventory --workload gutenberg-rest-route-fuzz --run-id gutenberg-rest-route-fuzz --seed 1 --max-duration 10m
 ```
+
+Run heavy campaigns through the offloaded Lab path and use persisted `homeboy runs` artifacts as proof; listing workloads does not prove execution.
 
 ## Gap Report Contract
 

--- a/WordPress/wordpress-develop/README.md
+++ b/WordPress/wordpress-develop/README.md
@@ -32,7 +32,7 @@ The `fuzzer` profile groups these manifests:
 - `fuzz/media-users.json` covers attachment/media metadata, REST media endpoints, users, roles, capabilities, media library rendering, users list rendering, and profile screen rendering.
 - `fuzz/performance-surfaces.json` covers representative frontend, REST, admin, editor, media, cron, and option/autoload pages as performance observation targets, including request timing, query count, and asset observations.
 
-Supporting manifests live in `manifests/` and define the intended coverage gap report shape. The manifests are declarative until Homeboy Extensions exposes a first-class fuzz runner for these generic WordPress primitives.
+Supporting manifests live in `manifests/` and define the intended coverage gap report shape. The manifests stay declarative until an offloaded `homeboy fuzz run` records persisted run evidence for the selected workload.
 
 ## Browser Request Coverage
 
@@ -53,7 +53,7 @@ Static contract tests live in `fuzz/core-fuzz-contracts.test.mjs` and can run wi
 
 Runtime-state coverage expects `hooks-cron-options/` artifacts for hook inventory, cron schedule rows, autoloaded options, transient state, rewrite rules, and a runtime-state summary. Performance coverage expects `performance-surfaces/performance_surfaces.json` with one observation row per declared surface and request timing/query count fields for every non-database-only page.
 
-These are proof contracts, not local benchmark instructions. Collect them through the offloaded fuzz runner once available; do not use `homeboy bench` as a fallback for this Core package.
+These are proof contracts, not local benchmark instructions. Collect them through offloaded `homeboy fuzz run` evidence; do not use `homeboy bench` as a fallback for this Core package.
 
 ## D/E/P Proof Contract
 

--- a/WordPress/wordpress-develop/fuzz/rest-api.json
+++ b/WordPress/wordpress-develop/fuzz/rest-api.json
@@ -2,7 +2,7 @@
   "schema": "homeboy/fuzz-workload/v1",
   "id": "rest-api",
   "label": "WordPress Core REST API coverage",
-  "safety_class": "mixed_read_isolated_mutation",
+  "safety_class": "isolated_mutation",
   "surface_ids": ["wordpress-core-rest-routes"],
   "operations": ["rest-route-inventory", "generated-rest-case-plan", "request-case-execution", "permission-boundary-classification", "role-boundary-execution"],
   "case_budget": 250,
@@ -32,7 +32,7 @@
         { "name": "generated_rest_request_cases", "path": "rest-api/generated_rest_request_cases.json", "required": false, "metadata": { "semantic_key": "fuzz.rest.generated_cases" } },
         { "name": "rest_permission_boundaries", "path": "rest-api/rest_permission_boundaries.json", "required": false, "metadata": { "semantic_key": "fuzz.rest.permission_boundaries" } }
       ],
-      "metadata": { "safety_class": "mixed_read_isolated_mutation" }
+      "metadata": { "safety_class": "isolated_mutation" }
     }
   ],
   "limits": { "max_cases": 250, "max_duration_seconds": 1200 },

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -16,6 +16,7 @@ const failures = [];
 const studioModelRigGenerator = join(root, 'scripts/generate-studio-agent-model-rigs.mjs');
 const personalPathPrefix = '/Users/' + 'chubes/';
 const tsrmlsPatchMarker = 'PHP-WASM-COMBINED-FIXES ' + 'TSRMLS fallback';
+const homeboyFuzzSafetyClasses = new Set(['read_only', 'idempotent', 'isolated_mutation', 'destructive']);
 
 if (!existsSync(root)) {
   console.error(`Lint root does not exist: ${root}`);
@@ -192,6 +193,10 @@ function validateFuzzWorkloadShape(rel, workload, context, packageRoot) {
     }
   }
 
+  if (typeof workload.safety_class === 'string' && !homeboyFuzzSafetyClasses.has(workload.safety_class)) {
+    failures.push(`${rel}: ${context} safety_class must be one of ${[...homeboyFuzzSafetyClasses].join(', ')}`);
+  }
+
   if (!workload.metadata || typeof workload.metadata !== 'object' || Array.isArray(workload.metadata)) {
     failures.push(`${rel}: ${context} must declare metadata`);
   }
@@ -355,6 +360,10 @@ function lintFuzzWorkload(file) {
     if (typeof workload[field] !== 'string' || workload[field].length === 0) {
       failures.push(`${rel}: fuzz workload must define non-empty string field ${field}`);
     }
+  }
+
+  if (typeof workload.safety_class === 'string' && !homeboyFuzzSafetyClasses.has(workload.safety_class)) {
+    failures.push(`${rel}: fuzz workload safety_class must be one of ${[...homeboyFuzzSafetyClasses].join(', ')}`);
   }
 
   for (const field of ['surface_ids', 'operations', 'cases']) {

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -127,6 +127,18 @@ test('rejects invalid declared fuzz workload shapes', () => {
   assert.match(result.stderr, /must declare a non-empty string label/);
 });
 
+test('rejects fuzz workload safety classes outside the Homeboy contract', () => {
+  const directory = createRigPackage({
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload({ safety_class: 'read_only_inventory' }),
+    },
+  });
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /safety_class must be one of read_only, idempotent, isolated_mutation, destructive/);
+});
+
 test('rejects missing fuzz workload backing files', () => {
   const directory = createRigPackage({
     fuzzWorkloads: {


### PR DESCRIPTION
## Summary
- validate rig fuzz workload safety classes against Homeboy's merged fuzz safety contract
- normalize Core and Jetpack fuzz manifests to supported safety classes
- update fuzz proof docs to use `homeboy fuzz list/run` and avoid bench-fallback proof claims

## Verification
- `node --test scripts/lint-rig-packages.test.mjs`
- `node scripts/lint-rig-packages.mjs`
- `node WordPress/wordpress-develop/tools/validate-fuzz-manifests.mjs && node WordPress/gutenberg/tools/validate-fuzz-manifests.mjs && node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs`

## Notes
- Did not run local/offloaded fuzz campaigns; this PR only updates declarations, linting, and proof wiring.
- Local installed `homeboy` binary did not expose `homeboy fuzz`; Homeboy `origin/main` source was inspected for the merged contract.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting repo state, updating lint/docs/manifests, running verification, and drafting this PR description.