### PR TITLE
Project Woo REST inventory fuzz case

### DIFF
--- a/woocommerce/woocommerce/fuzz/woocommerce-rest-route-inventory.json
+++ b/woocommerce/woocommerce/fuzz/woocommerce-rest-route-inventory.json
@@ -48,6 +48,50 @@
     "path": "${package.root}/bench/woocommerce-rest-route-inventory.php",
     "entry": "woocommerce-rest-route-inventory"
   },
+  "plan": {
+    "schema": "wordpress-fuzz-plan/v1",
+    "id": "woocommerce-rest-route-inventory",
+    "targets": [
+      {
+        "id": "woocommerce-rest-routes",
+        "surface_id": "woocommerce-rest-routes",
+        "operation_id": "route-discovery",
+        "cases": [
+          {
+            "id": "woocommerce-rest-route-inventory:default",
+            "operation_id": "route-discovery",
+            "required_capabilities": [
+              "wordpress.inventory-rest-routes"
+            ],
+            "command": "wordpress.inventory-rest-routes",
+            "input": {
+              "plugin": "woocommerce/woocommerce.php",
+              "namespaces": [
+                "wc/v1",
+                "wc/v2",
+                "wc/v3",
+                "wc/store/v1",
+                "wc/store/v2",
+                "wc-admin",
+                "wc-analytics"
+              ],
+              "artifact": "route_inventory"
+            },
+            "metadata": {
+              "safety_class": "read_only",
+              "expected_artifact": "route_inventory"
+            }
+          }
+        ],
+        "metadata": {
+          "primitive": "wordpress.inventory-rest-routes"
+        }
+      }
+    ],
+    "metadata": {
+      "blocked_until": "wordpress.inventory-rest-routes"
+    }
+  },
   "cases": [
     {
       "case_id": "woocommerce-rest-route-inventory:default",


### PR DESCRIPTION
## Summary
- Add a WordPress fuzz-plan projection for the WooCommerce REST route inventory workload.
- Emit a concrete case that requires `wordpress.inventory-rest-routes` and targets Woo REST namespaces.

## Verification
- `homeboy fuzz plan --rig woocommerce-performance --workload woocommerce-rest-route-inventory --run-id wc-rest-route-inventory-pr-check2 --seed 1 --max-duration 10m`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Wiring the Woo fuzz workload projection and validating the Homeboy fuzz plan.