### PR TITLE
Require Jetpack fuzz proof artifacts

### DIFF
--- a/Automattic/jetpack/fuzz/jetpack-admin-page-coverage.json
+++ b/Automattic/jetpack/fuzz/jetpack-admin-page-coverage.json
@@ -3,7 +3,10 @@
   "id": "jetpack-admin-page-coverage",
   "label": "Jetpack admin page coverage",
   "safety_class": "read_only",
-  "surface_ids": ["jetpack-admin-pages", "wordpress-admin-pages"],
+  "surface_ids": [
+    "jetpack-admin-pages",
+    "wordpress-admin-pages"
+  ],
   "operations": [
     "admin-page-discovery",
     "permission-boundary-classification",
@@ -21,11 +24,18 @@
     "expected_artifact_semantic_key": "fuzz.report",
     "admin_target_contract": {
       "product": "jetpack",
-      "discovery_sources": ["global_menu", "global_submenu", "registered_pages", "jetpack_admin_page_registry"],
+      "discovery_sources": [
+        "global_menu",
+        "global_submenu",
+        "registered_pages",
+        "jetpack_admin_page_registry"
+      ],
       "default_role": "administrator",
       "default_capability": "manage_options",
       "request_policy": {
-        "safe_methods": ["GET"],
+        "safe_methods": [
+          "GET"
+        ],
         "get_first": true,
         "follow_redirects": false,
         "submit_forms": false,
@@ -35,47 +45,86 @@
       "skip_reasons": [
         {
           "code": "destructive_action",
-          "matches": ["action=delete", "action=remove", "action=trash", "action=reset"],
+          "matches": [
+            "action=delete",
+            "action=remove",
+            "action=trash",
+            "action=reset"
+          ],
           "reason": "Would delete, remove, trash, or reset local Jetpack data."
         },
         {
           "code": "plugin_install_or_update",
-          "matches": ["action=install", "action=update", "update.php", "plugin-install.php"],
+          "matches": [
+            "action=install",
+            "action=update",
+            "update.php",
+            "plugin-install.php"
+          ],
           "reason": "Would install or update plugin code instead of observing admin rendering."
         },
         {
           "code": "module_state_mutation",
-          "matches": ["action=activate", "action=deactivate", "module=", "activate-module", "deactivate-module"],
+          "matches": [
+            "action=activate",
+            "action=deactivate",
+            "module=",
+            "activate-module",
+            "deactivate-module"
+          ],
           "reason": "Would alter Jetpack module state; module mutations belong to the module-state lane."
         },
         {
           "code": "connection_mutation",
-          "matches": ["action=disconnect", "connect_url", "jetpack_reconnect", "jetpack_disconnect"],
+          "matches": [
+            "action=disconnect",
+            "connect_url",
+            "jetpack_reconnect",
+            "jetpack_disconnect"
+          ],
           "reason": "Would connect, reconnect, or disconnect a site from WordPress.com."
         },
         {
           "code": "nonce_required",
-          "matches": ["_wpnonce=", "_ajax_nonce="],
+          "matches": [
+            "_wpnonce=",
+            "_ajax_nonce="
+          ],
           "reason": "Nonce-bearing action URLs are classified instead of replayed."
         },
         {
           "code": "credential_unavailable",
-          "matches": ["calypso", "wordpress.com", "wpcom"],
+          "matches": [
+            "calypso",
+            "wordpress.com",
+            "wpcom"
+          ],
           "reason": "Live WordPress.com credentials are not available in the local fixture."
         },
         {
           "code": "capability_denied",
-          "matches": ["capability_mismatch"],
+          "matches": [
+            "capability_mismatch"
+          ],
           "reason": "The target requires a capability not held by the tested role."
         },
         {
           "code": "external_service_required",
-          "matches": ["external_service", "oauth", "public-api.wordpress.com"],
+          "matches": [
+            "external_service",
+            "oauth",
+            "public-api.wordpress.com"
+          ],
           "reason": "The target requires a live external service boundary."
         },
         {
           "code": "unsupported_method",
-          "matches": ["POST", "PUT", "PATCH", "DELETE"],
+          "matches": [
+            "POST",
+            "PUT",
+            "PATCH",
+            "DELETE"
+          ],
           "reason": "The admin coverage lane only performs GET requests."
         }
       ],
@@ -87,9 +136,18 @@
           "hash_route": "#/dashboard",
           "label": "Jetpack dashboard",
           "required_capability": "manage_options",
-          "safe_methods": ["GET"],
-          "expected_states": ["connected", "disconnected"],
-          "proof_artifacts": ["admin_page_coverage", "admin_menu_enumeration", "admin_query_attribution"]
+          "safe_methods": [
+            "GET"
+          ],
+          "expected_states": [
+            "connected",
+            "disconnected"
+          ],
+          "proof_artifacts": [
+            "admin_page_coverage",
+            "admin_menu_enumeration",
+            "admin_query_attribution"
+          ]
         },
         {
           "id": "jetpack-connection",
@@ -98,10 +156,21 @@
           "hash_route": "#/connection",
           "label": "Jetpack connection",
           "required_capability": "manage_options",
-          "safe_methods": ["GET"],
-          "expected_states": ["connected", "disconnected"],
-          "destructive_skip_codes": ["connection_mutation", "credential_unavailable"],
-          "proof_artifacts": ["admin_page_coverage", "admin_skip_reasons"]
+          "safe_methods": [
+            "GET"
+          ],
+          "expected_states": [
+            "connected",
+            "disconnected"
+          ],
+          "destructive_skip_codes": [
+            "connection_mutation",
+            "credential_unavailable"
+          ],
+          "proof_artifacts": [
+            "admin_page_coverage",
+            "admin_skip_reasons"
+          ]
         },
         {
           "id": "jetpack-settings-general",
@@ -110,8 +179,13 @@
           "hash_route": "#/settings",
           "label": "Jetpack settings",
           "required_capability": "manage_options",
-          "safe_methods": ["GET"],
-          "proof_artifacts": ["admin_page_coverage", "admin_query_attribution"]
+          "safe_methods": [
+            "GET"
+          ],
+          "proof_artifacts": [
+            "admin_page_coverage",
+            "admin_query_attribution"
+          ]
         },
         {
           "id": "jetpack-settings-performance",
@@ -120,8 +194,13 @@
           "hash_route": "#/settings?term=performance",
           "label": "Jetpack performance settings",
           "required_capability": "manage_options",
-          "safe_methods": ["GET"],
-          "proof_artifacts": ["admin_page_coverage", "admin_query_attribution"]
+          "safe_methods": [
+            "GET"
+          ],
+          "proof_artifacts": [
+            "admin_page_coverage",
+            "admin_query_attribution"
+          ]
         },
         {
           "id": "jetpack-settings-writing",
@@ -130,8 +209,13 @@
           "hash_route": "#/settings?term=writing",
           "label": "Jetpack writing settings",
           "required_capability": "manage_options",
-          "safe_methods": ["GET"],
-          "proof_artifacts": ["admin_page_coverage", "admin_query_attribution"]
+          "safe_methods": [
+            "GET"
+          ],
+          "proof_artifacts": [
+            "admin_page_coverage",
+            "admin_query_attribution"
+          ]
         },
         {
           "id": "jetpack-settings-sharing",
@@ -140,8 +224,13 @@
           "hash_route": "#/settings?term=sharing",
           "label": "Jetpack sharing settings",
           "required_capability": "manage_options",
-          "safe_methods": ["GET"],
-          "proof_artifacts": ["admin_page_coverage", "admin_query_attribution"]
+          "safe_methods": [
+            "GET"
+          ],
+          "proof_artifacts": [
+            "admin_page_coverage",
+            "admin_query_attribution"
+          ]
         },
         {
           "id": "jetpack-settings-discussion",
@@ -150,8 +239,13 @@
           "hash_route": "#/settings?term=discussion",
           "label": "Jetpack discussion settings",
           "required_capability": "manage_options",
-          "safe_methods": ["GET"],
-          "proof_artifacts": ["admin_page_coverage", "admin_query_attribution"]
+          "safe_methods": [
+            "GET"
+          ],
+          "proof_artifacts": [
+            "admin_page_coverage",
+            "admin_query_attribution"
+          ]
         },
         {
           "id": "jetpack-settings-security",
@@ -160,8 +254,13 @@
           "hash_route": "#/settings?term=security",
           "label": "Jetpack security settings",
           "required_capability": "manage_options",
-          "safe_methods": ["GET"],
-          "proof_artifacts": ["admin_page_coverage", "admin_query_attribution"]
+          "safe_methods": [
+            "GET"
+          ],
+          "proof_artifacts": [
+            "admin_page_coverage",
+            "admin_query_attribution"
+          ]
         },
         {
           "id": "jetpack-modules",
@@ -169,36 +268,81 @@
           "admin_path": "/wp-admin/admin.php?page=jetpack_modules",
           "label": "Jetpack modules",
           "required_capability": "manage_options",
-          "safe_methods": ["GET"],
-          "destructive_skip_codes": ["module_state_mutation", "nonce_required"],
-          "proof_artifacts": ["admin_page_coverage", "admin_menu_enumeration", "admin_skip_reasons"]
+          "safe_methods": [
+            "GET"
+          ],
+          "destructive_skip_codes": [
+            "module_state_mutation",
+            "nonce_required"
+          ],
+          "proof_artifacts": [
+            "admin_page_coverage",
+            "admin_menu_enumeration",
+            "admin_skip_reasons"
+          ]
         }
       ],
       "proof_artifact_expectations": [
         {
           "name": "admin_page_coverage",
           "semantic_key": "fuzz.report",
-          "required_fields": ["target_id", "admin_path", "method", "status", "role", "required_capability", "state", "evidence_refs"]
+          "required_fields": [
+            "target_id",
+            "admin_path",
+            "method",
+            "status",
+            "role",
+            "required_capability",
+            "state",
+            "evidence_refs"
+          ]
         },
         {
           "name": "admin_menu_enumeration",
           "semantic_key": "fuzz.admin_menu_enumeration",
-          "required_fields": ["source", "menu_slug", "admin_path", "required_capability", "included"]
+          "required_fields": [
+            "source",
+            "menu_slug",
+            "admin_path",
+            "required_capability",
+            "included"
+          ]
         },
         {
           "name": "admin_skip_reasons",
           "semantic_key": "fuzz.skip_reasons",
-          "required_fields": ["target_id", "skip_code", "matched_pattern", "reason"]
+          "required_fields": [
+            "target_id",
+            "skip_code",
+            "matched_pattern",
+            "reason"
+          ]
         },
         {
           "name": "admin_query_attribution",
           "semantic_key": "fuzz.admin_query_attribution",
-          "required_fields": ["target_id", "query_count", "slow_queries", "caller_summary"]
+          "required_fields": [
+            "target_id",
+            "query_count",
+            "slow_queries",
+            "caller_summary"
+          ]
         }
+      ]
+    },
+    "readiness": {
+      "level": "executable",
+      "coverage_contract": "Jetpack admin page/menu loading, capability boundaries, safe GET-only requests, skipped destructive actions, and query-attribution proof artifacts.",
+      "upstream_blockers": [
+        "Reviewer-facing fuzz run artifacts are required before this workload can be marked proven."
       ]
     }
   },
-  "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "jetpack",
+    "component": "jetpack"
+  },
   "workload": {
     "runner": "wp-codebox",
     "type": "generic",
@@ -208,7 +352,10 @@
   "cases": [
     {
       "case_id": "jetpack-admin-page-coverage:default",
-      "surface_ids": ["jetpack-admin-pages", "wordpress-admin-pages"],
+      "surface_ids": [
+        "jetpack-admin-pages",
+        "wordpress-admin-pages"
+      ],
       "operations": [
         "admin-page-discovery",
         "permission-boundary-classification",
@@ -216,14 +363,23 @@
         "menu-page-enumeration",
         "destructive-skip-classification"
       ],
-      "metadata": { "safety_class": "read_only" },
+      "metadata": {
+        "safety_class": "read_only"
+      },
       "inputs": {
-        "roles": ["administrator"],
+        "roles": [
+          "administrator"
+        ],
         "capability_requirements": {
           "default": "manage_options",
           "per_target_field": "required_capability"
         },
-        "menu_sources": ["global_menu", "global_submenu", "registered_pages", "jetpack_admin_page_registry"],
+        "menu_sources": [
+          "global_menu",
+          "global_submenu",
+          "registered_pages",
+          "jetpack_admin_page_registry"
+        ],
         "include_menu_slugs": [
           "jetpack",
           "jetpack#/dashboard",
@@ -237,7 +393,9 @@
           "jetpack_modules"
         ],
         "page_targets_ref": "metadata.admin_target_contract.page_targets",
-        "safe_methods": ["GET"],
+        "safe_methods": [
+          "GET"
+        ],
         "get_first": true,
         "submit_forms": false,
         "follow_redirects": false,
@@ -269,7 +427,14 @@
         "proof_artifact_expectations_ref": "metadata.admin_target_contract.proof_artifact_expectations"
       },
       "phases": {
-        "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }],
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=jetpack/jetpack.php"
+            ]
+          }
+        ],
         "action": [
           {
             "command": "wordpress.fuzz-admin-pages",
@@ -285,39 +450,60 @@
             ]
           }
         ],
-        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=admin_page_coverage"] }]
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=admin_page_coverage"
+            ]
+          }
+        ]
       },
       "artifacts": [
         {
           "name": "admin_page_coverage",
           "path": "jetpack-admin-page-coverage/admin_page_coverage.json",
-          "required": false,
-          "metadata": { "semantic_key": "fuzz.report" }
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
         },
         {
           "name": "admin_menu_enumeration",
           "path": "jetpack-admin-page-coverage/admin_menu_enumeration.json",
-          "required": false,
-          "metadata": { "semantic_key": "fuzz.admin_menu_enumeration" }
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.admin_menu_enumeration"
+          }
         },
         {
           "name": "admin_skip_reasons",
           "path": "jetpack-admin-page-coverage/admin_skip_reasons.json",
-          "required": false,
-          "metadata": { "semantic_key": "fuzz.skip_reasons" }
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.skip_reasons"
+          }
         },
         {
           "name": "admin_query_attribution",
           "path": "jetpack-admin-page-coverage/admin_query_attribution.json",
-          "required": false,
-          "metadata": { "semantic_key": "fuzz.admin_query_attribution" }
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.admin_query_attribution"
+          }
         }
       ]
     }
   ],
-  "limits": { "max_cases": 40, "max_duration_seconds": 600 },
+  "limits": {
+    "max_cases": 40,
+    "max_duration_seconds": 600
+  },
   "coverage": {
-    "surface_ids": ["jetpack-admin-pages", "wordpress-admin-pages"],
+    "surface_ids": [
+      "jetpack-admin-pages",
+      "wordpress-admin-pages"
+    ],
     "operations": [
       "admin-page-discovery",
       "permission-boundary-classification",
@@ -328,19 +514,29 @@
   },
   "artifacts": {
     "expected": [
-      { "name": "admin_page_coverage", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false },
+      {
+        "name": "admin_page_coverage",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": true
+      },
       {
         "name": "admin_menu_enumeration",
         "role": "coverage_inventory",
         "semantic_key": "fuzz.admin_menu_enumeration",
-        "required": false
+        "required": true
       },
-      { "name": "admin_skip_reasons", "role": "safety_report", "semantic_key": "fuzz.skip_reasons", "required": false },
+      {
+        "name": "admin_skip_reasons",
+        "role": "safety_report",
+        "semantic_key": "fuzz.skip_reasons",
+        "required": true
+      },
       {
         "name": "admin_query_attribution",
         "role": "query_attribution",
         "semantic_key": "fuzz.admin_query_attribution",
-        "required": false
+        "required": true
       }
     ]
   }

--- a/Automattic/jetpack/fuzz/jetpack-connected-disconnected-fixtures.json
+++ b/Automattic/jetpack/fuzz/jetpack-connected-disconnected-fixtures.json
@@ -3,8 +3,18 @@
   "id": "jetpack-connected-disconnected-fixtures",
   "label": "Jetpack connected and disconnected fixture coverage",
   "safety_class": "isolated_mutation",
-  "surface_ids": ["jetpack-connection", "jetpack-modules", "jetpack-sync", "wordpress-options"],
-  "operations": ["connected-fixture-state", "disconnected-fixture-state", "token-placeholder-serialization", "skip-reason-classification"],
+  "surface_ids": [
+    "jetpack-connection",
+    "jetpack-modules",
+    "jetpack-sync",
+    "wordpress-options"
+  ],
+  "operations": [
+    "connected-fixture-state",
+    "disconnected-fixture-state",
+    "token-placeholder-serialization",
+    "skip-reason-classification"
+  ],
   "case_budget": 80,
   "duration_budget_seconds": 900,
   "metadata": {
@@ -13,21 +23,40 @@
     "workload_path": "${package.root}/manifests/full-surface-coverage.json",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report",
-    "fixture_states": ["connected", "disconnected"],
+    "fixture_states": [
+      "connected",
+      "disconnected"
+    ],
     "fixture_state_contract": {
       "connected": {
         "description": "Synthetic local connected-site shape with placeholder blog/user IDs and fake token material only.",
-        "required_options": ["jetpack_options", "jetpack_private_options", "jetpack_active_modules"],
+        "required_options": [
+          "jetpack_options",
+          "jetpack_private_options",
+          "jetpack_active_modules"
+        ],
         "expected_connection_state": "locally_connected_without_wpcom_sandbox",
-        "allowed_secret_values": ["__JETPACK_FAKE_BLOG_TOKEN__", "__JETPACK_FAKE_USER_TOKEN__"],
-        "expected_skip_reasons": ["credential_unavailable", "external_service_required"],
+        "allowed_secret_values": [
+          "__JETPACK_FAKE_BLOG_TOKEN__",
+          "__JETPACK_FAKE_USER_TOKEN__"
+        ],
+        "expected_skip_reasons": [
+          "credential_unavailable",
+          "external_service_required"
+        ],
         "network_calls_allowed": false
       },
       "disconnected": {
         "description": "Clean local disconnected-site shape with connection options absent or reset to empty defaults.",
-        "required_absent_options": ["jetpack_private_options.blog_token", "jetpack_private_options.user_tokens"],
+        "required_absent_options": [
+          "jetpack_private_options.blog_token",
+          "jetpack_private_options.user_tokens"
+        ],
         "expected_connection_state": "disconnected_without_wpcom_sandbox",
-        "expected_skip_reasons": ["connection_required", "disconnected_expected"],
+        "expected_skip_reasons": [
+          "connection_required",
+          "disconnected_expected"
+        ],
         "network_calls_allowed": false
       }
     },
@@ -35,9 +64,20 @@
       "real_wpcom_credentials_allowed": false,
       "real_tokens_allowed": false,
       "placeholder_tokens_only": true,
-      "redact_token_fields": ["blog_token", "user_token", "token", "secret", "access_token"],
+      "redact_token_fields": [
+        "blog_token",
+        "user_token",
+        "token",
+        "secret",
+        "access_token"
+      ],
       "redaction_placeholder": "[redacted:jetpack-fixture-token]",
-      "artifact_must_not_contain_patterns": ["Bearer ", "token_secret", "oauth_token_secret", "public-api.wordpress.com/rest/v1.1/me"]
+      "artifact_must_not_contain_patterns": [
+        "Bearer ",
+        "token_secret",
+        "oauth_token_secret",
+        "public-api.wordpress.com/rest/v1.1/me"
+      ]
     },
     "wpcom_sandbox_blockers": [
       "No WP.com OAuth application, sandbox blog, or service account is provisioned for this fixture lane.",
@@ -45,9 +85,22 @@
       "The Jetpack external HTTP guardrail owns network blocking proof for this lane."
     ],
     "module_availability_expectations": {
-      "available_in_both_states": ["shortcodes", "markdown", "widget-visibility"],
-      "connected_fixture_may_enable": ["stats", "publicize", "related-posts", "protect"],
-      "requires_connected_or_wpcom_service": ["stats", "publicize", "protect"],
+      "available_in_both_states": [
+        "shortcodes",
+        "markdown",
+        "widget-visibility"
+      ],
+      "connected_fixture_may_enable": [
+        "stats",
+        "publicize",
+        "related-posts",
+        "protect"
+      ],
+      "requires_connected_or_wpcom_service": [
+        "stats",
+        "publicize",
+        "protect"
+      ],
       "unavailable_reason": "credential_unavailable"
     },
     "reset_contract": {
@@ -55,25 +108,261 @@
       "restore_original_values": true,
       "rollback_required": true,
       "reset_after_each_state": true,
-      "option_patterns": ["jetpack_options", "jetpack_private_options", "jetpack_active_modules", "jetpack_sync_settings_*"],
-      "transient_patterns": ["jetpack_%", "jp_%"],
+      "option_patterns": [
+        "jetpack_options",
+        "jetpack_private_options",
+        "jetpack_active_modules",
+        "jetpack_sync_settings_*"
+      ],
+      "transient_patterns": [
+        "jetpack_%",
+        "jp_%"
+      ],
       "failure_policy": "fail_if_fixture_state_leaks_after_assert"
     },
     "mutation_policy": "snapshot_connection_options_restore_after_assert",
     "artifact_expectations": {
-      "required": ["connected_fixture_rows", "disconnected_fixture_rows", "token_placeholder_serialization", "skip_reason_rows", "rollback_reset_rows", "redaction_rows"],
-      "optional": ["module_state_diffs", "sync_queue_diffs"]
+      "required": [
+        "connected_fixture_rows",
+        "disconnected_fixture_rows",
+        "token_placeholder_serialization",
+        "skip_reason_rows",
+        "rollback_reset_rows",
+        "redaction_rows"
+      ],
+      "optional": [
+        "module_state_diffs",
+        "sync_queue_diffs"
+      ]
     },
     "proof_artifact_expectations": {
-      "connection_fixture_matrix": ["state", "connection_state", "option_snapshot_hash", "module_expectations", "skip_reasons"],
-      "connection_skip_reasons": ["state", "surface", "reason_code", "blocked_by_wpcom_sandbox"],
-      "connection_reset_report": ["state", "restored_options", "restored_transients", "leaked_keys", "passed"]
+      "connection_fixture_matrix": [
+        "state",
+        "connection_state",
+        "option_snapshot_hash",
+        "module_expectations",
+        "skip_reasons"
+      ],
+      "connection_skip_reasons": [
+        "state",
+        "surface",
+        "reason_code",
+        "blocked_by_wpcom_sandbox"
+      ],
+      "connection_reset_report": [
+        "state",
+        "restored_options",
+        "restored_transients",
+        "leaked_keys",
+        "passed"
+      ]
+    },
+    "readiness": {
+      "level": "executable",
+      "coverage_contract": "Jetpack connected and disconnected fixture states using placeholder tokens, redaction checks, skip-reason classification, and rollback/reset artifacts.",
+      "upstream_blockers": [
+        "Reviewer-facing fuzz run artifacts are required before this workload can be marked proven."
+      ]
     }
   },
-  "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
-  "workload": { "runner": "wp-codebox", "type": "generic", "path": "${package.root}/manifests/full-surface-coverage.json", "entry": "jetpack-connected-disconnected-fixtures" },
-  "cases": [{ "case_id": "jetpack-connected-disconnected-fixtures:default", "surface_ids": ["jetpack-connection", "jetpack-modules", "jetpack-sync", "wordpress-options"], "operations": ["connected-fixture-state", "disconnected-fixture-state", "token-placeholder-serialization", "skip-reason-classification"], "inputs": { "states": ["connected", "disconnected"], "fixture_states": ["connected", "disconnected"], "explicit_fixture_states": { "connected": "synthetic_placeholder_connection_without_wpcom_sandbox", "disconnected": "clean_local_disconnect_without_wpcom_sandbox" }, "connection_options": ["jetpack_options", "jetpack_private_options", "jetpack_active_modules", "jetpack_sync_settings_sync_wait_time"], "fixture_options": ["jetpack_options", "jetpack_private_options", "jetpack_active_modules", "jetpack_sync_settings_*"], "redact_option_fields": ["blog_token", "user_token", "token", "secret", "access_token"], "allowed_fake_tokens": ["__JETPACK_FAKE_BLOG_TOKEN__", "__JETPACK_FAKE_USER_TOKEN__"], "real_wpcom_credentials_allowed": false, "real_tokens_allowed": false, "network_calls_allowed": false, "wpcom_sandbox_required": false, "secret_placeholders_only": true, "restore_original_values": true, "reset_after_each_state": true, "rollback_required": true, "module_availability_expectations": { "available_in_both_states": ["shortcodes", "markdown", "widget-visibility"], "connected_fixture_may_enable": ["stats", "publicize", "related-posts", "protect"], "requires_connected_or_wpcom_service": ["stats", "publicize", "protect"] }, "skip_reason_codes": ["credential_unavailable", "external_service_required", "connection_required", "disconnected_expected", "connected_required", "destructive_action", "unsupported_fixture"] }, "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }], "action": [{ "command": "wordpress.fuzz-plugin-connection-fixtures", "args": ["states=connected,disconnected", "secret_placeholders_only=true", "restore_original_values=true", "rollback_required=true", "classify_skips=true"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=connection_fixture_matrix"] }] }, "artifacts": [{ "name": "connection_fixture_matrix", "path": "jetpack-connected-disconnected-fixtures/connection_fixture_matrix.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }, { "name": "connection_skip_reasons", "path": "jetpack-connected-disconnected-fixtures/connection_skip_reasons.json", "required": false, "metadata": { "semantic_key": "fuzz.skip_reasons" } }, { "name": "connection_reset_report", "path": "jetpack-connected-disconnected-fixtures/connection_reset_report.json", "required": false, "metadata": { "semantic_key": "fuzz.rollback_report" } }], "metadata": { "safety_class": "isolated_mutation", "mutation_policy": "snapshot_connection_options_restore_after_assert" } }],
-  "limits": { "max_cases": 80, "max_duration_seconds": 900 },
-  "coverage": { "surface_ids": ["jetpack-connection", "jetpack-modules", "jetpack-sync", "wordpress-options"], "operations": ["connected-fixture-state", "disconnected-fixture-state", "token-placeholder-serialization", "skip-reason-classification"] },
-  "artifacts": { "expected": [{ "name": "connection_fixture_matrix", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }, { "name": "connection_skip_reasons", "role": "safety_report", "semantic_key": "fuzz.skip_reasons", "required": false }, { "name": "connection_reset_report", "role": "rollback_report", "semantic_key": "fuzz.rollback_report", "required": false }] }
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "jetpack",
+    "component": "jetpack"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "generic",
+    "path": "${package.root}/manifests/full-surface-coverage.json",
+    "entry": "jetpack-connected-disconnected-fixtures"
+  },
+  "cases": [
+    {
+      "case_id": "jetpack-connected-disconnected-fixtures:default",
+      "surface_ids": [
+        "jetpack-connection",
+        "jetpack-modules",
+        "jetpack-sync",
+        "wordpress-options"
+      ],
+      "operations": [
+        "connected-fixture-state",
+        "disconnected-fixture-state",
+        "token-placeholder-serialization",
+        "skip-reason-classification"
+      ],
+      "inputs": {
+        "states": [
+          "connected",
+          "disconnected"
+        ],
+        "fixture_states": [
+          "connected",
+          "disconnected"
+        ],
+        "explicit_fixture_states": {
+          "connected": "synthetic_placeholder_connection_without_wpcom_sandbox",
+          "disconnected": "clean_local_disconnect_without_wpcom_sandbox"
+        },
+        "connection_options": [
+          "jetpack_options",
+          "jetpack_private_options",
+          "jetpack_active_modules",
+          "jetpack_sync_settings_sync_wait_time"
+        ],
+        "fixture_options": [
+          "jetpack_options",
+          "jetpack_private_options",
+          "jetpack_active_modules",
+          "jetpack_sync_settings_*"
+        ],
+        "redact_option_fields": [
+          "blog_token",
+          "user_token",
+          "token",
+          "secret",
+          "access_token"
+        ],
+        "allowed_fake_tokens": [
+          "__JETPACK_FAKE_BLOG_TOKEN__",
+          "__JETPACK_FAKE_USER_TOKEN__"
+        ],
+        "real_wpcom_credentials_allowed": false,
+        "real_tokens_allowed": false,
+        "network_calls_allowed": false,
+        "wpcom_sandbox_required": false,
+        "secret_placeholders_only": true,
+        "restore_original_values": true,
+        "reset_after_each_state": true,
+        "rollback_required": true,
+        "module_availability_expectations": {
+          "available_in_both_states": [
+            "shortcodes",
+            "markdown",
+            "widget-visibility"
+          ],
+          "connected_fixture_may_enable": [
+            "stats",
+            "publicize",
+            "related-posts",
+            "protect"
+          ],
+          "requires_connected_or_wpcom_service": [
+            "stats",
+            "publicize",
+            "protect"
+          ]
+        },
+        "skip_reason_codes": [
+          "credential_unavailable",
+          "external_service_required",
+          "connection_required",
+          "disconnected_expected",
+          "connected_required",
+          "destructive_action",
+          "unsupported_fixture"
+        ]
+      },
+      "phases": {
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=jetpack/jetpack.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.fuzz-plugin-connection-fixtures",
+            "args": [
+              "states=connected,disconnected",
+              "secret_placeholders_only=true",
+              "restore_original_values=true",
+              "rollback_required=true",
+              "classify_skips=true"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=connection_fixture_matrix"
+            ]
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "connection_fixture_matrix",
+          "path": "jetpack-connected-disconnected-fixtures/connection_fixture_matrix.json",
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        },
+        {
+          "name": "connection_skip_reasons",
+          "path": "jetpack-connected-disconnected-fixtures/connection_skip_reasons.json",
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.skip_reasons"
+          }
+        },
+        {
+          "name": "connection_reset_report",
+          "path": "jetpack-connected-disconnected-fixtures/connection_reset_report.json",
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.rollback_report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "isolated_mutation",
+        "mutation_policy": "snapshot_connection_options_restore_after_assert"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 80,
+    "max_duration_seconds": 900
+  },
+  "coverage": {
+    "surface_ids": [
+      "jetpack-connection",
+      "jetpack-modules",
+      "jetpack-sync",
+      "wordpress-options"
+    ],
+    "operations": [
+      "connected-fixture-state",
+      "disconnected-fixture-state",
+      "token-placeholder-serialization",
+      "skip-reason-classification"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "connection_fixture_matrix",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": true
+      },
+      {
+        "name": "connection_skip_reasons",
+        "role": "safety_report",
+        "semantic_key": "fuzz.skip_reasons",
+        "required": true
+      },
+      {
+        "name": "connection_reset_report",
+        "role": "rollback_report",
+        "semantic_key": "fuzz.rollback_report",
+        "required": true
+      }
+    ]
+  }
 }

--- a/Automattic/jetpack/fuzz/jetpack-external-http-guardrail.json
+++ b/Automattic/jetpack/fuzz/jetpack-external-http-guardrail.json
@@ -3,8 +3,15 @@
   "id": "jetpack-external-http-guardrail",
   "label": "Jetpack external HTTP guardrail",
   "safety_class": "read_only",
-  "surface_ids": ["jetpack-external-http", "jetpack-connection", "jetpack-sync"],
-  "operations": ["external-http-blocklist-probe", "network-side-effect-classification"],
+  "surface_ids": [
+    "jetpack-external-http",
+    "jetpack-connection",
+    "jetpack-sync"
+  ],
+  "operations": [
+    "external-http-blocklist-probe",
+    "network-side-effect-classification"
+  ],
   "case_budget": 1,
   "duration_budget_seconds": 300,
   "metadata": {
@@ -19,32 +26,52 @@
         "class": "connection-api",
         "description": "Jetpack site registration, connection status, and token verification calls that normally target WordPress.com APIs.",
         "connected_state": "connected_required",
-        "hosts": ["public-api.wordpress.com"],
-        "path_prefixes": ["/rest/v1.1/sites/", "/rest/v1.2/sites/"],
+        "hosts": [
+          "public-api.wordpress.com"
+        ],
+        "path_prefixes": [
+          "/rest/v1.1/sites/",
+          "/rest/v1.2/sites/"
+        ],
         "fixture_policy": "classify_without_live_credentials"
       },
       {
         "class": "sync-dispatch",
         "description": "Jetpack sync sender, action queue, and retry dispatch boundaries.",
         "connected_state": "connected_required",
-        "hosts": ["public-api.wordpress.com"],
-        "path_prefixes": ["/rest/v1.1/sites/", "/rest/v1.2/sites/"],
+        "hosts": [
+          "public-api.wordpress.com"
+        ],
+        "path_prefixes": [
+          "/rest/v1.1/sites/",
+          "/rest/v1.2/sites/"
+        ],
         "fixture_policy": "record_blocked_or_skipped_dispatch"
       },
       {
         "class": "module-service-api",
         "description": "Module-owned service calls such as stats, publicize, subscriptions, protect, and related posts.",
         "connected_state": "module_and_connection_dependent",
-        "hosts": ["public-api.wordpress.com"],
-        "path_prefixes": ["/rest/v1.1/", "/rest/v1.2/"],
+        "hosts": [
+          "public-api.wordpress.com"
+        ],
+        "path_prefixes": [
+          "/rest/v1.1/",
+          "/rest/v1.2/"
+        ],
         "fixture_policy": "classify_module_boundary_without_external_call"
       },
       {
         "class": "synthetic-blocked-probe",
         "description": "Rig-owned synthetic probes used to prove unapproved outbound requests are intercepted before leaving the runner.",
         "connected_state": "not_required",
-        "hosts": ["jetpack-homeboy-guardrail.invalid"],
-        "path_prefixes": ["/rest/v1.1/sites/", "/guardrail-probe"],
+        "hosts": [
+          "jetpack-homeboy-guardrail.invalid"
+        ],
+        "path_prefixes": [
+          "/rest/v1.1/sites/",
+          "/guardrail-probe"
+        ],
         "fixture_policy": "must_be_blocked"
       }
     ],
@@ -79,9 +106,16 @@
       "raw_secret_values_allowed_in_artifacts": false
     },
     "connection_requirements": {
-      "states": ["connected", "disconnected"],
+      "states": [
+        "connected",
+        "disconnected"
+      ],
       "real_wpcom_credentials_allowed": false,
-      "connected_required_classes": ["connection-api", "sync-dispatch", "module-service-api"],
+      "connected_required_classes": [
+        "connection-api",
+        "sync-dispatch",
+        "module-service-api"
+      ],
       "disconnected_expectation": "classify_as_connection_required_or_credential_unavailable_without_calling_wpcom",
       "placeholder_credentials_only": true
     },
@@ -101,9 +135,20 @@
       ],
       "reviewer_facing_refs_required": true,
       "local_paths_allowed_as_proof_refs": false
+    },
+    "readiness": {
+      "level": "executable",
+      "coverage_contract": "Jetpack external HTTP guardrail coverage for allowed/blocked hosts, redacted secrets, connected-state skips, and no live external service calls.",
+      "upstream_blockers": [
+        "Reviewer-facing fuzz run artifacts are required before this workload can be marked proven."
+      ]
     }
   },
-  "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "jetpack",
+    "component": "jetpack"
+  },
   "workload": {
     "runner": "wp-codebox",
     "type": "php",
@@ -112,9 +157,16 @@
   },
   "network_guardrail": {
     "block_network": true,
-    "allowlist_domains": ["public-api.wordpress.com"],
-    "blocked_domains": ["jetpack-homeboy-guardrail.invalid"],
-    "probe_hosts": ["jetpack-homeboy-guardrail.invalid", "public-api.wordpress.com"],
+    "allowlist_domains": [
+      "public-api.wordpress.com"
+    ],
+    "blocked_domains": [
+      "jetpack-homeboy-guardrail.invalid"
+    ],
+    "probe_hosts": [
+      "jetpack-homeboy-guardrail.invalid",
+      "public-api.wordpress.com"
+    ],
     "real_external_service_calls_allowed": false,
     "expectations": [
       {
@@ -138,64 +190,143 @@
   "cases": [
     {
       "case_id": "jetpack-external-http-guardrail:default",
-      "surface_ids": ["jetpack-external-http", "jetpack-connection", "jetpack-sync"],
-      "operations": ["external-http-blocklist-probe", "network-side-effect-classification"],
+      "surface_ids": [
+        "jetpack-external-http",
+        "jetpack-connection",
+        "jetpack-sync"
+      ],
+      "operations": [
+        "external-http-blocklist-probe",
+        "network-side-effect-classification"
+      ],
       "inputs": {
-        "endpoint_classes": ["connection-api", "sync-dispatch", "module-service-api", "synthetic-blocked-probe"],
-        "allowlist_domains": ["public-api.wordpress.com"],
-        "blocked_domains": ["jetpack-homeboy-guardrail.invalid"],
+        "endpoint_classes": [
+          "connection-api",
+          "sync-dispatch",
+          "module-service-api",
+          "synthetic-blocked-probe"
+        ],
+        "allowlist_domains": [
+          "public-api.wordpress.com"
+        ],
+        "blocked_domains": [
+          "jetpack-homeboy-guardrail.invalid"
+        ],
         "real_external_service_calls_allowed": false,
         "real_wpcom_credentials_allowed": false,
-        "states": ["connected", "disconnected"],
+        "states": [
+          "connected",
+          "disconnected"
+        ],
         "secret_redaction_required": true,
         "proof_artifacts_required_before_proven": true,
-        "skip_reason_codes": ["connection_required", "credential_unavailable", "external_service_required", "blocked_external_http"]
+        "skip_reason_codes": [
+          "connection_required",
+          "credential_unavailable",
+          "external_service_required",
+          "blocked_external_http"
+        ]
       },
       "phases": {
         "setup": [
-          { "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] },
-          { "command": "wordpress.ensure-external-http-guardrail", "args": ["allowlist=public-api.wordpress.com", "block_network=true"] }
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=jetpack/jetpack.php"
+            ]
+          },
+          {
+            "command": "wordpress.ensure-external-http-guardrail",
+            "args": [
+              "allowlist=public-api.wordpress.com",
+              "block_network=true"
+            ]
+          }
         ],
         "action": [
-          { "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/jetpack-external-http-guardrail.php", "type=php"] }
+          {
+            "command": "wordpress.run-workload",
+            "args": [
+              "path=${package.root}/bench/jetpack-external-http-guardrail.php",
+              "type=php"
+            ]
+          }
         ],
         "assert": [
-          { "command": "wordpress.collect-workload-result", "args": ["artifact=external_http_guardrail"] }
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=external_http_guardrail"
+            ]
+          }
         ]
       },
       "artifacts": [
         {
           "name": "external_http_guardrail",
           "path": "jetpack-external-http-guardrail/external_http_guardrail.json",
-          "required": false,
-          "metadata": { "semantic_key": "fuzz.report" }
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
         },
         {
           "name": "external_http_redaction_assertions",
           "path": "jetpack-external-http-guardrail/external_http_redaction_assertions.json",
-          "required": false,
-          "metadata": { "semantic_key": "fuzz.secret_redaction" }
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.secret_redaction"
+          }
         },
         {
           "name": "external_http_skip_reasons",
           "path": "jetpack-external-http-guardrail/external_http_skip_reasons.json",
-          "required": false,
-          "metadata": { "semantic_key": "fuzz.skip_reasons" }
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.skip_reasons"
+          }
         }
       ],
-      "metadata": { "safety_class": "read_only" }
+      "metadata": {
+        "safety_class": "read_only"
+      }
     }
   ],
-  "limits": { "max_cases": 1, "max_duration_seconds": 300 },
+  "limits": {
+    "max_cases": 1,
+    "max_duration_seconds": 300
+  },
   "coverage": {
-    "surface_ids": ["jetpack-external-http", "jetpack-connection", "jetpack-sync"],
-    "operations": ["external-http-blocklist-probe", "network-side-effect-classification"]
+    "surface_ids": [
+      "jetpack-external-http",
+      "jetpack-connection",
+      "jetpack-sync"
+    ],
+    "operations": [
+      "external-http-blocklist-probe",
+      "network-side-effect-classification"
+    ]
   },
   "artifacts": {
     "expected": [
-      { "name": "external_http_guardrail", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false },
-      { "name": "external_http_redaction_assertions", "role": "fuzz_report", "semantic_key": "fuzz.secret_redaction", "required": false },
-      { "name": "external_http_skip_reasons", "role": "fuzz_report", "semantic_key": "fuzz.skip_reasons", "required": false }
+      {
+        "name": "external_http_guardrail",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": true
+      },
+      {
+        "name": "external_http_redaction_assertions",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.secret_redaction",
+        "required": true
+      },
+      {
+        "name": "external_http_skip_reasons",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.skip_reasons",
+        "required": true
+      }
     ]
   }
 }

--- a/Automattic/jetpack/fuzz/jetpack-performance-observation.json
+++ b/Automattic/jetpack/fuzz/jetpack-performance-observation.json
@@ -3,8 +3,22 @@
   "id": "jetpack-performance-observation",
   "label": "Jetpack performance observation summary",
   "safety_class": "read_only",
-  "surface_ids": ["jetpack-performance", "jetpack-rest-routes", "jetpack-admin-pages", "jetpack-public-frontend", "jetpack-sync", "performance-guardrails"],
-  "operations": ["request-timing-summary", "query-count-summary", "asset-summary", "sync-queue-summary", "external-http-guardrail-summary", "slow-surface-classification"],
+  "surface_ids": [
+    "jetpack-performance",
+    "jetpack-rest-routes",
+    "jetpack-admin-pages",
+    "jetpack-public-frontend",
+    "jetpack-sync",
+    "performance-guardrails"
+  ],
+  "operations": [
+    "request-timing-summary",
+    "query-count-summary",
+    "asset-summary",
+    "sync-queue-summary",
+    "external-http-guardrail-summary",
+    "slow-surface-classification"
+  ],
   "case_budget": 80,
   "duration_budget_seconds": 900,
   "metadata": {
@@ -22,19 +36,240 @@
       "max_external_http_attempts": 0,
       "max_sync_queue_delta": 0
     },
-    "observed_surfaces": ["rest-generated-cases", "admin-page-coverage", "browser-request-coverage", "public-module-frontend", "sync-queue", "db-query-profile", "external-http-guardrail"],
-    "hotspot_classes": ["slow-rest-route", "slow-admin-screen", "asset-bloat", "duplicate-db-query", "autoloaded-option-query", "sync-queue-delta", "external-http-attempt"],
+    "observed_surfaces": [
+      "rest-generated-cases",
+      "admin-page-coverage",
+      "browser-request-coverage",
+      "public-module-frontend",
+      "sync-queue",
+      "db-query-profile",
+      "external-http-guardrail"
+    ],
+    "hotspot_classes": [
+      "slow-rest-route",
+      "slow-admin-screen",
+      "asset-bloat",
+      "duplicate-db-query",
+      "autoloaded-option-query",
+      "sync-queue-delta",
+      "external-http-attempt"
+    ],
     "query_attribution_expectations": {
       "source_artifact": "rest_db_query_profile",
-      "join_keys": ["rest_route", "http_method", "connection_state", "module", "hotspot_class"],
-      "summary_fields": ["query_count", "duplicate_query_count", "slow_query_count", "tables", "options"]
+      "join_keys": [
+        "rest_route",
+        "http_method",
+        "connection_state",
+        "module",
+        "hotspot_class"
+      ],
+      "summary_fields": [
+        "query_count",
+        "duplicate_query_count",
+        "slow_query_count",
+        "tables",
+        "options"
+      ]
     },
-    "connected_state_caveats": ["Disconnected runs are expected to surface guarded skips for WordPress.com-backed modules", "Connected runs require placeholder credentials and blocked outbound HTTP, so remote-backed latency is classified as a caveat rather than a pass/fail budget"]
+    "connected_state_caveats": [
+      "Disconnected runs are expected to surface guarded skips for WordPress.com-backed modules",
+      "Connected runs require placeholder credentials and blocked outbound HTTP, so remote-backed latency is classified as a caveat rather than a pass/fail budget"
+    ],
+    "readiness": {
+      "level": "executable",
+      "coverage_contract": "Jetpack non-benchmark performance observation surfaces, product budgets, hotspot classes, query attribution, and connected-state caveats.",
+      "upstream_blockers": [
+        "Reviewer-facing fuzz run artifacts are required before this workload can be marked proven."
+      ]
+    }
   },
-  "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
-  "workload": { "runner": "wp-codebox", "type": "generic", "path": "${package.root}/manifests/full-surface-coverage.json", "entry": "jetpack-performance-observation" },
-  "cases": [{ "case_id": "jetpack-performance-observation:default", "surface_ids": ["jetpack-performance", "jetpack-rest-routes", "jetpack-admin-pages", "jetpack-public-frontend", "jetpack-sync", "performance-guardrails"], "operations": ["request-timing-summary", "query-count-summary", "asset-summary", "sync-queue-summary", "external-http-guardrail-summary", "slow-surface-classification"], "inputs": { "observation_surfaces": ["rest_generated_cases", "admin_page_coverage", "browser_request_coverage", "public_module_frontend_coverage", "sync_queue_coverage", "db_query_profile", "external_http_guardrail"], "metrics": ["request_count", "response_status_count", "duration_ms", "query_count", "duplicate_query_count", "slow_query_count", "asset_count", "external_http_attempt_count", "sync_queue_delta", "skip_reason_count"], "budget_keys": ["max_rest_p95_duration_ms", "max_admin_p95_duration_ms", "max_public_frontend_p95_duration_ms", "max_queries_per_rest_case", "max_assets_per_public_request", "max_external_http_attempts", "max_sync_queue_delta"], "hotspot_classes": ["slow-rest-route", "slow-admin-screen", "asset-bloat", "duplicate-db-query", "autoloaded-option-query", "sync-queue-delta", "external-http-attempt"], "query_attribution_source": "rest_db_query_profile", "states": ["connected", "disconnected"], "proof_required_before_status_p": true }, "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }], "action": [{ "command": "wordpress.summarize-fuzz-artifacts", "args": ["surface=jetpack-performance", "include=timing,queries,assets,sync,http,skips"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=jetpack_performance_observation"] }] }, "artifacts": [{ "name": "jetpack_performance_observation", "path": "jetpack-performance-observation/jetpack_performance_observation.json", "required": false, "metadata": { "semantic_key": "fuzz.report", "contains": ["product_budget_comparison", "hotspot_classification", "query_attribution_summary", "connected_state_caveats"] } }, { "name": "jetpack_performance_surface_summary", "path": "jetpack-performance-observation/jetpack_performance_surface_summary.json", "required": false, "metadata": { "semantic_key": "fuzz.performance_surface_summary", "contains": ["surface_rollups", "budget_status", "artifact_inputs", "skip_reason_rollups"] } }], "metadata": { "safety_class": "read_only" } }],
-  "limits": { "max_cases": 80, "max_duration_seconds": 900 },
-  "coverage": { "surface_ids": ["jetpack-performance", "jetpack-rest-routes", "jetpack-admin-pages", "jetpack-public-frontend", "jetpack-sync", "performance-guardrails"], "operations": ["request-timing-summary", "query-count-summary", "asset-summary", "sync-queue-summary", "external-http-guardrail-summary", "slow-surface-classification"] },
-  "artifacts": { "expected": [{ "name": "jetpack_performance_observation", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false, "contains": ["product_budget_comparison", "hotspot_classification", "query_attribution_summary", "connected_state_caveats"] }, { "name": "jetpack_performance_surface_summary", "role": "performance_summary", "semantic_key": "fuzz.performance_surface_summary", "required": false, "contains": ["surface_rollups", "budget_status", "artifact_inputs", "skip_reason_rollups"] }] }
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "jetpack",
+    "component": "jetpack"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "generic",
+    "path": "${package.root}/manifests/full-surface-coverage.json",
+    "entry": "jetpack-performance-observation"
+  },
+  "cases": [
+    {
+      "case_id": "jetpack-performance-observation:default",
+      "surface_ids": [
+        "jetpack-performance",
+        "jetpack-rest-routes",
+        "jetpack-admin-pages",
+        "jetpack-public-frontend",
+        "jetpack-sync",
+        "performance-guardrails"
+      ],
+      "operations": [
+        "request-timing-summary",
+        "query-count-summary",
+        "asset-summary",
+        "sync-queue-summary",
+        "external-http-guardrail-summary",
+        "slow-surface-classification"
+      ],
+      "inputs": {
+        "observation_surfaces": [
+          "rest_generated_cases",
+          "admin_page_coverage",
+          "browser_request_coverage",
+          "public_module_frontend_coverage",
+          "sync_queue_coverage",
+          "db_query_profile",
+          "external_http_guardrail"
+        ],
+        "metrics": [
+          "request_count",
+          "response_status_count",
+          "duration_ms",
+          "query_count",
+          "duplicate_query_count",
+          "slow_query_count",
+          "asset_count",
+          "external_http_attempt_count",
+          "sync_queue_delta",
+          "skip_reason_count"
+        ],
+        "budget_keys": [
+          "max_rest_p95_duration_ms",
+          "max_admin_p95_duration_ms",
+          "max_public_frontend_p95_duration_ms",
+          "max_queries_per_rest_case",
+          "max_assets_per_public_request",
+          "max_external_http_attempts",
+          "max_sync_queue_delta"
+        ],
+        "hotspot_classes": [
+          "slow-rest-route",
+          "slow-admin-screen",
+          "asset-bloat",
+          "duplicate-db-query",
+          "autoloaded-option-query",
+          "sync-queue-delta",
+          "external-http-attempt"
+        ],
+        "query_attribution_source": "rest_db_query_profile",
+        "states": [
+          "connected",
+          "disconnected"
+        ],
+        "proof_required_before_status_p": true
+      },
+      "phases": {
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=jetpack/jetpack.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.summarize-fuzz-artifacts",
+            "args": [
+              "surface=jetpack-performance",
+              "include=timing,queries,assets,sync,http,skips"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=jetpack_performance_observation"
+            ]
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "jetpack_performance_observation",
+          "path": "jetpack-performance-observation/jetpack_performance_observation.json",
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.report",
+            "contains": [
+              "product_budget_comparison",
+              "hotspot_classification",
+              "query_attribution_summary",
+              "connected_state_caveats"
+            ]
+          }
+        },
+        {
+          "name": "jetpack_performance_surface_summary",
+          "path": "jetpack-performance-observation/jetpack_performance_surface_summary.json",
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.performance_surface_summary",
+            "contains": [
+              "surface_rollups",
+              "budget_status",
+              "artifact_inputs",
+              "skip_reason_rollups"
+            ]
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "read_only"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 80,
+    "max_duration_seconds": 900
+  },
+  "coverage": {
+    "surface_ids": [
+      "jetpack-performance",
+      "jetpack-rest-routes",
+      "jetpack-admin-pages",
+      "jetpack-public-frontend",
+      "jetpack-sync",
+      "performance-guardrails"
+    ],
+    "operations": [
+      "request-timing-summary",
+      "query-count-summary",
+      "asset-summary",
+      "sync-queue-summary",
+      "external-http-guardrail-summary",
+      "slow-surface-classification"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "jetpack_performance_observation",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": true,
+        "contains": [
+          "product_budget_comparison",
+          "hotspot_classification",
+          "query_attribution_summary",
+          "connected_state_caveats"
+        ]
+      },
+      {
+        "name": "jetpack_performance_surface_summary",
+        "role": "performance_summary",
+        "semantic_key": "fuzz.performance_surface_summary",
+        "required": true,
+        "contains": [
+          "surface_rollups",
+          "budget_status",
+          "artifact_inputs",
+          "skip_reason_rollups"
+        ]
+      }
+    ]
+  }
 }

--- a/Automattic/jetpack/fuzz/jetpack-public-module-frontend-coverage.json
+++ b/Automattic/jetpack/fuzz/jetpack-public-module-frontend-coverage.json
@@ -3,15 +3,216 @@
   "id": "jetpack-public-module-frontend-coverage",
   "label": "Jetpack public module frontend coverage",
   "safety_class": "read_only",
-  "surface_ids": ["jetpack-public-frontend", "jetpack-modules", "browser-requests"],
-  "operations": ["module-frontend-render", "asset-request-capture", "xhr-fetch-capture", "connected-disconnected-classification", "public-route-enumeration"],
+  "surface_ids": [
+    "jetpack-public-frontend",
+    "jetpack-modules",
+    "browser-requests"
+  ],
+  "operations": [
+    "module-frontend-render",
+    "asset-request-capture",
+    "xhr-fetch-capture",
+    "connected-disconnected-classification",
+    "public-route-enumeration"
+  ],
   "case_budget": 80,
   "duration_budget_seconds": 900,
-  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "workload_path": "${package.root}/manifests/full-surface-coverage.json", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report" },
-  "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
-  "workload": { "runner": "wp-codebox", "type": "generic", "path": "${package.root}/manifests/full-surface-coverage.json", "entry": "jetpack-public-module-frontend-coverage" },
-  "cases": [{ "case_id": "jetpack-public-module-frontend-coverage:default", "surface_ids": ["jetpack-public-frontend", "jetpack-modules", "browser-requests"], "operations": ["module-frontend-render", "asset-request-capture", "xhr-fetch-capture", "connected-disconnected-classification", "public-route-enumeration"], "inputs": { "states": ["connected", "disconnected"], "module_scenarios": [{ "module": "shortcodes", "routes": ["/?p=1201"] }, { "module": "contact-form", "routes": ["/?p=1201"] }, { "module": "related-posts", "routes": ["/?p=1201"] }, { "module": "markdown", "routes": ["/?page_id=1203"] }, { "module": "stats", "routes": ["/", "/?p=1201"], "skip_when": ["credential_unavailable", "external_service_required"] }], "request_classes": ["document", "script", "style", "image", "xhr", "fetch"], "skip_reason_codes": ["credential_unavailable", "external_service_required", "module_unavailable", "connection_required", "destructive_action", "unsupported_fixture"] }, "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }], "action": [{ "command": "wordpress.trace-browser-coverage", "args": ["surface=jetpack-public-modules", "states=connected,disconnected", "classify_skips=true"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=public_module_frontend_coverage"] }] }, "artifacts": [{ "name": "public_module_frontend_coverage", "path": "jetpack-public-module-frontend-coverage/public_module_frontend_coverage.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }, { "name": "public_module_request_matrix", "path": "jetpack-public-module-frontend-coverage/public_module_request_matrix.json", "required": false, "metadata": { "semantic_key": "fuzz.browser_request_matrix" } }, { "name": "public_module_skip_reasons", "path": "jetpack-public-module-frontend-coverage/public_module_skip_reasons.json", "required": false, "metadata": { "semantic_key": "fuzz.skip_reasons" } }], "metadata": { "safety_class": "read_only" } }],
-  "limits": { "max_cases": 80, "max_duration_seconds": 900 },
-  "coverage": { "surface_ids": ["jetpack-public-frontend", "jetpack-modules", "browser-requests"], "operations": ["module-frontend-render", "asset-request-capture", "xhr-fetch-capture", "connected-disconnected-classification", "public-route-enumeration"] },
-  "artifacts": { "expected": [{ "name": "public_module_frontend_coverage", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }, { "name": "public_module_request_matrix", "role": "coverage_inventory", "semantic_key": "fuzz.browser_request_matrix", "required": false }, { "name": "public_module_skip_reasons", "role": "safety_report", "semantic_key": "fuzz.skip_reasons", "required": false }] }
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/manifests/full-surface-coverage.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report",
+    "readiness": {
+      "level": "executable",
+      "coverage_contract": "Jetpack public module frontend request coverage, module route classes, state-dependent skips, and request matrix artifacts.",
+      "upstream_blockers": [
+        "Reviewer-facing fuzz run artifacts are required before this workload can be marked proven."
+      ]
+    }
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "jetpack",
+    "component": "jetpack"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "generic",
+    "path": "${package.root}/manifests/full-surface-coverage.json",
+    "entry": "jetpack-public-module-frontend-coverage"
+  },
+  "cases": [
+    {
+      "case_id": "jetpack-public-module-frontend-coverage:default",
+      "surface_ids": [
+        "jetpack-public-frontend",
+        "jetpack-modules",
+        "browser-requests"
+      ],
+      "operations": [
+        "module-frontend-render",
+        "asset-request-capture",
+        "xhr-fetch-capture",
+        "connected-disconnected-classification",
+        "public-route-enumeration"
+      ],
+      "inputs": {
+        "states": [
+          "connected",
+          "disconnected"
+        ],
+        "module_scenarios": [
+          {
+            "module": "shortcodes",
+            "routes": [
+              "/?p=1201"
+            ]
+          },
+          {
+            "module": "contact-form",
+            "routes": [
+              "/?p=1201"
+            ]
+          },
+          {
+            "module": "related-posts",
+            "routes": [
+              "/?p=1201"
+            ]
+          },
+          {
+            "module": "markdown",
+            "routes": [
+              "/?page_id=1203"
+            ]
+          },
+          {
+            "module": "stats",
+            "routes": [
+              "/",
+              "/?p=1201"
+            ],
+            "skip_when": [
+              "credential_unavailable",
+              "external_service_required"
+            ]
+          }
+        ],
+        "request_classes": [
+          "document",
+          "script",
+          "style",
+          "image",
+          "xhr",
+          "fetch"
+        ],
+        "skip_reason_codes": [
+          "credential_unavailable",
+          "external_service_required",
+          "module_unavailable",
+          "connection_required",
+          "destructive_action",
+          "unsupported_fixture"
+        ]
+      },
+      "phases": {
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=jetpack/jetpack.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.trace-browser-coverage",
+            "args": [
+              "surface=jetpack-public-modules",
+              "states=connected,disconnected",
+              "classify_skips=true"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=public_module_frontend_coverage"
+            ]
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "public_module_frontend_coverage",
+          "path": "jetpack-public-module-frontend-coverage/public_module_frontend_coverage.json",
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        },
+        {
+          "name": "public_module_request_matrix",
+          "path": "jetpack-public-module-frontend-coverage/public_module_request_matrix.json",
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.browser_request_matrix"
+          }
+        },
+        {
+          "name": "public_module_skip_reasons",
+          "path": "jetpack-public-module-frontend-coverage/public_module_skip_reasons.json",
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.skip_reasons"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "read_only"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 80,
+    "max_duration_seconds": 900
+  },
+  "coverage": {
+    "surface_ids": [
+      "jetpack-public-frontend",
+      "jetpack-modules",
+      "browser-requests"
+    ],
+    "operations": [
+      "module-frontend-render",
+      "asset-request-capture",
+      "xhr-fetch-capture",
+      "connected-disconnected-classification",
+      "public-route-enumeration"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "public_module_frontend_coverage",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": true
+      },
+      {
+        "name": "public_module_request_matrix",
+        "role": "coverage_inventory",
+        "semantic_key": "fuzz.browser_request_matrix",
+        "required": true
+      },
+      {
+        "name": "public_module_skip_reasons",
+        "role": "safety_report",
+        "semantic_key": "fuzz.skip_reasons",
+        "required": true
+      }
+    ]
+  }
 }

--- a/Automattic/jetpack/fuzz/rest-db-query-profile.json
+++ b/Automattic/jetpack/fuzz/rest-db-query-profile.json
@@ -3,8 +3,14 @@
   "id": "rest-db-query-profile",
   "label": "Jetpack REST DB query profile",
   "safety_class": "read_only",
-  "surface_ids": ["jetpack-rest-routes", "wordpress-database"],
-  "operations": ["request-case-query-profile", "query-attribution"],
+  "surface_ids": [
+    "jetpack-rest-routes",
+    "wordpress-database"
+  ],
+  "operations": [
+    "request-case-query-profile",
+    "query-attribution"
+  ],
   "case_budget": 50,
   "duration_budget_seconds": 600,
   "metadata": {
@@ -20,19 +26,178 @@
       "max_slow_queries_per_case": 0,
       "slow_query_threshold_ms": 100
     },
-    "observed_surfaces": ["jetpack/v4", "wpcom/v2", "module-state", "connection-state", "wordpress-options", "jetpack-sync-tables"],
-    "hotspot_classes": ["autoloaded-option-read", "module-option-read", "connection-option-read", "sync-queue-table-read", "route-permission-check", "remote-service-short-circuit"],
+    "observed_surfaces": [
+      "jetpack/v4",
+      "wpcom/v2",
+      "module-state",
+      "connection-state",
+      "wordpress-options",
+      "jetpack-sync-tables"
+    ],
+    "hotspot_classes": [
+      "autoloaded-option-read",
+      "module-option-read",
+      "connection-option-read",
+      "sync-queue-table-read",
+      "route-permission-check",
+      "remote-service-short-circuit"
+    ],
     "query_attribution_expectations": {
-      "group_by": ["rest_route", "http_method", "permission_class", "module", "connection_state", "hotspot_class"],
-      "required_fields": ["query_count", "duplicate_query_count", "slow_query_count", "tables", "options", "callers"],
+      "group_by": [
+        "rest_route",
+        "http_method",
+        "permission_class",
+        "module",
+        "connection_state",
+        "hotspot_class"
+      ],
+      "required_fields": [
+        "query_count",
+        "duplicate_query_count",
+        "slow_query_count",
+        "tables",
+        "options",
+        "callers"
+      ],
       "redaction": "option values and token-like fragments must be classified, not recorded verbatim"
     },
-    "connected_state_caveats": ["Disconnected fixtures may classify WordPress.com-dependent routes as guarded skips instead of measuring remote-backed behavior", "Connected fixtures use placeholder credentials only and must not perform live WordPress.com service calls"]
+    "connected_state_caveats": [
+      "Disconnected fixtures may classify WordPress.com-dependent routes as guarded skips instead of measuring remote-backed behavior",
+      "Connected fixtures use placeholder credentials only and must not perform live WordPress.com service calls"
+    ],
+    "readiness": {
+      "level": "executable",
+      "coverage_contract": "Jetpack REST database query profile coverage, query attribution, hotspot classification, budget comparison, and connected-state caveats.",
+      "upstream_blockers": [
+        "Reviewer-facing fuzz run artifacts are required before this workload can be marked proven."
+      ]
+    }
   },
-  "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
-  "workload": { "runner": "wp-codebox", "type": "json", "path": "${package.root}/bench/rest-db-query-profile.workload.json", "entry": "rest-db-query-profile" },
-  "cases": [{ "case_id": "rest-db-query-profile:default", "surface_ids": ["jetpack-rest-routes", "wordpress-database"], "operations": ["request-case-query-profile", "query-attribution"], "inputs": { "profiled_namespaces": ["jetpack/v4", "wpcom/v2"], "states": ["connected", "disconnected"], "budget_keys": ["max_queries_per_rest_case", "max_uncached_options_queries_per_case", "max_slow_queries_per_case"], "hotspot_classes": ["autoloaded-option-read", "module-option-read", "connection-option-read", "sync-queue-table-read", "route-permission-check", "remote-service-short-circuit"], "query_attribution_required": true, "external_service_calls_allowed": false }, "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }], "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/rest-db-query-profile.workload.json", "type=json"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=rest_db_query_profile"] }] }, "artifacts": [{ "name": "rest_db_query_profile", "path": "rest-db-query-profile/rest_db_query_profile.json", "required": false, "metadata": { "semantic_key": "fuzz.report", "contains": ["per_route_query_counts", "hotspot_classification", "query_attribution", "budget_comparison", "connected_state_caveats"] } }], "metadata": { "safety_class": "read_only" } }],
-  "limits": { "max_cases": 50, "max_duration_seconds": 600 },
-  "coverage": { "surface_ids": ["jetpack-rest-routes", "wordpress-database"], "operations": ["request-case-query-profile", "query-attribution"] },
-  "artifacts": { "expected": [{ "name": "rest_db_query_profile", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false, "contains": ["per_route_query_counts", "hotspot_classification", "query_attribution", "budget_comparison", "connected_state_caveats"] }] }
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "jetpack",
+    "component": "jetpack"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "json",
+    "path": "${package.root}/bench/rest-db-query-profile.workload.json",
+    "entry": "rest-db-query-profile"
+  },
+  "cases": [
+    {
+      "case_id": "rest-db-query-profile:default",
+      "surface_ids": [
+        "jetpack-rest-routes",
+        "wordpress-database"
+      ],
+      "operations": [
+        "request-case-query-profile",
+        "query-attribution"
+      ],
+      "inputs": {
+        "profiled_namespaces": [
+          "jetpack/v4",
+          "wpcom/v2"
+        ],
+        "states": [
+          "connected",
+          "disconnected"
+        ],
+        "budget_keys": [
+          "max_queries_per_rest_case",
+          "max_uncached_options_queries_per_case",
+          "max_slow_queries_per_case"
+        ],
+        "hotspot_classes": [
+          "autoloaded-option-read",
+          "module-option-read",
+          "connection-option-read",
+          "sync-queue-table-read",
+          "route-permission-check",
+          "remote-service-short-circuit"
+        ],
+        "query_attribution_required": true,
+        "external_service_calls_allowed": false
+      },
+      "phases": {
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=jetpack/jetpack.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.run-workload",
+            "args": [
+              "path=${package.root}/bench/rest-db-query-profile.workload.json",
+              "type=json"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=rest_db_query_profile"
+            ]
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "rest_db_query_profile",
+          "path": "rest-db-query-profile/rest_db_query_profile.json",
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.report",
+            "contains": [
+              "per_route_query_counts",
+              "hotspot_classification",
+              "query_attribution",
+              "budget_comparison",
+              "connected_state_caveats"
+            ]
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "read_only"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 50,
+    "max_duration_seconds": 600
+  },
+  "coverage": {
+    "surface_ids": [
+      "jetpack-rest-routes",
+      "wordpress-database"
+    ],
+    "operations": [
+      "request-case-query-profile",
+      "query-attribution"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "rest_db_query_profile",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": true,
+        "contains": [
+          "per_route_query_counts",
+          "hotspot_classification",
+          "query_attribution",
+          "budget_comparison",
+          "connected_state_caveats"
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- Require declared proof artifacts for executable Jetpack fuzz manifests.
- Add executable readiness metadata where needed.
- Keep schema-only placeholders optional and avoid claiming proven status.

## Testing
- `node Automattic/jetpack/tools/validate-fuzz-manifests.mjs`
- `node scripts/lint-rig-packages.mjs --strict-fuzz-readiness Automattic/jetpack`
- `node --test Automattic/jetpack/manifests/full-surface-coverage.test.mjs`
- `node --test scripts/fuzz-manifest-helpers.test.mjs scripts/lint-rig-packages.test.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Jetpack fuzz manifest investigation, metadata updates, validation, and PR description drafting.
