### PR TITLE
Refine Jetpack external HTTP fuzz guardrails

### DIFF
--- a/Automattic/jetpack/fuzz/jetpack-external-http-guardrail.json
+++ b/Automattic/jetpack/fuzz/jetpack-external-http-guardrail.json
@@ -7,12 +7,195 @@
   "operations": ["external-http-blocklist-probe", "network-side-effect-classification"],
   "case_budget": 1,
   "duration_budget_seconds": 300,
-  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "workload_path": "${package.root}/bench/jetpack-external-http-guardrail.php", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report", "network_policy": "block_synthetic_external_requests_and_classify_wpcom_boundaries" },
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/jetpack-external-http-guardrail.php",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report",
+    "network_policy": "block_synthetic_external_requests_and_classify_wpcom_boundaries",
+    "endpoint_classes": [
+      {
+        "class": "connection-api",
+        "description": "Jetpack site registration, connection status, and token verification calls that normally target WordPress.com APIs.",
+        "connected_state": "connected_required",
+        "hosts": ["public-api.wordpress.com"],
+        "path_prefixes": ["/rest/v1.1/sites/", "/rest/v1.2/sites/"],
+        "fixture_policy": "classify_without_live_credentials"
+      },
+      {
+        "class": "sync-dispatch",
+        "description": "Jetpack sync sender, action queue, and retry dispatch boundaries.",
+        "connected_state": "connected_required",
+        "hosts": ["public-api.wordpress.com"],
+        "path_prefixes": ["/rest/v1.1/sites/", "/rest/v1.2/sites/"],
+        "fixture_policy": "record_blocked_or_skipped_dispatch"
+      },
+      {
+        "class": "module-service-api",
+        "description": "Module-owned service calls such as stats, publicize, subscriptions, protect, and related posts.",
+        "connected_state": "module_and_connection_dependent",
+        "hosts": ["public-api.wordpress.com"],
+        "path_prefixes": ["/rest/v1.1/", "/rest/v1.2/"],
+        "fixture_policy": "classify_module_boundary_without_external_call"
+      },
+      {
+        "class": "synthetic-blocked-probe",
+        "description": "Rig-owned synthetic probes used to prove unapproved outbound requests are intercepted before leaving the runner.",
+        "connected_state": "not_required",
+        "hosts": ["jetpack-homeboy-guardrail.invalid"],
+        "path_prefixes": ["/rest/v1.1/sites/", "/guardrail-probe"],
+        "fixture_policy": "must_be_blocked"
+      }
+    ],
+    "host_policy": {
+      "allowed_boundaries": [
+        {
+          "host": "public-api.wordpress.com",
+          "purpose": "WordPress.com REST API boundary for Jetpack connection, sync, and module service calls.",
+          "call_policy": "declared_boundary_only_not_called",
+          "credential_policy": "no_live_wpcom_credentials"
+        }
+      ],
+      "blocked_hosts": [
+        {
+          "host": "jetpack-homeboy-guardrail.invalid",
+          "purpose": "Synthetic blocked-probe host controlled by the rig.",
+          "call_policy": "must_not_leave_runner"
+        }
+      ],
+      "unknown_hosts": "blocked_and_reported"
+    },
+    "secret_redaction": {
+      "expectations": [
+        "authorization_headers_redacted",
+        "oauth_token_query_params_redacted",
+        "jetpack_blog_token_redacted",
+        "jetpack_user_token_redacted",
+        "signed_request_secrets_redacted",
+        "cookie_and_nonce_values_redacted"
+      ],
+      "redaction_placeholder": "[redacted]",
+      "raw_secret_values_allowed_in_artifacts": false
+    },
+    "connection_requirements": {
+      "states": ["connected", "disconnected"],
+      "real_wpcom_credentials_allowed": false,
+      "connected_required_classes": ["connection-api", "sync-dispatch", "module-service-api"],
+      "disconnected_expectation": "classify_as_connection_required_or_credential_unavailable_without_calling_wpcom",
+      "placeholder_credentials_only": true
+    },
+    "proof_artifact_expectations": {
+      "required_before_proven": [
+        "external_http_guardrail",
+        "blocked_request_rows",
+        "allowlisted_boundary_rows",
+        "redaction_assertion_rows",
+        "connection_state_skip_rows"
+      ],
+      "semantic_keys": [
+        "fuzz.report",
+        "fuzz.external_http_guardrail",
+        "fuzz.secret_redaction",
+        "fuzz.skip_reasons"
+      ],
+      "reviewer_facing_refs_required": true,
+      "local_paths_allowed_as_proof_refs": false
+    }
+  },
   "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
-  "workload": { "runner": "wp-codebox", "type": "php", "path": "${package.root}/bench/jetpack-external-http-guardrail.php", "entry": "jetpack-external-http-guardrail" },
-  "network_guardrail": { "block_network": true, "allowlist_domains": ["public-api.wordpress.com"], "probe_hosts": ["jetpack-homeboy-guardrail.invalid", "public-api.wordpress.com"], "real_external_service_calls_allowed": false, "expectations": [{ "host": "jetpack-homeboy-guardrail.invalid", "classification": "blocked", "reason": "synthetic .invalid host must never leave the runner" }, { "host": "public-api.wordpress.com", "classification": "allowlisted_boundary_not_called", "reason": "declares the WP.com boundary without live credentials or real service calls" }] },
-  "cases": [{ "case_id": "jetpack-external-http-guardrail:default", "surface_ids": ["jetpack-external-http", "jetpack-connection", "jetpack-sync"], "operations": ["external-http-blocklist-probe", "network-side-effect-classification"], "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }, { "command": "wordpress.ensure-external-http-guardrail", "args": ["allowlist=public-api.wordpress.com", "block_network=true"] }], "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/jetpack-external-http-guardrail.php", "type=php"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=external_http_guardrail"] }] }, "artifacts": [{ "name": "external_http_guardrail", "path": "jetpack-external-http-guardrail/external_http_guardrail.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }], "metadata": { "safety_class": "read_only" } }],
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "php",
+    "path": "${package.root}/bench/jetpack-external-http-guardrail.php",
+    "entry": "jetpack-external-http-guardrail"
+  },
+  "network_guardrail": {
+    "block_network": true,
+    "allowlist_domains": ["public-api.wordpress.com"],
+    "blocked_domains": ["jetpack-homeboy-guardrail.invalid"],
+    "probe_hosts": ["jetpack-homeboy-guardrail.invalid", "public-api.wordpress.com"],
+    "real_external_service_calls_allowed": false,
+    "expectations": [
+      {
+        "host": "jetpack-homeboy-guardrail.invalid",
+        "classification": "blocked",
+        "reason": "synthetic .invalid host must never leave the runner",
+        "endpoint_class": "synthetic-blocked-probe",
+        "connected_state_required": false,
+        "redaction_required": true
+      },
+      {
+        "host": "public-api.wordpress.com",
+        "classification": "allowlisted_boundary_not_called",
+        "reason": "declares the WP.com boundary without live credentials or real service calls",
+        "endpoint_class": "connection-api",
+        "connected_state_required": true,
+        "redaction_required": true
+      }
+    ]
+  },
+  "cases": [
+    {
+      "case_id": "jetpack-external-http-guardrail:default",
+      "surface_ids": ["jetpack-external-http", "jetpack-connection", "jetpack-sync"],
+      "operations": ["external-http-blocklist-probe", "network-side-effect-classification"],
+      "inputs": {
+        "endpoint_classes": ["connection-api", "sync-dispatch", "module-service-api", "synthetic-blocked-probe"],
+        "allowlist_domains": ["public-api.wordpress.com"],
+        "blocked_domains": ["jetpack-homeboy-guardrail.invalid"],
+        "real_external_service_calls_allowed": false,
+        "real_wpcom_credentials_allowed": false,
+        "states": ["connected", "disconnected"],
+        "secret_redaction_required": true,
+        "proof_artifacts_required_before_proven": true,
+        "skip_reason_codes": ["connection_required", "credential_unavailable", "external_service_required", "blocked_external_http"]
+      },
+      "phases": {
+        "setup": [
+          { "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] },
+          { "command": "wordpress.ensure-external-http-guardrail", "args": ["allowlist=public-api.wordpress.com", "block_network=true"] }
+        ],
+        "action": [
+          { "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/jetpack-external-http-guardrail.php", "type=php"] }
+        ],
+        "assert": [
+          { "command": "wordpress.collect-workload-result", "args": ["artifact=external_http_guardrail"] }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "external_http_guardrail",
+          "path": "jetpack-external-http-guardrail/external_http_guardrail.json",
+          "required": false,
+          "metadata": { "semantic_key": "fuzz.report" }
+        },
+        {
+          "name": "external_http_redaction_assertions",
+          "path": "jetpack-external-http-guardrail/external_http_redaction_assertions.json",
+          "required": false,
+          "metadata": { "semantic_key": "fuzz.secret_redaction" }
+        },
+        {
+          "name": "external_http_skip_reasons",
+          "path": "jetpack-external-http-guardrail/external_http_skip_reasons.json",
+          "required": false,
+          "metadata": { "semantic_key": "fuzz.skip_reasons" }
+        }
+      ],
+      "metadata": { "safety_class": "read_only" }
+    }
+  ],
   "limits": { "max_cases": 1, "max_duration_seconds": 300 },
-  "coverage": { "surface_ids": ["jetpack-external-http", "jetpack-connection", "jetpack-sync"], "operations": ["external-http-blocklist-probe", "network-side-effect-classification"] },
-  "artifacts": { "expected": [{ "name": "external_http_guardrail", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+  "coverage": {
+    "surface_ids": ["jetpack-external-http", "jetpack-connection", "jetpack-sync"],
+    "operations": ["external-http-blocklist-probe", "network-side-effect-classification"]
+  },
+  "artifacts": {
+    "expected": [
+      { "name": "external_http_guardrail", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false },
+      { "name": "external_http_redaction_assertions", "role": "fuzz_report", "semantic_key": "fuzz.secret_redaction", "required": false },
+      { "name": "external_http_skip_reasons", "role": "fuzz_report", "semantic_key": "fuzz.skip_reasons", "required": false }
+    ]
+  }
 }

--- a/Automattic/jetpack/manifests/full-surface-coverage.test.mjs
+++ b/Automattic/jetpack/manifests/full-surface-coverage.test.mjs
@@ -80,13 +80,41 @@ test('Jetpack fuzz workload manifests carry coverage contract metadata', () => {
 
 test('Jetpack external HTTP guardrail blocks synthetic probes', () => {
   const guardrail = readFuzzManifest('jetpack-external-http-guardrail');
+  const metadata = guardrail.metadata;
+  const caseInputs = defaultCase(guardrail).inputs;
 
   assert.equal(guardrail.network_guardrail.block_network, true);
   assert.ok(guardrail.network_guardrail.allowlist_domains.includes('public-api.wordpress.com'));
+  assert.ok(guardrail.network_guardrail.blocked_domains.includes('jetpack-homeboy-guardrail.invalid'));
   assert.equal(guardrail.network_guardrail.real_external_service_calls_allowed, false);
   assert.ok(guardrail.network_guardrail.probe_hosts.includes('jetpack-homeboy-guardrail.invalid'));
   assert.ok(guardrail.network_guardrail.expectations.some((expectation) => expectation.classification === 'blocked'));
   assert.ok(guardrail.network_guardrail.expectations.some((expectation) => expectation.classification === 'allowlisted_boundary_not_called'));
+  assert.deepEqual(
+    new Set(metadata.endpoint_classes.map((endpointClass) => endpointClass.class)),
+    new Set(['connection-api', 'sync-dispatch', 'module-service-api', 'synthetic-blocked-probe'])
+  );
+  assert.deepEqual(
+    new Set(metadata.host_policy.allowed_boundaries.map((boundary) => boundary.host)),
+    new Set(['public-api.wordpress.com'])
+  );
+  assert.deepEqual(
+    new Set(metadata.host_policy.blocked_hosts.map((boundary) => boundary.host)),
+    new Set(['jetpack-homeboy-guardrail.invalid'])
+  );
+  assert.equal(metadata.host_policy.unknown_hosts, 'blocked_and_reported');
+  assert.equal(metadata.secret_redaction.raw_secret_values_allowed_in_artifacts, false);
+  assert.ok(metadata.secret_redaction.expectations.includes('authorization_headers_redacted'));
+  assert.ok(metadata.secret_redaction.expectations.includes('jetpack_blog_token_redacted'));
+  assert.equal(metadata.connection_requirements.real_wpcom_credentials_allowed, false);
+  assert.ok(metadata.connection_requirements.states.includes('connected'));
+  assert.ok(metadata.connection_requirements.states.includes('disconnected'));
+  assert.ok(metadata.proof_artifact_expectations.required_before_proven.includes('redaction_assertion_rows'));
+  assert.ok(metadata.proof_artifact_expectations.required_before_proven.includes('connection_state_skip_rows'));
+  assert.equal(caseInputs.real_external_service_calls_allowed, false);
+  assert.equal(caseInputs.real_wpcom_credentials_allowed, false);
+  assert.equal(caseInputs.secret_redaction_required, true);
+  assert.ok(caseInputs.skip_reason_codes.includes('blocked_external_http'));
 });
 
 test('Jetpack REST request cases cover namespaces and permission classes', () => {

--- a/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
+++ b/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
@@ -200,7 +200,30 @@ const externalHttp = manifestFor('jetpack-external-http-guardrail');
 assert.equal(externalHttp.network_guardrail.block_network, true, 'Jetpack external HTTP guardrail must block network probes');
 assert.equal(externalHttp.network_guardrail.real_external_service_calls_allowed, false, 'Jetpack external HTTP guardrail must not permit live service calls');
 assert.ok(externalHttp.network_guardrail.allowlist_domains.includes('public-api.wordpress.com'), 'Jetpack external HTTP guardrail must declare WP.com boundary');
+assert.ok(externalHttp.network_guardrail.blocked_domains.includes('jetpack-homeboy-guardrail.invalid'), 'Jetpack external HTTP guardrail must declare blocked hosts');
 assert.ok(externalHttp.network_guardrail.probe_hosts.includes('jetpack-homeboy-guardrail.invalid'), 'Jetpack external HTTP guardrail must use synthetic probe host');
+assert.deepEqual(
+  new Set(externalHttp.metadata.endpoint_classes.map((endpointClass) => endpointClass.class)),
+  new Set(['connection-api', 'sync-dispatch', 'module-service-api', 'synthetic-blocked-probe']),
+  'Jetpack external HTTP guardrail endpoint classes drifted'
+);
+assert.deepEqual(
+  new Set(externalHttp.metadata.host_policy.allowed_boundaries.map((boundary) => boundary.host)),
+  new Set(['public-api.wordpress.com']),
+  'Jetpack external HTTP guardrail allowed host policy drifted'
+);
+assert.deepEqual(
+  new Set(externalHttp.metadata.host_policy.blocked_hosts.map((boundary) => boundary.host)),
+  new Set(['jetpack-homeboy-guardrail.invalid']),
+  'Jetpack external HTTP guardrail blocked host policy drifted'
+);
+assert.equal(externalHttp.metadata.secret_redaction.raw_secret_values_allowed_in_artifacts, false, 'Jetpack external HTTP guardrail must redact raw secrets from artifacts');
+assert.ok(externalHttp.metadata.secret_redaction.expectations.includes('jetpack_blog_token_redacted'), 'Jetpack external HTTP guardrail must redact Jetpack blog tokens');
+assert.equal(externalHttp.metadata.connection_requirements.real_wpcom_credentials_allowed, false, 'Jetpack external HTTP guardrail must not require live WPCOM credentials');
+assert.ok(externalHttp.metadata.proof_artifact_expectations.required_before_proven.includes('redaction_assertion_rows'), 'Jetpack external HTTP guardrail proof must include redaction assertions');
+assert.ok(externalHttp.metadata.proof_artifact_expectations.required_before_proven.includes('connection_state_skip_rows'), 'Jetpack external HTTP guardrail proof must include connection skip rows');
+assert.equal(externalHttp.cases[0].inputs.real_external_service_calls_allowed, false, 'Jetpack external HTTP guardrail case must disallow live external service calls');
+assert.equal(externalHttp.cases[0].inputs.secret_redaction_required, true, 'Jetpack external HTTP guardrail case must require redaction checks');
 
 const performance = manifestFor('jetpack-performance-observation');
 assert.ok(performance.cases[0].inputs.observation_surfaces.includes('external_http_guardrail'), 'Jetpack performance observation must summarize HTTP guardrails');


### PR DESCRIPTION
## Summary
- Refine Jetpack external HTTP fuzz guardrails.
- Add known endpoint classes, allowed/blocked host policy, token redaction expectations, connected-state requirements, and proof artifact expectations.
- Avoid real network calls or credentials.

## Testing
- `node Automattic/jetpack/tools/validate-fuzz-manifests.mjs`
- `node --test Automattic/jetpack/manifests/full-surface-coverage.test.mjs`
- `node scripts/lint-rig-packages.mjs Automattic/jetpack`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Jetpack fuzz manifest investigation, metadata updates, validation, and PR description drafting.
