### PR TITLE
Centralize fuzz manifest validation helpers

### DIFF
--- a/Automattic/jetpack/manifests/full-surface-coverage.test.mjs
+++ b/Automattic/jetpack/manifests/full-surface-coverage.test.mjs
@@ -139,7 +139,7 @@ test('Jetpack inventory fuzz workloads define module option/table and cron sync 
   const moduleInventory = JSON.parse(readFileSync(path.join(fuzzRoot, 'jetpack-module-option-table-inventory.json'), 'utf8'));
   const cronSyncActions = JSON.parse(readFileSync(path.join(fuzzRoot, 'jetpack-cron-sync-actions.json'), 'utf8'));
 
-  assert.equal(moduleInventory.safety_class, 'read_only_inventory');
+  assert.equal(moduleInventory.safety_class, 'read_only');
   assert.ok(moduleInventory.coverage.operations.includes('module-option-inventory'));
   assert.ok(moduleInventory.coverage.operations.includes('module-table-inventory'));
   assert.ok(moduleInventory.cases[0].inputs.read_only);

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ WordPress/wordpress-playground/stacks/playground-combined.json
 
 This keeps bench workloads beside the rig that uses them and makes ownership obvious when this repo becomes a shared rig package.
 
+Generic fuzz manifest validation helpers live in
+`scripts/fuzz-manifest-helpers.mjs`. Product validators should use those helpers
+for shared workload shape, rig linkage, and bench/fuzz separation checks, while
+keeping product-specific assertions beside the product manifests for namespaces,
+routes, fixtures, thresholds, skip reasons, and proof contracts.
+
 Reusable helper patterns live under `shared/`. The first shared web performance
 pattern is `shared/webperf/deferred-init-webperf.mjs`, which lets trace workloads
 mark feature-not-needed and feature-needed phases, count feature/third-party

--- a/WordPress/gutenberg/tools/validate-fuzz-manifests.mjs
+++ b/WordPress/gutenberg/tools/validate-fuzz-manifests.mjs
@@ -1,41 +1,33 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict';
-import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  assertGenericFuzzManifest,
+  collectFuzzManifests,
+  declaredBenchProfileIds,
+  declaredBenchWorkloadIds,
+  declaredFuzzIds,
+  readJson,
+} from '../../../scripts/fuzz-manifest-helpers.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
-const fuzzDir = path.join(packageRoot, 'fuzz');
-const rig = JSON.parse(readFileSync(path.join(packageRoot, 'rigs/gutenberg-api-route-inventory/rig.json'), 'utf8'));
+const rig = readJson(packageRoot, 'rigs/gutenberg-api-route-inventory/rig.json');
 
-const declaredFuzzIds = new Set(
-  (rig.fuzz_workloads?.wordpress || []).map((entry) => path.basename(entry.path, '.json'))
-);
-const fuzzManifests = readdirSync(fuzzDir)
-  .filter((file) => file.endsWith('.json'))
-  .filter((file) => declaredFuzzIds.has(path.basename(file, '.json')))
-  .sort()
-  .map((file) => ({
-    file,
-    path: path.join(fuzzDir, file),
-    manifest: JSON.parse(readFileSync(path.join(fuzzDir, file), 'utf8')),
-  }));
+const declaredIds = declaredFuzzIds(rig);
+const benchWorkloadIds = declaredBenchWorkloadIds(rig);
+const benchProfileIds = declaredBenchProfileIds(rig);
+const fuzzManifests = collectFuzzManifests(packageRoot, { declaredIds });
 
-assert.equal(fuzzManifests.length, declaredFuzzIds.size, 'expected one manifest per declared Gutenberg fuzz workload');
+assert.equal(fuzzManifests.length, declaredIds.size, 'expected one manifest per declared Gutenberg fuzz workload');
 
-const fuzzerProfile = JSON.parse(readFileSync(path.join(packageRoot, 'manifests/fuzzer-profile.json'), 'utf8'));
-const apiDbLabCell = JSON.parse(readFileSync(path.join(packageRoot, 'manifests/api-db-lab-cell.json'), 'utf8'));
-const benchWorkloadIds = new Set(
-  Object.values(rig.bench_workloads || {})
-    .flat()
-    .map((entry) => path.basename(entry.path, path.extname(entry.path)))
-);
-const benchProfileIds = new Set(Object.values(rig.bench_profiles || {}).flat());
-const restRouteCoverage = JSON.parse(readFileSync(path.join(packageRoot, 'manifests/rest-route-coverage.json'), 'utf8'));
-const restCases = JSON.parse(readFileSync(path.join(packageRoot, 'bench/generated-rest-request-cases.workload.json'), 'utf8'));
-const dbInventory = JSON.parse(readFileSync(path.join(packageRoot, 'bench/db-inventory.workload.json'), 'utf8'));
-const restQueryProfile = JSON.parse(readFileSync(path.join(packageRoot, 'bench/rest-db-query-profile.workload.json'), 'utf8'));
+const fuzzerProfile = readJson(packageRoot, 'manifests/fuzzer-profile.json');
+const apiDbLabCell = readJson(packageRoot, 'manifests/api-db-lab-cell.json');
+const restRouteCoverage = readJson(packageRoot, 'manifests/rest-route-coverage.json');
+const restCases = readJson(packageRoot, 'bench/generated-rest-request-cases.workload.json');
+const dbInventory = readJson(packageRoot, 'bench/db-inventory.workload.json');
+const restQueryProfile = readJson(packageRoot, 'bench/rest-db-query-profile.workload.json');
 
 const requiredSurfaces = new Set([
   'gutenberg-rest-routes',
@@ -55,38 +47,14 @@ const requiredSurfaces = new Set([
 const coveredSurfaces = new Set();
 
 for (const { file, manifest } of fuzzManifests) {
-  assert.equal(manifest.schema, 'homeboy/fuzz-workload/v1', `${file} schema mismatch`);
-  assert.equal(typeof manifest.id, 'string', `${file} requires id`);
-  assert.ok(declaredFuzzIds.has(manifest.id), `${manifest.id} is not declared in rig fuzz_workloads.wordpress`);
-  assert.ok(!benchWorkloadIds.has(manifest.id), `${manifest.id} must not appear in bench_workloads`);
-  assert.ok(!benchProfileIds.has(manifest.id), `${manifest.id} must not appear in bench_profiles`);
-
-  assert.equal(manifest.target?.type, 'wordpress-plugin', `${manifest.id} target.type mismatch`);
-  assert.equal(manifest.target?.slug, 'gutenberg', `${manifest.id} target.slug mismatch`);
-  assert.equal(manifest.workload?.runner, 'wp-codebox', `${manifest.id} workload.runner mismatch`);
-  assert.equal(manifest.workload?.path, manifest.metadata?.workload_path, `${manifest.id} workload path must match metadata`);
-  assert.ok(['php', 'json', 'trace'].includes(manifest.workload?.type), `${manifest.id} workload.type must be php, json, or trace`);
-  assert.deepEqual(manifest.coverage?.surface_ids, manifest.surface_ids, `${manifest.id} coverage surface ids drifted`);
-  assert.deepEqual(manifest.coverage?.operations, manifest.operations, `${manifest.id} coverage operations drifted`);
-  assert.equal(manifest.limits?.max_cases, manifest.case_budget, `${manifest.id} max_cases must match case_budget`);
-  assert.equal(manifest.limits?.max_duration_seconds, manifest.duration_budget_seconds, `${manifest.id} max_duration_seconds must match duration_budget_seconds`);
-
-  assert.equal(manifest.cases?.length, 1, `${manifest.id} requires one default runner case`);
-  const [runnerCase] = manifest.cases;
-  assert.equal(runnerCase.case_id, `${manifest.id}:default`, `${manifest.id} default case id mismatch`);
-  assert.deepEqual(runnerCase.surface_ids, manifest.surface_ids, `${manifest.id} case surface ids drifted`);
-  assert.deepEqual(runnerCase.operations, manifest.operations, `${manifest.id} case operations drifted`);
-  assert.ok(Array.isArray(runnerCase.phases?.action), `${manifest.id} requires action phase`);
-  assert.ok(runnerCase.phases.action.length > 0, `${manifest.id} requires at least one action step`);
-  assert.ok(Array.isArray(runnerCase.artifacts), `${manifest.id} requires case artifacts`);
-  assert.ok(Array.isArray(manifest.artifacts?.expected), `${manifest.id} requires expected artifacts`);
-
-  for (const artifact of runnerCase.artifacts) {
-    assert.equal(artifact.required, true, `${manifest.id} case artifact ${artifact.name} must be required`);
-  }
-  for (const artifact of manifest.artifacts.expected) {
-    assert.equal(artifact.required, true, `${manifest.id} expected artifact ${artifact.name} must be required`);
-  }
+  assertGenericFuzzManifest(manifest, {
+    file,
+    declaredIds,
+    benchWorkloadIds,
+    benchProfileIds,
+    targetSlug: 'gutenberg',
+    workloadTypes: ['php', 'json', 'trace'],
+  });
 
   if (manifest.operations?.includes('skipped-destructive-action-classification')) {
     assert.ok(Array.isArray(manifest.metadata?.skipped_reason_codes), `${manifest.id} requires skipped reason codes`);

--- a/WordPress/wordpress-develop/tools/validate-fuzz-manifests.mjs
+++ b/WordPress/wordpress-develop/tools/validate-fuzz-manifests.mjs
@@ -1,25 +1,21 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { declaredFuzzIds, readJson } from '../../../scripts/fuzz-manifest-helpers.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
 
-function readJson(relativePath) {
-  return JSON.parse(readFileSync(path.join(packageRoot, relativePath), 'utf8'));
-}
+const rig = readJson(packageRoot, 'rigs/wordpress-core-fuzz-coverage/rig.json');
+const hooksWorkload = readJson(packageRoot, 'fuzz/hooks-cron-options.json');
+const hooksManifest = readJson(packageRoot, 'manifests/hooks-cron-options.json');
+const performanceWorkload = readJson(packageRoot, 'fuzz/performance-surfaces.json');
+const performanceManifest = readJson(packageRoot, 'manifests/performance-surfaces.json');
 
-const rig = readJson('rigs/wordpress-core-fuzz-coverage/rig.json');
-const hooksWorkload = readJson('fuzz/hooks-cron-options.json');
-const hooksManifest = readJson('manifests/hooks-cron-options.json');
-const performanceWorkload = readJson('fuzz/performance-surfaces.json');
-const performanceManifest = readJson('manifests/performance-surfaces.json');
-
-const declaredFuzzIds = new Set((rig.fuzz_workloads?.wordpress || []).map((entry) => path.basename(entry.path, '.json')));
+const declaredIds = declaredFuzzIds(rig);
 for (const id of ['hooks-cron-options', 'performance-surfaces']) {
-  assert.ok(declaredFuzzIds.has(id), `${id} must be declared in rig fuzz_workloads.wordpress`);
+  assert.ok(declaredIds.has(id), `${id} must be declared in rig fuzz_workloads.wordpress`);
   for (const profile of ['fuzzer', 'full-surface']) {
     assert.ok(rig.fuzz_profiles?.[profile]?.includes(id), `${profile} must include ${id}`);
   }

--- a/docs/fuzz-coverage-matrix.md
+++ b/docs/fuzz-coverage-matrix.md
@@ -16,6 +16,11 @@ to `P` only when reviewer-facing run artifacts, bug evidence, or PR evidence are
 linked from the package docs; no full-surface product row is proven by this
 matrix alone.
 
+Product manifest validators share generic workload-shape, rig-linkage, and
+bench/fuzz separation checks through `scripts/fuzz-manifest-helpers.mjs`.
+Product-specific validators remain responsible for product namespaces, routes,
+fixtures, thresholds, skip reasons, and proof contracts.
+
 ## Summary
 
 | Project | API | DB | Admin | External HTTP | Hooks / cron / options | Frontend / rendering | Performance-related fuzz |

--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+export function readJson(root, ...parts) {
+  return JSON.parse(readFileSync(path.join(root, ...parts), 'utf8'));
+}
+
+export function workloadIdFromPath(workloadPath) {
+  return path.basename(workloadPath)
+    .replace(/\.workload\.json$/, '')
+    .replace(/\.bench\.mjs$/, '')
+    .replace(/\.php$/, '')
+    .replace(/\.mjs$/, '')
+    .replace(/\.js$/, '')
+    .replace(/\.json$/, '');
+}
+
+export function declaredFuzzIds(rig, runner = 'wordpress') {
+  return new Set((rig.fuzz_workloads?.[runner] || []).map((entry) => workloadIdFromPath(entry.path || entry)));
+}
+
+export function declaredBenchWorkloadIds(rig) {
+  return new Set(
+    Object.values(rig.bench_workloads || {})
+      .flat()
+      .map((entry) => workloadIdFromPath(entry.path || entry))
+  );
+}
+
+export function declaredBenchProfileIds(rig) {
+  return new Set(Object.values(rig.bench_profiles || {}).flat());
+}
+
+export function collectFuzzManifests(packageRoot, { declaredIds } = {}) {
+  const fuzzDir = path.join(packageRoot, 'fuzz');
+
+  return readdirSync(fuzzDir)
+    .filter((file) => file.endsWith('.json'))
+    .filter((file) => !declaredIds || declaredIds.has(workloadIdFromPath(file)))
+    .sort()
+    .map((file) => ({
+      file,
+      path: path.join(fuzzDir, file),
+      manifest: readJson(fuzzDir, file),
+    }));
+}
+
+export function assertGenericFuzzManifest(manifest, {
+  file,
+  declaredIds,
+  benchWorkloadIds = new Set(),
+  benchProfileIds = new Set(),
+  targetType = 'wordpress-plugin',
+  targetSlug,
+  workloadTypes = ['php', 'json'],
+  requireCaseSafetyClass = false,
+  requireCaseArtifacts = true,
+  requireExpectedArtifacts = true,
+  requireExpectedArtifactSemanticKeys = false,
+} = {}) {
+  assert.equal(manifest.schema, 'homeboy/fuzz-workload/v1', `${file} schema mismatch`);
+  assert.equal(typeof manifest.id, 'string', `${file} requires id`);
+
+  if (declaredIds) {
+    assert.ok(declaredIds.has(manifest.id), `${manifest.id} is not declared in rig fuzz_workloads.wordpress`);
+  }
+
+  assert.ok(!benchWorkloadIds.has(manifest.id), `${manifest.id} must not appear in bench_workloads`);
+  assert.ok(!benchProfileIds.has(manifest.id), `${manifest.id} must not appear in bench_profiles`);
+
+  assert.equal(manifest.target?.type, targetType, `${manifest.id} target.type mismatch`);
+  if (targetSlug) {
+    assert.equal(manifest.target?.slug, targetSlug, `${manifest.id} target.slug mismatch`);
+  }
+
+  assert.equal(manifest.workload?.runner, 'wp-codebox', `${manifest.id} workload.runner mismatch`);
+  assert.equal(manifest.workload?.path, manifest.metadata?.workload_path, `${manifest.id} workload path must match metadata`);
+  assert.ok(workloadTypes.includes(manifest.workload?.type), `${manifest.id} workload.type must be ${workloadTypes.join(', or ')}`);
+  assert.deepEqual(manifest.coverage?.surface_ids, manifest.surface_ids, `${manifest.id} coverage surface ids drifted`);
+  assert.deepEqual(manifest.coverage?.operations, manifest.operations, `${manifest.id} coverage operations drifted`);
+  assert.equal(manifest.limits?.max_cases, manifest.case_budget, `${manifest.id} max_cases must match case_budget`);
+  assert.equal(manifest.limits?.max_duration_seconds, manifest.duration_budget_seconds, `${manifest.id} max_duration_seconds must match duration_budget_seconds`);
+
+  assert.equal(manifest.cases?.length, 1, `${manifest.id} requires one default runner case`);
+  const [runnerCase] = manifest.cases;
+  assert.equal(runnerCase.case_id, `${manifest.id}:default`, `${manifest.id} default case id mismatch`);
+  if (requireCaseSafetyClass) {
+    assert.equal(runnerCase.metadata?.safety_class, manifest.safety_class, `${manifest.id} case safety class must match workload safety class`);
+  }
+  assert.deepEqual(runnerCase.surface_ids, manifest.surface_ids, `${manifest.id} case surface ids drifted`);
+  assert.deepEqual(runnerCase.operations, manifest.operations, `${manifest.id} case operations drifted`);
+  assert.ok(Array.isArray(runnerCase.phases?.action), `${manifest.id} requires action phase`);
+  assert.ok(runnerCase.phases.action.length > 0, `${manifest.id} requires at least one action step`);
+  assert.ok(Array.isArray(runnerCase.artifacts), `${manifest.id} requires case artifacts`);
+  assert.ok(Array.isArray(manifest.artifacts?.expected), `${manifest.id} requires expected artifacts`);
+
+  if (requireCaseArtifacts) {
+    for (const artifact of runnerCase.artifacts) {
+      assert.equal(artifact.required, true, `${manifest.id} case artifact ${artifact.name} must be required`);
+    }
+  }
+
+  for (const artifact of manifest.artifacts.expected) {
+    if (requireExpectedArtifacts) {
+      assert.equal(artifact.required, true, `${manifest.id} expected artifact ${artifact.name} must be required`);
+    }
+    if (requireExpectedArtifactSemanticKeys) {
+      assert.equal(typeof artifact.semantic_key, 'string', `${manifest.id} expected artifact ${artifact.name} requires semantic_key`);
+    }
+  }
+
+  return runnerCase;
+}

--- a/scripts/fuzz-manifest-helpers.test.mjs
+++ b/scripts/fuzz-manifest-helpers.test.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { assertGenericFuzzManifest, declaredFuzzIds, workloadIdFromPath } from './fuzz-manifest-helpers.mjs';
+
+function fuzzManifest(overrides = {}) {
+  return {
+    schema: 'homeboy/fuzz-workload/v1',
+    id: 'product-fuzz',
+    label: 'Product fuzz',
+    safety_class: 'read_only',
+    surface_ids: ['product-api'],
+    operations: ['route-inventory'],
+    case_budget: 10,
+    duration_budget_seconds: 60,
+    metadata: { workload_path: '${package.root}/bench/product.workload.json' },
+    target: { type: 'wordpress-plugin', slug: 'product' },
+    workload: { runner: 'wp-codebox', type: 'json', path: '${package.root}/bench/product.workload.json' },
+    cases: [
+      {
+        case_id: 'product-fuzz:default',
+        surface_ids: ['product-api'],
+        operations: ['route-inventory'],
+        phases: { action: [{ command: 'product.inventory' }] },
+        artifacts: [{ name: 'report', path: 'report.json', required: true }],
+        metadata: { safety_class: 'read_only' },
+      },
+    ],
+    limits: { max_cases: 10, max_duration_seconds: 60 },
+    coverage: { surface_ids: ['product-api'], operations: ['route-inventory'] },
+    artifacts: { expected: [{ name: 'report', semantic_key: 'fuzz.report', required: true }] },
+    ...overrides,
+  };
+}
+
+test('workloadIdFromPath strips supported workload suffixes', () => {
+  assert.equal(workloadIdFromPath('${package.root}/fuzz/product-fuzz.json'), 'product-fuzz');
+  assert.equal(workloadIdFromPath('${package.root}/bench/product-fuzz.workload.json'), 'product-fuzz');
+  assert.equal(workloadIdFromPath('${package.root}/bench/product-fuzz.php'), 'product-fuzz');
+});
+
+test('declaredFuzzIds accepts object and string workload declarations', () => {
+  assert.deepEqual(declaredFuzzIds({
+    fuzz_workloads: {
+      wordpress: [
+        { path: '${package.root}/fuzz/product-fuzz.json' },
+        '${package.root}/fuzz/other-fuzz.json',
+      ],
+    },
+  }), new Set(['product-fuzz', 'other-fuzz']));
+});
+
+test('assertGenericFuzzManifest accepts a linked generic fuzz workload contract', () => {
+  const runnerCase = assertGenericFuzzManifest(fuzzManifest(), {
+    file: 'product-fuzz.json',
+    declaredIds: new Set(['product-fuzz']),
+    targetSlug: 'product',
+    requireCaseSafetyClass: true,
+    requireExpectedArtifactSemanticKeys: true,
+  });
+
+  assert.equal(runnerCase.case_id, 'product-fuzz:default');
+});
+
+test('assertGenericFuzzManifest rejects fuzz workloads that leak into bench paths', () => {
+  assert.throws(
+    () => assertGenericFuzzManifest(fuzzManifest(), {
+      file: 'product-fuzz.json',
+      declaredIds: new Set(['product-fuzz']),
+      benchWorkloadIds: new Set(['product-fuzz']),
+      targetSlug: 'product',
+    }),
+    /must not appear in bench_workloads/
+  );
+});
+
+test('assertGenericFuzzManifest can preserve product-specific optional artifact semantics', () => {
+  const manifest = fuzzManifest({
+    cases: [
+      {
+        case_id: 'product-fuzz:default',
+        surface_ids: ['product-api'],
+        operations: ['route-inventory'],
+        phases: { action: [{ command: 'product.inventory' }] },
+        artifacts: [{ name: 'diagnostic', path: 'diagnostic.json', required: false }],
+      },
+    ],
+    artifacts: { expected: [{ name: 'diagnostic', semantic_key: 'fuzz.diagnostic', required: false }] },
+  });
+
+  assert.doesNotThrow(() => assertGenericFuzzManifest(manifest, {
+    file: 'product-fuzz.json',
+    declaredIds: new Set(['product-fuzz']),
+    targetSlug: 'product',
+    requireCaseArtifacts: false,
+    requireExpectedArtifacts: false,
+    requireExpectedArtifactSemanticKeys: true,
+  }));
+});

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -1,14 +1,20 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict';
-import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  assertGenericFuzzManifest,
+  collectFuzzManifests,
+  declaredBenchProfileIds,
+  declaredBenchWorkloadIds,
+  declaredFuzzIds,
+  readJson,
+} from '../../../scripts/fuzz-manifest-helpers.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
-const fuzzDir = path.join(packageRoot, 'fuzz');
-const rig = JSON.parse(readFileSync(path.join(packageRoot, 'rigs/woocommerce-performance/rig.json'), 'utf8'));
-const coverageManifest = JSON.parse(readFileSync(path.join(packageRoot, 'manifests/full-surface-coverage.json'), 'utf8'));
+const rig = readJson(packageRoot, 'rigs/woocommerce-performance/rig.json');
+const coverageManifest = readJson(packageRoot, 'manifests/full-surface-coverage.json');
 
 const expectedFuzzIds = new Set([
   'action-scheduler-lookup-table-coverage',
@@ -45,35 +51,22 @@ const requiredProofContracts = new Map([
   ['woocommerce-external-http-guardrail', ['external-http-guardrails']],
 ]);
 
-const fuzzManifests = readdirSync(fuzzDir)
-  .filter((file) => file.endsWith('.json'))
-  .sort()
-  .map((file) => ({
-    file,
-    path: path.join(fuzzDir, file),
-    manifest: JSON.parse(readFileSync(path.join(fuzzDir, file), 'utf8')),
-  }));
+const fuzzManifests = collectFuzzManifests(packageRoot);
 
 assert.equal(fuzzManifests.length, 20, 'expected 20 WooCommerce fuzz manifests');
 
-const declaredFuzzIds = new Set(
-  (rig.fuzz_workloads?.wordpress || []).map((entry) => path.basename(entry.path, '.json'))
-);
-const benchWorkloadIds = new Set(
-  Object.values(rig.bench_workloads || {})
-    .flat()
-    .map((entry) => path.basename(entry.path, path.extname(entry.path)))
-);
-const benchProfileIds = new Set(Object.values(rig.bench_profiles || {}).flat());
+const declaredIds = declaredFuzzIds(rig);
+const benchWorkloadIds = declaredBenchWorkloadIds(rig);
+const benchProfileIds = declaredBenchProfileIds(rig);
 const actualFuzzIds = new Set(fuzzManifests.map(({ manifest }) => manifest.id));
 const coverageProfileWorkloadIds = new Set(Object.entries(coverageManifest.coverage_profiles['full-surface'])
   .filter(([surface]) => surface !== 'browser_requests')
   .flatMap(([, workloadIds]) => workloadIds));
 
 assert.deepEqual(actualFuzzIds, expectedFuzzIds, 'WooCommerce fuzz manifest ids drifted');
-assert.deepEqual(declaredFuzzIds, expectedFuzzIds, 'rig fuzz_workloads.wordpress ids drifted');
+assert.deepEqual(declaredIds, expectedFuzzIds, 'rig fuzz_workloads.wordpress ids drifted');
 for (const workloadId of coverageProfileWorkloadIds) {
-  assert.ok(declaredFuzzIds.has(workloadId), `${workloadId} full-surface profile entry must route through fuzz_workloads.wordpress`);
+  assert.ok(declaredIds.has(workloadId), `${workloadId} full-surface profile entry must route through fuzz_workloads.wordpress`);
 }
 
 const fullSurfaceFuzzIds = new Set(Object.entries(coverageManifest.coverage_profiles['full-surface'])
@@ -81,44 +74,27 @@ const fullSurfaceFuzzIds = new Set(Object.entries(coverageManifest.coverage_prof
   .flatMap(([, workloadIds]) => workloadIds));
 
 for (const workloadId of fullSurfaceFuzzIds) {
-  assert.ok(declaredFuzzIds.has(workloadId), `${workloadId} full-surface coverage is not backed by a fuzz workload`);
+  assert.ok(declaredIds.has(workloadId), `${workloadId} full-surface coverage is not backed by a fuzz workload`);
 }
 
 for (const { file, manifest } of fuzzManifests) {
-  assert.equal(manifest.schema, 'homeboy/fuzz-workload/v1', `${file} schema mismatch`);
-  assert.equal(typeof manifest.id, 'string', `${file} requires id`);
-  assert.ok(declaredFuzzIds.has(manifest.id), `${manifest.id} is not declared in rig fuzz_workloads.wordpress`);
-  assert.ok(!benchWorkloadIds.has(manifest.id), `${manifest.id} must not appear in bench_workloads`);
-  assert.ok(!benchProfileIds.has(manifest.id), `${manifest.id} must not appear in bench_profiles`);
+  const runnerCase = assertGenericFuzzManifest(manifest, {
+    file,
+    declaredIds,
+    benchWorkloadIds,
+    benchProfileIds,
+    targetSlug: 'woocommerce',
+    workloadTypes: ['php', 'json'],
+    requireCaseSafetyClass: true,
+    requireCaseArtifacts: false,
+    requireExpectedArtifacts: false,
+    requireExpectedArtifactSemanticKeys: true,
+  });
 
-  assert.equal(manifest.target?.type, 'wordpress-plugin', `${manifest.id} target.type mismatch`);
-  assert.equal(manifest.target?.slug, 'woocommerce', `${manifest.id} target.slug mismatch`);
-  assert.equal(manifest.workload?.runner, 'wp-codebox', `${manifest.id} workload.runner mismatch`);
-  assert.equal(manifest.workload?.path, manifest.metadata?.workload_path, `${manifest.id} workload path must match metadata`);
-  assert.ok(['php', 'json'].includes(manifest.workload?.type), `${manifest.id} workload.type must be php or json`);
   assert.equal(manifest.metadata?.fixture?.runtime, 'wp-codebox', `${manifest.id} fixture runtime must be wp-codebox`);
   assert.equal(manifest.metadata?.fixture?.scope, 'disposable-wordpress', `${manifest.id} fixture scope must be disposable-wordpress`);
   assert.equal(manifest.metadata?.fixture?.component, 'woocommerce', `${manifest.id} fixture component must be woocommerce`);
   assert.equal(manifest.metadata?.fixture?.activation, 'woocommerce/woocommerce.php', `${manifest.id} fixture activation must be woocommerce/woocommerce.php`);
-  assert.deepEqual(manifest.coverage?.surface_ids, manifest.surface_ids, `${manifest.id} coverage surface ids drifted`);
-  assert.deepEqual(manifest.coverage?.operations, manifest.operations, `${manifest.id} coverage operations drifted`);
-  assert.equal(manifest.limits?.max_cases, manifest.case_budget, `${manifest.id} max_cases must match case_budget`);
-  assert.equal(manifest.limits?.max_duration_seconds, manifest.duration_budget_seconds, `${manifest.id} max_duration_seconds must match duration_budget_seconds`);
-
-  assert.equal(manifest.cases?.length, 1, `${manifest.id} requires one default runner case`);
-  const [runnerCase] = manifest.cases;
-  assert.equal(runnerCase.case_id, `${manifest.id}:default`, `${manifest.id} default case id mismatch`);
-  assert.equal(runnerCase.metadata?.safety_class, manifest.safety_class, `${manifest.id} case safety class must match workload safety class`);
-  assert.deepEqual(runnerCase.surface_ids, manifest.surface_ids, `${manifest.id} case surface ids drifted`);
-  assert.deepEqual(runnerCase.operations, manifest.operations, `${manifest.id} case operations drifted`);
-  assert.ok(Array.isArray(runnerCase.phases?.action), `${manifest.id} requires action phase`);
-  assert.ok(runnerCase.phases.action.length > 0, `${manifest.id} requires at least one action step`);
-  assert.ok(Array.isArray(runnerCase.artifacts), `${manifest.id} requires case artifacts`);
-  assert.ok(Array.isArray(manifest.artifacts?.expected), `${manifest.id} requires expected artifacts`);
-
-  for (const artifact of manifest.artifacts.expected) {
-    assert.equal(typeof artifact.semantic_key, 'string', `${manifest.id} expected artifact ${artifact.name} requires semantic_key`);
-  }
 
   const requiredContractIds = requiredProofContracts.get(manifest.id) || [];
   if (requiredContractIds.length > 0) {


### PR DESCRIPTION
## Summary
- Add shared fuzz manifest helper utilities for workload ID parsing, manifest collection, rig linkage, bench/fuzz separation, and generic workload-shape assertions.
- Rewire Gutenberg, WooCommerce, and WordPress Core fuzz validators to use the shared helper while keeping product-specific coverage/proof assertions local.
- Update docs for the helper boundary and align the Jetpack inventory safety-class test with the current public Homeboy safety contract.

## Tests
- `node --test scripts/fuzz-manifest-helpers.test.mjs scripts/lint-rig-packages.test.mjs WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs WordPress/gutenberg/tools/fuzz-coverage.test.mjs woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs woocommerce/woocommerce/bench/admin-page-coverage.test.mjs Automattic/jetpack/manifests/full-surface-coverage.test.mjs`
- `node scripts/lint-rig-packages.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the helper extraction, validator rewiring, docs/test updates, and verification.