### PR TITLE
Deduplicate Woo runtime dependency prep

### DIFF
--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -131,7 +131,7 @@
         "kind": "requirement",
         "label": "WooCommerce Composer package autoloader exists or can be prepared",
         "file": "${components.woocommerce.path}/vendor/autoload_packages.php",
-        "prepare_command": "woocommerce_component_source=\"${components.woocommerce.path}\"; woocommerce_plugin_source=\"$woocommerce_component_source\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\" ]; then woocommerce_plugin_source=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\" ]; then woocommerce_plugin_source=\"$woocommerce_plugin_source/$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\"; fi; fi; XDEBUG_MODE=off composer --working-dir=\"$woocommerce_plugin_source\" install --no-interaction --no-progress; if [ \"$woocommerce_plugin_source\" != \"$woocommerce_component_source\" ]; then mkdir -p \"$woocommerce_component_source/vendor\"; cp \"$woocommerce_plugin_source/vendor/autoload_packages.php\" \"$woocommerce_component_source/vendor/autoload_packages.php\"; fi",
+        "prepare_command": "bash \"${package.root}/tools/prepare-runtime-dependency.sh\" composer \"${components.woocommerce.path}\"",
         "prepare_phases": ["up", "bench_prepare"],
         "remediation": "Install Composer on the runner, then run: homeboy rig up woocommerce-performance"
       },
@@ -139,7 +139,7 @@
         "kind": "requirement",
         "label": "WooCommerce generated feature config exists or can be prepared",
         "file": "${components.woocommerce.path}/includes/react-admin/feature-config.php",
-        "prepare_command": "woocommerce_component_source=\"${components.woocommerce.path}\"; php \"$woocommerce_component_source/bin/generate-feature-config.php\"; woocommerce_plugin_source=\"$woocommerce_component_source\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\" ]; then woocommerce_plugin_source=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\" ]; then woocommerce_plugin_source=\"$woocommerce_plugin_source/$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\"; fi; fi; if [ \"$woocommerce_plugin_source\" != \"$woocommerce_component_source\" ]; then php \"$woocommerce_plugin_source/bin/generate-feature-config.php\"; fi",
+        "prepare_command": "bash \"${package.root}/tools/prepare-runtime-dependency.sh\" feature-config \"${components.woocommerce.path}\"",
         "prepare_phases": ["up", "bench_prepare"],
         "remediation": "Ensure PHP is available, then run: homeboy rig up woocommerce-performance"
       },
@@ -147,7 +147,7 @@
         "kind": "requirement",
         "label": "WooCommerce admin script asset registry exists or can be built",
         "file": "${components.woocommerce.path}/assets/client/admin/wp-admin-scripts/command-palette.asset.php",
-        "prepare_command": "woocommerce_component_source=\"${components.woocommerce.path}\"; woocommerce_source_root=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -z \"$woocommerce_source_root\" ]; then woocommerce_source_root=$(cd \"$woocommerce_component_source/../..\" && pwd); fi; cd \"$woocommerce_source_root\" || exit 1; if [ ! -x \"$woocommerce_component_source/client/admin/node_modules/.bin/wireit\" ]; then pnpm install --frozen-lockfile; fi; pnpm --filter @woocommerce/plugin-woocommerce build:admin || [ -r \"$woocommerce_component_source/assets/client/admin/wp-admin-scripts/command-palette.asset.php\" ]",
+        "prepare_command": "bash \"${package.root}/tools/prepare-runtime-dependency.sh\" admin-assets \"${components.woocommerce.path}\"",
         "prepare_phases": ["up", "bench_prepare"],
         "remediation": "Install pnpm dependencies and build Woo admin assets, or run: homeboy rig up woocommerce-performance"
       },
@@ -158,58 +158,8 @@
         "remediation": "Use a packaged WooCommerce plugin checkout or build the WooCommerce admin assets before running admin-page-coverage fuzz workloads."
       }
     ],
-    "up": [
-      {
-        "kind": "requirement",
-        "label": "Prepare WooCommerce Composer dependencies when missing",
-        "file": "${components.woocommerce.path}/vendor/autoload_packages.php",
-        "prepare_command": "woocommerce_component_source=\"${components.woocommerce.path}\"; woocommerce_plugin_source=\"$woocommerce_component_source\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\" ]; then woocommerce_plugin_source=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\" ]; then woocommerce_plugin_source=\"$woocommerce_plugin_source/$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\"; fi; fi; XDEBUG_MODE=off composer --working-dir=\"$woocommerce_plugin_source\" install --no-interaction --no-progress; if [ \"$woocommerce_plugin_source\" != \"$woocommerce_component_source\" ]; then mkdir -p \"$woocommerce_component_source/vendor\"; cp \"$woocommerce_plugin_source/vendor/autoload_packages.php\" \"$woocommerce_component_source/vendor/autoload_packages.php\"; fi",
-        "prepare_phases": ["up"],
-        "remediation": "Install Composer on the runner, then run: homeboy rig up woocommerce-performance"
-      },
-      {
-        "kind": "requirement",
-        "label": "Generate WooCommerce feature config when missing",
-        "file": "${components.woocommerce.path}/includes/react-admin/feature-config.php",
-        "prepare_command": "woocommerce_component_source=\"${components.woocommerce.path}\"; php \"$woocommerce_component_source/bin/generate-feature-config.php\"; woocommerce_plugin_source=\"$woocommerce_component_source\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\" ]; then woocommerce_plugin_source=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\" ]; then woocommerce_plugin_source=\"$woocommerce_plugin_source/$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\"; fi; fi; if [ \"$woocommerce_plugin_source\" != \"$woocommerce_component_source\" ]; then php \"$woocommerce_plugin_source/bin/generate-feature-config.php\"; fi",
-        "prepare_phases": ["up"],
-        "remediation": "Ensure PHP is available, then run: homeboy rig up woocommerce-performance"
-      },
-      {
-        "kind": "requirement",
-        "label": "Build WooCommerce admin script asset registry when missing",
-        "file": "${components.woocommerce.path}/assets/client/admin/wp-admin-scripts/command-palette.asset.php",
-        "prepare_command": "woocommerce_component_source=\"${components.woocommerce.path}\"; woocommerce_source_root=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -z \"$woocommerce_source_root\" ]; then woocommerce_source_root=$(cd \"$woocommerce_component_source/../..\" && pwd); fi; cd \"$woocommerce_source_root\" || exit 1; if [ ! -x \"$woocommerce_component_source/client/admin/node_modules/.bin/wireit\" ]; then pnpm install --frozen-lockfile; fi; pnpm --filter @woocommerce/plugin-woocommerce build:admin || [ -r \"$woocommerce_component_source/assets/client/admin/wp-admin-scripts/command-palette.asset.php\" ]",
-        "prepare_phases": ["up"],
-        "remediation": "Install pnpm dependencies and build Woo admin assets, or run: homeboy rig up woocommerce-performance"
-      }
-    ],
-    "bench_prepare": [
-      {
-        "kind": "requirement",
-        "label": "Prepare WooCommerce Composer dependencies when missing",
-        "file": "${components.woocommerce.path}/vendor/autoload_packages.php",
-        "prepare_command": "woocommerce_component_source=\"${components.woocommerce.path}\"; woocommerce_plugin_source=\"$woocommerce_component_source\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\" ]; then woocommerce_plugin_source=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\" ]; then woocommerce_plugin_source=\"$woocommerce_plugin_source/$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\"; fi; fi; XDEBUG_MODE=off composer --working-dir=\"$woocommerce_plugin_source\" install --no-interaction --no-progress; if [ \"$woocommerce_plugin_source\" != \"$woocommerce_component_source\" ]; then mkdir -p \"$woocommerce_component_source/vendor\"; cp \"$woocommerce_plugin_source/vendor/autoload_packages.php\" \"$woocommerce_component_source/vendor/autoload_packages.php\"; fi",
-        "prepare_phases": ["bench_prepare"],
-        "remediation": "Install Composer on the runner, then run: homeboy rig up woocommerce-performance"
-      },
-      {
-        "kind": "requirement",
-        "label": "Generate WooCommerce feature config when missing",
-        "file": "${components.woocommerce.path}/includes/react-admin/feature-config.php",
-        "prepare_command": "woocommerce_component_source=\"${components.woocommerce.path}\"; php \"$woocommerce_component_source/bin/generate-feature-config.php\"; woocommerce_plugin_source=\"$woocommerce_component_source\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\" ]; then woocommerce_plugin_source=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -n \"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\" ]; then woocommerce_plugin_source=\"$woocommerce_plugin_source/$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH\"; fi; fi; if [ \"$woocommerce_plugin_source\" != \"$woocommerce_component_source\" ]; then php \"$woocommerce_plugin_source/bin/generate-feature-config.php\"; fi",
-        "prepare_phases": ["bench_prepare"],
-        "remediation": "Ensure PHP is available, then run: homeboy rig up woocommerce-performance"
-      },
-      {
-        "kind": "requirement",
-        "label": "Build WooCommerce admin script asset registry when missing",
-        "file": "${components.woocommerce.path}/assets/client/admin/wp-admin-scripts/command-palette.asset.php",
-        "prepare_command": "woocommerce_component_source=\"${components.woocommerce.path}\"; woocommerce_source_root=\"$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT\"; if [ -z \"$woocommerce_source_root\" ]; then woocommerce_source_root=$(cd \"$woocommerce_component_source/../..\" && pwd); fi; cd \"$woocommerce_source_root\" || exit 1; if [ ! -x \"$woocommerce_component_source/client/admin/node_modules/.bin/wireit\" ]; then pnpm install --frozen-lockfile; fi; pnpm --filter @woocommerce/plugin-woocommerce build:admin || [ -r \"$woocommerce_component_source/assets/client/admin/wp-admin-scripts/command-palette.asset.php\" ]",
-        "prepare_phases": ["bench_prepare"],
-        "remediation": "Install pnpm dependencies and build Woo admin assets, or run: homeboy rig up woocommerce-performance"
-      }
-    ],
+    "up": [],
+    "bench_prepare": [],
     "down": []
   }
 }

--- a/woocommerce/woocommerce/tools/prepare-runtime-dependency.sh
+++ b/woocommerce/woocommerce/tools/prepare-runtime-dependency.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+task="${1:-}"
+woocommerce_component_source="${2:-}"
+
+if [ -z "$task" ] || [ -z "$woocommerce_component_source" ]; then
+  printf 'Usage: %s <composer|feature-config|admin-assets> <woocommerce-plugin-path>\n' "$0" >&2
+  exit 2
+fi
+
+woocommerce_plugin_source="$woocommerce_component_source"
+if [ -n "${HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT:-}" ]; then
+  woocommerce_plugin_source="$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT"
+  if [ -n "${HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH:-}" ]; then
+    woocommerce_plugin_source="$woocommerce_plugin_source/$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH"
+  fi
+fi
+
+case "$task" in
+  composer)
+    XDEBUG_MODE=off composer --working-dir="$woocommerce_plugin_source" install --no-interaction --no-progress
+    if [ "$woocommerce_plugin_source" != "$woocommerce_component_source" ]; then
+      mkdir -p "$woocommerce_component_source/vendor"
+      cp "$woocommerce_plugin_source/vendor/autoload_packages.php" "$woocommerce_component_source/vendor/autoload_packages.php"
+    fi
+    ;;
+  feature-config)
+    php "$woocommerce_component_source/bin/generate-feature-config.php"
+    if [ "$woocommerce_plugin_source" != "$woocommerce_component_source" ]; then
+      php "$woocommerce_plugin_source/bin/generate-feature-config.php"
+    fi
+    ;;
+  admin-assets)
+    woocommerce_source_root="${HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT:-}"
+    if [ -z "$woocommerce_source_root" ]; then
+      woocommerce_source_root=$(cd "$woocommerce_component_source/../.." && pwd)
+    fi
+    cd "$woocommerce_source_root" || exit 1
+    if [ ! -x "$woocommerce_component_source/client/admin/node_modules/.bin/wireit" ]; then
+      pnpm install --frozen-lockfile
+    fi
+    pnpm --filter @woocommerce/plugin-woocommerce build:admin || [ -r "$woocommerce_component_source/assets/client/admin/wp-admin-scripts/command-palette.asset.php" ]
+    ;;
+  *)
+    printf 'Unknown WooCommerce runtime dependency task: %s\n' "$task" >&2
+    exit 2
+    ;;
+esac

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -15,6 +16,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
 const rig = readJson(packageRoot, 'rigs/woocommerce-performance/rig.json');
 const coverageManifest = readJson(packageRoot, 'manifests/full-surface-coverage.json');
+const runtimeDependencyHelper = path.join(packageRoot, 'tools/prepare-runtime-dependency.sh');
 
 const expectedFuzzIds = new Set([
   'action-scheduler-lookup-table-coverage',
@@ -53,6 +55,8 @@ const requiredProofContracts = new Map([
 
 const fuzzManifests = collectFuzzManifests(packageRoot);
 
+assert.ok(existsSync(runtimeDependencyHelper), 'WooCommerce runtime dependency prep helper must exist');
+
 assert.equal(fuzzManifests.length, 20, 'expected 20 WooCommerce fuzz manifests');
 
 const declaredIds = declaredFuzzIds(rig);
@@ -65,6 +69,27 @@ const coverageProfileWorkloadIds = new Set(Object.entries(coverageManifest.cover
 
 assert.deepEqual(actualFuzzIds, expectedFuzzIds, 'WooCommerce fuzz manifest ids drifted');
 assert.deepEqual(declaredIds, expectedFuzzIds, 'rig fuzz_workloads.wordpress ids drifted');
+
+const runtimePrepFiles = new Set([
+  '${components.woocommerce.path}/vendor/autoload_packages.php',
+  '${components.woocommerce.path}/includes/react-admin/feature-config.php',
+  '${components.woocommerce.path}/assets/client/admin/wp-admin-scripts/command-palette.asset.php',
+]);
+const runtimePrepCheckSteps = (rig.pipeline?.check || []).filter((step) => runtimePrepFiles.has(step.file));
+
+assert.equal(runtimePrepCheckSteps.length, runtimePrepFiles.size, 'WooCommerce runtime dependency prep must be declared once in check');
+
+for (const step of runtimePrepCheckSteps) {
+  assert.equal(step.kind, 'requirement', `${step.file} prep step must use a requirement declaration`);
+  assert.deepEqual(step.prepare_phases, ['up', 'bench_prepare'], `${step.file} prep phases drifted`);
+  assert.match(step.prepare_command, /tools\/prepare-runtime-dependency\.sh/, `${step.file} must use the shared WooCommerce runtime dependency helper`);
+}
+
+for (const phase of ['up', 'bench_prepare']) {
+  const duplicatedPrepSteps = (rig.pipeline?.[phase] || []).filter((step) => runtimePrepFiles.has(step.file) || /prepare-runtime-dependency\.sh/.test(step.prepare_command || ''));
+  assert.equal(duplicatedPrepSteps.length, 0, `WooCommerce runtime dependency prep must not be duplicated in pipeline.${phase}`);
+}
+
 for (const workloadId of coverageProfileWorkloadIds) {
   assert.ok(declaredIds.has(workloadId), `${workloadId} full-surface profile entry must route through fuzz_workloads.wordpress`);
 }


### PR DESCRIPTION
## Summary
- Add a single Woo runtime dependency preparation helper.
- Remove duplicated prep declarations from up and bench_prepare.
- Add validator coverage to prevent prep drift.

## Tests
- node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
- node scripts/lint-rig-packages.mjs woocommerce/woocommerce
- node --test scripts/fuzz-manifest-helpers.test.mjs scripts/lint-rig-packages.test.mjs
- git diff --check

Note: homeboy rig show woocommerce-performance is blocked by a stale local rig registry path unrelated to this change.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and implementing dependency prep consolidation, rig config updates, and validation.