### PR TITLE
Normalize full-surface coverage maps

### DIFF
--- a/Automattic/jetpack/manifests/full-surface-coverage.json
+++ b/Automattic/jetpack/manifests/full-surface-coverage.json
@@ -16,6 +16,56 @@
     "wordpress-plugin-sync-queue-coverage",
     "wordpress-plugin-cron-sync-actions"
   ],
+  "coverage_map": {
+    "rest": {
+      "surface_type": "rest",
+      "surface_id": "rest_api",
+      "coverage_goal": "all registered Jetpack and WP.com REST routes and generated safe cases",
+      "workload_ids": ["jetpack-rest-route-inventory", "generated-rest-request-cases"],
+      "artifact_schemas": ["homeboy/wordpress-rest-route-inventory/v1", "homeboy/wordpress-rest-request-cases/v1"]
+    },
+    "admin": {
+      "surface_type": "admin",
+      "surface_id": "authenticated_admin_pages",
+      "coverage_goal": "bounded safe wp-admin Jetpack menu, submenu, hash-route, and settings-tab GET coverage",
+      "workload_ids": ["jetpack-admin-page-coverage"],
+      "artifact_schemas": ["homeboy/wordpress-admin-page-coverage/v1"]
+    },
+    "frontend": {
+      "surface_type": "frontend",
+      "surface_id": "public_frontend",
+      "coverage_goal": "public Jetpack module frontend rendering and request coverage with connected/disconnected expectations",
+      "workload_ids": ["jetpack-public-module-frontend-coverage"],
+      "artifact_schemas": ["wp-codebox/browser-request-coverage/v1"]
+    },
+    "browser": {
+      "surface_type": "browser",
+      "surface_id": "browser_requests",
+      "coverage_goal": "Jetpack admin, settings, module, connection, public post, and public page browser request coverage",
+      "workload_ids": ["dashboard", "connection", "modules", "settings", "public_post_modules", "public_page_modules"],
+      "artifact_schemas": ["wp-codebox/browser-request-coverage/v1"]
+    },
+    "database": {
+      "surface_type": "database",
+      "surface_id": "database",
+      "coverage_goal": "Jetpack database inventory, REST query profile, module option/table, sync queue, cron, and option matrix coverage",
+      "workload_ids": ["db-inventory", "rest-db-query-profile", "jetpack-module-option-table-inventory", "jetpack-options-matrix", "jetpack-sync-queue-coverage", "jetpack-cron-sync-actions"],
+      "artifact_schemas": ["homeboy/wordpress-db-inventory/v1", "homeboy/wordpress-rest-db-query-profile/v1", "homeboy/jetpack-module-option-table-inventory/v1"]
+    }
+  },
+  "gap_report": {
+    "schema": "homeboy-rigs/wordpress-coverage-gap-report/v1",
+    "semantic_key": "fuzz.report",
+    "inputs": ["jetpack-rest-route-inventory", "generated-rest-request-cases", "rest-db-query-profile", "db-inventory", "jetpack-admin-page-coverage", "jetpack-public-module-frontend-coverage", "jetpack-browser-coverage"],
+    "required_fields": ["surface_type", "expected", "covered", "gaps", "status", "evidence_refs"],
+    "compare": {
+      "rest": "registered Jetpack and WP.com routes minus generated safe request cases",
+      "admin": "safe Jetpack admin targets minus admin enumeration visits and skipped reason rows",
+      "frontend": "declared public module frontend scenarios minus captured rendering request rows",
+      "browser": "declared Jetpack browser scenarios minus captured browser request coverage rows",
+      "database": "Jetpack database inventory and query profiles minus module option, table, sync queue, cron, and option matrix attribution rows"
+    }
+  },
   "surfaces": {
     "rest_api": {
       "manifest": "manifests/rest-route-coverage.json",

--- a/Automattic/jetpack/manifests/full-surface-coverage.test.mjs
+++ b/Automattic/jetpack/manifests/full-surface-coverage.test.mjs
@@ -3,6 +3,7 @@ import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { assertFullSurfaceCoverageManifest } from '../../../scripts/fuzz-manifest-helpers.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
@@ -20,6 +21,10 @@ const expectedSafetyClassifications = new Set([
   'performance_observation',
   'read_only_inventory',
 ]);
+
+test('Jetpack full-surface manifest uses shared coverage-map and gap-report schema', () => {
+  assertFullSurfaceCoverageManifest(manifest, { file: 'Jetpack full-surface coverage' });
+});
 
 function workloadIdFromPath(workloadPath) {
   return path.basename(workloadPath).replace(/\.json$/, '');

--- a/WordPress/gutenberg/manifests/full-surface-coverage.json
+++ b/WordPress/gutenberg/manifests/full-surface-coverage.json
@@ -10,6 +10,56 @@
     "wordpress-external-http-guardrail",
     "browser-request-coverage"
   ],
+  "coverage_map": {
+    "rest": {
+      "surface_type": "rest",
+      "surface_id": "rest_api",
+      "coverage_goal": "all registered Gutenberg editor REST routes and generated safe cases",
+      "workload_ids": ["gutenberg-rest-route-inventory", "generated-rest-request-cases"],
+      "artifact_schemas": ["homeboy/wordpress-rest-route-inventory/v1", "homeboy/wordpress-rest-request-cases/v1"]
+    },
+    "admin": {
+      "surface_type": "admin",
+      "surface_id": "admin_editor_pages",
+      "coverage_goal": "safe wp-admin menu, editor, site editor, template, and pattern browser GET enumeration",
+      "workload_ids": ["gutenberg-admin-page-coverage"],
+      "artifact_schemas": ["homeboy-rigs/gutenberg-admin-page-coverage/v1"]
+    },
+    "frontend": {
+      "surface_type": "frontend",
+      "surface_id": "frontend_rendering",
+      "coverage_goal": "published Gutenberg fixture rendering, dynamic block rendering, and frontend request coverage",
+      "workload_ids": ["frontend-rendering-request-coverage", "block-rendering-coverage"],
+      "artifact_schemas": ["wp-codebox/browser-request-coverage/v1"]
+    },
+    "browser": {
+      "surface_type": "browser",
+      "surface_id": "browser_requests",
+      "coverage_goal": "Gutenberg editor, site editor, template, pattern, and frontend browser request coverage",
+      "workload_ids": ["post_editor", "site_editor", "template_editor", "patterns", "frontend_rendering"],
+      "artifact_schemas": ["wp-codebox/browser-request-coverage/v1"]
+    },
+    "database": {
+      "surface_type": "database",
+      "surface_id": "database",
+      "coverage_goal": "Gutenberg database inventory, REST query profile, option prefix, postmeta, and entity attribution coverage",
+      "workload_ids": ["db-inventory", "rest-db-query-profile"],
+      "artifact_schemas": ["homeboy/wordpress-db-inventory/v1", "homeboy/wordpress-rest-db-query-profile/v1"]
+    }
+  },
+  "gap_report": {
+    "schema": "homeboy-rigs/wordpress-coverage-gap-report/v1",
+    "semantic_key": "fuzz.report",
+    "inputs": ["gutenberg-rest-route-inventory", "generated-rest-request-cases", "rest-db-query-profile", "db-inventory", "gutenberg-admin-page-coverage", "frontend-rendering-request-coverage", "gutenberg-browser-coverage"],
+    "required_fields": ["surface_type", "expected", "covered", "gaps", "status", "evidence_refs"],
+    "compare": {
+      "rest": "registered Gutenberg-facing route inventory minus generated safe request cases",
+      "admin": "safe admin/editor targets minus admin enumeration and captured browser request coverage scenarios",
+      "frontend": "declared frontend fixture/rendering scenarios minus captured browser request coverage scenarios",
+      "browser": "declared Gutenberg browser scenarios minus captured browser request coverage rows",
+      "database": "fixture DB inventory plus REST query profiles minus route, option prefix, postmeta, and Gutenberg entity attribution rows"
+    }
+  },
   "surfaces": {
     "rest_api": {
       "manifest": "manifests/rest-route-coverage.json",
@@ -63,34 +113,6 @@
       "fuzz_workload": "gutenberg-editor-performance-observation",
       "coverage_artifact": "homeboy/gutenberg-performance-observation/v1"
     }
-  },
-  "coverage_gap_reporting": {
-    "inputs": [
-      "gutenberg-rest-route-inventory",
-      "generated-rest-request-cases",
-      "rest-db-query-profile",
-      "db-inventory",
-      "gutenberg-external-http-guardrail",
-      "gutenberg-browser-coverage"
-    ],
-    "artifact_expectations": {
-      "rest_route_inventory": { "required": true, "semantic_key": "fuzz.report" },
-      "rest_request_cases": { "required": true, "semantic_key": "fuzz.report" },
-      "rest_db_query_profile": { "required": true, "semantic_key": "fuzz.report" },
-      "db_inventory": { "required": true, "semantic_key": "fuzz.report" },
-      "gutenberg_runtime_state": { "required": true, "semantic_key": "fuzz.report" },
-      "external_http_guardrail": { "required": true, "semantic_key": "fuzz.report" },
-      "browser_request_coverage": { "required": true, "semantic_key": "fuzz.report" }
-    },
-    "compare": {
-      "rest_routes": "registered Gutenberg-facing route inventory minus generated safe request cases",
-      "admin_editor_pages": "safe admin/editor targets minus admin enumeration and captured browser request coverage scenarios",
-      "frontend_rendering": "declared frontend fixture/rendering scenarios minus captured browser request coverage scenarios",
-      "permissions": "protected editor routes with authenticated success cases and unauthenticated 401/403 boundary cases",
-      "database": "fixture DB inventory plus REST query profiles per covered route, query attribution group, option prefix, postmeta key, and Gutenberg entity type",
-      "external_http": "observed outbound HTTP hosts minus approved Gutenberg hosts"
-    },
-    "report_shape": "homeboy-rigs/gutenberg-fuzzer-coverage-gap/v1"
   },
   "coverage_profiles": {
     "fuzzer": {

--- a/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
+++ b/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { assertFullSurfaceCoverageManifest } from '../../../scripts/fuzz-manifest-helpers.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.join(__dirname, '..');
@@ -10,6 +11,7 @@ const readJson = (relativePath) => JSON.parse(readFileSync(path.join(root, relat
 
 test('Gutenberg full-surface profile names proof-ready admin and frontend coverage', () => {
   const manifest = readJson('manifests/full-surface-coverage.json');
+  assertFullSurfaceCoverageManifest(manifest, { file: 'Gutenberg full-surface coverage' });
   assert.ok(manifest.coverage_profiles.fuzzer.authenticated_admin_pages.includes('gutenberg-admin-page-coverage'));
   assert.ok(manifest.coverage_profiles.fuzzer.frontend_rendering.includes('frontend-rendering-request-coverage'));
   assert.ok(manifest.coverage_profiles.fuzzer.block_rendering.includes('block-rendering-coverage'));

--- a/WordPress/gutenberg/tools/validate-fuzz-manifests.mjs
+++ b/WordPress/gutenberg/tools/validate-fuzz-manifests.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
+  assertFullSurfaceCoverageManifest,
   assertGenericFuzzManifest,
   collectFuzzManifests,
   declaredBenchProfileIds,
@@ -24,6 +25,7 @@ assert.equal(fuzzManifests.length, declaredIds.size, 'expected one manifest per 
 
 const fuzzerProfile = readJson(packageRoot, 'manifests/fuzzer-profile.json');
 const apiDbLabCell = readJson(packageRoot, 'manifests/api-db-lab-cell.json');
+const fullSurfaceCoverage = readJson(packageRoot, 'manifests/full-surface-coverage.json');
 const restRouteCoverage = readJson(packageRoot, 'manifests/rest-route-coverage.json');
 const restCases = readJson(packageRoot, 'bench/generated-rest-request-cases.workload.json');
 const dbInventory = readJson(packageRoot, 'bench/db-inventory.workload.json');
@@ -45,6 +47,8 @@ const requiredSurfaces = new Set([
   'gutenberg-performance-observation',
 ]);
 const coveredSurfaces = new Set();
+
+assertFullSurfaceCoverageManifest(fullSurfaceCoverage, { file: 'Gutenberg full-surface coverage' });
 
 for (const { file, manifest } of fuzzManifests) {
   assertGenericFuzzManifest(manifest, {

--- a/WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs
+++ b/WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs
@@ -3,6 +3,7 @@ import { readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { assertFullSurfaceCoverageManifest } from '../../../scripts/fuzz-manifest-helpers.mjs';
 
 const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
 const packageRoot = path.join( __dirname, '..' );
@@ -62,6 +63,7 @@ test( 'Core fuzz rig and full-surface profile include admin and frontend coverag
 	assert.ok( allProfiles.includes( 'frontend-rendering-request-coverage' ) );
 	assert.ok( ! rig.bench_workloads );
 	assert.ok( ! rig.bench_profiles );
+	assertFullSurfaceCoverageManifest( manifest, { file: 'WordPress Core full-surface coverage' } );
 	assert.ok( manifest.coverage_profiles[ 'full-surface' ].includes( 'frontend-rendering-request-coverage' ) );
 } );
 

--- a/WordPress/wordpress-develop/manifests/full-surface-coverage.json
+++ b/WordPress/wordpress-develop/manifests/full-surface-coverage.json
@@ -1,5 +1,5 @@
 {
-  "schema": "homeboy-rigs/wordpress-core-full-surface-coverage/v1",
+  "schema": "homeboy-rigs/wordpress-full-surface-coverage/v1",
   "property": "WordPress/wordpress-develop",
   "description": "Coverage targets for WordPress Core fuzzing across API, database, admin, runtime registration, content, media, users, and performance surfaces.",
   "requires_primitives": [
@@ -19,23 +19,60 @@
     "wordpress-media-user-permission-coverage",
     "wordpress-performance-observation"
   ],
+  "coverage_map": {
+    "rest": {
+      "surface_type": "rest",
+      "surface_id": "rest-api",
+      "coverage_goal": "registered Core REST routes, generated safe request cases, and role permission-boundary rows",
+      "workload_ids": ["rest-api"],
+      "artifact_schemas": ["homeboy/wordpress-rest-route-inventory/v1", "homeboy/wordpress-rest-request-cases/v1"]
+    },
+    "admin": {
+      "surface_type": "admin",
+      "surface_id": "admin-page-coverage",
+      "coverage_goal": "safe Core wp-admin page enumeration with role boundaries, skipped reasons, and query attribution",
+      "workload_ids": ["admin-page-coverage"],
+      "artifact_schemas": ["homeboy-rigs/wordpress-core-admin-page-coverage/v1"]
+    },
+    "frontend": {
+      "surface_type": "frontend",
+      "surface_id": "frontend-rendering-request-coverage",
+      "coverage_goal": "front page, singular, archive, search, feed, attachment, and request/rendering coverage",
+      "workload_ids": ["frontend-rendering-request-coverage"],
+      "artifact_schemas": ["wp-codebox/browser-request-coverage/v1"]
+    },
+    "browser": {
+      "surface_type": "browser",
+      "surface_id": "wordpress-core-browser-coverage",
+      "coverage_goal": "Core frontend, posts, pages, media, users, editor, and site editor browser request coverage",
+      "workload_ids": ["front_page", "posts_list", "post_editor", "pages_list", "page_editor", "site_editor", "media_library", "media_new", "users_list", "profile"],
+      "artifact_schemas": ["wp-codebox/browser-request-coverage/v1"]
+    },
+    "database": {
+      "surface_type": "database",
+      "surface_id": "db-inventory-query-profile",
+      "coverage_goal": "Core schema inventory, query profiles, options, postmeta, rewrite, and runtime-state attribution coverage",
+      "workload_ids": ["db-inventory-query-profile", "hooks-cron-options"],
+      "artifact_schemas": ["homeboy/wordpress-db-inventory/v1", "homeboy/wordpress-rest-db-query-profile/v1", "homeboy/wordpress-runtime-state-coverage/v1"]
+    }
+  },
+  "gap_report": {
+    "schema": "homeboy-rigs/wordpress-coverage-gap-report/v1",
+    "semantic_key": "fuzz.report",
+    "inputs": ["rest-api", "db-inventory-query-profile", "admin-page-coverage", "frontend-rendering-request-coverage", "hooks-cron-options", "wordpress-core-browser-coverage"],
+    "required_fields": ["surface_type", "expected", "covered", "gaps", "status", "evidence_refs"],
+    "compare": {
+      "rest": "registered Core REST routes minus generated safe request cases and role permission-boundary rows",
+      "admin": "manifest admin pages minus captured readiness and query attribution artifacts",
+      "frontend": "front page, singular, archive, search, feed, attachment, and request coverage artifacts minus captured rendering rows",
+      "browser": "declared Core browser scenarios minus captured browser request coverage rows",
+      "database": "Core schema inventory and query profiles minus options, postmeta, rewrite, hook, cron, and transient attribution rows"
+    }
+  },
   "coverage_profiles": {
     "smoke": ["rest-api", "db-inventory-query-profile", "admin-page-coverage", "frontend-rendering-request-coverage"],
     "fuzzer": ["rest-api", "db-inventory-query-profile", "admin-page-coverage", "frontend-rendering-request-coverage", "hooks-cron-options", "content-types-taxonomies", "media-users", "performance-surfaces"],
     "full-surface": ["rest-api", "db-inventory-query-profile", "admin-page-coverage", "frontend-rendering-request-coverage", "hooks-cron-options", "content-types-taxonomies", "media-users", "performance-surfaces"]
-  },
-  "coverage_gap_reporting": {
-    "report_shape": "homeboy-rigs/wordpress-core-fuzzer-coverage-gap/v1",
-    "compare": {
-      "rest_api": "registered core REST routes minus generated safe request cases and role permission-boundary rows",
-      "database": "core schema inventory plus query profiles per covered REST case with options, postmeta, and rewrite attribution",
-      "admin_pages": "manifest admin pages minus captured readiness and query attribution artifacts",
-      "runtime_state": "registered hooks, cron events, rewrite rules, postmeta keys, autoloaded options, and transients minus inventory rows",
-      "frontend_rendering": "front page, singular, archive, search, feed, attachment, and request coverage artifacts minus captured rendering/readiness rows",
-      "content": "registered post types, statuses, taxonomies, terms, and permalink structures minus inventory rows",
-      "media_users": "attachment, user, role, and capability surfaces minus permission coverage rows",
-      "performance": "declared representative performance surfaces minus observation artifacts"
-    }
   },
   "proof_artifact_contract": {
     "declared": ["manifest row exists", "fuzz workload references manifest", "rig profile references workload id"],

--- a/WordPress/wordpress-develop/tools/validate-fuzz-manifests.mjs
+++ b/WordPress/wordpress-develop/tools/validate-fuzz-manifests.mjs
@@ -2,7 +2,7 @@
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { declaredFuzzIds, readJson } from '../../../scripts/fuzz-manifest-helpers.mjs';
+import { assertFullSurfaceCoverageManifest, declaredFuzzIds, readJson } from '../../../scripts/fuzz-manifest-helpers.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
@@ -12,8 +12,11 @@ const hooksWorkload = readJson(packageRoot, 'fuzz/hooks-cron-options.json');
 const hooksManifest = readJson(packageRoot, 'manifests/hooks-cron-options.json');
 const performanceWorkload = readJson(packageRoot, 'fuzz/performance-surfaces.json');
 const performanceManifest = readJson(packageRoot, 'manifests/performance-surfaces.json');
+const fullSurfaceCoverage = readJson(packageRoot, 'manifests/full-surface-coverage.json');
 
 const declaredIds = declaredFuzzIds(rig);
+assertFullSurfaceCoverageManifest(fullSurfaceCoverage, { file: 'WordPress Core full-surface coverage' });
+
 for (const id of ['hooks-cron-options', 'performance-surfaces']) {
   assert.ok(declaredIds.has(id), `${id} must be declared in rig fuzz_workloads.wordpress`);
   for (const profile of ['fuzzer', 'full-surface']) {

--- a/docs/fuzz-coverage-matrix.md
+++ b/docs/fuzz-coverage-matrix.md
@@ -17,9 +17,11 @@ linked from the package docs; no full-surface product row is proven by this
 matrix alone.
 
 Product manifest validators share generic workload-shape, rig-linkage, and
-bench/fuzz separation checks through `scripts/fuzz-manifest-helpers.mjs`.
-Product-specific validators remain responsible for product namespaces, routes,
-fixtures, thresholds, skip reasons, and proof contracts.
+bench/fuzz separation checks through `scripts/fuzz-manifest-helpers.mjs`. The
+same helper validates the shared full-surface `coverage_map` for REST, admin,
+frontend, browser, and database surfaces, plus the shared `gap_report` artifact
+schema. Product-specific validators remain responsible for product namespaces,
+routes, fixtures, thresholds, skip reasons, and proof contracts.
 
 Generic readiness metadata is available for product manifests that need an
 explicit fuzz-readiness contract without claiming proof. `metadata.readiness`

--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -4,6 +4,8 @@ import path from 'node:path';
 
 export const fuzzReadinessLevels = new Set(['declared', 'executable', 'proven']);
 export const fuzzCrudOperations = new Set(['create', 'read', 'update', 'delete']);
+export const fullSurfaceCoverageTypes = new Set(['rest', 'admin', 'frontend', 'browser', 'database']);
+export const fullSurfaceGapReportFields = new Set(['surface_type', 'expected', 'covered', 'gaps', 'status', 'evidence_refs']);
 
 export function readJson(root, ...parts) {
   return JSON.parse(readFileSync(path.join(root, ...parts), 'utf8'));
@@ -173,5 +175,50 @@ export function assertFuzzMutationReadiness(mutation, { file } = {}) {
   for (const artifact of mutation.rollback_artifacts) {
     assert.equal(typeof artifact, 'string', `${file} metadata.readiness.mutation.rollback_artifacts entries must be strings`);
     assert.notEqual(artifact.trim(), '', `${file} metadata.readiness.mutation.rollback_artifacts entries must be non-empty`);
+  }
+}
+
+export function assertFullSurfaceCoverageManifest(manifest, { file = manifest.property } = {}) {
+  assert.equal(manifest.schema, 'homeboy-rigs/wordpress-full-surface-coverage/v1', `${file} schema mismatch`);
+  assert.equal(typeof manifest.property, 'string', `${file} requires property`);
+  assert.notEqual(manifest.property.trim(), '', `${file} requires non-empty property`);
+  assert.ok(manifest.coverage_map && typeof manifest.coverage_map === 'object' && !Array.isArray(manifest.coverage_map), `${file} requires coverage_map`);
+
+  for (const surfaceType of fullSurfaceCoverageTypes) {
+    const entry = manifest.coverage_map[surfaceType];
+    assert.ok(entry && typeof entry === 'object' && !Array.isArray(entry), `${file} coverage_map.${surfaceType} must be an object`);
+    assert.equal(entry.surface_type, surfaceType, `${file} coverage_map.${surfaceType}.surface_type mismatch`);
+    assert.equal(typeof entry.surface_id, 'string', `${file} coverage_map.${surfaceType}.surface_id must be a string`);
+    assert.notEqual(entry.surface_id.trim(), '', `${file} coverage_map.${surfaceType}.surface_id must be non-empty`);
+    assert.equal(typeof entry.coverage_goal, 'string', `${file} coverage_map.${surfaceType}.coverage_goal must be a string`);
+    assert.notEqual(entry.coverage_goal.trim(), '', `${file} coverage_map.${surfaceType}.coverage_goal must be non-empty`);
+    assertStringArray(entry.workload_ids, `${file} coverage_map.${surfaceType}.workload_ids`);
+    assertStringArray(entry.artifact_schemas, `${file} coverage_map.${surfaceType}.artifact_schemas`);
+  }
+
+  assert.ok(manifest.gap_report && typeof manifest.gap_report === 'object' && !Array.isArray(manifest.gap_report), `${file} requires gap_report`);
+  assert.equal(manifest.gap_report.schema, 'homeboy-rigs/wordpress-coverage-gap-report/v1', `${file} gap_report.schema mismatch`);
+  assertStringArray(manifest.gap_report.inputs, `${file} gap_report.inputs`);
+  assertStringArray(manifest.gap_report.required_fields, `${file} gap_report.required_fields`);
+  assert.equal(manifest.gap_report.semantic_key, 'fuzz.report', `${file} gap_report.semantic_key mismatch`);
+  assert.ok(manifest.gap_report.compare && typeof manifest.gap_report.compare === 'object' && !Array.isArray(manifest.gap_report.compare), `${file} gap_report.compare must be an object`);
+
+  const requiredFields = new Set(manifest.gap_report.required_fields);
+  for (const field of fullSurfaceGapReportFields) {
+    assert.ok(requiredFields.has(field), `${file} gap_report.required_fields missing ${field}`);
+  }
+
+  for (const surfaceType of fullSurfaceCoverageTypes) {
+    assert.equal(typeof manifest.gap_report.compare[surfaceType], 'string', `${file} gap_report.compare.${surfaceType} must be a string`);
+    assert.notEqual(manifest.gap_report.compare[surfaceType].trim(), '', `${file} gap_report.compare.${surfaceType} must be non-empty`);
+  }
+}
+
+function assertStringArray(value, label) {
+  assert.ok(Array.isArray(value), `${label} must be an array`);
+  assert.ok(value.length > 0, `${label} must not be empty`);
+  for (const entry of value) {
+    assert.equal(typeof entry, 'string', `${label} entries must be strings`);
+    assert.notEqual(entry.trim(), '', `${label} entries must be non-empty`);
   }
 }

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.json
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.json
@@ -11,6 +11,56 @@
     "browser-request-coverage",
     "wordpress-authenticated-admin-page-coverage"
   ],
+  "coverage_map": {
+    "rest": {
+      "surface_type": "rest",
+      "surface_id": "rest_api",
+      "coverage_goal": "all WooCommerce REST, Store API, wc-admin, and wc-analytics safe route cases",
+      "workload_ids": ["woocommerce-rest-route-inventory", "generated-rest-request-cases", "rest-permission-boundary-matrix", "rest-namespace-generated-cases", "rest-schema-query-attribution"],
+      "artifact_schemas": ["homeboy/wordpress-rest-route-inventory/v1", "homeboy/wordpress-rest-request-cases/v1", "homeboy/wordpress-rest-db-query-profile/v1"]
+    },
+    "admin": {
+      "surface_type": "admin",
+      "surface_id": "authenticated_admin_pages",
+      "coverage_goal": "bounded safe WooCommerce wp-admin and Woo admin menu/submenu GET coverage",
+      "workload_ids": ["admin-page-coverage"],
+      "artifact_schemas": ["homeboy-rigs/woocommerce-admin-page-coverage/v1"]
+    },
+    "frontend": {
+      "surface_type": "frontend",
+      "surface_id": "frontend_rendering",
+      "coverage_goal": "shop, product, cart, checkout, asset, XHR/fetch, and skipped-action frontend request coverage",
+      "workload_ids": ["frontend-rendering-request-coverage"],
+      "artifact_schemas": ["wp-codebox/browser-request-coverage/v1"]
+    },
+    "browser": {
+      "surface_type": "browser",
+      "surface_id": "browser_requests",
+      "coverage_goal": "WooCommerce cart, checkout, product, admin, fetch, XHR, websocket, and asset browser request coverage",
+      "workload_ids": ["shop", "product", "cart", "checkout", "orders_admin", "products_admin", "analytics_admin"],
+      "artifact_schemas": ["wp-codebox/browser-request-coverage/v1"]
+    },
+    "database": {
+      "surface_type": "database",
+      "surface_id": "database",
+      "coverage_goal": "WooCommerce database inventory, REST query profile, lookup table, option, transient, and attribution coverage",
+      "workload_ids": ["db-inventory", "rest-db-query-profile", "rest-schema-query-attribution", "action-scheduler-lookup-table-coverage", "options-transients-coverage"],
+      "artifact_schemas": ["homeboy/wordpress-db-inventory/v1", "homeboy/wordpress-rest-db-query-profile/v1", "homeboy/woocommerce-options-transients-coverage/v1"]
+    }
+  },
+  "gap_report": {
+    "schema": "homeboy-rigs/wordpress-coverage-gap-report/v1",
+    "semantic_key": "fuzz.report",
+    "inputs": ["woocommerce-rest-route-inventory", "generated-rest-request-cases", "rest-db-query-profile", "db-inventory", "admin-page-coverage", "frontend-rendering-request-coverage", "woocommerce-browser-coverage"],
+    "required_fields": ["surface_type", "expected", "covered", "gaps", "status", "evidence_refs"],
+    "compare": {
+      "rest": "registered WooCommerce routes minus generated safe request cases and permission-boundary rows",
+      "admin": "bounded safe WooCommerce admin targets minus admin enumeration visits and skips",
+      "frontend": "declared shop/product/cart/checkout frontend scenarios minus captured rendering request rows",
+      "browser": "declared WooCommerce browser scenarios minus captured browser request coverage rows",
+      "database": "WooCommerce database inventory and query profiles minus route, table, option, transient, and lookup attribution rows"
+    }
+  },
   "surfaces": {
     "rest_api": {
       "budget_manifest": "manifests/rest-route-budgets.json",

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { assertFullSurfaceCoverageManifest } from '../../../scripts/fuzz-manifest-helpers.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
@@ -42,6 +43,10 @@ const requiredFuzzProofContracts = new Map([
   ['performance-hotspots-artifact-summary', ['artifact-summary-expectations']],
   ['woocommerce-external-http-guardrail', ['external-http-guardrails']],
 ]);
+
+test('full-surface manifest uses shared coverage-map and gap-report schema', () => {
+  assertFullSurfaceCoverageManifest(manifest, { file: 'woocommerce full-surface coverage' });
+});
 
 test('full-surface executable workloads have coverage contract metadata', () => {
   const workloadIds = executableCoverageWorkloadIds();

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
+  assertFullSurfaceCoverageManifest,
   assertGenericFuzzManifest,
   collectFuzzManifests,
   declaredBenchProfileIds,
@@ -15,6 +16,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
 const rig = readJson(packageRoot, 'rigs/woocommerce-performance/rig.json');
 const coverageManifest = readJson(packageRoot, 'manifests/full-surface-coverage.json');
+
+assertFullSurfaceCoverageManifest(coverageManifest, { file: 'WooCommerce full-surface coverage' });
 
 const expectedFuzzIds = new Set([
   'action-scheduler-lookup-table-coverage',


### PR DESCRIPTION
## Summary
- Add shared full-surface coverage map and gap report validation.
- Normalize WooCommerce, Gutenberg, Jetpack, and WordPress Core manifests around shared REST/admin/frontend/browser/database coverage maps.
- Document the shared contract without moving product-specific coverage data out of product manifests.

## Tests
- node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
- node WordPress/gutenberg/tools/validate-fuzz-manifests.mjs
- node WordPress/wordpress-develop/tools/validate-fuzz-manifests.mjs
- node --test woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs Automattic/jetpack/manifests/full-surface-coverage.test.mjs WordPress/gutenberg/tools/fuzz-coverage.test.mjs WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing shared coverage map schema validation, manifest normalization, and tests.