### PR TITLE
Run product fuzz contract tests in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,3 +19,10 @@ jobs:
           php-version: '8.3'
           coverage: none
       - run: node scripts/lint-rig-packages.mjs
+      - name: Test fuzz contracts
+        run: >-
+          node --test
+          Automattic/jetpack/manifests/full-surface-coverage.test.mjs
+          WordPress/gutenberg/tools/fuzz-coverage.test.mjs
+          WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs
+          woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.json
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.json
@@ -415,6 +415,18 @@
         "optional": ["rollback verification rows", "skipped sensitive option reasons"]
       }
     },
+    "codebox-fuzz-suite-smoke": {
+      "surface": "wp_codebox_public_fuzz_suite",
+      "coverage_shape": "Schema-level public WP Codebox fuzz-suite smoke contract for a read-only WooCommerce Store API cart route",
+      "safety": {
+        "classification": "read_only_inventory",
+        "notes": ["Validates public WP Codebox fuzz-suite and workload-run contract shapes", "Uses a read-only Store API cart route and records placeholder proof status until executable artifacts exist"]
+      },
+      "artifact_expectations": {
+        "required": ["fuzz suite manifest", "wordpress workload-run manifest"],
+        "optional": ["wp-codebox/fuzz-suite-result/v1 artifact"]
+      }
+    },
     "frontend-rendering-request-coverage": {
       "surface": "frontend_rendering_requests",
       "coverage_shape": "Shop, product, cart, and checkout frontend render/request coverage with assets, XHR/fetch requests, and skipped destructive action reason codes",


### PR DESCRIPTION
## Summary
- Add a focused CI step for product fuzz contract tests.
- Add WooCommerce codebox-fuzz-suite-smoke workload metadata so the new contract step passes.
- Keep the step limited to manifest/contract tests, not live fuzzing.

## Testing
- node --test Automattic/jetpack/manifests/full-surface-coverage.test.mjs WordPress/gutenberg/tools/fuzz-coverage.test.mjs WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
- node scripts/lint-rig-packages.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Wiring CI contract tests, fixing Woo manifest drift, local verification, and PR preparation.