### PR TITLE
Add fuzz readiness manifest metadata

### DIFF
--- a/Automattic/jetpack/fuzz/jetpack-cron-sync-actions.json
+++ b/Automattic/jetpack/fuzz/jetpack-cron-sync-actions.json
@@ -17,6 +17,15 @@
     "artifact_expectations": {
       "required": ["cron_events", "sync_actions", "queue_option_deltas", "rollback_rows"],
       "optional": ["blocked_dispatch_attempts", "serialized_action_samples", "skipped_actions"]
+    },
+    "readiness": {
+      "level": "executable",
+      "coverage_contract": "Jetpack cron, sync action, queue option delta, and rollback-safe cron mutation inventory with external HTTP blocked.",
+      "upstream_blockers": ["durable rollback artifact manifests and persisted proof links are required before proven status"],
+      "mutation": {
+        "safety_boundary": "Runs in isolated WP Codebox fixtures with remote dispatch disabled, original values restored, rollback required, and external HTTP guarded.",
+        "rollback_artifacts": ["cron_sync_actions"]
+      }
     }
   },
   "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },

--- a/Automattic/jetpack/fuzz/jetpack-rest-route-inventory.json
+++ b/Automattic/jetpack/fuzz/jetpack-rest-route-inventory.json
@@ -12,7 +12,18 @@
     "wordpress_runner": "wp-codebox",
     "workload_path": "${package.root}/bench/jetpack-rest-route-inventory.php",
     "expected_artifact_role": "fuzz_report",
-    "expected_artifact_semantic_key": "fuzz.report"
+    "expected_artifact_semantic_key": "fuzz.report",
+    "readiness": {
+      "level": "executable",
+      "coverage_contract": "Jetpack REST route discovery and permission-boundary classification for local Jetpack and WP.com compatibility namespaces.",
+      "upstream_blockers": ["connected-site and WP.com-dependent route proof needs durable skipped/forbidden artifact links before proven status"],
+      "crud": {
+        "create": { "level": "declared", "upstream_blocker": "safe connected-site mutation fixtures are not available" },
+        "read": { "level": "executable" },
+        "update": { "level": "declared", "upstream_blocker": "safe connected-site mutation fixtures are not available" },
+        "delete": { "level": "declared", "upstream_blocker": "safe connected-site mutation fixtures are not available" }
+      }
+    }
   },
   "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
   "workload": { "runner": "wp-codebox", "type": "php", "path": "${package.root}/bench/jetpack-rest-route-inventory.php", "entry": "jetpack-rest-route-inventory" },

--- a/WordPress/gutenberg/fuzz/gutenberg-editor-performance-observation.json
+++ b/WordPress/gutenberg/fuzz/gutenberg-editor-performance-observation.json
@@ -7,7 +7,18 @@
   "operations": ["request-timing-summary", "query-count-summary", "asset-fanout-summary", "site-editor-summary", "block-rendering-summary", "pattern-preview-summary", "notes-unsaved-attachment-summary", "external-http-guardrail-summary"],
   "case_budget": 80,
   "duration_budget_seconds": 900,
-  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "workload_path": "${package.root}/manifests/fuzzer-profile.json", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report" },
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/manifests/fuzzer-profile.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report",
+    "readiness": {
+      "level": "executable",
+      "coverage_contract": "Gutenberg editor performance observation summary across post editor, Site Editor, block rendering, pattern preview, notes attachment, and external HTTP guardrail sections.",
+      "upstream_blockers": ["full proven status needs persisted run artifact refs for every required performance observation section"]
+    }
+  },
   "target": { "type": "wordpress-plugin", "slug": "gutenberg", "component": "gutenberg" },
   "workload": { "runner": "wp-codebox", "type": "json", "path": "${package.root}/manifests/fuzzer-profile.json", "entry": "gutenberg-editor-performance-observation" },
   "cases": [{ "case_id": "gutenberg-editor-performance-observation:default", "surface_ids": ["gutenberg-performance-observation", "gutenberg-block-editor", "gutenberg-site-editor", "gutenberg-block-renderer", "performance-guardrails"], "operations": ["request-timing-summary", "query-count-summary", "asset-fanout-summary", "site-editor-summary", "block-rendering-summary", "pattern-preview-summary", "notes-unsaved-attachment-summary", "external-http-guardrail-summary"], "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=gutenberg/gutenberg.php"] }], "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/manifests/fuzzer-profile.json", "type=json", "surface=gutenberg-performance-observation"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=gutenberg_performance_observation"] }] }, "artifacts": [{ "name": "gutenberg_performance_observation", "path": "gutenberg-editor-performance-observation/gutenberg_performance_observation.json", "required": true, "metadata": { "semantic_key": "fuzz.report", "schema": "homeboy/gutenberg-performance-observation/v1", "summary_sections": ["post_editor", "site_editor", "block_rendering", "pattern_preview", "notes_unsaved_attachment", "external_http_guardrail"] } }], "metadata": { "safety_class": "read_only" } }],

--- a/WordPress/gutenberg/fuzz/gutenberg-rest-route-fuzz.json
+++ b/WordPress/gutenberg/fuzz/gutenberg-rest-route-fuzz.json
@@ -12,7 +12,18 @@
     "wordpress_runner": "wp-codebox",
     "workload_path": "${package.root}/bench/gutenberg-rest-route-inventory.php",
     "expected_artifact_role": "fuzz_report",
-    "expected_artifact_semantic_key": "fuzz.report"
+    "expected_artifact_semantic_key": "fuzz.report",
+    "readiness": {
+      "level": "executable",
+      "coverage_contract": "Gutenberg REST route inventory and permission-boundary classification for wp/v2 and __experimental editor routes.",
+      "upstream_blockers": ["durable proof artifact links are required before promoting route inventory coverage to proven"],
+      "crud": {
+        "create": { "level": "declared", "upstream_blocker": "safe fixture creation primitive is not available for Gutenberg REST mutations" },
+        "read": { "level": "executable" },
+        "update": { "level": "declared", "upstream_blocker": "safe fixture update primitive is not available for Gutenberg REST mutations" },
+        "delete": { "level": "declared", "upstream_blocker": "safe fixture delete primitive is not available for Gutenberg REST mutations" }
+      }
+    }
   },
   "target": { "type": "wordpress-plugin", "slug": "gutenberg", "component": "gutenberg" },
   "workload": {

--- a/WordPress/wordpress-develop/fuzz/performance-surfaces.json
+++ b/WordPress/wordpress-develop/fuzz/performance-surfaces.json
@@ -12,7 +12,12 @@
     "wordpress_runner": "wp-codebox",
     "coverage_manifest": "${package.root}/manifests/performance-surfaces.json",
     "expected_artifact_role": "fuzz_report",
-    "expected_artifact_semantic_key": "fuzz.report"
+    "expected_artifact_semantic_key": "fuzz.report",
+    "readiness": {
+      "level": "executable",
+      "coverage_contract": "WordPress Core representative frontend, REST, admin, editor, server, and database performance surface observations.",
+      "upstream_blockers": ["persisted run artifact refs are required before representative performance coverage can be marked proven"]
+    }
   },
   "target": { "type": "wordpress-core", "component": "wordpress-develop" },
   "workload": { "runner": "wp-codebox", "type": "declarative", "path": "${package.root}/manifests/performance-surfaces.json", "entry": "performance-surfaces" },

--- a/WordPress/wordpress-develop/fuzz/rest-api.json
+++ b/WordPress/wordpress-develop/fuzz/rest-api.json
@@ -12,7 +12,22 @@
     "wordpress_runner": "wp-codebox",
     "coverage_manifest": "${package.root}/manifests/rest-route-coverage.json",
     "expected_artifact_role": "fuzz_report",
-    "expected_artifact_semantic_key": "fuzz.report"
+    "expected_artifact_semantic_key": "fuzz.report",
+    "readiness": {
+      "level": "executable",
+      "coverage_contract": "WordPress Core REST route inventory, generated safe request cases, and role permission-boundary execution for representative core routes.",
+      "upstream_blockers": ["reviewer-facing execution summary and permission-boundary proof artifacts are required before proven status"],
+      "crud": {
+        "create": { "level": "declared", "upstream_blocker": "safe disposable REST mutation fixture creation primitive is not available" },
+        "read": { "level": "executable" },
+        "update": { "level": "declared", "upstream_blocker": "safe disposable REST mutation fixture update primitive is not available" },
+        "delete": { "level": "declared", "upstream_blocker": "safe disposable REST mutation fixture deletion primitive is not available" }
+      },
+      "mutation": {
+        "safety_boundary": "Core fixtures are isolated in WP Codebox; destructive REST methods are excluded from generated cases until rollback primitives exist.",
+        "rollback_artifacts": []
+      }
+    }
   },
   "target": { "type": "wordpress-core", "component": "wordpress-develop" },
   "workload": { "runner": "wp-codebox", "type": "declarative", "path": "${package.root}/manifests/rest-route-coverage.json", "entry": "rest-api" },


### PR DESCRIPTION
## Summary
- add readiness contracts to selected Jetpack, Gutenberg, and WordPress Core fuzz manifests
- classify executable coverage and remaining blockers for proof promotion
- keep this PR stacked on the Woo readiness metadata linter update

## Verification
- `node scripts/lint-rig-packages.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** implementing and validating fuzz readiness and generic primitive manifest updates.