### PR TITLE
Require proof bundle links for proven fuzz coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ proof references, and upstream primitive blockers. Use that metadata to declare
 what the rig can safely cover without adding product-specific fallback code for
 missing upstream fuzz primitives.
 
+`metadata.readiness.level: proven` is gated by proof-bundle linkage: reviewer-
+facing artifact refs, run IDs, gap reports, and required fuzz result artifact
+names. Keep rows at declared/executable until those links exist; local paths,
+localhost URLs, and optional artifacts are not proof.
+
 Reusable helper patterns live under `shared/`. The first shared web performance
 pattern is `shared/webperf/deferred-init-webperf.mjs`, which lets trace workloads
 mark feature-not-needed and feature-needed phases, count feature/third-party

--- a/WordPress/wordpress-develop/fuzz/hooks-cron-options.json
+++ b/WordPress/wordpress-develop/fuzz/hooks-cron-options.json
@@ -12,7 +12,14 @@
     "wordpress_runner": "wp-codebox",
     "coverage_manifest": "${package.root}/manifests/hooks-cron-options.json",
     "expected_artifact_role": "fuzz_report",
-    "expected_artifact_semantic_key": "fuzz.report"
+    "expected_artifact_semantic_key": "fuzz.report",
+    "readiness": {
+      "level": "executable",
+      "coverage_contract": "WordPress Core hook, cron, option, transient, postmeta, and rewrite inventories can run through the declared WP Codebox fuzz workload and emit required runtime-state artifacts before any proof claim.",
+      "upstream_blockers": [
+        "Reviewer-facing run artifacts, gap reports, and durable fuzz result artifact refs are required before this row can move to proven."
+      ]
+    }
   },
   "target": { "type": "wordpress-core", "component": "wordpress-develop" },
   "workload": { "runner": "wp-codebox", "type": "declarative", "path": "${package.root}/manifests/hooks-cron-options.json", "entry": "hooks-cron-options" },

--- a/WordPress/wordpress-develop/tools/validate-fuzz-manifests.mjs
+++ b/WordPress/wordpress-develop/tools/validate-fuzz-manifests.mjs
@@ -2,7 +2,7 @@
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { declaredFuzzIds, readJson } from '../../../scripts/fuzz-manifest-helpers.mjs';
+import { assertFuzzReadinessMetadata, declaredFuzzIds, readJson } from '../../../scripts/fuzz-manifest-helpers.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
@@ -22,6 +22,7 @@ for (const id of ['hooks-cron-options', 'performance-surfaces']) {
 }
 
 assert.equal(hooksWorkload.workload?.path, '${package.root}/manifests/hooks-cron-options.json', 'hooks workload must use the runtime-state coverage manifest');
+assertFuzzReadinessMetadata(hooksWorkload, { file: 'hooks-cron-options.json' });
 assert.deepEqual(hooksWorkload.coverage?.surface_ids, hooksWorkload.surface_ids, 'hooks coverage surface ids drifted');
 assert.deepEqual(hooksWorkload.coverage?.operations, hooksWorkload.operations, 'hooks coverage operations drifted');
 assert.equal(hooksWorkload.limits?.max_cases, hooksWorkload.case_budget, 'hooks max_cases must match case_budget');
@@ -39,6 +40,7 @@ for (const kind of ['hooks', 'cron', 'options', 'transients', 'rewrite_rules']) 
 }
 
 assert.deepEqual(performanceWorkload.coverage?.surface_ids, performanceWorkload.surface_ids, 'performance coverage surface ids drifted');
+assertFuzzReadinessMetadata(performanceWorkload, { file: 'performance-surfaces.json' });
 assert.deepEqual(performanceWorkload.coverage?.operations, performanceWorkload.operations, 'performance coverage operations drifted');
 assert.equal(performanceWorkload.limits?.max_cases, performanceWorkload.case_budget, 'performance max_cases must match case_budget');
 assert.equal(performanceWorkload.artifacts?.expected?.[0]?.required, true, 'performance summary artifact must be required');

--- a/docs/fuzz-coverage-matrix.md
+++ b/docs/fuzz-coverage-matrix.md
@@ -5,16 +5,16 @@ WordPress Core, Gutenberg, and Jetpack. It separates three levels of confidence:
 
 - **Declared**: the repo names the surface in a manifest, scenario file, or rig profile.
 - **Executable**: the repo contains a workload or trace file plus a rig/profile path that can run it.
-- **Proven**: the repo links the workload to reviewer-facing bug evidence, PR evidence, or a documented artifact contract. A full-surface proof bundle is not committed here.
+- **Proven**: the repo links the workload to reviewer-facing bug evidence, PR evidence, run IDs, gap reports, and required fuzz result artifacts. A full-surface proof bundle is not committed here.
 
 Status key: `D` declared, `E` executable, `P` proven, `Partial` covered by narrower workloads only, `Pending` waiting on another minion/upstream PR, `Gap` not yet represented beyond generic template guidance.
 
 This page is an inventory and coverage contract, not a proof bundle. Product
 manifest skeletons can move a row to `D` or `D/E` when they name the surface,
 wire it to a rig/profile, and declare the expected artifact shape. A row moves
-to `P` only when reviewer-facing run artifacts, bug evidence, or PR evidence are
-linked from the package docs; no full-surface product row is proven by this
-matrix alone.
+to `P` only when `metadata.readiness.proof_bundle` links reviewer-facing proof
+artifact refs, run IDs, gap reports, and required fuzz result artifacts; no
+full-surface product row is proven by this matrix alone.
 
 Product manifest validators share generic workload-shape, rig-linkage, and
 bench/fuzz separation checks through `scripts/fuzz-manifest-helpers.mjs`.
@@ -26,15 +26,19 @@ explicit fuzz-readiness contract without claiming proof. `metadata.readiness`
 uses `level: declared|executable|proven`, a `coverage_contract` string,
 optional `proof_refs`, optional `upstream_blockers`, optional CRUD operation
 levels for `create`, `read`, `update`, and `delete`, and optional mutation
-rollback fields (`safety_boundary`, `rollback_artifacts`). Product packages can
-use this shared shape to distinguish planned CRUD/mutation coverage from
-executable workloads and reviewer-facing proof artifacts.
+rollback fields (`safety_boundary`, `rollback_artifacts`). `level: proven`
+requires a `proof_bundle` with non-local `artifact_refs`, reviewer-facing
+`run_ids`, `gap_reports`, and `fuzz_result_artifacts` that name required case or
+expected artifacts. Product packages can use this shared shape to distinguish
+planned CRUD/mutation coverage from executable workloads and reviewer-facing
+proof artifacts.
 
 The repo-wide package linter reports missing `metadata.readiness` on fuzz
 manifests as a warning. Use `node scripts/lint-rig-packages.mjs
 --strict-fuzz-readiness` when a package is ready to make readiness metadata a
 hard gate. Manifests that opt into `level: proven` must keep their proof
-artifacts required so proof claims cannot silently pass with optional output.
+artifacts required and linked through the proof bundle so proof claims cannot
+silently pass with optional output or local-only evidence.
 
 ## Summary
 

--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 export const fuzzReadinessLevels = new Set(['declared', 'executable', 'proven']);
 export const fuzzCrudOperations = new Set(['create', 'read', 'update', 'delete']);
+export const fuzzProofBundleFields = new Set(['artifact_refs', 'run_ids', 'gap_reports', 'fuzz_result_artifacts']);
 
 export function readJson(root, ...parts) {
   return JSON.parse(readFileSync(path.join(root, ...parts), 'utf8'));
@@ -131,6 +132,7 @@ export function assertFuzzReadinessMetadata(manifest, { file = manifest.id } = {
 
   if (readiness.level === 'proven') {
     assert.ok(Array.isArray(readiness.proof_refs) && readiness.proof_refs.length > 0, `${file} proven readiness requires proof_refs`);
+    assertFuzzProofBundle(readiness.proof_bundle, manifest, { file });
   }
 
   if (readiness.upstream_blockers !== undefined) {
@@ -148,6 +150,46 @@ export function assertFuzzReadinessMetadata(manifest, { file = manifest.id } = {
   if (readiness.mutation !== undefined) {
     assertFuzzMutationReadiness(readiness.mutation, { file });
   }
+}
+
+export function assertFuzzProofBundle(proofBundle, manifest, { file } = {}) {
+  assert.ok(proofBundle && typeof proofBundle === 'object' && !Array.isArray(proofBundle), `${file} proven readiness requires proof_bundle`);
+
+  for (const field of fuzzProofBundleFields) {
+    assert.ok(Array.isArray(proofBundle[field]) && proofBundle[field].length > 0, `${file} metadata.readiness.proof_bundle.${field} must be a non-empty array`);
+    for (const value of proofBundle[field]) {
+      assert.equal(typeof value, 'string', `${file} metadata.readiness.proof_bundle.${field} entries must be strings`);
+      assert.notEqual(value.trim(), '', `${file} metadata.readiness.proof_bundle.${field} entries must be non-empty`);
+
+      if (field !== 'fuzz_result_artifacts') {
+        assertReviewerFacingRef(value, `${file} metadata.readiness.proof_bundle.${field}`);
+      }
+    }
+  }
+
+  const requiredArtifactNames = collectRequiredArtifactNames(manifest);
+  for (const artifactName of proofBundle.fuzz_result_artifacts) {
+    assert.ok(requiredArtifactNames.has(artifactName), `${file} proof_bundle.fuzz_result_artifacts ${artifactName} must name a required case or expected artifact`);
+  }
+}
+
+function collectRequiredArtifactNames(manifest) {
+  return new Set([
+    ...(manifest.cases || []).flatMap((runnerCase) => runnerCase.artifacts || []),
+    ...(manifest.artifacts?.expected || []),
+  ]
+    .filter((artifact) => artifact?.required === true)
+    .map((artifact) => artifact?.name)
+    .filter(Boolean));
+}
+
+function assertReviewerFacingRef(value, context) {
+  assert.ok(
+    /^(https:\/\/|gh:|homeboy-runs:|artifact:|run:)/.test(value),
+    `${context} entries must be reviewer-facing refs`
+  );
+  assert.ok(!/^(https?:\/\/)?(localhost|127\.0\.0\.1)([:/]|$)/.test(value), `${context} entries must not use local URLs`);
+  assert.ok(!value.startsWith('/Users/'), `${context} entries must not use local filesystem paths`);
 }
 
 export function assertFuzzCrudReadiness(crud, { file } = {}) {

--- a/scripts/fuzz-manifest-helpers.test.mjs
+++ b/scripts/fuzz-manifest-helpers.test.mjs
@@ -125,6 +125,25 @@ test('assertFuzzReadinessMetadata accepts declared CRUD and isolated mutation co
   }), { file: 'product-fuzz.json' }));
 });
 
+test('assertFuzzReadinessMetadata accepts proven readiness with proof bundle linkage', () => {
+  assert.doesNotThrow(() => assertFuzzReadinessMetadata(fuzzManifest({
+    metadata: {
+      workload_path: '${package.root}/bench/product.workload.json',
+      readiness: {
+        level: 'proven',
+        coverage_contract: 'Product API CRUD coverage with reviewer-facing fuzz run artifacts.',
+        proof_refs: ['https://github.com/example/product/issues/123'],
+        proof_bundle: {
+          artifact_refs: ['https://github.com/example/product/issues/123#issuecomment-456'],
+          run_ids: ['run:product-fuzz-proof'],
+          gap_reports: ['https://github.com/example/product/issues/124'],
+          fuzz_result_artifacts: ['report'],
+        },
+      },
+    },
+  }), { file: 'product-fuzz.json' }));
+});
+
 test('assertFuzzReadinessMetadata rejects proven readiness without proof refs', () => {
   assert.throws(
     () => assertFuzzReadinessMetadata(fuzzManifest({
@@ -137,6 +156,66 @@ test('assertFuzzReadinessMetadata rejects proven readiness without proof refs', 
       },
     }), { file: 'product-fuzz.json' }),
     /proven readiness requires proof_refs/
+  );
+});
+
+test('assertFuzzReadinessMetadata rejects proven readiness without proof bundle linkage', () => {
+  assert.throws(
+    () => assertFuzzReadinessMetadata(fuzzManifest({
+      metadata: {
+        workload_path: '${package.root}/bench/product.workload.json',
+        readiness: {
+          level: 'proven',
+          coverage_contract: 'Product API CRUD coverage.',
+          proof_refs: ['https://github.com/example/product/issues/123'],
+        },
+      },
+    }), { file: 'product-fuzz.json' }),
+    /proven readiness requires proof_bundle/
+  );
+});
+
+test('assertFuzzReadinessMetadata rejects local proof bundle refs', () => {
+  assert.throws(
+    () => assertFuzzReadinessMetadata(fuzzManifest({
+      metadata: {
+        workload_path: '${package.root}/bench/product.workload.json',
+        readiness: {
+          level: 'proven',
+          coverage_contract: 'Product API CRUD coverage.',
+          proof_refs: ['https://github.com/example/product/issues/123'],
+          proof_bundle: {
+            artifact_refs: ['https://localhost:8881/artifacts/product-fuzz'],
+            run_ids: ['run:product-fuzz-proof'],
+            gap_reports: ['https://github.com/example/product/issues/124'],
+            fuzz_result_artifacts: ['report'],
+          },
+        },
+      },
+    }), { file: 'product-fuzz.json' }),
+    /must not use local URLs/
+  );
+});
+
+test('assertFuzzReadinessMetadata rejects proof bundle artifacts that are not required outputs', () => {
+  assert.throws(
+    () => assertFuzzReadinessMetadata(fuzzManifest({
+      metadata: {
+        workload_path: '${package.root}/bench/product.workload.json',
+        readiness: {
+          level: 'proven',
+          coverage_contract: 'Product API CRUD coverage.',
+          proof_refs: ['https://github.com/example/product/issues/123'],
+          proof_bundle: {
+            artifact_refs: ['https://github.com/example/product/issues/123#issuecomment-456'],
+            run_ids: ['run:product-fuzz-proof'],
+            gap_reports: ['https://github.com/example/product/issues/124'],
+            fuzz_result_artifacts: ['missing-report'],
+          },
+        },
+      },
+    }), { file: 'product-fuzz.json' }),
+    /must name a required case or expected artifact/
   );
 });
 

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -216,6 +216,27 @@ test('rejects fuzz ids in bench workloads and profiles', () => {
   assert.match(result.stderr, /bench profile smoke references generic-fuzz, but that id belongs to a fuzz workload/);
 });
 
+test('rejects proven fuzz readiness without proof bundle linkage', () => {
+  const directory = createRigPackage({
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload({
+        metadata: {
+          kind: 'generic-fuzz',
+          readiness: {
+            level: 'proven',
+            coverage_contract: 'Generic fuzz coverage is proven.',
+            proof_refs: ['https://github.com/example/product/issues/123'],
+          },
+        },
+      }),
+    },
+  });
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /proven readiness requires proof_bundle/);
+});
+
 test('accepts package-root scoped lint for rigs and fuzz directories', () => {
   const directory = createRigPackage({
     fuzzWorkloads: {

--- a/woocommerce/woocommerce/fuzz/checkout-concurrent-create-order.json
+++ b/woocommerce/woocommerce/fuzz/checkout-concurrent-create-order.json
@@ -33,6 +33,21 @@
         "https://github.com/chubes4/homeboy-rigs/issues/253",
         "https://github.com/chubes4/homeboy-rigs/issues/254"
       ],
+      "proof_bundle": {
+        "artifact_refs": [
+          "https://github.com/chubes4/homeboy-rigs/issues/254"
+        ],
+        "run_ids": [
+          "run:wc-checkout-atomicity"
+        ],
+        "gap_reports": [
+          "https://github.com/chubes4/homeboy-rigs/issues/253",
+          "https://github.com/chubes4/homeboy-rigs/issues/254"
+        ],
+        "fuzz_result_artifacts": [
+          "raw_result"
+        ]
+      },
       "crud": {
         "create": {
           "level": "proven"

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -96,6 +96,12 @@ for (const { file, manifest } of fuzzManifests) {
   assert.equal(manifest.metadata?.fixture?.component, 'woocommerce', `${manifest.id} fixture component must be woocommerce`);
   assert.equal(manifest.metadata?.fixture?.activation, 'woocommerce/woocommerce.php', `${manifest.id} fixture activation must be woocommerce/woocommerce.php`);
 
+  if (manifest.metadata?.readiness?.level === 'proven') {
+    const proofBundle = manifest.metadata.readiness.proof_bundle;
+    assert.ok(proofBundle, `${manifest.id} proven readiness must link a proof bundle`);
+    assert.ok(proofBundle.run_ids.length > 0, `${manifest.id} proven readiness must link at least one run id`);
+  }
+
   const requiredContractIds = requiredProofContracts.get(manifest.id) || [];
   if (requiredContractIds.length > 0) {
     const proofContracts = manifest.proof_contracts || [];


### PR DESCRIPTION
## Summary
- Add proof-bundle validation for readiness level proven.
- Require reviewer-facing artifact refs, run IDs, gap reports, and fuzz result artifacts.
- Reject local-only proof refs and document D/E/P transition requirements.

## Tests
- node --test scripts/fuzz-manifest-helpers.test.mjs
- node --test scripts/lint-rig-packages.test.mjs
- node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
- node WordPress/gutenberg/tools/validate-fuzz-manifests.mjs
- node WordPress/wordpress-develop/tools/validate-fuzz-manifests.mjs
- node scripts/lint-rig-packages.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing proof-bundle validation, docs, readiness metadata, and tests.