### PR TITLE
Add runner-neutral fuzz workload intent

### DIFF
--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 export const fuzzReadinessLevels = new Set(['declared', 'executable', 'proven']);
 export const fuzzCrudOperations = new Set(['create', 'read', 'update', 'delete']);
+export const fuzzCaseIntentSchema = 'homeboy/fuzz-workload-intent/v1';
 
 export function readJson(root, ...parts) {
   return JSON.parse(readFileSync(path.join(root, ...parts), 'utf8'));
@@ -62,6 +63,7 @@ export function assertGenericFuzzManifest(manifest, {
   requireExpectedArtifacts = true,
   requireExpectedArtifactSemanticKeys = false,
   requireReadinessMetadata = false,
+  requireRunnerNeutralIntent = false,
 } = {}) {
   assert.equal(manifest.schema, 'homeboy/fuzz-workload/v1', `${file} schema mismatch`);
   assert.equal(typeof manifest.id, 'string', `${file} requires id`);
@@ -98,8 +100,13 @@ export function assertGenericFuzzManifest(manifest, {
   }
   assert.deepEqual(runnerCase.surface_ids, manifest.surface_ids, `${manifest.id} case surface ids drifted`);
   assert.deepEqual(runnerCase.operations, manifest.operations, `${manifest.id} case operations drifted`);
-  assert.ok(Array.isArray(runnerCase.phases?.action), `${manifest.id} requires action phase`);
-  assert.ok(runnerCase.phases.action.length > 0, `${manifest.id} requires at least one action step`);
+  if (runnerCase.intent) {
+    assertRunnerNeutralFuzzCaseIntent(manifest, runnerCase);
+  } else {
+    assert.equal(requireRunnerNeutralIntent, false, `${manifest.id} requires runner-neutral case intent`);
+    assert.ok(Array.isArray(runnerCase.phases?.action), `${manifest.id} requires action phase`);
+    assert.ok(runnerCase.phases.action.length > 0, `${manifest.id} requires at least one action step`);
+  }
   assert.ok(Array.isArray(runnerCase.artifacts), `${manifest.id} requires case artifacts`);
   assert.ok(Array.isArray(manifest.artifacts?.expected), `${manifest.id} requires expected artifacts`);
 
@@ -119,6 +126,38 @@ export function assertGenericFuzzManifest(manifest, {
   }
 
   return runnerCase;
+}
+
+export function assertRunnerNeutralFuzzCaseIntent(manifest, runnerCase) {
+  const intent = runnerCase.intent;
+  assert.ok(intent && typeof intent === 'object' && !Array.isArray(intent), `${manifest.id} case intent must be an object`);
+  assert.equal(intent.schema, fuzzCaseIntentSchema, `${manifest.id} case intent schema mismatch`);
+  assert.equal(intent.type, 'wordpress-plugin-workload', `${manifest.id} case intent type mismatch`);
+
+  assert.ok(intent.plugin && typeof intent.plugin === 'object' && !Array.isArray(intent.plugin), `${manifest.id} case intent requires plugin`);
+  assert.equal(typeof intent.plugin.activation, 'string', `${manifest.id} case intent plugin.activation must be a string`);
+
+  assert.ok(intent.execute && typeof intent.execute === 'object' && !Array.isArray(intent.execute), `${manifest.id} case intent requires execute`);
+  assert.equal(intent.execute.workload_ref, 'default', `${manifest.id} case intent execute.workload_ref must be default`);
+  assert.equal(intent.execute.path, manifest.workload?.path, `${manifest.id} case intent execute.path must match workload.path`);
+  assert.equal(intent.execute.type, manifest.workload?.type, `${manifest.id} case intent execute.type must match workload.type`);
+  if (manifest.workload?.entry) {
+    assert.equal(intent.execute.entry, manifest.workload.entry, `${manifest.id} case intent execute.entry must match workload.entry`);
+  }
+  if (intent.execute.parameters !== undefined) {
+    assert.ok(intent.execute.parameters && typeof intent.execute.parameters === 'object' && !Array.isArray(intent.execute.parameters), `${manifest.id} case intent execute.parameters must be an object`);
+  }
+
+  assert.ok(Array.isArray(intent.collect), `${manifest.id} case intent collect must be an array`);
+  assert.ok(intent.collect.length > 0, `${manifest.id} case intent collect must declare at least one artifact`);
+  const caseArtifactNames = new Set((runnerCase.artifacts || []).map((artifact) => artifact?.name).filter(Boolean));
+  for (const artifact of intent.collect) {
+    assert.ok(artifact && typeof artifact === 'object' && !Array.isArray(artifact), `${manifest.id} case intent collect entries must be objects`);
+    assert.equal(typeof artifact.artifact, 'string', `${manifest.id} case intent collect artifact must be a string`);
+    assert.ok(caseArtifactNames.has(artifact.artifact), `${manifest.id} case intent collect artifact ${artifact.artifact} is not declared on the case`);
+  }
+
+  assert.equal(runnerCase.phases, undefined, `${manifest.id} runner-neutral case intent must not embed runner command phases`);
 }
 
 export function assertFuzzReadinessMetadata(manifest, { file = manifest.id } = {}) {

--- a/scripts/fuzz-manifest-helpers.test.mjs
+++ b/scripts/fuzz-manifest-helpers.test.mjs
@@ -25,7 +25,17 @@ function fuzzManifest(overrides = {}) {
         case_id: 'product-fuzz:default',
         surface_ids: ['product-api'],
         operations: ['route-inventory'],
-        phases: { action: [{ command: 'product.inventory' }] },
+        intent: {
+          schema: 'homeboy/fuzz-workload-intent/v1',
+          type: 'wordpress-plugin-workload',
+          plugin: { activation: 'product/product.php' },
+          execute: {
+            workload_ref: 'default',
+            path: '${package.root}/bench/product.workload.json',
+            type: 'json',
+          },
+          collect: [{ artifact: 'report' }],
+        },
         artifacts: [{ name: 'report', path: 'report.json', required: true }],
         metadata: { safety_class: 'read_only' },
       },
@@ -61,9 +71,33 @@ test('assertGenericFuzzManifest accepts a linked generic fuzz workload contract'
     targetSlug: 'product',
     requireCaseSafetyClass: true,
     requireExpectedArtifactSemanticKeys: true,
+    requireRunnerNeutralIntent: true,
   });
 
   assert.equal(runnerCase.case_id, 'product-fuzz:default');
+});
+
+test('assertGenericFuzzManifest rejects runner commands when intent is required', () => {
+  assert.throws(
+    () => assertGenericFuzzManifest(fuzzManifest({
+      cases: [
+        {
+          case_id: 'product-fuzz:default',
+          surface_ids: ['product-api'],
+          operations: ['route-inventory'],
+          phases: { action: [{ command: 'wordpress.run-workload' }] },
+          artifacts: [{ name: 'report', path: 'report.json', required: true }],
+          metadata: { safety_class: 'read_only' },
+        },
+      ],
+    }), {
+      file: 'product-fuzz.json',
+      declaredIds: new Set(['product-fuzz']),
+      targetSlug: 'product',
+      requireRunnerNeutralIntent: true,
+    }),
+    /requires runner-neutral case intent/
+  );
 });
 
 test('assertGenericFuzzManifest rejects fuzz workloads that leak into bench paths', () => {
@@ -85,7 +119,17 @@ test('assertGenericFuzzManifest can preserve product-specific optional artifact 
         case_id: 'product-fuzz:default',
         surface_ids: ['product-api'],
         operations: ['route-inventory'],
-        phases: { action: [{ command: 'product.inventory' }] },
+        intent: {
+          schema: 'homeboy/fuzz-workload-intent/v1',
+          type: 'wordpress-plugin-workload',
+          plugin: { activation: 'product/product.php' },
+          execute: {
+            workload_ref: 'default',
+            path: '${package.root}/bench/product.workload.json',
+            type: 'json',
+          },
+          collect: [{ artifact: 'diagnostic' }],
+        },
         artifacts: [{ name: 'diagnostic', path: 'diagnostic.json', required: false }],
       },
     ],

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -3,7 +3,10 @@
 import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
-import { assertFuzzReadinessMetadata } from './fuzz-manifest-helpers.mjs';
+import {
+  assertFuzzReadinessMetadata,
+  assertRunnerNeutralFuzzCaseIntent,
+} from './fuzz-manifest-helpers.mjs';
 
 const args = process.argv.slice(2);
 const strictFuzzReadiness = args.includes('--strict-fuzz-readiness');
@@ -230,6 +233,14 @@ function validateFuzzWorkloadShape(rel, workload, context, packageRoot) {
       if (runnerCase?.metadata?.safety_class && runnerCase.metadata.safety_class !== workload.safety_class) {
         failures.push(`${rel}: ${context} case ${runnerCase.case_id || '(unknown)'} metadata.safety_class must match workload safety_class ${workload.safety_class}`);
       }
+
+      if (runnerCase?.intent) {
+        try {
+          assertRunnerNeutralFuzzCaseIntent(workload, runnerCase);
+        } catch (error) {
+          failures.push(`${rel}: ${context} ${error.message}`);
+        }
+      }
     }
   }
 }
@@ -387,6 +398,14 @@ function lintFuzzWorkload(file) {
     for (const runnerCase of workload.cases) {
       if (runnerCase?.metadata?.safety_class && runnerCase.metadata.safety_class !== workload.safety_class) {
         failures.push(`${rel}: fuzz workload case ${runnerCase.case_id || '(unknown)'} metadata.safety_class must match workload safety_class ${workload.safety_class}`);
+      }
+
+      if (runnerCase?.intent) {
+        try {
+          assertRunnerNeutralFuzzCaseIntent(workload, runnerCase);
+        } catch (error) {
+          failures.push(`${rel}: ${error.message}`);
+        }
       }
     }
   }

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -156,6 +156,37 @@ test('rejects fuzz case safety classes that drift from the workload', () => {
   assert.match(result.stderr, /case generic-fuzz:default metadata\.safety_class must match workload safety_class read_only/);
 });
 
+test('rejects runner-neutral fuzz intent that embeds command phases', () => {
+  const directory = createRigPackage({
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload({
+        cases: [
+          {
+            case_id: 'generic-fuzz:default',
+            phases: { action: [{ command: 'wordpress.run-workload' }] },
+            artifacts: [{ name: 'generic_report' }],
+            intent: {
+              schema: 'homeboy/fuzz-workload-intent/v1',
+              type: 'wordpress-plugin-workload',
+              plugin: { activation: 'generic/generic.php' },
+              execute: {
+                workload_ref: 'default',
+                path: '${package.root}/bench/generic.workload.json',
+                type: 'json',
+              },
+              collect: [{ artifact: 'generic_report' }],
+            },
+          },
+        ],
+      }),
+    },
+  });
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /runner-neutral case intent must not embed runner command phases/);
+});
+
 test('rejects missing fuzz workload backing files', () => {
   const directory = createRigPackage({
     fuzzWorkloads: {

--- a/woocommerce/woocommerce/fuzz/action-scheduler-lookup-table-coverage.json
+++ b/woocommerce/woocommerce/fuzz/action-scheduler-lookup-table-coverage.json
@@ -3,15 +3,115 @@
   "id": "action-scheduler-lookup-table-coverage",
   "label": "WooCommerce Action Scheduler and lookup table coverage",
   "safety_class": "read_only",
-  "surface_ids": ["woocommerce-action-scheduler", "woocommerce-lookup-tables", "woocommerce-database-tables"],
-  "operations": ["action-scheduler-delta", "lookup-table-inventory", "lookup-row-attribution"],
+  "surface_ids": [
+    "woocommerce-action-scheduler",
+    "woocommerce-lookup-tables",
+    "woocommerce-database-tables"
+  ],
+  "operations": [
+    "action-scheduler-delta",
+    "lookup-table-inventory",
+    "lookup-row-attribution"
+  ],
   "case_budget": 80,
   "duration_budget_seconds": 900,
-  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "workload_path": "${package.root}/bench/db-inventory.workload.json", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report", "fixture": { "runtime": "wp-codebox", "scope": "disposable-wordpress", "component": "woocommerce", "activation": "woocommerce/woocommerce.php" } },
-  "target": { "type": "wordpress-plugin", "slug": "woocommerce", "component": "woocommerce" },
-  "workload": { "runner": "wp-codebox", "type": "json", "path": "${package.root}/bench/db-inventory.workload.json", "entry": "action-scheduler-lookup-table-coverage" },
-  "cases": [{ "case_id": "action-scheduler-lookup-table-coverage:default", "surface_ids": ["woocommerce-action-scheduler", "woocommerce-lookup-tables", "woocommerce-database-tables"], "operations": ["action-scheduler-delta", "lookup-table-inventory", "lookup-row-attribution"], "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=woocommerce/woocommerce.php"] }], "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/db-inventory.workload.json", "type=json", "surface=woocommerce-action-scheduler-lookup-tables"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=action_scheduler_lookup_table_coverage"] }] }, "artifacts": [{ "name": "action_scheduler_lookup_table_coverage", "path": "action-scheduler-lookup-table-coverage/action_scheduler_lookup_table_coverage.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }], "metadata": { "safety_class": "read_only" } }],
-  "limits": { "max_cases": 80, "max_duration_seconds": 900 },
-  "coverage": { "surface_ids": ["woocommerce-action-scheduler", "woocommerce-lookup-tables", "woocommerce-database-tables"], "operations": ["action-scheduler-delta", "lookup-table-inventory", "lookup-row-attribution"] },
-  "artifacts": { "expected": [{ "name": "action_scheduler_lookup_table_coverage", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/db-inventory.workload.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report",
+    "fixture": {
+      "runtime": "wp-codebox",
+      "scope": "disposable-wordpress",
+      "component": "woocommerce",
+      "activation": "woocommerce/woocommerce.php"
+    }
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "json",
+    "path": "${package.root}/bench/db-inventory.workload.json",
+    "entry": "action-scheduler-lookup-table-coverage"
+  },
+  "cases": [
+    {
+      "case_id": "action-scheduler-lookup-table-coverage:default",
+      "surface_ids": [
+        "woocommerce-action-scheduler",
+        "woocommerce-lookup-tables",
+        "woocommerce-database-tables"
+      ],
+      "operations": [
+        "action-scheduler-delta",
+        "lookup-table-inventory",
+        "lookup-row-attribution"
+      ],
+      "artifacts": [
+        {
+          "name": "action_scheduler_lookup_table_coverage",
+          "path": "action-scheduler-lookup-table-coverage/action_scheduler_lookup_table_coverage.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "read_only"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/db-inventory.workload.json",
+          "type": "json",
+          "entry": "action-scheduler-lookup-table-coverage",
+          "parameters": {
+            "surface": "woocommerce-action-scheduler-lookup-tables"
+          }
+        },
+        "collect": [
+          {
+            "artifact": "action_scheduler_lookup_table_coverage"
+          }
+        ]
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 80,
+    "max_duration_seconds": 900
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-action-scheduler",
+      "woocommerce-lookup-tables",
+      "woocommerce-database-tables"
+    ],
+    "operations": [
+      "action-scheduler-delta",
+      "lookup-table-inventory",
+      "lookup-row-attribution"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "action_scheduler_lookup_table_coverage",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": false
+      }
+    ]
+  }
 }

--- a/woocommerce/woocommerce/fuzz/admin-page-coverage.json
+++ b/woocommerce/woocommerce/fuzz/admin-page-coverage.json
@@ -81,35 +81,6 @@
         "skipped-destructive-reason-classification",
         "query-attribution"
       ],
-      "phases": {
-        "setup": [
-          {
-            "command": "wordpress.ensure-plugin-active",
-            "args": [
-              "plugin=woocommerce/woocommerce.php"
-            ]
-          }
-        ],
-        "action": [
-          {
-            "command": "wordpress.fuzz-admin-pages",
-            "args": [
-              "safe_methods=GET",
-              "max_pages=80",
-              "enumerate_menus=true",
-              "classify_skips=true"
-            ]
-          }
-        ],
-        "assert": [
-          {
-            "command": "wordpress.collect-workload-result",
-            "args": [
-              "artifact=admin_page_coverage"
-            ]
-          }
-        ]
-      },
       "artifacts": [
         {
           "name": "admin_page_coverage",
@@ -133,6 +104,30 @@
       ],
       "metadata": {
         "safety_class": "read_only"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/admin-page-coverage.php",
+          "type": "php",
+          "entry": "admin-page-coverage",
+          "parameters": {
+            "safe_methods": "GET",
+            "max_pages": "80",
+            "enumerate_menus": "true",
+            "classify_skips": "true"
+          }
+        },
+        "collect": [
+          {
+            "artifact": "admin_page_coverage"
+          }
+        ]
       }
     }
   ],

--- a/woocommerce/woocommerce/fuzz/cart-session-overwrite-race.json
+++ b/woocommerce/woocommerce/fuzz/cart-session-overwrite-race.json
@@ -71,33 +71,6 @@
         "session-write-race",
         "cart-hash-guardrail"
       ],
-      "phases": {
-        "setup": [
-          {
-            "command": "wordpress.ensure-plugin-active",
-            "args": [
-              "plugin=woocommerce/woocommerce.php"
-            ]
-          }
-        ],
-        "action": [
-          {
-            "command": "wordpress.run-workload",
-            "args": [
-              "path=${package.root}/bench/cart-session-overwrite-race.php",
-              "type=php"
-            ]
-          }
-        ],
-        "assert": [
-          {
-            "command": "wordpress.collect-workload-result",
-            "args": [
-              "artifact=raw_result"
-            ]
-          }
-        ]
-      },
       "artifacts": [
         {
           "name": "raw_result",
@@ -110,6 +83,24 @@
       ],
       "metadata": {
         "safety_class": "isolated_mutation"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/cart-session-overwrite-race.php",
+          "type": "php",
+          "entry": "cart-session-overwrite-race"
+        },
+        "collect": [
+          {
+            "artifact": "raw_result"
+          }
+        ]
       }
     }
   ],

--- a/woocommerce/woocommerce/fuzz/checkout-concurrent-create-order.json
+++ b/woocommerce/woocommerce/fuzz/checkout-concurrent-create-order.json
@@ -86,33 +86,6 @@
         "concurrent-checkout-post",
         "session-side-effect-guardrails"
       ],
-      "phases": {
-        "setup": [
-          {
-            "command": "wordpress.ensure-plugin-active",
-            "args": [
-              "plugin=woocommerce/woocommerce.php"
-            ]
-          }
-        ],
-        "action": [
-          {
-            "command": "wordpress.run-workload",
-            "args": [
-              "path=${package.root}/bench/checkout-concurrent-create-order.php",
-              "type=php"
-            ]
-          }
-        ],
-        "assert": [
-          {
-            "command": "wordpress.collect-workload-result",
-            "args": [
-              "artifact=raw_result"
-            ]
-          }
-        ]
-      },
       "artifacts": [
         {
           "name": "raw_result",
@@ -125,6 +98,24 @@
       ],
       "metadata": {
         "safety_class": "isolated_mutation"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/checkout-concurrent-create-order.php",
+          "type": "php",
+          "entry": "checkout-concurrent-create-order"
+        },
+        "collect": [
+          {
+            "artifact": "raw_result"
+          }
+        ]
       }
     }
   ],

--- a/woocommerce/woocommerce/fuzz/checkout-gateway-compatibility-matrix.json
+++ b/woocommerce/woocommerce/fuzz/checkout-gateway-compatibility-matrix.json
@@ -76,33 +76,6 @@
         "idempotency-repro",
         "dependency-readiness-classification"
       ],
-      "phases": {
-        "setup": [
-          {
-            "command": "wordpress.ensure-plugin-active",
-            "args": [
-              "plugin=woocommerce/woocommerce.php"
-            ]
-          }
-        ],
-        "action": [
-          {
-            "command": "wordpress.run-workload",
-            "args": [
-              "path=${package.root}/bench/checkout-gateway-compatibility-matrix.php",
-              "type=php"
-            ]
-          }
-        ],
-        "assert": [
-          {
-            "command": "wordpress.collect-workload-result",
-            "args": [
-              "artifact=gateway_matrix"
-            ]
-          }
-        ]
-      },
       "artifacts": [
         {
           "name": "gateway_matrix",
@@ -115,6 +88,24 @@
       ],
       "metadata": {
         "safety_class": "isolated_mutation"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/checkout-gateway-compatibility-matrix.php",
+          "type": "php",
+          "entry": "checkout-gateway-compatibility-matrix"
+        },
+        "collect": [
+          {
+            "artifact": "gateway_matrix"
+          }
+        ]
       }
     }
   ],

--- a/woocommerce/woocommerce/fuzz/checkout-shipping-cache.json
+++ b/woocommerce/woocommerce/fuzz/checkout-shipping-cache.json
@@ -61,33 +61,6 @@
         "cache-key-churn",
         "real-input-rehash"
       ],
-      "phases": {
-        "setup": [
-          {
-            "command": "wordpress.ensure-plugin-active",
-            "args": [
-              "plugin=woocommerce/woocommerce.php"
-            ]
-          }
-        ],
-        "action": [
-          {
-            "command": "wordpress.run-workload",
-            "args": [
-              "path=${package.root}/bench/checkout-shipping-cache.php",
-              "type=php"
-            ]
-          }
-        ],
-        "assert": [
-          {
-            "command": "wordpress.collect-workload-result",
-            "args": [
-              "artifact=raw_result"
-            ]
-          }
-        ]
-      },
       "artifacts": [
         {
           "name": "raw_result",
@@ -100,6 +73,24 @@
       ],
       "metadata": {
         "safety_class": "isolated_mutation"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/checkout-shipping-cache.php",
+          "type": "php",
+          "entry": "checkout-shipping-cache"
+        },
+        "collect": [
+          {
+            "artifact": "raw_result"
+          }
+        ]
       }
     }
   ],

--- a/woocommerce/woocommerce/fuzz/db-inventory.json
+++ b/woocommerce/woocommerce/fuzz/db-inventory.json
@@ -59,33 +59,6 @@
         "table-inventory",
         "index-inventory"
       ],
-      "phases": {
-        "setup": [
-          {
-            "command": "wordpress.ensure-plugin-active",
-            "args": [
-              "plugin=woocommerce/woocommerce.php"
-            ]
-          }
-        ],
-        "action": [
-          {
-            "command": "wordpress.run-workload",
-            "args": [
-              "path=${package.root}/bench/db-inventory.workload.json",
-              "type=json"
-            ]
-          }
-        ],
-        "assert": [
-          {
-            "command": "wordpress.collect-workload-result",
-            "args": [
-              "artifact=db_inventory"
-            ]
-          }
-        ]
-      },
       "artifacts": [
         {
           "name": "db_inventory",
@@ -98,6 +71,24 @@
       ],
       "metadata": {
         "safety_class": "read_only"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/db-inventory.workload.json",
+          "type": "json",
+          "entry": "db-inventory"
+        },
+        "collect": [
+          {
+            "artifact": "db_inventory"
+          }
+        ]
       }
     }
   ],

--- a/woocommerce/woocommerce/fuzz/frontend-rendering-request-coverage.json
+++ b/woocommerce/woocommerce/fuzz/frontend-rendering-request-coverage.json
@@ -67,34 +67,6 @@
         "xhr-fetch-capture",
         "skipped-destructive-action-classification"
       ],
-      "phases": {
-        "setup": [
-          {
-            "command": "wordpress.ensure-plugin-active",
-            "args": [
-              "plugin=woocommerce/woocommerce.php"
-            ]
-          }
-        ],
-        "action": [
-          {
-            "command": "wordpress.run-workload",
-            "args": [
-              "path=${package.root}/bench/woocommerce-browser-coverage.trace.mjs",
-              "type=trace",
-              "surface=frontend"
-            ]
-          }
-        ],
-        "assert": [
-          {
-            "command": "wordpress.collect-workload-result",
-            "args": [
-              "artifact=frontend_rendering_request_coverage"
-            ]
-          }
-        ]
-      },
       "artifacts": [
         {
           "name": "frontend_rendering_request_coverage",
@@ -107,6 +79,27 @@
       ],
       "metadata": {
         "safety_class": "read_only"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/woocommerce-browser-coverage.trace.mjs",
+          "type": "json",
+          "entry": "frontend-rendering-request-coverage",
+          "parameters": {
+            "surface": "frontend"
+          }
+        },
+        "collect": [
+          {
+            "artifact": "frontend_rendering_request_coverage"
+          }
+        ]
       }
     }
   ],

--- a/woocommerce/woocommerce/fuzz/generated-rest-request-cases.json
+++ b/woocommerce/woocommerce/fuzz/generated-rest-request-cases.json
@@ -46,33 +46,6 @@
         "generated-rest-case-plan",
         "request-case-execution"
       ],
-      "phases": {
-        "setup": [
-          {
-            "command": "wordpress.ensure-plugin-active",
-            "args": [
-              "plugin=woocommerce/woocommerce.php"
-            ]
-          }
-        ],
-        "action": [
-          {
-            "command": "wordpress.run-workload",
-            "args": [
-              "path=${package.root}/bench/generated-rest-request-cases.workload.json",
-              "type=json"
-            ]
-          }
-        ],
-        "assert": [
-          {
-            "command": "wordpress.collect-workload-result",
-            "args": [
-              "artifact=rest_request_cases"
-            ]
-          }
-        ]
-      },
       "artifacts": [
         {
           "name": "rest_request_cases",
@@ -85,6 +58,24 @@
       ],
       "metadata": {
         "safety_class": "isolated_mutation"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/generated-rest-request-cases.workload.json",
+          "type": "json",
+          "entry": "generated-rest-request-cases"
+        },
+        "collect": [
+          {
+            "artifact": "rest_request_cases"
+          }
+        ]
       }
     }
   ],

--- a/woocommerce/woocommerce/fuzz/layered-nav-catalog-crawl.json
+++ b/woocommerce/woocommerce/fuzz/layered-nav-catalog-crawl.json
@@ -48,33 +48,6 @@
         "facet-url-crawl",
         "transient-entry-cap-guardrail"
       ],
-      "phases": {
-        "setup": [
-          {
-            "command": "wordpress.ensure-plugin-active",
-            "args": [
-              "plugin=woocommerce/woocommerce.php"
-            ]
-          }
-        ],
-        "action": [
-          {
-            "command": "wordpress.run-workload",
-            "args": [
-              "path=${package.root}/bench/layered-nav-catalog-crawl.php",
-              "type=php"
-            ]
-          }
-        ],
-        "assert": [
-          {
-            "command": "wordpress.collect-workload-result",
-            "args": [
-              "artifact=raw_result"
-            ]
-          }
-        ]
-      },
       "artifacts": [
         {
           "name": "raw_result",
@@ -87,6 +60,24 @@
       ],
       "metadata": {
         "safety_class": "isolated_mutation"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/layered-nav-catalog-crawl.php",
+          "type": "php",
+          "entry": "layered-nav-catalog-crawl"
+        },
+        "collect": [
+          {
+            "artifact": "raw_result"
+          }
+        ]
       }
     }
   ],

--- a/woocommerce/woocommerce/fuzz/layered-nav-count-cache.json
+++ b/woocommerce/woocommerce/fuzz/layered-nav-count-cache.json
@@ -46,33 +46,6 @@
         "taxonomy-filter-count-cache",
         "transient-entry-cap-guardrail"
       ],
-      "phases": {
-        "setup": [
-          {
-            "command": "wordpress.ensure-plugin-active",
-            "args": [
-              "plugin=woocommerce/woocommerce.php"
-            ]
-          }
-        ],
-        "action": [
-          {
-            "command": "wordpress.run-workload",
-            "args": [
-              "path=${package.root}/bench/layered-nav-count-cache.php",
-              "type=php"
-            ]
-          }
-        ],
-        "assert": [
-          {
-            "command": "wordpress.collect-workload-result",
-            "args": [
-              "artifact=raw_result"
-            ]
-          }
-        ]
-      },
       "artifacts": [
         {
           "name": "raw_result",
@@ -85,6 +58,24 @@
       ],
       "metadata": {
         "safety_class": "isolated_mutation"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/layered-nav-count-cache.php",
+          "type": "php",
+          "entry": "layered-nav-count-cache"
+        },
+        "collect": [
+          {
+            "artifact": "raw_result"
+          }
+        ]
       }
     }
   ],

--- a/woocommerce/woocommerce/fuzz/options-transients-coverage.json
+++ b/woocommerce/woocommerce/fuzz/options-transients-coverage.json
@@ -56,34 +56,6 @@
         "action-scheduler-delta",
         "rollback-safe-option-mutation"
       ],
-      "phases": {
-        "setup": [
-          {
-            "command": "wordpress.ensure-plugin-active",
-            "args": [
-              "plugin=woocommerce/woocommerce.php"
-            ]
-          }
-        ],
-        "action": [
-          {
-            "command": "wordpress.run-workload",
-            "args": [
-              "path=${package.root}/bench/db-inventory.workload.json",
-              "type=json",
-              "surface=woocommerce-options-transients"
-            ]
-          }
-        ],
-        "assert": [
-          {
-            "command": "wordpress.collect-workload-result",
-            "args": [
-              "artifact=options_transients_coverage"
-            ]
-          }
-        ]
-      },
       "artifacts": [
         {
           "name": "options_transients_coverage",
@@ -96,6 +68,27 @@
       ],
       "metadata": {
         "safety_class": "isolated_mutation"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/db-inventory.workload.json",
+          "type": "json",
+          "entry": "options-transients-coverage",
+          "parameters": {
+            "surface": "woocommerce-options-transients"
+          }
+        },
+        "collect": [
+          {
+            "artifact": "options_transients_coverage"
+          }
+        ]
       }
     }
   ],

--- a/woocommerce/woocommerce/fuzz/performance-hotspots-artifact-summary.json
+++ b/woocommerce/woocommerce/fuzz/performance-hotspots-artifact-summary.json
@@ -62,34 +62,6 @@
         "gateway-compatibility-summary",
         "external-http-guardrail-summary"
       ],
-      "phases": {
-        "setup": [
-          {
-            "command": "wordpress.ensure-plugin-active",
-            "args": [
-              "plugin=woocommerce/woocommerce.php"
-            ]
-          }
-        ],
-        "action": [
-          {
-            "command": "wordpress.run-workload",
-            "args": [
-              "path=${package.root}/bench/rest-db-query-profile.workload.json",
-              "type=json",
-              "surface=woocommerce-performance-hotspots"
-            ]
-          }
-        ],
-        "assert": [
-          {
-            "command": "wordpress.collect-workload-result",
-            "args": [
-              "artifact=performance_hotspots_summary"
-            ]
-          }
-        ]
-      },
       "artifacts": [
         {
           "name": "performance_hotspots_summary",
@@ -102,6 +74,27 @@
       ],
       "metadata": {
         "safety_class": "isolated_mutation"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/rest-db-query-profile.workload.json",
+          "type": "json",
+          "entry": "performance-hotspots-artifact-summary",
+          "parameters": {
+            "surface": "woocommerce-performance-hotspots"
+          }
+        },
+        "collect": [
+          {
+            "artifact": "performance_hotspots_summary"
+          }
+        ]
       }
     }
   ],

--- a/woocommerce/woocommerce/fuzz/rest-db-query-profile.json
+++ b/woocommerce/woocommerce/fuzz/rest-db-query-profile.json
@@ -48,33 +48,6 @@
         "rest-query-profile",
         "query-shape-attribution"
       ],
-      "phases": {
-        "setup": [
-          {
-            "command": "wordpress.ensure-plugin-active",
-            "args": [
-              "plugin=woocommerce/woocommerce.php"
-            ]
-          }
-        ],
-        "action": [
-          {
-            "command": "wordpress.run-workload",
-            "args": [
-              "path=${package.root}/bench/rest-db-query-profile.workload.json",
-              "type=json"
-            ]
-          }
-        ],
-        "assert": [
-          {
-            "command": "wordpress.collect-workload-result",
-            "args": [
-              "artifact=rest_db_query_profile"
-            ]
-          }
-        ]
-      },
       "artifacts": [
         {
           "name": "rest_db_query_profile",
@@ -87,6 +60,24 @@
       ],
       "metadata": {
         "safety_class": "read_only"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/rest-db-query-profile.workload.json",
+          "type": "json",
+          "entry": "rest-db-query-profile"
+        },
+        "collect": [
+          {
+            "artifact": "rest_db_query_profile"
+          }
+        ]
       }
     }
   ],

--- a/woocommerce/woocommerce/fuzz/rest-namespace-generated-cases.json
+++ b/woocommerce/woocommerce/fuzz/rest-namespace-generated-cases.json
@@ -3,15 +3,118 @@
   "id": "rest-namespace-generated-cases",
   "label": "WooCommerce REST namespace generated case coverage",
   "safety_class": "read_only",
-  "surface_ids": ["woocommerce-rest-routes", "woocommerce-store-api", "woocommerce-admin-api", "woocommerce-analytics-api"],
-  "operations": ["namespace-classification", "generated-safe-get-cases", "route-gap-attribution"],
+  "surface_ids": [
+    "woocommerce-rest-routes",
+    "woocommerce-store-api",
+    "woocommerce-admin-api",
+    "woocommerce-analytics-api"
+  ],
+  "operations": [
+    "namespace-classification",
+    "generated-safe-get-cases",
+    "route-gap-attribution"
+  ],
   "case_budget": 240,
   "duration_budget_seconds": 1200,
-  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "workload_path": "${package.root}/bench/generated-rest-request-cases.workload.json", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report", "fixture": { "runtime": "wp-codebox", "scope": "disposable-wordpress", "component": "woocommerce", "activation": "woocommerce/woocommerce.php" } },
-  "target": { "type": "wordpress-plugin", "slug": "woocommerce", "component": "woocommerce" },
-  "workload": { "runner": "wp-codebox", "type": "json", "path": "${package.root}/bench/generated-rest-request-cases.workload.json", "entry": "rest-namespace-generated-cases" },
-  "cases": [{ "case_id": "rest-namespace-generated-cases:default", "surface_ids": ["woocommerce-rest-routes", "woocommerce-store-api", "woocommerce-admin-api", "woocommerce-analytics-api"], "operations": ["namespace-classification", "generated-safe-get-cases", "route-gap-attribution"], "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=woocommerce/woocommerce.php"] }], "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/generated-rest-request-cases.workload.json", "type=json", "surface=woocommerce-rest-namespaces"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=rest_namespace_generated_cases"] }] }, "artifacts": [{ "name": "rest_namespace_generated_cases", "path": "rest-namespace-generated-cases/rest_namespace_generated_cases.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }], "metadata": { "safety_class": "read_only" } }],
-  "limits": { "max_cases": 240, "max_duration_seconds": 1200 },
-  "coverage": { "surface_ids": ["woocommerce-rest-routes", "woocommerce-store-api", "woocommerce-admin-api", "woocommerce-analytics-api"], "operations": ["namespace-classification", "generated-safe-get-cases", "route-gap-attribution"] },
-  "artifacts": { "expected": [{ "name": "rest_namespace_generated_cases", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/generated-rest-request-cases.workload.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report",
+    "fixture": {
+      "runtime": "wp-codebox",
+      "scope": "disposable-wordpress",
+      "component": "woocommerce",
+      "activation": "woocommerce/woocommerce.php"
+    }
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "json",
+    "path": "${package.root}/bench/generated-rest-request-cases.workload.json",
+    "entry": "rest-namespace-generated-cases"
+  },
+  "cases": [
+    {
+      "case_id": "rest-namespace-generated-cases:default",
+      "surface_ids": [
+        "woocommerce-rest-routes",
+        "woocommerce-store-api",
+        "woocommerce-admin-api",
+        "woocommerce-analytics-api"
+      ],
+      "operations": [
+        "namespace-classification",
+        "generated-safe-get-cases",
+        "route-gap-attribution"
+      ],
+      "artifacts": [
+        {
+          "name": "rest_namespace_generated_cases",
+          "path": "rest-namespace-generated-cases/rest_namespace_generated_cases.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "read_only"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/generated-rest-request-cases.workload.json",
+          "type": "json",
+          "entry": "rest-namespace-generated-cases",
+          "parameters": {
+            "surface": "woocommerce-rest-namespaces"
+          }
+        },
+        "collect": [
+          {
+            "artifact": "rest_namespace_generated_cases"
+          }
+        ]
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 240,
+    "max_duration_seconds": 1200
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-rest-routes",
+      "woocommerce-store-api",
+      "woocommerce-admin-api",
+      "woocommerce-analytics-api"
+    ],
+    "operations": [
+      "namespace-classification",
+      "generated-safe-get-cases",
+      "route-gap-attribution"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "rest_namespace_generated_cases",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": false
+      }
+    ]
+  }
 }

--- a/woocommerce/woocommerce/fuzz/rest-permission-boundary-matrix.json
+++ b/woocommerce/woocommerce/fuzz/rest-permission-boundary-matrix.json
@@ -3,15 +3,118 @@
   "id": "rest-permission-boundary-matrix",
   "label": "WooCommerce REST permission boundary matrix",
   "safety_class": "read_only",
-  "surface_ids": ["woocommerce-rest-routes", "woocommerce-store-api", "woocommerce-admin-api", "wordpress-permissions"],
-  "operations": ["namespace-inventory", "role-boundary-classification", "status-contract-attribution"],
+  "surface_ids": [
+    "woocommerce-rest-routes",
+    "woocommerce-store-api",
+    "woocommerce-admin-api",
+    "wordpress-permissions"
+  ],
+  "operations": [
+    "namespace-inventory",
+    "role-boundary-classification",
+    "status-contract-attribution"
+  ],
   "case_budget": 240,
   "duration_budget_seconds": 1200,
-  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "workload_path": "${package.root}/bench/generated-rest-request-cases.workload.json", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report", "fixture": { "runtime": "wp-codebox", "scope": "disposable-wordpress", "component": "woocommerce", "activation": "woocommerce/woocommerce.php" } },
-  "target": { "type": "wordpress-plugin", "slug": "woocommerce", "component": "woocommerce" },
-  "workload": { "runner": "wp-codebox", "type": "json", "path": "${package.root}/bench/generated-rest-request-cases.workload.json", "entry": "rest-permission-boundary-matrix" },
-  "cases": [{ "case_id": "rest-permission-boundary-matrix:default", "surface_ids": ["woocommerce-rest-routes", "woocommerce-store-api", "woocommerce-admin-api", "wordpress-permissions"], "operations": ["namespace-inventory", "role-boundary-classification", "status-contract-attribution"], "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=woocommerce/woocommerce.php"] }], "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/generated-rest-request-cases.workload.json", "type=json", "surface=woocommerce-permission-boundaries"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=rest_permission_boundary_matrix"] }] }, "artifacts": [{ "name": "rest_permission_boundary_matrix", "path": "rest-permission-boundary-matrix/rest_permission_boundary_matrix.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }], "metadata": { "safety_class": "read_only" } }],
-  "limits": { "max_cases": 240, "max_duration_seconds": 1200 },
-  "coverage": { "surface_ids": ["woocommerce-rest-routes", "woocommerce-store-api", "woocommerce-admin-api", "wordpress-permissions"], "operations": ["namespace-inventory", "role-boundary-classification", "status-contract-attribution"] },
-  "artifacts": { "expected": [{ "name": "rest_permission_boundary_matrix", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/generated-rest-request-cases.workload.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report",
+    "fixture": {
+      "runtime": "wp-codebox",
+      "scope": "disposable-wordpress",
+      "component": "woocommerce",
+      "activation": "woocommerce/woocommerce.php"
+    }
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "json",
+    "path": "${package.root}/bench/generated-rest-request-cases.workload.json",
+    "entry": "rest-permission-boundary-matrix"
+  },
+  "cases": [
+    {
+      "case_id": "rest-permission-boundary-matrix:default",
+      "surface_ids": [
+        "woocommerce-rest-routes",
+        "woocommerce-store-api",
+        "woocommerce-admin-api",
+        "wordpress-permissions"
+      ],
+      "operations": [
+        "namespace-inventory",
+        "role-boundary-classification",
+        "status-contract-attribution"
+      ],
+      "artifacts": [
+        {
+          "name": "rest_permission_boundary_matrix",
+          "path": "rest-permission-boundary-matrix/rest_permission_boundary_matrix.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "read_only"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/generated-rest-request-cases.workload.json",
+          "type": "json",
+          "entry": "rest-permission-boundary-matrix",
+          "parameters": {
+            "surface": "woocommerce-permission-boundaries"
+          }
+        },
+        "collect": [
+          {
+            "artifact": "rest_permission_boundary_matrix"
+          }
+        ]
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 240,
+    "max_duration_seconds": 1200
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-rest-routes",
+      "woocommerce-store-api",
+      "woocommerce-admin-api",
+      "wordpress-permissions"
+    ],
+    "operations": [
+      "namespace-inventory",
+      "role-boundary-classification",
+      "status-contract-attribution"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "rest_permission_boundary_matrix",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": false
+      }
+    ]
+  }
 }

--- a/woocommerce/woocommerce/fuzz/rest-schema-query-attribution.json
+++ b/woocommerce/woocommerce/fuzz/rest-schema-query-attribution.json
@@ -3,15 +3,115 @@
   "id": "rest-schema-query-attribution",
   "label": "WooCommerce REST schema and query attribution",
   "safety_class": "read_only",
-  "surface_ids": ["woocommerce-rest-routes", "woocommerce-database-queries", "woocommerce-rest-schema"],
-  "operations": ["rest-schema-attribution", "query-shape-attribution", "route-to-table-attribution"],
+  "surface_ids": [
+    "woocommerce-rest-routes",
+    "woocommerce-database-queries",
+    "woocommerce-rest-schema"
+  ],
+  "operations": [
+    "rest-schema-attribution",
+    "query-shape-attribution",
+    "route-to-table-attribution"
+  ],
   "case_budget": 120,
   "duration_budget_seconds": 1200,
-  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "workload_path": "${package.root}/bench/rest-db-query-profile.workload.json", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report", "fixture": { "runtime": "wp-codebox", "scope": "disposable-wordpress", "component": "woocommerce", "activation": "woocommerce/woocommerce.php" } },
-  "target": { "type": "wordpress-plugin", "slug": "woocommerce", "component": "woocommerce" },
-  "workload": { "runner": "wp-codebox", "type": "json", "path": "${package.root}/bench/rest-db-query-profile.workload.json", "entry": "rest-schema-query-attribution" },
-  "cases": [{ "case_id": "rest-schema-query-attribution:default", "surface_ids": ["woocommerce-rest-routes", "woocommerce-database-queries", "woocommerce-rest-schema"], "operations": ["rest-schema-attribution", "query-shape-attribution", "route-to-table-attribution"], "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=woocommerce/woocommerce.php"] }], "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/rest-db-query-profile.workload.json", "type=json", "surface=woocommerce-rest-schema-query-attribution"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=rest_schema_query_attribution"] }] }, "artifacts": [{ "name": "rest_schema_query_attribution", "path": "rest-schema-query-attribution/rest_schema_query_attribution.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }], "metadata": { "safety_class": "read_only" } }],
-  "limits": { "max_cases": 120, "max_duration_seconds": 1200 },
-  "coverage": { "surface_ids": ["woocommerce-rest-routes", "woocommerce-database-queries", "woocommerce-rest-schema"], "operations": ["rest-schema-attribution", "query-shape-attribution", "route-to-table-attribution"] },
-  "artifacts": { "expected": [{ "name": "rest_schema_query_attribution", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/rest-db-query-profile.workload.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report",
+    "fixture": {
+      "runtime": "wp-codebox",
+      "scope": "disposable-wordpress",
+      "component": "woocommerce",
+      "activation": "woocommerce/woocommerce.php"
+    }
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "json",
+    "path": "${package.root}/bench/rest-db-query-profile.workload.json",
+    "entry": "rest-schema-query-attribution"
+  },
+  "cases": [
+    {
+      "case_id": "rest-schema-query-attribution:default",
+      "surface_ids": [
+        "woocommerce-rest-routes",
+        "woocommerce-database-queries",
+        "woocommerce-rest-schema"
+      ],
+      "operations": [
+        "rest-schema-attribution",
+        "query-shape-attribution",
+        "route-to-table-attribution"
+      ],
+      "artifacts": [
+        {
+          "name": "rest_schema_query_attribution",
+          "path": "rest-schema-query-attribution/rest_schema_query_attribution.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "read_only"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/rest-db-query-profile.workload.json",
+          "type": "json",
+          "entry": "rest-schema-query-attribution",
+          "parameters": {
+            "surface": "woocommerce-rest-schema-query-attribution"
+          }
+        },
+        "collect": [
+          {
+            "artifact": "rest_schema_query_attribution"
+          }
+        ]
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 120,
+    "max_duration_seconds": 1200
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-rest-routes",
+      "woocommerce-database-queries",
+      "woocommerce-rest-schema"
+    ],
+    "operations": [
+      "rest-schema-attribution",
+      "query-shape-attribution",
+      "route-to-table-attribution"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "rest_schema_query_attribution",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": false
+      }
+    ]
+  }
 }

--- a/woocommerce/woocommerce/fuzz/rollback-safe-options-transients-mutations.json
+++ b/woocommerce/woocommerce/fuzz/rollback-safe-options-transients-mutations.json
@@ -3,15 +3,140 @@
   "id": "rollback-safe-options-transients-mutations",
   "label": "WooCommerce rollback-safe option and transient mutations",
   "safety_class": "isolated_mutation",
-  "surface_ids": ["woocommerce-options", "woocommerce-transients", "wordpress-options"],
-  "operations": ["rollback-safe-option-mutation", "transient-growth-attribution", "skipped-sensitive-option-attribution"],
+  "surface_ids": [
+    "woocommerce-options",
+    "woocommerce-transients",
+    "wordpress-options"
+  ],
+  "operations": [
+    "rollback-safe-option-mutation",
+    "transient-growth-attribution",
+    "skipped-sensitive-option-attribution"
+  ],
   "case_budget": 80,
   "duration_budget_seconds": 900,
-  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "workload_path": "${package.root}/bench/db-inventory.workload.json", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report", "readiness": { "level": "executable", "coverage_contract": "WP Codebox can execute rollback-safe WooCommerce option/transient mutations and emit rollback, transient-growth, and skipped-sensitive-option artifacts before any proof claim.", "crud": { "create": { "level": "executable" }, "read": { "level": "executable" }, "update": { "level": "executable" }, "delete": { "level": "declared", "upstream_blocker": "Rollback-safe delete fixture primitives are required before delete cases can execute." } }, "mutation": { "safety_boundary": "Option and transient mutations are bounded to disposable WP Codebox fixtures and sensitive options are skipped by contract.", "rollback_artifacts": ["rollback_safe_options_transients_mutations"] } }, "fixture": { "runtime": "wp-codebox", "scope": "disposable-wordpress", "component": "woocommerce", "activation": "woocommerce/woocommerce.php" } },
-  "target": { "type": "wordpress-plugin", "slug": "woocommerce", "component": "woocommerce" },
-  "workload": { "runner": "wp-codebox", "type": "json", "path": "${package.root}/bench/db-inventory.workload.json", "entry": "rollback-safe-options-transients-mutations" },
-  "cases": [{ "case_id": "rollback-safe-options-transients-mutations:default", "surface_ids": ["woocommerce-options", "woocommerce-transients", "wordpress-options"], "operations": ["rollback-safe-option-mutation", "transient-growth-attribution", "skipped-sensitive-option-attribution"], "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=woocommerce/woocommerce.php"] }], "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/db-inventory.workload.json", "type=json", "surface=woocommerce-rollback-safe-options-transients"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=rollback_safe_options_transients_mutations"] }] }, "artifacts": [{ "name": "rollback_safe_options_transients_mutations", "path": "rollback-safe-options-transients-mutations/rollback_safe_options_transients_mutations.json", "required": true, "metadata": { "semantic_key": "fuzz.report" } }], "metadata": { "safety_class": "isolated_mutation" } }],
-  "limits": { "max_cases": 80, "max_duration_seconds": 900 },
-  "coverage": { "surface_ids": ["woocommerce-options", "woocommerce-transients", "wordpress-options"], "operations": ["rollback-safe-option-mutation", "transient-growth-attribution", "skipped-sensitive-option-attribution"] },
-  "artifacts": { "expected": [{ "name": "rollback_safe_options_transients_mutations", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": true }] }
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/db-inventory.workload.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report",
+    "readiness": {
+      "level": "executable",
+      "coverage_contract": "WP Codebox can execute rollback-safe WooCommerce option/transient mutations and emit rollback, transient-growth, and skipped-sensitive-option artifacts before any proof claim.",
+      "crud": {
+        "create": {
+          "level": "executable"
+        },
+        "read": {
+          "level": "executable"
+        },
+        "update": {
+          "level": "executable"
+        },
+        "delete": {
+          "level": "declared",
+          "upstream_blocker": "Rollback-safe delete fixture primitives are required before delete cases can execute."
+        }
+      },
+      "mutation": {
+        "safety_boundary": "Option and transient mutations are bounded to disposable WP Codebox fixtures and sensitive options are skipped by contract.",
+        "rollback_artifacts": [
+          "rollback_safe_options_transients_mutations"
+        ]
+      }
+    },
+    "fixture": {
+      "runtime": "wp-codebox",
+      "scope": "disposable-wordpress",
+      "component": "woocommerce",
+      "activation": "woocommerce/woocommerce.php"
+    }
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "json",
+    "path": "${package.root}/bench/db-inventory.workload.json",
+    "entry": "rollback-safe-options-transients-mutations"
+  },
+  "cases": [
+    {
+      "case_id": "rollback-safe-options-transients-mutations:default",
+      "surface_ids": [
+        "woocommerce-options",
+        "woocommerce-transients",
+        "wordpress-options"
+      ],
+      "operations": [
+        "rollback-safe-option-mutation",
+        "transient-growth-attribution",
+        "skipped-sensitive-option-attribution"
+      ],
+      "artifacts": [
+        {
+          "name": "rollback_safe_options_transients_mutations",
+          "path": "rollback-safe-options-transients-mutations/rollback_safe_options_transients_mutations.json",
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "isolated_mutation"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/db-inventory.workload.json",
+          "type": "json",
+          "entry": "rollback-safe-options-transients-mutations",
+          "parameters": {
+            "surface": "woocommerce-rollback-safe-options-transients"
+          }
+        },
+        "collect": [
+          {
+            "artifact": "rollback_safe_options_transients_mutations"
+          }
+        ]
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 80,
+    "max_duration_seconds": 900
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-options",
+      "woocommerce-transients",
+      "wordpress-options"
+    ],
+    "operations": [
+      "rollback-safe-option-mutation",
+      "transient-growth-attribution",
+      "skipped-sensitive-option-attribution"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "rollback_safe_options_transients_mutations",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": true
+      }
+    ]
+  }
 }

--- a/woocommerce/woocommerce/fuzz/woocommerce-external-http-guardrail.json
+++ b/woocommerce/woocommerce/fuzz/woocommerce-external-http-guardrail.json
@@ -46,33 +46,6 @@
         "external-http-blocklist-probe",
         "network-side-effect-classification"
       ],
-      "phases": {
-        "setup": [
-          {
-            "command": "wordpress.ensure-plugin-active",
-            "args": [
-              "plugin=woocommerce/woocommerce.php"
-            ]
-          }
-        ],
-        "action": [
-          {
-            "command": "wordpress.run-workload",
-            "args": [
-              "path=${package.root}/bench/woocommerce-external-http-guardrail.php",
-              "type=php"
-            ]
-          }
-        ],
-        "assert": [
-          {
-            "command": "wordpress.collect-workload-result",
-            "args": [
-              "artifact=external_http_guardrail"
-            ]
-          }
-        ]
-      },
       "artifacts": [
         {
           "name": "external_http_guardrail",
@@ -85,6 +58,24 @@
       ],
       "metadata": {
         "safety_class": "read_only"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/woocommerce-external-http-guardrail.php",
+          "type": "php",
+          "entry": "woocommerce-external-http-guardrail"
+        },
+        "collect": [
+          {
+            "artifact": "external_http_guardrail"
+          }
+        ]
       }
     }
   ],

--- a/woocommerce/woocommerce/fuzz/woocommerce-rest-route-inventory.json
+++ b/woocommerce/woocommerce/fuzz/woocommerce-rest-route-inventory.json
@@ -24,38 +24,17 @@
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report",
     "readiness": {
-      "level": "executable",
-      "coverage_contract": "WP Codebox can execute the WooCommerce REST route inventory and emit route and permission-boundary classification artifacts.",
-      "crud": {
-        "create": {
-          "level": "declared",
-          "upstream_blocker": "Safe REST mutation fixture primitives are required before create cases can execute."
-        },
-        "read": {
-          "level": "executable"
-        },
-        "update": {
-          "level": "declared",
-          "upstream_blocker": "Safe REST mutation fixture primitives are required before update cases can execute."
-        },
-        "delete": {
-          "level": "declared",
-          "upstream_blocker": "Rollback-safe delete fixtures are required before delete cases can execute."
-        }
-      }
+      "level": "declared",
+      "coverage_contract": "REST route inventory should be supplied by a generic WordPress route inventory primitive, with WooCommerce contributing namespaces and artifact expectations.",
+      "upstream_blockers": [
+        "Expose an artifact-compatible generic REST route inventory command before replacing the WooCommerce PHP workload."
+      ]
     },
     "fixture": {
       "runtime": "wp-codebox",
       "scope": "disposable-wordpress",
       "component": "woocommerce",
       "activation": "woocommerce/woocommerce.php"
-    },
-    "readiness": {
-      "level": "declared",
-      "coverage_contract": "REST route inventory should be supplied by a generic WordPress route inventory primitive, with WooCommerce contributing namespaces and artifact expectations.",
-      "upstream_blockers": [
-        "Expose an artifact-compatible generic REST route inventory command before replacing the WooCommerce PHP workload."
-      ]
     }
   },
   "target": {
@@ -80,33 +59,6 @@
         "route-discovery",
         "permission-boundary-classification"
       ],
-      "phases": {
-        "setup": [
-          {
-            "command": "wordpress.ensure-plugin-active",
-            "args": [
-              "plugin=woocommerce/woocommerce.php"
-            ]
-          }
-        ],
-        "action": [
-          {
-            "command": "wordpress.run-workload",
-            "args": [
-              "path=${package.root}/bench/woocommerce-rest-route-inventory.php",
-              "type=php"
-            ]
-          }
-        ],
-        "assert": [
-          {
-            "command": "wordpress.collect-workload-result",
-            "args": [
-              "artifact=route_inventory"
-            ]
-          }
-        ]
-      },
       "artifacts": [
         {
           "name": "route_inventory",
@@ -119,6 +71,24 @@
       ],
       "metadata": {
         "safety_class": "read_only"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/woocommerce-rest-route-inventory.php",
+          "type": "php",
+          "entry": "woocommerce-rest-route-inventory"
+        },
+        "collect": [
+          {
+            "artifact": "route_inventory"
+          }
+        ]
       }
     }
   ],

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -89,6 +89,7 @@ for (const { file, manifest } of fuzzManifests) {
     requireCaseArtifacts: false,
     requireExpectedArtifacts: false,
     requireExpectedArtifactSemanticKeys: true,
+    requireRunnerNeutralIntent: true,
   });
 
   assert.equal(manifest.metadata?.fixture?.runtime, 'wp-codebox', `${manifest.id} fixture runtime must be wp-codebox`);


### PR DESCRIPTION
## Summary
- Add homeboy/fuzz-workload-intent/v1 validation.
- Convert WooCommerce fuzz manifests away from embedded runner phase commands.
- Keep current WP Codebox compatibility isolated in workload runner metadata.

## Tests
- node --test scripts/fuzz-manifest-helpers.test.mjs scripts/lint-rig-packages.test.mjs
- node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
- node scripts/lint-rig-packages.mjs woocommerce/woocommerce
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing runner-neutral fuzz intent contracts, Woo manifest conversion, and validators.