### PR TITLE
Add Woo target inventory manifest

### DIFF
--- a/woocommerce/woocommerce/manifests/full-surface-coverage.json
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.json
@@ -9,8 +9,12 @@
     "wordpress-db-inventory",
     "wordpress-external-http-guardrail",
     "browser-request-coverage",
-    "wordpress-authenticated-admin-page-coverage"
+    "wordpress-authenticated-admin-page-coverage",
+    "wordpress-block-inventory",
+    "wordpress-options-transients-inventory",
+    "wordpress-performance-hotspots-summary"
   ],
+  "target_inventory_manifest": "manifests/target-inventory.json",
   "surfaces": {
     "rest_api": {
       "budget_manifest": "manifests/rest-route-budgets.json",

--- a/woocommerce/woocommerce/manifests/target-inventory.json
+++ b/woocommerce/woocommerce/manifests/target-inventory.json
@@ -1,0 +1,100 @@
+{
+  "schema": "homeboy-rigs/wordpress-target-inventory/v1",
+  "property": "woocommerce/woocommerce",
+  "generator": "tools/generate-target-inventory.mjs",
+  "description": "Generated WooCommerce target inventory contract for WP Codebox/Homeboy Extensions primitives and Woo-owned artifact expectations.",
+  "runtime": {
+    "runner": "wp-codebox",
+    "fixture_scope": "disposable-wordpress",
+    "component": "woocommerce",
+    "activation": "woocommerce/woocommerce.php"
+  },
+  "source_manifests": {
+    "full_surface": "manifests/full-surface-coverage.json",
+    "rig": "rigs/woocommerce-performance/rig.json"
+  },
+  "inventory_primitives": {
+    "rest_routes": {
+      "command": "wordpress.inventory-rest-routes",
+      "status": "preferred",
+      "artifact_schema": "homeboy/wordpress-rest-route-inventory/v1",
+      "workload_ids": ["woocommerce-rest-route-inventory", "generated-rest-request-cases", "rest-permission-boundary-matrix", "rest-namespace-generated-cases", "rest-schema-query-attribution"]
+    },
+    "admin_pages": {
+      "command": "wordpress.fuzz-admin-pages",
+      "status": "preferred",
+      "artifact_schema": "homeboy-rigs/woocommerce-admin-page-coverage/v1",
+      "workload_ids": ["admin-page-coverage"]
+    },
+    "frontend_pages": {
+      "command": "wordpress.trace-browser-coverage",
+      "status": "preferred",
+      "artifact_schema": "wp-codebox/browser-request-coverage/v1",
+      "workload_ids": ["frontend-rendering-request-coverage"]
+    },
+    "database": {
+      "command": "wordpress.inventory-database",
+      "status": "preferred",
+      "artifact_schema": "homeboy/wordpress-db-inventory/v1",
+      "workload_ids": ["db-inventory", "rest-db-query-profile", "rest-schema-query-attribution", "action-scheduler-lookup-table-coverage"]
+    },
+    "blocks": {
+      "command": "wordpress.inventory-blocks",
+      "status": "preferred",
+      "artifact_schema": "homeboy/wordpress-block-inventory/v1",
+      "workload_ids": ["frontend-rendering-request-coverage"]
+    },
+    "options_transients": {
+      "command": "wordpress.inventory-options-transients",
+      "status": "preferred",
+      "artifact_schema": "homeboy/woocommerce-options-transients-coverage/v1",
+      "workload_ids": ["options-transients-coverage", "action-scheduler-lookup-table-coverage", "rollback-safe-options-transients-mutations"]
+    },
+    "performance_hotspots": {
+      "command": "wordpress.summarize-performance-hotspots",
+      "status": "preferred",
+      "artifact_schema": "homeboy/woocommerce-performance-hotspots-summary/v1",
+      "workload_ids": ["performance-hotspots-artifact-summary"]
+    }
+  },
+  "targets": {
+    "rest_routes": {
+      "namespaces": ["wc/v1", "wc/v2", "wc/v3", "wc/store/v1", "wc/store/v2", "wc-admin", "wc-analytics"],
+      "required_sections": ["routes", "namespaces", "permission_boundaries", "generated_safe_get_cases", "query_attribution"],
+      "gap_report_sections": ["routes_without_generated_cases", "routes_without_permission_boundary_cases", "routes_without_query_attribution"]
+    },
+    "admin_pages": {
+      "sources": ["global $menu", "global $submenu"],
+      "roles": ["administrator", "shop_manager"],
+      "safe_methods": ["GET"],
+      "skip_reason_codes": ["creation_install_update_or_export_screen", "unsafe_query_arg_action", "unsafe_query_arg_action2", "unsafe_query_arg_delete", "unsafe_query_arg_trash", "unsafe_query_arg_untrash", "unsafe_query_arg_activate", "unsafe_query_arg_deactivate", "setup_or_onboarding_screen", "role_unavailable", "permission_boundary"],
+      "required_sections": ["contract", "targets", "visits", "skipped", "request_logs", "query_attribution", "metrics"]
+    },
+    "frontend_pages": {
+      "scenarios": ["shop", "product", "cart", "checkout", "orders_admin", "products_admin", "analytics_admin"],
+      "required_sections": ["pages", "requests", "assets", "xhr_fetch", "console", "errors", "skipped_destructive_actions"],
+      "gap_report_sections": ["pages_without_request_coverage", "scenarios_without_artifacts", "unexpected_failed_requests"]
+    },
+    "database": {
+      "table_prefixes": ["woocommerce_", "wc_", "actionscheduler_"],
+      "required_sections": ["tables", "columns", "indexes", "row_counts", "query_profiles"],
+      "query_attribution_fields": ["request_case_id", "route", "method", "query_type", "table", "stack_summary", "caller_summary"]
+    },
+    "blocks": {
+      "block_name_prefixes": ["woocommerce/"],
+      "frontend_contexts": ["shop", "product", "cart", "checkout"],
+      "required_sections": ["registered_blocks", "rendered_blocks", "block_assets", "block_rest_requests", "block_query_profiles"]
+    },
+    "options_transients": {
+      "option_prefixes": ["woocommerce_", "woocommerce-", "wc_", "_wc_", "_woocommerce_"],
+      "transient_prefixes": ["_transient_wc_", "_transient_timeout_wc_", "_site_transient_wc_", "_site_transient_timeout_wc_", "_transient_woocommerce_", "_transient_timeout_woocommerce_"],
+      "required_sections": ["options", "transients", "autoloaded_options", "action_scheduler", "lookup_tables", "rollback_mutations"]
+    },
+    "performance_hotspots": {
+      "workloads": ["performance-hotspots-artifact-summary"],
+      "focus_areas": ["checkout", "cart_session", "catalog_layered_navigation", "admin_dashboard", "rest_api", "cache_invalidation", "external_http"],
+      "required_sections": ["request_timing", "query_counts", "cache_invalidation", "transient_growth", "gateway_compatibility", "external_http_guardrail"]
+    }
+  },
+  "declared_fuzz_workloads": ["action-scheduler-lookup-table-coverage", "admin-page-coverage", "cart-session-overwrite-race", "checkout-concurrent-create-order", "checkout-gateway-compatibility-matrix", "checkout-shipping-cache", "db-inventory", "frontend-rendering-request-coverage", "generated-rest-request-cases", "layered-nav-catalog-crawl", "layered-nav-count-cache", "options-transients-coverage", "performance-hotspots-artifact-summary", "rest-db-query-profile", "rest-namespace-generated-cases", "rest-permission-boundary-matrix", "rest-schema-query-attribution", "rollback-safe-options-transients-mutations", "woocommerce-external-http-guardrail", "woocommerce-rest-route-inventory"]
+}

--- a/woocommerce/woocommerce/tools/generate-target-inventory.mjs
+++ b/woocommerce/woocommerce/tools/generate-target-inventory.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  declaredFuzzIds,
+  readJson,
+} from '../../../scripts/fuzz-manifest-helpers.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.join(__dirname, '..');
+
+const rig = readJson(packageRoot, 'rigs/woocommerce-performance/rig.json');
+const coverage = readJson(packageRoot, 'manifests/full-surface-coverage.json');
+
+const declaredWorkloads = [...declaredFuzzIds(rig)].sort();
+
+const inventory = {
+  schema: 'homeboy-rigs/wordpress-target-inventory/v1',
+  property: 'woocommerce/woocommerce',
+  generator: 'tools/generate-target-inventory.mjs',
+  description: 'Generated WooCommerce target inventory contract for WP Codebox/Homeboy Extensions primitives and Woo-owned artifact expectations.',
+  runtime: {
+    runner: 'wp-codebox',
+    fixture_scope: 'disposable-wordpress',
+    component: 'woocommerce',
+    activation: 'woocommerce/woocommerce.php',
+  },
+  source_manifests: {
+    full_surface: 'manifests/full-surface-coverage.json',
+    rig: 'rigs/woocommerce-performance/rig.json',
+  },
+  inventory_primitives: {
+    rest_routes: {
+      command: 'wordpress.inventory-rest-routes',
+      status: 'preferred',
+      artifact_schema: 'homeboy/wordpress-rest-route-inventory/v1',
+      workload_ids: coverage.coverage_profiles['full-surface'].rest_api,
+    },
+    admin_pages: {
+      command: 'wordpress.fuzz-admin-pages',
+      status: 'preferred',
+      artifact_schema: coverage.surfaces.authenticated_admin_pages.enumeration_contract.artifact_expectations.schema,
+      workload_ids: coverage.coverage_profiles['full-surface'].authenticated_admin_pages,
+    },
+    frontend_pages: {
+      command: 'wordpress.trace-browser-coverage',
+      status: 'preferred',
+      artifact_schema: coverage.surfaces.frontend_rendering.coverage_artifact,
+      workload_ids: coverage.coverage_profiles['full-surface'].frontend_rendering,
+    },
+    database: {
+      command: 'wordpress.inventory-database',
+      status: 'preferred',
+      artifact_schema: coverage.surfaces.database.inventory_artifact,
+      workload_ids: coverage.coverage_profiles['full-surface'].database,
+    },
+    blocks: {
+      command: 'wordpress.inventory-blocks',
+      status: 'preferred',
+      artifact_schema: 'homeboy/wordpress-block-inventory/v1',
+      workload_ids: coverage.coverage_profiles['full-surface'].frontend_rendering,
+    },
+    options_transients: {
+      command: 'wordpress.inventory-options-transients',
+      status: 'preferred',
+      artifact_schema: coverage.surfaces.options_transients.coverage_artifact,
+      workload_ids: coverage.coverage_profiles['full-surface'].options_transients,
+    },
+    performance_hotspots: {
+      command: 'wordpress.summarize-performance-hotspots',
+      status: 'preferred',
+      artifact_schema: coverage.surfaces.performance_hotspots.coverage_artifact,
+      workload_ids: coverage.coverage_profiles['full-surface'].performance_hotspots,
+    },
+  },
+  targets: {
+    rest_routes: {
+      namespaces: ['wc/v1', 'wc/v2', 'wc/v3', 'wc/store/v1', 'wc/store/v2', 'wc-admin', 'wc-analytics'],
+      required_sections: ['routes', 'namespaces', 'permission_boundaries', 'generated_safe_get_cases', 'query_attribution'],
+      gap_report_sections: ['routes_without_generated_cases', 'routes_without_permission_boundary_cases', 'routes_without_query_attribution'],
+    },
+    admin_pages: {
+      sources: coverage.surfaces.authenticated_admin_pages.enumeration_contract.sources,
+      roles: Object.keys(coverage.surfaces.authenticated_admin_pages.enumeration_contract.roles),
+      safe_methods: coverage.surfaces.authenticated_admin_pages.enumeration_contract.methods,
+      skip_reason_codes: coverage.surfaces.authenticated_admin_pages.enumeration_contract.skip_reason_codes,
+      required_sections: coverage.surfaces.authenticated_admin_pages.enumeration_contract.artifact_expectations.required,
+    },
+    frontend_pages: {
+      scenarios: coverage.coverage_profiles['full-surface'].browser_requests,
+      required_sections: ['pages', 'requests', 'assets', 'xhr_fetch', 'console', 'errors', 'skipped_destructive_actions'],
+      gap_report_sections: ['pages_without_request_coverage', 'scenarios_without_artifacts', 'unexpected_failed_requests'],
+    },
+    database: {
+      table_prefixes: ['woocommerce_', 'wc_', 'actionscheduler_'],
+      required_sections: ['tables', 'columns', 'indexes', 'row_counts', 'query_profiles'],
+      query_attribution_fields: ['request_case_id', 'route', 'method', 'query_type', 'table', 'stack_summary', 'caller_summary'],
+    },
+    blocks: {
+      block_name_prefixes: ['woocommerce/'],
+      frontend_contexts: ['shop', 'product', 'cart', 'checkout'],
+      required_sections: ['registered_blocks', 'rendered_blocks', 'block_assets', 'block_rest_requests', 'block_query_profiles'],
+    },
+    options_transients: {
+      option_prefixes: ['woocommerce_', 'woocommerce-', 'wc_', '_wc_', '_woocommerce_'],
+      transient_prefixes: ['_transient_wc_', '_transient_timeout_wc_', '_site_transient_wc_', '_site_transient_timeout_wc_', '_transient_woocommerce_', '_transient_timeout_woocommerce_'],
+      required_sections: ['options', 'transients', 'autoloaded_options', 'action_scheduler', 'lookup_tables', 'rollback_mutations'],
+    },
+    performance_hotspots: {
+      workloads: coverage.coverage_profiles['full-surface'].performance_hotspots,
+      focus_areas: ['checkout', 'cart_session', 'catalog_layered_navigation', 'admin_dashboard', 'rest_api', 'cache_invalidation', 'external_http'],
+      required_sections: ['request_timing', 'query_counts', 'cache_invalidation', 'transient_growth', 'gateway_compatibility', 'external_http_guardrail'],
+    },
+  },
+  declared_fuzz_workloads: declaredWorkloads,
+};
+
+process.stdout.write(`${JSON.stringify(inventory, null, 2)}\n`);

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -15,6 +16,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
 const rig = readJson(packageRoot, 'rigs/woocommerce-performance/rig.json');
 const coverageManifest = readJson(packageRoot, 'manifests/full-surface-coverage.json');
+const targetInventory = readJson(packageRoot, 'manifests/target-inventory.json');
 
 const expectedFuzzIds = new Set([
   'action-scheduler-lookup-table-coverage',
@@ -76,6 +78,64 @@ const fullSurfaceFuzzIds = new Set(Object.entries(coverageManifest.coverage_prof
 for (const workloadId of fullSurfaceFuzzIds) {
   assert.ok(declaredIds.has(workloadId), `${workloadId} full-surface coverage is not backed by a fuzz workload`);
 }
+
+const generatedTargetInventory = JSON.parse(execFileSync(process.execPath, [
+  path.join(packageRoot, 'tools/generate-target-inventory.mjs'),
+], { encoding: 'utf8' }));
+
+assert.deepEqual(targetInventory, generatedTargetInventory, 'WooCommerce target inventory artifact must match the generator output');
+assert.equal(coverageManifest.target_inventory_manifest, 'manifests/target-inventory.json', 'full-surface coverage must point at the target inventory manifest');
+assert.equal(targetInventory.schema, 'homeboy-rigs/wordpress-target-inventory/v1', 'target inventory schema drifted');
+assert.equal(targetInventory.runtime?.runner, 'wp-codebox', 'target inventory must run through WP Codebox');
+assert.equal(targetInventory.runtime?.activation, 'woocommerce/woocommerce.php', 'target inventory must activate WooCommerce');
+assert.deepEqual(new Set(targetInventory.declared_fuzz_workloads), expectedFuzzIds, 'target inventory declared fuzz workloads drifted');
+
+const requiredTargetSurfaces = new Set([
+  'rest_routes',
+  'admin_pages',
+  'frontend_pages',
+  'database',
+  'blocks',
+  'options_transients',
+  'performance_hotspots',
+]);
+
+assert.deepEqual(new Set(Object.keys(targetInventory.targets)), requiredTargetSurfaces, 'target inventory surfaces drifted');
+assert.deepEqual(new Set(Object.keys(targetInventory.inventory_primitives)), requiredTargetSurfaces, 'target inventory primitive surfaces drifted');
+
+for (const surface of requiredTargetSurfaces) {
+  const primitive = targetInventory.inventory_primitives[surface];
+  const target = targetInventory.targets[surface];
+
+  assert.equal(primitive.status, 'preferred', `${surface} must prefer the generic WP Codebox/Homeboy Extensions primitive`);
+  assert.equal(typeof primitive.command, 'string', `${surface} requires primitive command`);
+  assert.ok(primitive.command.startsWith('wordpress.'), `${surface} primitive command must be WordPress-scoped`);
+  assert.equal(typeof primitive.artifact_schema, 'string', `${surface} requires artifact schema`);
+  assert.ok(Array.isArray(primitive.workload_ids), `${surface} requires workload_ids`);
+  assert.ok(primitive.workload_ids.length > 0, `${surface} must map to at least one workload`);
+  assert.ok(Array.isArray(target.required_sections), `${surface} target requires required_sections`);
+  assert.ok(target.required_sections.length > 0, `${surface} target required_sections must not be empty`);
+
+  for (const workloadId of primitive.workload_ids) {
+    assert.ok(declaredIds.has(workloadId), `${surface} target inventory workload ${workloadId} is not declared in rig fuzz_workloads.wordpress`);
+  }
+}
+
+for (const namespace of ['wc/v3', 'wc/store/v1', 'wc-admin', 'wc-analytics']) {
+  assert.ok(targetInventory.targets.rest_routes.namespaces.includes(namespace), `REST target inventory missing ${namespace}`);
+}
+
+for (const scenario of ['shop', 'product', 'cart', 'checkout']) {
+  assert.ok(targetInventory.targets.frontend_pages.scenarios.includes(scenario), `frontend target inventory missing ${scenario}`);
+  assert.ok(targetInventory.targets.blocks.frontend_contexts.includes(scenario), `block target inventory missing ${scenario}`);
+}
+
+assert.ok(targetInventory.targets.blocks.block_name_prefixes.includes('woocommerce/'), 'block target inventory must include WooCommerce block namespace');
+assert.ok(targetInventory.targets.database.table_prefixes.includes('woocommerce_'), 'database target inventory must include WooCommerce table prefix');
+assert.ok(targetInventory.targets.database.table_prefixes.includes('actionscheduler_'), 'database target inventory must include Action Scheduler table prefix');
+assert.ok(targetInventory.targets.options_transients.option_prefixes.includes('woocommerce_'), 'options/transients target inventory must include WooCommerce option prefix');
+assert.ok(targetInventory.targets.performance_hotspots.focus_areas.includes('checkout'), 'performance target inventory must include checkout focus area');
+assert.ok(targetInventory.targets.performance_hotspots.focus_areas.includes('catalog_layered_navigation'), 'performance target inventory must include catalog layered navigation focus area');
 
 for (const { file, manifest } of fuzzManifests) {
   const runnerCase = assertGenericFuzzManifest(manifest, {


### PR DESCRIPTION
## Summary
- Add generated Woo target inventory manifest.
- Link target inventory from full-surface coverage metadata.
- Validate inventory coverage for REST, admin, frontend, DB/query, blocks, options/transients, and performance hotspot surfaces.

## Tests
- node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
- node --test scripts/fuzz-manifest-helpers.test.mjs
- node --test woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
- node --test woocommerce/woocommerce/bench/admin-page-coverage.test.mjs
- node --test woocommerce/woocommerce/bench/checkout-shipping-cache.test.mjs
- node scripts/lint-rig-packages.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing Woo target inventory generation, manifest wiring, and validation.