### PR TITLE
Add Woo Codebox fuzz proof path

### DIFF
--- a/woocommerce/woocommerce/bench/codebox-fuzz-suite-smoke.workload.json
+++ b/woocommerce/woocommerce/bench/codebox-fuzz-suite-smoke.workload.json
@@ -1,0 +1,44 @@
+{
+  "schema": "wp-codebox/wordpress-workload-run/v1",
+  "wordpress_version": "latest",
+  "runtime_env": {
+    "WP_CODEBOX_PUBLIC_CONTRACT_PROOF": "schema-only"
+  },
+  "before": [
+    {
+      "command": "wordpress.ensure-plugin-active",
+      "args": [
+        "plugin=woocommerce/woocommerce.php"
+      ]
+    }
+  ],
+  "steps": [
+    {
+      "command": "wp-codebox/run-fuzz-suite",
+      "args": [
+        "suite=${package.root}/manifests/codebox-fuzz-suite-smoke.json"
+      ]
+    }
+  ],
+  "artifacts": [
+    {
+      "name": "codebox_fuzz_suite_result",
+      "path": "codebox-fuzz-suite-smoke/fuzz-suite-result.json",
+      "kind": "json",
+      "contentType": "application/json",
+      "required": false,
+      "metadata": {
+        "schema": "wp-codebox/fuzz-suite-result/v1",
+        "semantic_key": "fuzz.suite_result",
+        "proof_placeholder": true
+      }
+    }
+  ],
+  "metadata": {
+    "runner": "wp-codebox",
+    "workload": "codebox-fuzz-suite-smoke",
+    "contract": "wp-codebox/wordpress-workload-run/v1",
+    "fuzz_suite": "${package.root}/manifests/codebox-fuzz-suite-smoke.json",
+    "proof_status": "schema_only_placeholder"
+  }
+}

--- a/woocommerce/woocommerce/fuzz/codebox-fuzz-suite-smoke.json
+++ b/woocommerce/woocommerce/fuzz/codebox-fuzz-suite-smoke.json
@@ -1,0 +1,134 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "codebox-fuzz-suite-smoke",
+  "label": "Codebox public fuzz-suite smoke contract",
+  "safety_class": "read_only",
+  "surface_ids": [
+    "woocommerce-store-api",
+    "wp-codebox-public-fuzz-suite"
+  ],
+  "operations": [
+    "public-fuzz-suite-contract",
+    "run-wordpress-workload-contract",
+    "schema-only-proof-placeholder"
+  ],
+  "case_budget": 1,
+  "duration_budget_seconds": 60,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/codebox-fuzz-suite-smoke.workload.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.suite_result",
+    "public_codebox_contracts": [
+      "wp-codebox/fuzz-suite/v1",
+      "wp-codebox/wordpress-workload-run/v1",
+      "wp-codebox/fuzz-suite-result/v1"
+    ],
+    "readiness": {
+      "level": "declared",
+      "coverage_contract": "Schema-level smoke path for WooCommerce through public WP Codebox fuzz-suite and run-wordpress-workload contracts. This does not claim full-surface proof until a real fuzz-suite-result artifact is captured."
+    },
+    "fixture": {
+      "runtime": "wp-codebox",
+      "scope": "disposable-wordpress",
+      "component": "woocommerce",
+      "activation": "woocommerce/woocommerce.php",
+      "suite_manifest": "${package.root}/manifests/codebox-fuzz-suite-smoke.json"
+    }
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "json",
+    "path": "${package.root}/bench/codebox-fuzz-suite-smoke.workload.json",
+    "entry": "wp-codebox/run-fuzz-suite"
+  },
+  "cases": [
+    {
+      "case_id": "codebox-fuzz-suite-smoke:default",
+      "surface_ids": [
+        "woocommerce-store-api",
+        "wp-codebox-public-fuzz-suite"
+      ],
+      "operations": [
+        "public-fuzz-suite-contract",
+        "run-wordpress-workload-contract",
+        "schema-only-proof-placeholder"
+      ],
+      "phases": {
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=woocommerce/woocommerce.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.run-workload",
+            "args": [
+              "path=${package.root}/bench/codebox-fuzz-suite-smoke.workload.json",
+              "type=json"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=codebox_fuzz_suite_result"
+            ]
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "codebox_fuzz_suite_result",
+          "path": "codebox-fuzz-suite-smoke/fuzz-suite-result.json",
+          "required": false,
+          "metadata": {
+            "schema": "wp-codebox/fuzz-suite-result/v1",
+            "semantic_key": "fuzz.suite_result",
+            "proof_placeholder": true
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "read_only"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 1,
+    "max_duration_seconds": 60
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-store-api",
+      "wp-codebox-public-fuzz-suite"
+    ],
+    "operations": [
+      "public-fuzz-suite-contract",
+      "run-wordpress-workload-contract",
+      "schema-only-proof-placeholder"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "codebox_fuzz_suite_result",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.suite_result",
+        "schema": "wp-codebox/fuzz-suite-result/v1",
+        "required": false,
+        "proof_placeholder": true
+      }
+    ]
+  }
+}

--- a/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
+++ b/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
@@ -1,0 +1,35 @@
+{
+  "schema": "wp-codebox/fuzz-suite/v1",
+  "id": "woocommerce-codebox-fuzz-suite-smoke",
+  "version": "1.0.0",
+  "target": {
+    "kind": "rest",
+    "id": "woocommerce-store-api-cart",
+    "entrypoint": "/wc/store/v1/cart",
+    "label": "WooCommerce Store API cart read smoke",
+    "metadata": {
+      "component": "woocommerce",
+      "plugin": "woocommerce/woocommerce.php"
+    }
+  },
+  "cases": [
+    {
+      "id": "woocommerce-store-api-cart-read-only",
+      "description": "Schema-level public Codebox fuzz-suite smoke case for a read-only WooCommerce Store API route.",
+      "input": {
+        "method": "GET",
+        "path": "/wc/store/v1/cart",
+        "params": {}
+      },
+      "metadata": {
+        "safety_class": "read_only",
+        "proof_status": "placeholder"
+      }
+    }
+  ],
+  "metadata": {
+    "component": "woocommerce",
+    "contract": "wp-codebox/fuzz-suite/v1",
+    "proof_status": "schema_only_placeholder"
+  }
+}

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -90,6 +90,7 @@
       { "path": "${package.root}/fuzz/action-scheduler-lookup-table-coverage.json" },
       { "path": "${package.root}/fuzz/options-transients-coverage.json" },
       { "path": "${package.root}/fuzz/rollback-safe-options-transients-mutations.json" },
+      { "path": "${package.root}/fuzz/codebox-fuzz-suite-smoke.json" },
       { "path": "${package.root}/fuzz/frontend-rendering-request-coverage.json" },
       { "path": "${package.root}/fuzz/performance-hotspots-artifact-summary.json" },
       { "path": "${package.root}/fuzz/woocommerce-external-http-guardrail.json" }

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -23,6 +23,7 @@ const expectedFuzzIds = new Set([
   'checkout-concurrent-create-order',
   'checkout-gateway-compatibility-matrix',
   'checkout-shipping-cache',
+  'codebox-fuzz-suite-smoke',
   'db-inventory',
   'frontend-rendering-request-coverage',
   'generated-rest-request-cases',
@@ -53,7 +54,7 @@ const requiredProofContracts = new Map([
 
 const fuzzManifests = collectFuzzManifests(packageRoot);
 
-assert.equal(fuzzManifests.length, 20, 'expected 20 WooCommerce fuzz manifests');
+assert.equal(fuzzManifests.length, 21, 'expected 21 WooCommerce fuzz manifests');
 
 const declaredIds = declaredFuzzIds(rig);
 const benchWorkloadIds = declaredBenchWorkloadIds(rig);
@@ -135,6 +136,31 @@ for (const { file, manifest } of fuzzManifests) {
     );
   }
 }
+
+const codeboxSmokeManifest = fuzzManifests.find(({ manifest }) => manifest.id === 'codebox-fuzz-suite-smoke')?.manifest;
+assert.ok(codeboxSmokeManifest, 'codebox-fuzz-suite-smoke manifest is missing');
+assert.equal(codeboxSmokeManifest.metadata?.readiness?.level, 'declared', 'codebox smoke must not claim proven readiness without proof artifacts');
+assert.deepEqual(codeboxSmokeManifest.metadata?.public_codebox_contracts, [
+  'wp-codebox/fuzz-suite/v1',
+  'wp-codebox/wordpress-workload-run/v1',
+  'wp-codebox/fuzz-suite-result/v1',
+]);
+assert.equal(codeboxSmokeManifest.artifacts.expected[0]?.required, false, 'codebox smoke proof artifact is a placeholder until captured');
+assert.equal(codeboxSmokeManifest.artifacts.expected[0]?.proof_placeholder, true, 'codebox smoke expected artifact must be marked as a placeholder');
+
+const codeboxWorkloadRun = readJson(packageRoot, 'bench/codebox-fuzz-suite-smoke.workload.json');
+assert.equal(codeboxWorkloadRun.schema, 'wp-codebox/wordpress-workload-run/v1');
+assert.ok(codeboxWorkloadRun.before.some((step) => step.command === 'wordpress.ensure-plugin-active'), 'codebox workload must activate WooCommerce');
+assert.ok(codeboxWorkloadRun.steps.some((step) => step.command === 'wp-codebox/run-fuzz-suite'), 'codebox workload must route through public run-fuzz-suite ability');
+assert.equal(codeboxWorkloadRun.artifacts[0]?.metadata?.schema, 'wp-codebox/fuzz-suite-result/v1');
+assert.equal(codeboxWorkloadRun.artifacts[0]?.required, false, 'codebox workload proof artifact must remain optional until captured');
+
+const codeboxSuite = readJson(packageRoot, 'manifests/codebox-fuzz-suite-smoke.json');
+assert.equal(codeboxSuite.schema, 'wp-codebox/fuzz-suite/v1');
+assert.equal(codeboxSuite.target?.kind, 'rest');
+assert.equal(codeboxSuite.target?.entrypoint, '/wc/store/v1/cart');
+assert.equal(codeboxSuite.cases?.[0]?.input?.method, 'GET');
+assert.equal(codeboxSuite.cases?.[0]?.metadata?.proof_status, 'placeholder');
 
 const proofReadyContracts = {
   'rest-namespace-generated-cases': ['namespace-classification', 'generated-safe-get-cases', 'route-gap-attribution'],


### PR DESCRIPTION
## Summary
- Add declared Woo Codebox fuzz-suite smoke workload.
- Add public wp-codebox/fuzz-suite/v1 and wordpress-workload-run/v1 contract fixtures.
- Wire the smoke path into the Woo performance rig without claiming proven coverage.

## Tests
- node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
- node scripts/lint-rig-packages.mjs
- node --test scripts/fuzz-manifest-helpers.test.mjs scripts/lint-rig-packages.test.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing Woo Codebox fuzz proof path contracts, rig wiring, and validation.