### PR TITLE
Enforce Jetpack fuzz readiness contracts

### DIFF
--- a/Automattic/jetpack/fuzz/jetpack-module-option-table-inventory.json
+++ b/Automattic/jetpack/fuzz/jetpack-module-option-table-inventory.json
@@ -3,8 +3,18 @@
   "id": "jetpack-module-option-table-inventory",
   "label": "Jetpack module option and table inventory",
   "safety_class": "read_only",
-  "surface_ids": ["jetpack-modules", "jetpack-options", "jetpack-tables", "wordpress-options"],
-  "operations": ["module-option-inventory", "module-table-inventory", "autoload-classification", "serialized-value-boundary-classification"],
+  "surface_ids": [
+    "jetpack-modules",
+    "jetpack-options",
+    "jetpack-tables",
+    "wordpress-options"
+  ],
+  "operations": [
+    "module-option-inventory",
+    "module-table-inventory",
+    "autoload-classification",
+    "serialized-value-boundary-classification"
+  ],
   "case_budget": 80,
   "duration_budget_seconds": 600,
   "metadata": {
@@ -17,48 +27,273 @@
       "level": "executable",
       "coverage_contract": "Read-only Jetpack module, option, autoload, serialized value, and option-table inventory for module-state and option-matrix fuzz inputs. The workload classifies write safety but does not mutate options.",
       "crud": {
-        "create": { "level": "declared", "upstream_blocker": "inventory workload is read-only and does not create module or option state" },
-        "read": { "level": "executable" },
-        "update": { "level": "declared", "upstream_blocker": "update writes belong to planned mutation workloads and require isolated connected-state fixtures" },
-        "delete": { "level": "declared", "upstream_blocker": "inventory workload is read-only and does not delete module or option state" }
+        "create": {
+          "level": "declared",
+          "upstream_blocker": "inventory workload is read-only and does not create module or option state"
+        },
+        "read": {
+          "level": "executable"
+        },
+        "update": {
+          "level": "declared",
+          "upstream_blocker": "update writes belong to planned mutation workloads and require isolated connected-state fixtures"
+        },
+        "delete": {
+          "level": "declared",
+          "upstream_blocker": "inventory workload is read-only and does not delete module or option state"
+        }
       }
     },
     "artifact_expectations": {
-      "required": ["module_inventory", "module_group_rows", "option_inventory", "option_key_inventory", "read_update_safety_rows", "table_inventory", "serialization_boundaries"],
-      "optional": ["autoload_counts", "missing_table_reasons", "module_dependency_edges", "connected_state_blockers"]
+      "required": [
+        "module_inventory",
+        "module_group_rows",
+        "option_inventory",
+        "option_key_inventory",
+        "read_update_safety_rows",
+        "table_inventory",
+        "serialization_boundaries"
+      ],
+      "optional": [
+        "autoload_counts",
+        "missing_table_reasons",
+        "module_dependency_edges",
+        "connected_state_blockers"
+      ]
     }
   },
-  "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
-  "workload": { "runner": "wp-codebox", "type": "generic", "path": "${package.root}/manifests/full-surface-coverage.json", "entry": "wordpress-plugin-module-option-table-inventory" },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "jetpack",
+    "component": "jetpack"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "generic",
+    "path": "${package.root}/manifests/full-surface-coverage.json",
+    "entry": "wordpress-plugin-module-option-table-inventory"
+  },
   "cases": [
     {
       "case_id": "jetpack-module-option-table-inventory:default",
-      "surface_ids": ["jetpack-modules", "jetpack-options", "jetpack-tables", "wordpress-options"],
-      "operations": ["module-option-inventory", "module-table-inventory", "autoload-classification", "serialized-value-boundary-classification"],
+      "surface_ids": [
+        "jetpack-modules",
+        "jetpack-options",
+        "jetpack-tables",
+        "wordpress-options"
+      ],
+      "operations": [
+        "module-option-inventory",
+        "module-table-inventory",
+        "autoload-classification",
+        "serialized-value-boundary-classification"
+      ],
       "inputs": {
-        "module_allowlist": ["stats", "publicize", "related-posts", "markdown", "shortcodes", "widget-visibility", "photon", "sitemaps", "protect", "monitor", "subscriptions", "comments", "likes", "carousel", "contact-form", "tiled-gallery"],
-        "module_groups": { "traffic": ["stats", "related-posts", "sitemaps"], "sharing": ["publicize", "sharing", "likes"], "writing": ["markdown", "shortcodes", "contact-form"], "media": ["photon", "carousel", "tiled-gallery"], "security": ["protect", "monitor"], "community": ["subscriptions", "comments", "widget-visibility"] },
-        "option_keys": ["jetpack_active_modules", "jetpack_options", "jetpack_private_options", "jetpack_available_modules", "jetpack_sync_settings", "jetpack_sync_error_idc", "jetpack_idc_options", "jetpack_connection_active_plugins", "jetpack_connection_xmlrpc_verified_errors", "stats_options", "sharedaddy_options", "sharing-options", "jetpack_protect_key", "jetpack_protect_error", "jetpack_monitor_active", "jetpack_subscriptions", "jetpack_relatedposts", "jetpack_sitemap_state", "jpsq_sync_checkout", "jpsq_sync_started", "jpsq_full_sync_started"],
-        "option_prefixes": ["jetpack_", "jetpack_%", "jpsq_", "stats_options", "sharedaddy_options", "sharing-options"],
-        "read_safe_option_keys": ["jetpack_active_modules", "jetpack_options", "jetpack_available_modules", "stats_options", "sharedaddy_options", "sharing-options", "jetpack_relatedposts", "jetpack_sitemap_state"],
-        "update_planned_option_keys": ["jetpack_active_modules", "jetpack_options", "jetpack_sync_settings", "jetpack_idc_options", "stats_options", "sharedaddy_options", "sharing-options"],
-        "connected_state_blocked_option_keys": ["jetpack_private_options", "jetpack_sync_settings", "jetpack_connection_active_plugins", "jetpack_connection_xmlrpc_verified_errors", "jetpack_protect_key", "jetpack_monitor_active", "jpsq_sync_checkout", "jpsq_sync_started", "jpsq_full_sync_started"],
-        "table_patterns": ["%_jetpack_%", "%_wc_connect%"],
+        "module_allowlist": [
+          "stats",
+          "publicize",
+          "related-posts",
+          "markdown",
+          "shortcodes",
+          "widget-visibility",
+          "photon",
+          "sitemaps",
+          "protect",
+          "monitor",
+          "subscriptions",
+          "comments",
+          "likes",
+          "carousel",
+          "contact-form",
+          "tiled-gallery"
+        ],
+        "module_groups": {
+          "traffic": [
+            "stats",
+            "related-posts",
+            "sitemaps"
+          ],
+          "sharing": [
+            "publicize",
+            "sharing",
+            "likes"
+          ],
+          "writing": [
+            "markdown",
+            "shortcodes",
+            "contact-form"
+          ],
+          "media": [
+            "photon",
+            "carousel",
+            "tiled-gallery"
+          ],
+          "security": [
+            "protect",
+            "monitor"
+          ],
+          "community": [
+            "subscriptions",
+            "comments",
+            "widget-visibility"
+          ]
+        },
+        "option_keys": [
+          "jetpack_active_modules",
+          "jetpack_options",
+          "jetpack_private_options",
+          "jetpack_available_modules",
+          "jetpack_sync_settings",
+          "jetpack_sync_error_idc",
+          "jetpack_idc_options",
+          "jetpack_connection_active_plugins",
+          "jetpack_connection_xmlrpc_verified_errors",
+          "stats_options",
+          "sharedaddy_options",
+          "sharing-options",
+          "jetpack_protect_key",
+          "jetpack_protect_error",
+          "jetpack_monitor_active",
+          "jetpack_subscriptions",
+          "jetpack_relatedposts",
+          "jetpack_sitemap_state",
+          "jpsq_sync_checkout",
+          "jpsq_sync_started",
+          "jpsq_full_sync_started"
+        ],
+        "option_prefixes": [
+          "jetpack_",
+          "jetpack_%",
+          "jpsq_",
+          "stats_options",
+          "sharedaddy_options",
+          "sharing-options"
+        ],
+        "read_safe_option_keys": [
+          "jetpack_active_modules",
+          "jetpack_options",
+          "jetpack_available_modules",
+          "stats_options",
+          "sharedaddy_options",
+          "sharing-options",
+          "jetpack_relatedposts",
+          "jetpack_sitemap_state"
+        ],
+        "update_planned_option_keys": [
+          "jetpack_active_modules",
+          "jetpack_options",
+          "jetpack_sync_settings",
+          "jetpack_idc_options",
+          "stats_options",
+          "sharedaddy_options",
+          "sharing-options"
+        ],
+        "connected_state_blocked_option_keys": [
+          "jetpack_private_options",
+          "jetpack_sync_settings",
+          "jetpack_connection_active_plugins",
+          "jetpack_connection_xmlrpc_verified_errors",
+          "jetpack_protect_key",
+          "jetpack_monitor_active",
+          "jpsq_sync_checkout",
+          "jpsq_sync_started",
+          "jpsq_full_sync_started"
+        ],
+        "table_patterns": [
+          "%_jetpack_%",
+          "%_wc_connect%"
+        ],
         "read_only": true,
         "secret_placeholders_only": true,
         "classify_read_update_safety": true,
-        "connected_state_required_for_mutation": true
+        "connected_state_required_for_mutation": true,
+        "skip_reason_codes": [
+          "connection_required",
+          "credential_unavailable"
+        ]
       },
       "phases": {
-        "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }],
-        "action": [{ "command": "wordpress.inventory-plugin-module-options-tables", "args": ["read_only=true", "secret_placeholders_only=true"] }],
-        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=module_option_table_inventory"] }]
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=jetpack/jetpack.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.inventory-plugin-module-options-tables",
+            "args": [
+              "read_only=true",
+              "secret_placeholders_only=true"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=module_option_table_inventory"
+            ]
+          }
+        ]
       },
-      "artifacts": [{ "name": "module_option_table_inventory", "path": "jetpack-module-option-table-inventory/module_option_table_inventory.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }, { "name": "option_table_safety_inventory", "path": "jetpack-module-option-table-inventory/option_table_safety_inventory.json", "required": false, "metadata": { "semantic_key": "fuzz.inventory" } }],
-      "metadata": { "safety_class": "read_only" }
+      "artifacts": [
+        {
+          "name": "module_option_table_inventory",
+          "path": "jetpack-module-option-table-inventory/module_option_table_inventory.json",
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        },
+        {
+          "name": "option_table_safety_inventory",
+          "path": "jetpack-module-option-table-inventory/option_table_safety_inventory.json",
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.inventory"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "read_only"
+      }
     }
   ],
-  "limits": { "max_cases": 80, "max_duration_seconds": 600 },
-  "coverage": { "surface_ids": ["jetpack-modules", "jetpack-options", "jetpack-tables", "wordpress-options"], "operations": ["module-option-inventory", "module-table-inventory", "autoload-classification", "serialized-value-boundary-classification"] },
-  "artifacts": { "expected": [{ "name": "module_option_table_inventory", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }, { "name": "option_table_safety_inventory", "role": "inventory", "semantic_key": "fuzz.inventory", "required": false }] }
+  "limits": {
+    "max_cases": 80,
+    "max_duration_seconds": 600
+  },
+  "coverage": {
+    "surface_ids": [
+      "jetpack-modules",
+      "jetpack-options",
+      "jetpack-tables",
+      "wordpress-options"
+    ],
+    "operations": [
+      "module-option-inventory",
+      "module-table-inventory",
+      "autoload-classification",
+      "serialized-value-boundary-classification"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "module_option_table_inventory",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": true
+      },
+      {
+        "name": "option_table_safety_inventory",
+        "role": "inventory",
+        "semantic_key": "fuzz.inventory",
+        "required": true
+      }
+    ]
+  }
 }

--- a/Automattic/jetpack/fuzz/jetpack-module-state-matrix.json
+++ b/Automattic/jetpack/fuzz/jetpack-module-state-matrix.json
@@ -3,15 +3,269 @@
   "id": "jetpack-module-state-matrix",
   "label": "Jetpack module state matrix",
   "safety_class": "read_only",
-  "surface_ids": ["jetpack-modules", "jetpack-settings"],
-  "operations": ["module-discovery", "module-group-inventory", "module-activate-deactivate-plan", "settings-state-classification", "dependency-classification", "connected-state-blocker-classification", "rollback-requirement-plan"],
+  "surface_ids": [
+    "jetpack-modules",
+    "jetpack-settings"
+  ],
+  "operations": [
+    "module-discovery",
+    "module-group-inventory",
+    "module-activate-deactivate-plan",
+    "settings-state-classification",
+    "dependency-classification",
+    "connected-state-blocker-classification",
+    "rollback-requirement-plan"
+  ],
   "case_budget": 80,
   "duration_budget_seconds": 900,
-  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "workload_path": "${package.root}/manifests/full-surface-coverage.json", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report", "mutation_policy": "declare_toggle_plan_until_isolated_connected_fixture_exists", "generic_primitive": { "status": "blocked", "reason": "Module activation and deactivation writes stay planned until runtime isolation, connected-state fixtures, HTTP guardrails, and rollback artifact capture are all available." }, "readiness": { "level": "declared", "coverage_contract": "Jetpack module discovery, grouping, dependency, settings-state, connected-state blocker, and rollback requirement matrix. Toggle execution is declared only until isolated connected/disconnected fixtures and rollback artifacts are available.", "upstream_blockers": ["runtime isolation fixture must prove Jetpack module toggles cannot affect a developer or connected production site", "connected and disconnected Jetpack fixture states must be explicit inputs before connection-sensitive module writes can run", "rollback artifact capture must persist before/after/restore rows for jetpack_active_modules and module settings"], "crud": { "create": { "level": "declared", "upstream_blocker": "module activation creates option/state deltas and requires isolated connected-state fixtures" }, "read": { "level": "executable" }, "update": { "level": "declared", "upstream_blocker": "module toggle/update writes require rollback artifacts and connected-state fixtures" }, "delete": { "level": "declared", "upstream_blocker": "module deactivation deletes or rewrites state and requires rollback artifacts" } }, "mutation": { "safety_boundary": "Planned only. Execution requires disposable WP Codebox isolation, explicit connected/disconnected fixture inputs, blocked external dispatch, and before/after/restore artifacts for every changed option.", "rollback_artifacts": ["module_state_rollback_plan", "module_option_before_after_restore_rows"] } }, "artifact_expectations": { "required": ["module_matrix", "module_group_rows", "dependency_rows", "connected_state_blockers", "rollback_requirement_rows"], "optional": ["settings_state_rows", "planned_toggle_rows"] } },
-  "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
-  "workload": { "runner": "wp-codebox", "type": "generic", "path": "${package.root}/manifests/full-surface-coverage.json", "entry": "wordpress-plugin-module-state-matrix" },
-  "cases": [{ "case_id": "jetpack-module-state-matrix:default", "surface_ids": ["jetpack-modules", "jetpack-settings"], "operations": ["module-discovery", "module-group-inventory", "module-activate-deactivate-plan", "settings-state-classification", "dependency-classification", "connected-state-blocker-classification", "rollback-requirement-plan"], "inputs": { "module_allowlist": ["stats", "publicize", "related-posts", "markdown", "shortcodes", "widget-visibility", "photon", "sitemaps", "protect", "monitor", "subscriptions", "comments", "likes", "carousel", "contact-form", "tiled-gallery"], "module_groups": { "traffic": ["stats", "related-posts", "sitemaps"], "sharing": ["publicize", "sharing", "likes"], "writing": ["markdown", "shortcodes", "contact-form"], "media": ["photon", "carousel", "tiled-gallery"], "security": ["protect", "monitor"], "community": ["subscriptions", "comments", "widget-visibility"] }, "connected_state_blockers": ["publicize", "protect", "monitor", "stats", "subscriptions"], "connected_state_required_for_mutation": true, "runtime_isolation_required_for_mutation": true, "external_dispatch": false, "execute_mutations": false, "mutation_mode": "declared_plan", "restore_original_values": true, "rollback_required": true, "rollback_requirements": ["snapshot jetpack_active_modules before toggle", "record every module option before/after/restore value shape", "restore active module list before assertions complete", "fail closed when connected/disconnected fixture state is unavailable"] }, "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }], "action": [{ "command": "wordpress.fuzz-plugin-module-state", "args": ["external_dispatch=false", "execute_mutations=false", "mutation_mode=declared_plan", "connected_state_required_for_mutation=true", "runtime_isolation_required_for_mutation=true", "rollback_required=true"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=module_state_matrix"] }] }, "artifacts": [{ "name": "module_state_matrix", "path": "jetpack-module-state-matrix/module_state_matrix.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }, { "name": "module_state_rollback_plan", "path": "jetpack-module-state-matrix/module_state_rollback_plan.json", "required": false, "metadata": { "semantic_key": "fuzz.rollback_plan" } }], "metadata": { "safety_class": "read_only", "mutation_policy": "declare_toggle_plan_until_isolated_connected_fixture_exists" } }],
-  "limits": { "max_cases": 80, "max_duration_seconds": 900 },
-  "coverage": { "surface_ids": ["jetpack-modules", "jetpack-settings"], "operations": ["module-discovery", "module-group-inventory", "module-activate-deactivate-plan", "settings-state-classification", "dependency-classification", "connected-state-blocker-classification", "rollback-requirement-plan"] },
-  "artifacts": { "expected": [{ "name": "module_state_matrix", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }, { "name": "module_state_rollback_plan", "role": "rollback_plan", "semantic_key": "fuzz.rollback_plan", "required": false }] }
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/manifests/full-surface-coverage.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report",
+    "mutation_policy": "declare_toggle_plan_until_isolated_connected_fixture_exists",
+    "generic_primitive": {
+      "status": "blocked",
+      "reason": "Module activation and deactivation writes stay planned until runtime isolation, connected-state fixtures, HTTP guardrails, and rollback artifact capture are all available."
+    },
+    "readiness": {
+      "level": "declared",
+      "coverage_contract": "Jetpack module discovery, grouping, dependency, settings-state, connected-state blocker, and rollback requirement matrix. Toggle execution is declared only until isolated connected/disconnected fixtures and rollback artifacts are available.",
+      "upstream_blockers": [
+        "runtime isolation fixture must prove Jetpack module toggles cannot affect a developer or connected production site",
+        "connected and disconnected Jetpack fixture states must be explicit inputs before connection-sensitive module writes can run",
+        "rollback artifact capture must persist before/after/restore rows for jetpack_active_modules and module settings"
+      ],
+      "crud": {
+        "create": {
+          "level": "declared",
+          "upstream_blocker": "module activation creates option/state deltas and requires isolated connected-state fixtures"
+        },
+        "read": {
+          "level": "executable"
+        },
+        "update": {
+          "level": "declared",
+          "upstream_blocker": "module toggle/update writes require rollback artifacts and connected-state fixtures"
+        },
+        "delete": {
+          "level": "declared",
+          "upstream_blocker": "module deactivation deletes or rewrites state and requires rollback artifacts"
+        }
+      },
+      "mutation": {
+        "safety_boundary": "Planned only. Execution requires disposable WP Codebox isolation, explicit connected/disconnected fixture inputs, blocked external dispatch, and before/after/restore artifacts for every changed option.",
+        "rollback_artifacts": [
+          "module_state_rollback_plan",
+          "module_option_before_after_restore_rows"
+        ]
+      }
+    },
+    "artifact_expectations": {
+      "required": [
+        "module_matrix",
+        "module_group_rows",
+        "dependency_rows",
+        "connected_state_blockers",
+        "rollback_requirement_rows"
+      ],
+      "optional": [
+        "settings_state_rows",
+        "planned_toggle_rows"
+      ]
+    }
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "jetpack",
+    "component": "jetpack"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "generic",
+    "path": "${package.root}/manifests/full-surface-coverage.json",
+    "entry": "wordpress-plugin-module-state-matrix"
+  },
+  "cases": [
+    {
+      "case_id": "jetpack-module-state-matrix:default",
+      "surface_ids": [
+        "jetpack-modules",
+        "jetpack-settings"
+      ],
+      "operations": [
+        "module-discovery",
+        "module-group-inventory",
+        "module-activate-deactivate-plan",
+        "settings-state-classification",
+        "dependency-classification",
+        "connected-state-blocker-classification",
+        "rollback-requirement-plan"
+      ],
+      "inputs": {
+        "module_allowlist": [
+          "stats",
+          "publicize",
+          "related-posts",
+          "markdown",
+          "shortcodes",
+          "widget-visibility",
+          "photon",
+          "sitemaps",
+          "protect",
+          "monitor",
+          "subscriptions",
+          "comments",
+          "likes",
+          "carousel",
+          "contact-form",
+          "tiled-gallery"
+        ],
+        "module_groups": {
+          "traffic": [
+            "stats",
+            "related-posts",
+            "sitemaps"
+          ],
+          "sharing": [
+            "publicize",
+            "sharing",
+            "likes"
+          ],
+          "writing": [
+            "markdown",
+            "shortcodes",
+            "contact-form"
+          ],
+          "media": [
+            "photon",
+            "carousel",
+            "tiled-gallery"
+          ],
+          "security": [
+            "protect",
+            "monitor"
+          ],
+          "community": [
+            "subscriptions",
+            "comments",
+            "widget-visibility"
+          ]
+        },
+        "connected_state_blockers": [
+          "publicize",
+          "protect",
+          "monitor",
+          "stats",
+          "subscriptions"
+        ],
+        "connected_state_required_for_mutation": true,
+        "runtime_isolation_required_for_mutation": true,
+        "external_dispatch": false,
+        "execute_mutations": false,
+        "mutation_mode": "declared_plan",
+        "restore_original_values": true,
+        "rollback_required": true,
+        "rollback_requirements": [
+          "snapshot jetpack_active_modules before toggle",
+          "record every module option before/after/restore value shape",
+          "restore active module list before assertions complete",
+          "fail closed when connected/disconnected fixture state is unavailable"
+        ],
+        "skip_reason_codes": [
+          "connection_required",
+          "credential_unavailable"
+        ]
+      },
+      "phases": {
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=jetpack/jetpack.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.fuzz-plugin-module-state",
+            "args": [
+              "external_dispatch=false",
+              "execute_mutations=false",
+              "mutation_mode=declared_plan",
+              "connected_state_required_for_mutation=true",
+              "runtime_isolation_required_for_mutation=true",
+              "rollback_required=true"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=module_state_matrix"
+            ]
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "module_state_matrix",
+          "path": "jetpack-module-state-matrix/module_state_matrix.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        },
+        {
+          "name": "module_state_rollback_plan",
+          "path": "jetpack-module-state-matrix/module_state_rollback_plan.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.rollback_plan"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "read_only",
+        "mutation_policy": "declare_toggle_plan_until_isolated_connected_fixture_exists"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 80,
+    "max_duration_seconds": 900
+  },
+  "coverage": {
+    "surface_ids": [
+      "jetpack-modules",
+      "jetpack-settings"
+    ],
+    "operations": [
+      "module-discovery",
+      "module-group-inventory",
+      "module-activate-deactivate-plan",
+      "settings-state-classification",
+      "dependency-classification",
+      "connected-state-blocker-classification",
+      "rollback-requirement-plan"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "module_state_matrix",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": false
+      },
+      {
+        "name": "module_state_rollback_plan",
+        "role": "rollback_plan",
+        "semantic_key": "fuzz.rollback_plan",
+        "required": false
+      }
+    ]
+  }
 }

--- a/Automattic/jetpack/fuzz/jetpack-options-matrix.json
+++ b/Automattic/jetpack/fuzz/jetpack-options-matrix.json
@@ -3,15 +3,283 @@
   "id": "jetpack-options-matrix",
   "label": "Jetpack options matrix",
   "safety_class": "read_only",
-  "surface_ids": ["jetpack-options", "wordpress-options"],
-  "operations": ["option-default-read", "option-inventory", "option-update-rollback-plan", "read-update-safety-classification", "connected-state-blocker-classification", "serialization-boundary-classification", "autoload-classification"],
+  "surface_ids": [
+    "jetpack-options",
+    "wordpress-options"
+  ],
+  "operations": [
+    "option-default-read",
+    "option-inventory",
+    "option-update-rollback-plan",
+    "read-update-safety-classification",
+    "connected-state-blocker-classification",
+    "serialization-boundary-classification",
+    "autoload-classification"
+  ],
   "case_budget": 120,
   "duration_budget_seconds": 900,
-  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "workload_path": "${package.root}/manifests/full-surface-coverage.json", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report", "mutation_policy": "declare_option_write_plan_until_isolated_connected_fixture_exists", "generic_primitive": { "status": "blocked", "reason": "Option writes remain planned until disposable runtime isolation, connected-state fixtures, and rollback artifacts are explicitly available." }, "readiness": { "level": "declared", "coverage_contract": "Jetpack option inventory, default reads, serialization/autoload classification, connected-state blockers, and option write rollback plans. Mutating writes are not executed without isolated runtime and connected-state fixtures.", "upstream_blockers": ["isolated runtime fixture must guarantee option writes are disposable", "connected-state fixture must provide synthetic Jetpack connection state for connection-sensitive options", "rollback artifact capture must persist before/after/restore rows before option writes are enabled"], "crud": { "create": { "level": "declared", "upstream_blocker": "new option writes require disposable runtime isolation and rollback artifacts" }, "read": { "level": "executable" }, "update": { "level": "declared", "upstream_blocker": "option updates require connected-state fixtures and rollback artifacts" }, "delete": { "level": "declared", "upstream_blocker": "option deletion is out of scope without rollback artifact proof" } }, "mutation": { "safety_boundary": "Planned only. Execution requires disposable WP Codebox isolation, synthetic Jetpack connected/disconnected fixtures, secret placeholders, and before/after/restore artifacts for every changed option.", "rollback_artifacts": ["option_write_rollback_plan", "option_before_after_restore_rows"] } }, "artifact_expectations": { "required": ["option_matrix", "read_update_safety_rows", "connected_state_blockers", "rollback_requirement_rows", "serialization_boundary_rows"], "optional": ["autoload_counts", "secret_placeholder_classifications", "planned_write_rows"] } },
-  "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
-  "workload": { "runner": "wp-codebox", "type": "generic", "path": "${package.root}/manifests/full-surface-coverage.json", "entry": "wordpress-plugin-option-matrix" },
-  "cases": [{ "case_id": "jetpack-options-matrix:default", "surface_ids": ["jetpack-options", "wordpress-options"], "operations": ["option-default-read", "option-inventory", "option-update-rollback-plan", "read-update-safety-classification", "connected-state-blocker-classification", "serialization-boundary-classification", "autoload-classification"], "inputs": { "option_keys": ["jetpack_active_modules", "jetpack_options", "jetpack_private_options", "jetpack_available_modules", "jetpack_sync_settings", "jetpack_sync_error_idc", "jetpack_idc_options", "jetpack_connection_active_plugins", "jetpack_connection_xmlrpc_verified_errors", "stats_options", "sharedaddy_options", "sharing-options", "jetpack_protect_key", "jetpack_protect_error", "jetpack_monitor_active", "jetpack_subscriptions", "jetpack_relatedposts", "jetpack_sitemap_state", "jpsq_sync_checkout", "jpsq_sync_started", "jpsq_full_sync_started"], "option_prefixes": ["jetpack_", "jetpack_%", "jpsq_", "stats_options", "sharedaddy_options", "sharing-options"], "read_safe_option_keys": ["jetpack_active_modules", "jetpack_options", "jetpack_available_modules", "stats_options", "sharedaddy_options", "sharing-options", "jetpack_relatedposts", "jetpack_sitemap_state"], "update_planned_option_keys": ["jetpack_active_modules", "jetpack_options", "jetpack_sync_settings", "jetpack_idc_options", "stats_options", "sharedaddy_options", "sharing-options"], "connected_state_blocked_option_keys": ["jetpack_private_options", "jetpack_sync_settings", "jetpack_connection_active_plugins", "jetpack_connection_xmlrpc_verified_errors", "jetpack_protect_key", "jetpack_monitor_active", "jpsq_sync_checkout", "jpsq_sync_started", "jpsq_full_sync_started"], "serialization_boundaries": ["scalar", "array", "object-placeholder", "empty-string", "falsey", "oversized-json"], "secret_placeholders_only": true, "connected_state_required_for_mutation": true, "runtime_isolation_required_for_mutation": true, "execute_mutations": false, "mutation_mode": "declared_plan", "restore_original_values": true, "rollback_required": true, "rollback_requirements": ["snapshot original option rows before write", "record autoload and serialized value shape before and after", "restore original values before assertions complete", "fail closed when connected/disconnected fixture state is unavailable"] }, "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }], "action": [{ "command": "wordpress.fuzz-plugin-options", "args": ["secret_placeholders_only=true", "execute_mutations=false", "mutation_mode=declared_plan", "connected_state_required_for_mutation=true", "runtime_isolation_required_for_mutation=true", "rollback_required=true"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=options_matrix"] }] }, "artifacts": [{ "name": "options_matrix", "path": "jetpack-options-matrix/options_matrix.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }, { "name": "option_write_rollback_plan", "path": "jetpack-options-matrix/option_write_rollback_plan.json", "required": false, "metadata": { "semantic_key": "fuzz.rollback_plan" } }], "metadata": { "safety_class": "read_only", "mutation_policy": "declare_option_write_plan_until_isolated_connected_fixture_exists" } }],
-  "limits": { "max_cases": 120, "max_duration_seconds": 900 },
-  "coverage": { "surface_ids": ["jetpack-options", "wordpress-options"], "operations": ["option-default-read", "option-inventory", "option-update-rollback-plan", "read-update-safety-classification", "connected-state-blocker-classification", "serialization-boundary-classification", "autoload-classification"] },
-  "artifacts": { "expected": [{ "name": "options_matrix", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }, { "name": "option_write_rollback_plan", "role": "rollback_plan", "semantic_key": "fuzz.rollback_plan", "required": false }] }
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/manifests/full-surface-coverage.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report",
+    "mutation_policy": "declare_option_write_plan_until_isolated_connected_fixture_exists",
+    "generic_primitive": {
+      "status": "blocked",
+      "reason": "Option writes remain planned until disposable runtime isolation, connected-state fixtures, and rollback artifacts are explicitly available."
+    },
+    "readiness": {
+      "level": "declared",
+      "coverage_contract": "Jetpack option inventory, default reads, serialization/autoload classification, connected-state blockers, and option write rollback plans. Mutating writes are not executed without isolated runtime and connected-state fixtures.",
+      "upstream_blockers": [
+        "isolated runtime fixture must guarantee option writes are disposable",
+        "connected-state fixture must provide synthetic Jetpack connection state for connection-sensitive options",
+        "rollback artifact capture must persist before/after/restore rows before option writes are enabled"
+      ],
+      "crud": {
+        "create": {
+          "level": "declared",
+          "upstream_blocker": "new option writes require disposable runtime isolation and rollback artifacts"
+        },
+        "read": {
+          "level": "executable"
+        },
+        "update": {
+          "level": "declared",
+          "upstream_blocker": "option updates require connected-state fixtures and rollback artifacts"
+        },
+        "delete": {
+          "level": "declared",
+          "upstream_blocker": "option deletion is out of scope without rollback artifact proof"
+        }
+      },
+      "mutation": {
+        "safety_boundary": "Planned only. Execution requires disposable WP Codebox isolation, synthetic Jetpack connected/disconnected fixtures, secret placeholders, and before/after/restore artifacts for every changed option.",
+        "rollback_artifacts": [
+          "option_write_rollback_plan",
+          "option_before_after_restore_rows"
+        ]
+      }
+    },
+    "artifact_expectations": {
+      "required": [
+        "option_matrix",
+        "read_update_safety_rows",
+        "connected_state_blockers",
+        "rollback_requirement_rows",
+        "serialization_boundary_rows"
+      ],
+      "optional": [
+        "autoload_counts",
+        "secret_placeholder_classifications",
+        "planned_write_rows"
+      ]
+    }
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "jetpack",
+    "component": "jetpack"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "generic",
+    "path": "${package.root}/manifests/full-surface-coverage.json",
+    "entry": "wordpress-plugin-option-matrix"
+  },
+  "cases": [
+    {
+      "case_id": "jetpack-options-matrix:default",
+      "surface_ids": [
+        "jetpack-options",
+        "wordpress-options"
+      ],
+      "operations": [
+        "option-default-read",
+        "option-inventory",
+        "option-update-rollback-plan",
+        "read-update-safety-classification",
+        "connected-state-blocker-classification",
+        "serialization-boundary-classification",
+        "autoload-classification"
+      ],
+      "inputs": {
+        "option_keys": [
+          "jetpack_active_modules",
+          "jetpack_options",
+          "jetpack_private_options",
+          "jetpack_available_modules",
+          "jetpack_sync_settings",
+          "jetpack_sync_error_idc",
+          "jetpack_idc_options",
+          "jetpack_connection_active_plugins",
+          "jetpack_connection_xmlrpc_verified_errors",
+          "stats_options",
+          "sharedaddy_options",
+          "sharing-options",
+          "jetpack_protect_key",
+          "jetpack_protect_error",
+          "jetpack_monitor_active",
+          "jetpack_subscriptions",
+          "jetpack_relatedposts",
+          "jetpack_sitemap_state",
+          "jpsq_sync_checkout",
+          "jpsq_sync_started",
+          "jpsq_full_sync_started"
+        ],
+        "option_prefixes": [
+          "jetpack_",
+          "jetpack_%",
+          "jpsq_",
+          "stats_options",
+          "sharedaddy_options",
+          "sharing-options"
+        ],
+        "read_safe_option_keys": [
+          "jetpack_active_modules",
+          "jetpack_options",
+          "jetpack_available_modules",
+          "stats_options",
+          "sharedaddy_options",
+          "sharing-options",
+          "jetpack_relatedposts",
+          "jetpack_sitemap_state"
+        ],
+        "update_planned_option_keys": [
+          "jetpack_active_modules",
+          "jetpack_options",
+          "jetpack_sync_settings",
+          "jetpack_idc_options",
+          "stats_options",
+          "sharedaddy_options",
+          "sharing-options"
+        ],
+        "connected_state_blocked_option_keys": [
+          "jetpack_private_options",
+          "jetpack_sync_settings",
+          "jetpack_connection_active_plugins",
+          "jetpack_connection_xmlrpc_verified_errors",
+          "jetpack_protect_key",
+          "jetpack_monitor_active",
+          "jpsq_sync_checkout",
+          "jpsq_sync_started",
+          "jpsq_full_sync_started"
+        ],
+        "serialization_boundaries": [
+          "scalar",
+          "array",
+          "object-placeholder",
+          "empty-string",
+          "falsey",
+          "oversized-json"
+        ],
+        "secret_placeholders_only": true,
+        "connected_state_required_for_mutation": true,
+        "runtime_isolation_required_for_mutation": true,
+        "execute_mutations": false,
+        "mutation_mode": "declared_plan",
+        "restore_original_values": true,
+        "rollback_required": true,
+        "rollback_requirements": [
+          "snapshot original option rows before write",
+          "record autoload and serialized value shape before and after",
+          "restore original values before assertions complete",
+          "fail closed when connected/disconnected fixture state is unavailable"
+        ],
+        "skip_reason_codes": [
+          "connection_required",
+          "credential_unavailable"
+        ]
+      },
+      "phases": {
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=jetpack/jetpack.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.fuzz-plugin-options",
+            "args": [
+              "secret_placeholders_only=true",
+              "execute_mutations=false",
+              "mutation_mode=declared_plan",
+              "connected_state_required_for_mutation=true",
+              "runtime_isolation_required_for_mutation=true",
+              "rollback_required=true"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=options_matrix"
+            ]
+          }
+        ]
+      },
+      "artifacts": [
+        {
+          "name": "options_matrix",
+          "path": "jetpack-options-matrix/options_matrix.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        },
+        {
+          "name": "option_write_rollback_plan",
+          "path": "jetpack-options-matrix/option_write_rollback_plan.json",
+          "required": false,
+          "metadata": {
+            "semantic_key": "fuzz.rollback_plan"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "read_only",
+        "mutation_policy": "declare_option_write_plan_until_isolated_connected_fixture_exists"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 120,
+    "max_duration_seconds": 900
+  },
+  "coverage": {
+    "surface_ids": [
+      "jetpack-options",
+      "wordpress-options"
+    ],
+    "operations": [
+      "option-default-read",
+      "option-inventory",
+      "option-update-rollback-plan",
+      "read-update-safety-classification",
+      "connected-state-blocker-classification",
+      "serialization-boundary-classification",
+      "autoload-classification"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "options_matrix",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": false
+      },
+      {
+        "name": "option_write_rollback_plan",
+        "role": "rollback_plan",
+        "semantic_key": "fuzz.rollback_plan",
+        "required": false
+      }
+    ]
+  }
 }

--- a/Automattic/jetpack/fuzz/jetpack-performance-observation.json
+++ b/Automattic/jetpack/fuzz/jetpack-performance-observation.json
@@ -158,7 +158,11 @@
           "connected",
           "disconnected"
         ],
-        "proof_required_before_status_p": true
+        "proof_required_before_status_p": true,
+        "skip_reason_codes": [
+          "connection_required",
+          "credential_unavailable"
+        ]
       },
       "phases": {
         "setup": [

--- a/Automattic/jetpack/fuzz/jetpack-rest-route-inventory.json
+++ b/Automattic/jetpack/fuzz/jetpack-rest-route-inventory.json
@@ -3,14 +3,23 @@
   "id": "jetpack-rest-route-inventory",
   "label": "Jetpack REST route inventory",
   "safety_class": "read_only",
-  "surface_ids": ["jetpack-rest-routes", "wordpress-rest-api"],
-  "operations": ["route-discovery", "permission-boundary-classification"],
+  "surface_ids": [
+    "jetpack-rest-routes",
+    "wordpress-rest-api"
+  ],
+  "operations": [
+    "route-discovery",
+    "permission-boundary-classification"
+  ],
   "case_budget": 1,
   "duration_budget_seconds": 300,
   "metadata": {
     "kind": "wordpress-plugin-fuzz",
     "wordpress_runner": "wp-codebox",
-    "generic_primitive": { "command": "wordpress.inventory-rest-routes", "status": "blocked" },
+    "generic_primitive": {
+      "command": "wordpress.inventory-rest-routes",
+      "status": "blocked"
+    },
     "workload_path": "${package.root}/bench/jetpack-rest-route-inventory.php",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report",
@@ -22,37 +31,146 @@
         "Expose an artifact-compatible generic REST route inventory command before replacing the Jetpack PHP workload."
       ],
       "crud": {
-        "create": { "level": "declared", "upstream_blocker": "safe connected-site mutation fixtures are not available" },
-        "read": { "level": "executable" },
-        "update": { "level": "declared", "upstream_blocker": "safe connected-site mutation fixtures are not available" },
-        "delete": { "level": "declared", "upstream_blocker": "safe connected-site mutation fixtures are not available" }
+        "create": {
+          "level": "declared",
+          "upstream_blocker": "safe connected-site mutation fixtures are not available"
+        },
+        "read": {
+          "level": "executable"
+        },
+        "update": {
+          "level": "declared",
+          "upstream_blocker": "safe connected-site mutation fixtures are not available"
+        },
+        "delete": {
+          "level": "declared",
+          "upstream_blocker": "safe connected-site mutation fixtures are not available"
+        }
       }
     },
     "target_selection": {
-      "route_namespace_allowlist": ["jetpack/v4", "wpcom/v2"],
-      "route_prefix_allowlist": ["/jetpack/v4/", "/wpcom/v2/"],
-      "excluded_route_families": ["wp/v2 core routes"],
+      "route_namespace_allowlist": [
+        "jetpack/v4",
+        "wpcom/v2"
+      ],
+      "route_prefix_allowlist": [
+        "/jetpack/v4/",
+        "/wpcom/v2/"
+      ],
+      "excluded_route_families": [
+        "wp/v2 core routes"
+      ],
       "inventory_only": true
     }
   },
-  "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
-  "workload": { "runner": "wp-codebox", "type": "php", "path": "${package.root}/bench/jetpack-rest-route-inventory.php", "entry": "jetpack-rest-route-inventory" },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "jetpack",
+    "component": "jetpack"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "php",
+    "path": "${package.root}/bench/jetpack-rest-route-inventory.php",
+    "entry": "jetpack-rest-route-inventory"
+  },
   "cases": [
     {
       "case_id": "jetpack-rest-route-inventory:default",
-      "surface_ids": ["jetpack-rest-routes", "wordpress-rest-api"],
-      "operations": ["route-discovery", "permission-boundary-classification"],
+      "surface_ids": [
+        "jetpack-rest-routes",
+        "wordpress-rest-api"
+      ],
+      "operations": [
+        "route-discovery",
+        "permission-boundary-classification"
+      ],
       "phases": {
-        "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }],
-        "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/jetpack-rest-route-inventory.php", "type=php"] }],
-        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=route_inventory"] }]
+        "setup": [
+          {
+            "command": "wordpress.ensure-plugin-active",
+            "args": [
+              "plugin=jetpack/jetpack.php"
+            ]
+          }
+        ],
+        "action": [
+          {
+            "command": "wordpress.run-workload",
+            "args": [
+              "path=${package.root}/bench/jetpack-rest-route-inventory.php",
+              "type=php"
+            ]
+          }
+        ],
+        "assert": [
+          {
+            "command": "wordpress.collect-workload-result",
+            "args": [
+              "artifact=route_inventory"
+            ]
+          }
+        ]
       },
-      "inputs": { "route_namespace_allowlist": ["jetpack/v4", "wpcom/v2"], "inventory_only": true, "execute_routes": false },
-      "artifacts": [{ "name": "route_inventory", "path": "jetpack-rest-route-inventory/route_inventory.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }, { "name": "route_namespace_counts", "path": "jetpack-rest-route-inventory/route_namespace_counts.json", "required": false, "metadata": { "semantic_key": "fuzz.rest.route_namespace_counts" } }],
-      "metadata": { "safety_class": "read_only" }
+      "inputs": {
+        "route_namespace_allowlist": [
+          "jetpack/v4",
+          "wpcom/v2"
+        ],
+        "inventory_only": true,
+        "execute_routes": false
+      },
+      "artifacts": [
+        {
+          "name": "route_inventory",
+          "path": "jetpack-rest-route-inventory/route_inventory.json",
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        },
+        {
+          "name": "route_namespace_counts",
+          "path": "jetpack-rest-route-inventory/route_namespace_counts.json",
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.rest.route_namespace_counts"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "read_only"
+      }
     }
   ],
-  "limits": { "max_cases": 1, "max_duration_seconds": 300 },
-  "coverage": { "surface_ids": ["jetpack-rest-routes", "wordpress-rest-api"], "operations": ["route-discovery", "permission-boundary-classification"] },
-  "artifacts": { "expected": [{ "name": "route_inventory", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }, { "name": "route_namespace_counts", "role": "coverage_summary", "semantic_key": "fuzz.rest.route_namespace_counts", "required": false }] }
+  "limits": {
+    "max_cases": 1,
+    "max_duration_seconds": 300
+  },
+  "coverage": {
+    "surface_ids": [
+      "jetpack-rest-routes",
+      "wordpress-rest-api"
+    ],
+    "operations": [
+      "route-discovery",
+      "permission-boundary-classification"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "route_inventory",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": true
+      },
+      {
+        "name": "route_namespace_counts",
+        "role": "coverage_summary",
+        "semantic_key": "fuzz.rest.route_namespace_counts",
+        "required": true
+      }
+    ]
+  }
 }

--- a/Automattic/jetpack/fuzz/rest-db-query-profile.json
+++ b/Automattic/jetpack/fuzz/rest-db-query-profile.json
@@ -118,7 +118,11 @@
           "remote-service-short-circuit"
         ],
         "query_attribution_required": true,
-        "external_service_calls_allowed": false
+        "external_service_calls_allowed": false,
+        "skip_reason_codes": [
+          "connection_required",
+          "credential_unavailable"
+        ]
       },
       "phases": {
         "setup": [

--- a/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
+++ b/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import {
   assertFullSurfaceCoverageManifest,
   assertGenericFuzzManifest,
+  assertJetpackFuzzManifestReadinessContract,
   collectFuzzManifests,
   declaredBenchProfileIds,
   declaredBenchWorkloadIds,
@@ -116,6 +117,7 @@ for (const { file, manifest } of fuzzManifests) {
   assert.equal(manifest.metadata?.kind, 'wordpress-plugin-fuzz', `${manifest.id} metadata.kind mismatch`);
   assert.equal(manifest.metadata?.wordpress_runner, 'wp-codebox', `${manifest.id} metadata.wordpress_runner must be wp-codebox`);
   assert.equal(manifest.target?.component, 'jetpack', `${manifest.id} target.component mismatch`);
+  assertJetpackFuzzManifestReadinessContract(manifest, { file });
 
   if (!manifest.metadata?.readiness) {
     warnings.push(`${manifest.id} does not declare metadata.readiness; treating coverage as declared, not proven`);

--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -64,8 +64,27 @@ export function fullSurfaceRequiredArtifactIds(coverageManifest, profile = 'full
 }
 
 export function fuzzManifestHasExecutableArtifactContract(manifest) {
-  return manifest.metadata?.readiness?.level !== 'declared'
+  return ['executable', 'proven'].includes(manifest.metadata?.readiness?.level)
     && manifest.metadata?.generic_primitive?.status !== 'blocked';
+}
+
+export function assertJetpackFuzzManifestReadinessContract(manifest, { file = manifest.id } = {}) {
+  assert.equal(manifest.target?.slug, 'jetpack', `${file} Jetpack manifest target.slug must be jetpack`);
+
+  const readiness = manifest.metadata?.readiness;
+  if (manifest.metadata?.generic_primitive?.status === 'blocked') {
+    assert.ok(Array.isArray(readiness?.upstream_blockers) && readiness.upstream_blockers.length > 0, `${file} blocked generic primitive requires readiness upstream_blockers`);
+  }
+
+  if (readiness?.level === 'declared') {
+    assert.ok(Array.isArray(readiness.upstream_blockers) && readiness.upstream_blockers.length > 0, `${file} declared Jetpack readiness requires upstream_blockers`);
+  }
+
+  if (fuzzManifestHasExecutableArtifactContract(manifest)) {
+    assertAllArtifactsRequired(manifest, { file });
+  }
+
+  assertJetpackConnectedStateContract(manifest, { file });
 }
 
 export function assertGenericFuzzManifest(manifest, {
@@ -237,6 +256,47 @@ function collectRequiredArtifactNames(manifest) {
     .filter((artifact) => artifact?.required === true)
     .map((artifact) => artifact?.name)
     .filter(Boolean));
+}
+
+function assertAllArtifactsRequired(manifest, { file } = {}) {
+  for (const runnerCase of manifest.cases || []) {
+    for (const artifact of runnerCase.artifacts || []) {
+      assert.equal(artifact.required, true, `${file} executable Jetpack readiness requires case artifact ${artifact.name} to be required`);
+    }
+  }
+
+  for (const artifact of manifest.artifacts?.expected || []) {
+    assert.equal(artifact.required, true, `${file} executable Jetpack readiness requires expected artifact ${artifact.name} to be required`);
+  }
+}
+
+function assertJetpackConnectedStateContract(manifest, { file } = {}) {
+  const cases = manifest.cases || [];
+  const coversConnectedState = manifest.operations?.some((operation) => typeof operation === 'string' && operation.includes('connected'))
+    || cases.some((runnerCase) => runnerCase.inputs?.states?.includes('connected') || runnerCase.inputs?.fixture_states?.includes('connected'));
+
+  if (!coversConnectedState) {
+    return;
+  }
+
+  for (const runnerCase of cases) {
+    const inputs = runnerCase.inputs || {};
+    const skipReasonCodes = inputs.skip_reason_codes || [];
+
+    assert.ok(skipReasonCodes.includes('connection_required'), `${file} connected-state cases must classify connection_required skips`);
+    assert.ok(
+      skipReasonCodes.includes('credential_unavailable') || skipReasonCodes.includes('external_service_required'),
+      `${file} connected-state cases must classify credential or external-service blockers`
+    );
+
+    if (inputs.real_wpcom_credentials_allowed !== undefined) {
+      assert.equal(inputs.real_wpcom_credentials_allowed, false, `${file} connected-state cases must not allow real WP.com credentials`);
+    }
+
+    if (manifest.operations?.includes('token-placeholder-serialization')) {
+      assert.equal(inputs.secret_placeholders_only, true, `${file} token placeholder serialization requires secret_placeholders_only`);
+    }
+  }
 }
 
 function assertReviewerFacingRef(value, context) {

--- a/scripts/fuzz-manifest-helpers.test.mjs
+++ b/scripts/fuzz-manifest-helpers.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
   assertFuzzReadinessMetadata,
   assertGenericFuzzManifest,
+  assertJetpackFuzzManifestReadinessContract,
   declaredFuzzIds,
   fullSurfaceRequiredArtifactIds,
   fuzzManifestHasExecutableArtifactContract,
@@ -165,7 +166,13 @@ test('fullSurfaceRequiredArtifactIds follows reviewer-facing coverage artifact e
 });
 
 test('fuzzManifestHasExecutableArtifactContract excludes declared or blocked contracts', () => {
-  assert.equal(fuzzManifestHasExecutableArtifactContract(fuzzManifest()), true);
+  assert.equal(fuzzManifestHasExecutableArtifactContract(fuzzManifest()), false);
+  assert.equal(fuzzManifestHasExecutableArtifactContract(fuzzManifest({
+    metadata: {
+      workload_path: '${package.root}/bench/product.workload.json',
+      readiness: { level: 'executable', coverage_contract: 'Executable product fuzz contract.' },
+    },
+  })), true);
   assert.equal(fuzzManifestHasExecutableArtifactContract(fuzzManifest({
     metadata: {
       workload_path: '${package.root}/bench/product.workload.json',
@@ -175,9 +182,65 @@ test('fuzzManifestHasExecutableArtifactContract excludes declared or blocked con
   assert.equal(fuzzManifestHasExecutableArtifactContract(fuzzManifest({
     metadata: {
       workload_path: '${package.root}/bench/product.workload.json',
+      readiness: { level: 'executable', coverage_contract: 'Blocked product fuzz contract.' },
       generic_primitive: { status: 'blocked' },
     },
   })), false);
+});
+
+test('assertJetpackFuzzManifestReadinessContract rejects executable readiness with optional artifacts', () => {
+  assert.throws(
+    () => assertJetpackFuzzManifestReadinessContract(fuzzManifest({
+      target: { type: 'wordpress-plugin', slug: 'jetpack', component: 'jetpack' },
+      metadata: {
+        workload_path: '${package.root}/bench/product.workload.json',
+        readiness: { level: 'executable', coverage_contract: 'Jetpack executable fuzz contract.' },
+      },
+      cases: [
+        {
+          case_id: 'product-fuzz:default',
+          surface_ids: ['product-api'],
+          operations: ['route-inventory'],
+          artifacts: [{ name: 'report', path: 'report.json', required: false }],
+        },
+      ],
+    }), { file: 'jetpack-fuzz.json' }),
+    /executable Jetpack readiness requires case artifact report to be required/
+  );
+});
+
+test('assertJetpackFuzzManifestReadinessContract requires blockers for declared blocked primitives', () => {
+  assert.throws(
+    () => assertJetpackFuzzManifestReadinessContract(fuzzManifest({
+      target: { type: 'wordpress-plugin', slug: 'jetpack', component: 'jetpack' },
+      metadata: {
+        workload_path: '${package.root}/bench/product.workload.json',
+        generic_primitive: { command: 'wordpress.inventory-database', status: 'blocked' },
+        readiness: { level: 'declared', coverage_contract: 'Jetpack placeholder contract.' },
+      },
+    }), { file: 'jetpack-fuzz.json' }),
+    /blocked generic primitive requires readiness upstream_blockers/
+  );
+});
+
+test('assertJetpackFuzzManifestReadinessContract enforces connected-state blocker classification', () => {
+  assert.throws(
+    () => assertJetpackFuzzManifestReadinessContract(fuzzManifest({
+      target: { type: 'wordpress-plugin', slug: 'jetpack', component: 'jetpack' },
+      surface_ids: ['jetpack-connection'],
+      operations: ['connected-fixture-state', 'token-placeholder-serialization'],
+      cases: [
+        {
+          case_id: 'product-fuzz:default',
+          surface_ids: ['jetpack-connection'],
+          operations: ['connected-fixture-state', 'token-placeholder-serialization'],
+          inputs: { states: ['connected'], skip_reason_codes: ['unsupported_fixture'] },
+          artifacts: [{ name: 'report', path: 'report.json', required: false }],
+        },
+      ],
+    }), { file: 'jetpack-fuzz.json' }),
+    /connected-state cases must classify connection_required skips/
+  );
 });
 
 test('assertFuzzReadinessMetadata accepts declared CRUD and isolated mutation contracts', () => {

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -5,6 +5,7 @@ import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import {
   assertFuzzReadinessMetadata,
+  assertJetpackFuzzManifestReadinessContract,
   assertRunnerNeutralFuzzCaseIntent,
 } from './fuzz-manifest-helpers.mjs';
 
@@ -419,6 +420,7 @@ function lintFuzzWorkload(file) {
   }
 
   lintFuzzReadinessMetadata(rel, workload);
+  lintJetpackFuzzContract(rel, workload);
 
   if (workload.limits) {
     if (!Number.isInteger(workload.limits.max_cases) || workload.limits.max_cases < 1) {
@@ -464,6 +466,23 @@ function lintFuzzReadinessMetadata(rel, workload) {
     failures.push(`${rel}: proven fuzz readiness requires required proof artifacts (${[...new Set(optionalArtifactNames)].join(', ')})`);
   } else if (readinessLevel === 'executable' && optionalArtifactNames.length > 0) {
     warnings.push(`${rel}: executable fuzz readiness has optional artifact(s): ${[...new Set(optionalArtifactNames)].join(', ')}`);
+  }
+}
+
+function lintJetpackFuzzContract(rel, workload) {
+  const isJetpackFuzz = rel.startsWith('Automattic/jetpack/fuzz/')
+    || (rel.startsWith('fuzz/') && root.endsWith('/Automattic/jetpack'))
+    || workload.target?.slug === 'jetpack'
+    || workload.target?.component === 'jetpack';
+
+  if (!isJetpackFuzz) {
+    return;
+  }
+
+  try {
+    assertJetpackFuzzManifestReadinessContract(workload, { file: rel });
+  } catch (error) {
+    failures.push(error.message);
   }
 }
 

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -56,6 +56,19 @@ function createWordPressDevelopFuzzPackage(workload) {
   return directory;
 }
 
+function createJetpackFuzzPackage(workload) {
+  const directory = mkdtempSync(join(tmpdir(), 'homeboy-rigs-jetpack-lint-'));
+  const fuzzRoot = join(directory, 'Automattic', 'jetpack', 'fuzz');
+  const benchRoot = join(directory, 'Automattic', 'jetpack', 'bench');
+
+  mkdirSync(fuzzRoot, { recursive: true });
+  mkdirSync(benchRoot, { recursive: true });
+  writeJson(join(benchRoot, 'generic.workload.json'), { id: 'generic' });
+  writeJson(join(fuzzRoot, `${workload.id}.json`), workload);
+
+  return directory;
+}
+
 function fuzzWorkload(overrides = {}) {
   return {
     schema: 'homeboy/fuzz-workload/v1',
@@ -322,6 +335,59 @@ test('requires WordPress Core proof artifacts when linting package root directly
 
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /fuzz\/rest-api\.json: rest-api must declare expected artifact semantic key fuzz\.rest\.route_inventory/);
+});
+
+test('requires Jetpack executable readiness artifacts to be required', () => {
+  const directory = createJetpackFuzzPackage(fuzzWorkload({
+    id: 'jetpack-fuzz',
+    target: { type: 'wordpress-plugin', slug: 'jetpack', component: 'jetpack' },
+    metadata: {
+      kind: 'wordpress-plugin-fuzz',
+      readiness: { level: 'executable', coverage_contract: 'Jetpack fuzz coverage can execute and produce proof artifacts.' },
+    },
+    cases: [{ case_id: 'jetpack-fuzz:default', artifacts: [{ name: 'jetpack_report', required: false }] }],
+    artifacts: { expected: [{ name: 'jetpack_report', semantic_key: 'fuzz.report', required: false }] },
+  }));
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /executable Jetpack readiness requires case artifact jetpack_report to be required/);
+});
+
+test('requires Jetpack declared placeholders to document upstream blockers', () => {
+  const directory = createJetpackFuzzPackage(fuzzWorkload({
+    id: 'jetpack-placeholder',
+    target: { type: 'wordpress-plugin', slug: 'jetpack', component: 'jetpack' },
+    metadata: {
+      kind: 'wordpress-plugin-fuzz',
+      generic_primitive: { command: 'wordpress.inventory-database', status: 'blocked' },
+      readiness: { level: 'declared', coverage_contract: 'Jetpack placeholder coverage awaits a generic primitive.' },
+    },
+  }));
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /blocked generic primitive requires readiness upstream_blockers/);
+});
+
+test('requires Jetpack connected-state blocker classification', () => {
+  const directory = createJetpackFuzzPackage(fuzzWorkload({
+    id: 'jetpack-connection',
+    target: { type: 'wordpress-plugin', slug: 'jetpack', component: 'jetpack' },
+    surface_ids: ['jetpack-connection'],
+    operations: ['connected-fixture-state', 'token-placeholder-serialization'],
+    cases: [
+      {
+        case_id: 'jetpack-connection:default',
+        inputs: { states: ['connected'], skip_reason_codes: ['unsupported_fixture'] },
+        artifacts: [{ name: 'connection_report', required: false }],
+      },
+    ],
+  }));
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /connected-state cases must classify connection_required skips/);
 });
 
 test('rejects WordPress Core fuzz workloads outside wordpress-develop', () => {


### PR DESCRIPTION
## Summary
- Add Jetpack-specific fuzz readiness enforcement shared by the Jetpack validator and package lint.
- Require executable/proven Jetpack readiness to mark case and expected artifacts as required.
- Require declared placeholder/blocker metadata to include upstream blockers and connected-state blocker classification where relevant.

## Testing
- `node --test scripts/fuzz-manifest-helpers.test.mjs scripts/lint-rig-packages.test.mjs`
- `node Automattic/jetpack/tools/validate-fuzz-manifests.mjs`
- `node scripts/lint-rig-packages.mjs Automattic/jetpack`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Jetpack fuzz validator investigation, implementation, validation, and PR description drafting.
