### PR TITLE
Document fuzz coverage inventory proof boundary

### DIFF
--- a/docs/fuzz-coverage-matrix.md
+++ b/docs/fuzz-coverage-matrix.md
@@ -9,6 +9,13 @@ WordPress Core, Gutenberg, and Jetpack. It separates three levels of confidence:
 
 Status key: `D` declared, `E` executable, `P` proven, `Partial` covered by narrower workloads only, `Pending` waiting on another minion/upstream PR, `Gap` not yet represented beyond generic template guidance.
 
+This page is an inventory and coverage contract, not a proof bundle. Product
+manifest skeletons can move a row to `D` or `D/E` when they name the surface,
+wire it to a rig/profile, and declare the expected artifact shape. A row moves
+to `P` only when reviewer-facing run artifacts, bug evidence, or PR evidence are
+linked from the package docs; no full-surface product row is proven by this
+matrix alone.
+
 ## Summary
 
 | Project | API | DB | Admin | External HTTP | Hooks / cron / options | Frontend / rendering | Performance-related fuzz |


### PR DESCRIPTION
## Summary
- Clarifies that the fuzz coverage matrix is an inventory and coverage contract, not a proof bundle.
- Makes the Declared/Executable/Proven boundary explicit for product manifest skeletons.
- Preserves the current docs/manifests-only scope and avoids claiming full-surface proven coverage without artifacts.

## Verification
- Inspected /Users/chubes/Developer/homeboy-rigs primary checkout; it is stale and dirty, so no edits were made there.
- Inspected /Users/chubes/Developer/homeboy-rigs@fuzz-full-coverage-proof-ready for the fuzz-ready matrix and fuzzer-profile manifests.
- Created DMC worktree /Users/chubes/Developer/homeboy-rigs@cook-fuzz-coverage-inventory from origin/main after DMC refused stale primary base creation.
- Ran `git diff --check`.
- Did not run local benchmarks, deploys, fuzz campaigns, or destructive commands.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Inspecting the existing fuzz-ready and main worktrees, drafting the minimal documentation clarification, and preparing this PR.