### PR TITLE
Refine Jetpack cron sync fuzzing

### DIFF
--- a/Automattic/jetpack/fuzz/jetpack-cron-sync-actions.json
+++ b/Automattic/jetpack/fuzz/jetpack-cron-sync-actions.json
@@ -15,16 +15,20 @@
     "expected_artifact_semantic_key": "fuzz.report",
     "network_policy": "block_all_synthetic_external_requests",
     "artifact_expectations": {
-      "required": ["cron_events", "sync_actions", "queue_option_deltas", "rollback_rows"],
-      "optional": ["blocked_dispatch_attempts", "serialized_action_samples", "skipped_actions"]
+      "required": ["cron_events", "sync_actions", "queue_option_deltas", "rollback_rows", "connected_disconnected_blockers", "replay_fixture_manifest", "proof_artifact_index"],
+      "optional": ["blocked_dispatch_attempts", "serialized_action_samples", "skipped_actions", "schedule_drift_rows"]
     },
     "readiness": {
       "level": "executable",
-      "coverage_contract": "Jetpack cron, sync action, queue option delta, and rollback-safe cron mutation inventory with external HTTP blocked.",
-      "upstream_blockers": ["durable rollback artifact manifests and persisted proof links are required before proven status"],
+      "coverage_contract": "Jetpack-specific cron hooks, sync actions, queue option deltas, connected/disconnected blockers, replay fixtures, and rollback-safe cron mutation inventory with external HTTP blocked.",
+      "upstream_blockers": [
+        "durable rollback artifact manifests and persisted proof links are required before proven status",
+        "connected Jetpack runs require synthetic token fixtures or reviewer-approved fixture credentials before credential-gated hooks can be replayed",
+        "cron and sync replay proof must come from a disposable fixture; this manifest does not add a generic cron runner or sync queue executor primitive"
+      ],
       "mutation": {
         "safety_boundary": "Runs in isolated WP Codebox fixtures with remote dispatch disabled, original values restored, rollback required, and external HTTP guarded.",
-        "rollback_artifacts": ["cron_sync_actions"]
+        "rollback_artifacts": ["cron_sync_actions", "cron_sync_rollback_rows", "queue_option_restore_rows"]
       }
     }
   },
@@ -36,9 +40,47 @@
       "surface_ids": ["jetpack-sync", "wordpress-cron", "wordpress-options"],
       "operations": ["cron-event-inventory", "sync-action-inventory", "queue-option-delta", "rollback-safe-cron-mutation"],
       "inputs": {
-        "cron_hooks": ["jetpack_clean_nonces", "jetpack_sync_cron", "jetpack_sync_full_cron", "jetpack_v2_heartbeat", "jetpack_scan_refresh_states_event"],
-        "synthetic_actions": ["post_save", "option_update", "comment_status", "module_toggle", "user_update"],
-        "queue_options": ["jpsq_sync_checkout", "jpsq_sync_started", "jpsq_full_sync_started", "jetpack_sync_settings_sync_wait_time"],
+        "cron_hooks": [
+          "jetpack_clean_nonces",
+          "jetpack_sync_cron",
+          "jetpack_sync_full_cron",
+          "jetpack_v2_heartbeat",
+          "jetpack_scan_refresh_states_event",
+          "jetpack_waf_rules_update_cron",
+          "jetpack_waf_ip_allow_list_update_cron"
+        ],
+        "product_hook_inventory": [
+          { "hook": "jetpack_clean_nonces", "surface": "connection-maintenance", "safety_class": "read_only_inventory", "connected_state": "any", "fixture_requirement": "installed_jetpack_no_remote_dispatch" },
+          { "hook": "jetpack_sync_cron", "surface": "incremental-sync", "safety_class": "isolated_fixture_mutation", "connected_state": "connected_required", "disconnected_blocker": "connected_required", "fixture_requirement": "synthetic_connection_placeholders" },
+          { "hook": "jetpack_sync_full_cron", "surface": "full-sync", "safety_class": "isolated_fixture_mutation", "connected_state": "connected_required", "disconnected_blocker": "connected_required", "fixture_requirement": "synthetic_connection_placeholders" },
+          { "hook": "jetpack_v2_heartbeat", "surface": "connection-heartbeat", "safety_class": "network_guarded_inventory", "connected_state": "connected_required", "disconnected_blocker": "credential_unavailable", "fixture_requirement": "http_guardrail_blocked_wpcom_boundary" },
+          { "hook": "jetpack_scan_refresh_states_event", "surface": "scan-state-refresh", "safety_class": "network_guarded_inventory", "connected_state": "connected_required", "disconnected_blocker": "credential_unavailable", "fixture_requirement": "http_guardrail_blocked_wpcom_boundary" },
+          { "hook": "jetpack_waf_rules_update_cron", "surface": "protect-waf-rules", "safety_class": "network_guarded_inventory", "connected_state": "connected_required", "disconnected_blocker": "credential_unavailable", "fixture_requirement": "http_guardrail_blocked_wpcom_boundary" },
+          { "hook": "jetpack_waf_ip_allow_list_update_cron", "surface": "protect-waf-allow-list", "safety_class": "network_guarded_inventory", "connected_state": "connected_required", "disconnected_blocker": "credential_unavailable", "fixture_requirement": "http_guardrail_blocked_wpcom_boundary" }
+        ],
+        "synthetic_actions": ["jetpack_sync_save_post", "jetpack_sync_save_option", "jetpack_sync_save_comment", "jetpack_sync_save_user", "jetpack_sync_module_toggle"],
+        "product_action_inventory": [
+          { "action": "jetpack_sync_save_post", "trigger_fixture": "post_crud_fixture", "payload_shape": "post_id_and_post_after", "safety_class": "isolated_fixture_mutation", "replay_required": true },
+          { "action": "jetpack_sync_save_option", "trigger_fixture": "option_update_fixture", "payload_shape": "option_name_old_value_new_value", "safety_class": "isolated_fixture_mutation", "replay_required": true },
+          { "action": "jetpack_sync_save_comment", "trigger_fixture": "comment_crud_fixture", "payload_shape": "comment_id_and_comment_after", "safety_class": "isolated_fixture_mutation", "replay_required": true },
+          { "action": "jetpack_sync_save_user", "trigger_fixture": "user_profile_fixture", "payload_shape": "user_id_and_user_after", "safety_class": "isolated_fixture_mutation", "replay_required": true },
+          { "action": "jetpack_sync_module_toggle", "trigger_fixture": "module_state_fixture", "payload_shape": "module_slug_previous_state_next_state", "safety_class": "isolated_fixture_mutation", "replay_required": true }
+        ],
+        "queue_options": ["jpsq_sync_checkout", "jpsq_sync_started", "jpsq_full_sync_started", "jetpack_sync_settings_sync_wait_time", "jetpack_sync_non_blocking", "jetpack_sync_checksum"],
+        "queue_surfaces": [
+          { "name": "jpsq_sync_checkout", "kind": "option", "mutation_policy": "snapshot_restore", "proof_rows": ["before", "after", "restored"] },
+          { "name": "jpsq_sync_started", "kind": "option", "mutation_policy": "snapshot_restore", "proof_rows": ["before", "after", "restored"] },
+          { "name": "jpsq_full_sync_started", "kind": "option", "mutation_policy": "snapshot_restore", "proof_rows": ["before", "after", "restored"] },
+          { "name": "jetpack_sync_settings_sync_wait_time", "kind": "option", "mutation_policy": "snapshot_restore", "proof_rows": ["before", "after", "restored"] },
+          { "name": "jetpack_sync_non_blocking", "kind": "option", "mutation_policy": "snapshot_restore", "proof_rows": ["before", "after", "restored"] },
+          { "name": "jetpack_sync_checksum", "kind": "option", "mutation_policy": "snapshot_restore", "proof_rows": ["before", "after", "restored"] }
+        ],
+        "connection_state_blockers": [
+          { "state": "disconnected", "classification": "blocked", "reason_code": "connected_required", "applies_to": ["jetpack_sync_cron", "jetpack_sync_full_cron", "jetpack_v2_heartbeat", "jetpack_scan_refresh_states_event"] },
+          { "state": "connected_placeholder", "classification": "guarded", "reason_code": "wpcom_boundary_blocked", "applies_to": ["jetpack_v2_heartbeat", "jetpack_scan_refresh_states_event", "jetpack_waf_rules_update_cron", "jetpack_waf_ip_allow_list_update_cron"] }
+        ],
+        "replay_fixture_requirements": ["isolated_wp_codebox_site", "jetpack_plugin_active", "synthetic_connection_placeholders", "external_http_guardrail", "pre_action_queue_snapshot", "post_action_queue_restore"],
+        "proof_artifact_expectations": ["cron event inventory with hook/source/state rows", "sync action inventory with payload-shape rows", "connected/disconnected blocker rows", "queue option before/after/restore rows", "replay fixture manifest", "external HTTP guardrail assertion", "proof artifact index"],
         "remote_dispatch": false,
         "restore_original_values": true,
         "rollback_required": true,
@@ -52,11 +94,19 @@
         "action": [{ "command": "wordpress.inventory-plugin-cron-sync-actions", "args": ["remote_dispatch=false", "restore_original_values=true", "rollback_required=true", "force_http_guardrail=true"] }],
         "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=cron_sync_actions"] }]
       },
-      "artifacts": [{ "name": "cron_sync_actions", "path": "jetpack-cron-sync-actions/cron_sync_actions.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }],
+      "artifacts": [
+        { "name": "cron_sync_actions", "path": "jetpack-cron-sync-actions/cron_sync_actions.json", "required": true, "metadata": { "semantic_key": "fuzz.report" } },
+        { "name": "cron_sync_replay_fixture", "path": "jetpack-cron-sync-actions/replay_fixture.json", "required": true, "metadata": { "semantic_key": "fuzz.replay_fixture" } },
+        { "name": "cron_sync_proof_index", "path": "jetpack-cron-sync-actions/proof_index.json", "required": true, "metadata": { "semantic_key": "fuzz.proof_index" } }
+      ],
       "metadata": { "safety_class": "isolated_mutation" }
     }
   ],
   "limits": { "max_cases": 80, "max_duration_seconds": 900 },
   "coverage": { "surface_ids": ["jetpack-sync", "wordpress-cron", "wordpress-options"], "operations": ["cron-event-inventory", "sync-action-inventory", "queue-option-delta", "rollback-safe-cron-mutation"] },
-  "artifacts": { "expected": [{ "name": "cron_sync_actions", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+  "artifacts": { "expected": [
+    { "name": "cron_sync_actions", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": true },
+    { "name": "cron_sync_replay_fixture", "role": "fixture_manifest", "semantic_key": "fuzz.replay_fixture", "required": true },
+    { "name": "cron_sync_proof_index", "role": "proof_index", "semantic_key": "fuzz.proof_index", "required": true }
+  ] }
 }

--- a/Automattic/jetpack/fuzz/jetpack-sync-queue-coverage.json
+++ b/Automattic/jetpack/fuzz/jetpack-sync-queue-coverage.json
@@ -7,11 +7,87 @@
   "operations": ["sync-queue-discovery", "sync-action-inventory", "action-serialization", "retry-boundary-classification", "queue-option-rollback"],
   "case_budget": 80,
   "duration_budget_seconds": 900,
-  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "workload_path": "${package.root}/manifests/full-surface-coverage.json", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report", "network_policy": "block_all_synthetic_external_requests", "mutation_policy": "snapshot_queue_options_restore_after_assert", "artifact_expectations": { "required": ["sync_queue", "serialized_action_samples", "queue_rollback_rows"], "optional": ["retry_boundary_rows", "blocked_dispatch_attempts"] } },
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/manifests/full-surface-coverage.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report",
+    "network_policy": "block_all_synthetic_external_requests",
+    "mutation_policy": "snapshot_queue_options_restore_after_assert",
+    "artifact_expectations": {
+      "required": ["sync_queue", "serialized_action_samples", "queue_rollback_rows", "queue_surface_inventory", "connected_disconnected_blockers", "replay_fixture_manifest", "proof_artifact_index"],
+      "optional": ["retry_boundary_rows", "blocked_dispatch_attempts", "queue_drain_skipped_rows"]
+    },
+    "readiness": {
+      "level": "executable",
+      "coverage_contract": "Jetpack sync queue surface inventory, local action serialization, retry-boundary classification, connected/disconnected blockers, replay fixtures, and queue option rollback without remote dispatch.",
+      "upstream_blockers": [
+        "durable rollback artifact manifests and persisted proof links are required before proven status",
+        "connected Jetpack queue dispatch requires synthetic token fixtures or reviewer-approved fixture credentials before credential-gated replay can be proven",
+        "queue execution proof must come from a disposable fixture; this manifest does not add a generic sync queue executor primitive"
+      ],
+      "mutation": {
+        "safety_boundary": "Runs only against isolated WP Codebox queue options and synthetic action payloads with remote dispatch disabled, original values restored, rollback required, and external HTTP guarded.",
+        "rollback_artifacts": ["sync_queue_coverage", "queue_rollback_rows", "queue_option_restore_rows"]
+      }
+    }
+  },
   "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
   "workload": { "runner": "wp-codebox", "type": "generic", "path": "${package.root}/manifests/full-surface-coverage.json", "entry": "wordpress-plugin-sync-queue-coverage" },
-  "cases": [{ "case_id": "jetpack-sync-queue-coverage:default", "surface_ids": ["jetpack-sync", "wordpress-cron", "wordpress-options"], "operations": ["sync-queue-discovery", "sync-action-inventory", "action-serialization", "retry-boundary-classification", "queue-option-rollback"], "inputs": { "remote_dispatch": false, "synthetic_actions": ["post_save", "option_update", "comment_status", "module_toggle", "user_update"], "queue_options": ["jpsq_sync_checkout", "jpsq_sync_started", "jpsq_full_sync_started", "jetpack_sync_settings_sync_wait_time"], "force_http_guardrail": true, "restore_original_values": true, "rollback_required": true }, "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }, { "command": "wordpress.ensure-external-http-guardrail", "args": ["allowlist=", "block_network=true"] }], "action": [{ "command": "wordpress.fuzz-plugin-sync-queue", "args": ["remote_dispatch=false", "force_http_guardrail=true", "restore_original_values=true", "rollback_required=true"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=sync_queue_coverage"] }] }, "artifacts": [{ "name": "sync_queue_coverage", "path": "jetpack-sync-queue-coverage/sync_queue_coverage.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }], "metadata": { "safety_class": "isolated_mutation", "mutation_policy": "snapshot_queue_options_restore_after_assert" } }],
+  "cases": [
+    {
+      "case_id": "jetpack-sync-queue-coverage:default",
+      "surface_ids": ["jetpack-sync", "wordpress-cron", "wordpress-options"],
+      "operations": ["sync-queue-discovery", "sync-action-inventory", "action-serialization", "retry-boundary-classification", "queue-option-rollback"],
+      "inputs": {
+        "remote_dispatch": false,
+        "synthetic_actions": ["jetpack_sync_save_post", "jetpack_sync_save_option", "jetpack_sync_save_comment", "jetpack_sync_save_user", "jetpack_sync_module_toggle"],
+        "product_action_inventory": [
+          { "action": "jetpack_sync_save_post", "queue_surface": "incremental_sync", "trigger_fixture": "post_crud_fixture", "payload_shape": "post_id_and_post_after", "serialization_expectation": "json_safe_without_secrets", "connected_state": "any", "replay_required": true },
+          { "action": "jetpack_sync_save_option", "queue_surface": "incremental_sync", "trigger_fixture": "option_update_fixture", "payload_shape": "option_name_old_value_new_value", "serialization_expectation": "redacted_secret_like_values", "connected_state": "any", "replay_required": true },
+          { "action": "jetpack_sync_save_comment", "queue_surface": "incremental_sync", "trigger_fixture": "comment_crud_fixture", "payload_shape": "comment_id_and_comment_after", "serialization_expectation": "json_safe_without_secrets", "connected_state": "any", "replay_required": true },
+          { "action": "jetpack_sync_save_user", "queue_surface": "incremental_sync", "trigger_fixture": "user_profile_fixture", "payload_shape": "user_id_and_user_after", "serialization_expectation": "redacted_pii_like_values", "connected_state": "any", "replay_required": true },
+          { "action": "jetpack_sync_module_toggle", "queue_surface": "module_state_sync", "trigger_fixture": "module_state_fixture", "payload_shape": "module_slug_previous_state_next_state", "serialization_expectation": "json_safe_without_secrets", "connected_state": "connected_placeholder", "connected_blocker": "wpcom_boundary_blocked", "replay_required": true }
+        ],
+        "queue_options": ["jpsq_sync_checkout", "jpsq_sync_started", "jpsq_full_sync_started", "jetpack_sync_settings_sync_wait_time", "jetpack_sync_non_blocking", "jetpack_sync_checksum"],
+        "queue_surfaces": [
+          { "name": "incremental_sync_queue", "kind": "option_backed_queue", "options": ["jpsq_sync_checkout", "jpsq_sync_started"], "safety_class": "isolated_fixture_mutation", "mutation_policy": "snapshot_restore" },
+          { "name": "full_sync_queue", "kind": "option_backed_queue", "options": ["jpsq_full_sync_started"], "safety_class": "isolated_fixture_mutation", "mutation_policy": "snapshot_restore" },
+          { "name": "sync_settings", "kind": "option_state", "options": ["jetpack_sync_settings_sync_wait_time", "jetpack_sync_non_blocking", "jetpack_sync_checksum"], "safety_class": "isolated_fixture_mutation", "mutation_policy": "snapshot_restore" }
+        ],
+        "connection_state_blockers": [
+          { "state": "disconnected", "classification": "blocked", "reason_code": "connected_required", "applies_to": ["remote_dispatch", "module_state_sync"] },
+          { "state": "connected_placeholder", "classification": "guarded", "reason_code": "wpcom_boundary_blocked", "applies_to": ["remote_dispatch", "queue_drain"] }
+        ],
+        "retry_boundary_classification": ["no_retry_without_remote_dispatch", "queue_option_restore_required", "blocked_dispatch_attempt_recorded"],
+        "replay_fixture_requirements": ["isolated_wp_codebox_site", "jetpack_plugin_active", "fixture_post_comment_user_option_rows", "synthetic_connection_placeholders", "external_http_guardrail", "pre_action_queue_snapshot", "post_action_queue_restore"],
+        "proof_artifact_expectations": ["queue surface inventory", "serialized action sample rows", "retry boundary rows", "connected/disconnected blocker rows", "queue option before/after/restore rows", "replay fixture manifest", "external HTTP guardrail assertion", "proof artifact index"],
+        "force_http_guardrail": true,
+        "restore_original_values": true,
+        "rollback_required": true
+      },
+      "phases": {
+        "setup": [
+          { "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] },
+          { "command": "wordpress.ensure-external-http-guardrail", "args": ["allowlist=", "block_network=true"] }
+        ],
+        "action": [{ "command": "wordpress.fuzz-plugin-sync-queue", "args": ["remote_dispatch=false", "force_http_guardrail=true", "restore_original_values=true", "rollback_required=true"] }],
+        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=sync_queue_coverage"] }]
+      },
+      "artifacts": [
+        { "name": "sync_queue_coverage", "path": "jetpack-sync-queue-coverage/sync_queue_coverage.json", "required": true, "metadata": { "semantic_key": "fuzz.report" } },
+        { "name": "sync_queue_replay_fixture", "path": "jetpack-sync-queue-coverage/replay_fixture.json", "required": true, "metadata": { "semantic_key": "fuzz.replay_fixture" } },
+        { "name": "sync_queue_proof_index", "path": "jetpack-sync-queue-coverage/proof_index.json", "required": true, "metadata": { "semantic_key": "fuzz.proof_index" } }
+      ],
+      "metadata": { "safety_class": "isolated_mutation", "mutation_policy": "snapshot_queue_options_restore_after_assert" }
+    }
+  ],
   "limits": { "max_cases": 80, "max_duration_seconds": 900 },
   "coverage": { "surface_ids": ["jetpack-sync", "wordpress-cron", "wordpress-options"], "operations": ["sync-queue-discovery", "sync-action-inventory", "action-serialization", "retry-boundary-classification", "queue-option-rollback"] },
-  "artifacts": { "expected": [{ "name": "sync_queue_coverage", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+  "artifacts": { "expected": [
+    { "name": "sync_queue_coverage", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": true },
+    { "name": "sync_queue_replay_fixture", "role": "fixture_manifest", "semantic_key": "fuzz.replay_fixture", "required": true },
+    { "name": "sync_queue_proof_index", "role": "proof_index", "semantic_key": "fuzz.proof_index", "required": true }
+  ] }
 }

--- a/Automattic/jetpack/manifests/full-surface-coverage.test.mjs
+++ b/Automattic/jetpack/manifests/full-surface-coverage.test.mjs
@@ -158,6 +158,33 @@ test('Jetpack inventory fuzz workloads define module option/table and cron sync 
   assert.ok(cronSyncActions.cases[0].inputs.synthetic_actions.length > 0);
 });
 
+test('Jetpack cron and sync manifests declare product-specific hooks, blockers, fixtures, and proof artifacts', () => {
+  const cronSyncActions = readFuzzManifest('jetpack-cron-sync-actions');
+  const syncQueueCoverage = readFuzzManifest('jetpack-sync-queue-coverage');
+  const cronInputs = defaultCase(cronSyncActions).inputs;
+  const queueInputs = defaultCase(syncQueueCoverage).inputs;
+
+  assert.ok(cronInputs.product_hook_inventory.some((entry) => entry.hook === 'jetpack_sync_cron'));
+  assert.ok(cronInputs.product_hook_inventory.some((entry) => entry.disconnected_blocker === 'connected_required'));
+  assert.ok(cronInputs.product_action_inventory.every((entry) => entry.action.startsWith('jetpack_sync_')));
+  assert.ok(cronInputs.queue_surfaces.some((surface) => surface.name === 'jpsq_sync_checkout'));
+  assert.ok(cronInputs.connection_state_blockers.some((blocker) => blocker.reason_code === 'wpcom_boundary_blocked'));
+  assert.ok(cronInputs.replay_fixture_requirements.includes('external_http_guardrail'));
+  assert.ok(cronInputs.proof_artifact_expectations.includes('proof artifact index'));
+
+  assert.ok(queueInputs.product_action_inventory.every((entry) => entry.action.startsWith('jetpack_sync_')));
+  assert.ok(queueInputs.queue_surfaces.some((surface) => surface.name === 'incremental_sync_queue'));
+  assert.ok(queueInputs.connection_state_blockers.some((blocker) => blocker.reason_code === 'connected_required'));
+  assert.ok(queueInputs.replay_fixture_requirements.includes('synthetic_connection_placeholders'));
+  assert.ok(queueInputs.proof_artifact_expectations.includes('queue option before/after/restore rows'));
+
+  for (const workload of [cronSyncActions, syncQueueCoverage]) {
+    assert.ok(workload.metadata.readiness.upstream_blockers.some((blocker) => blocker.includes('does not add a generic')));
+    assert.ok(workload.artifacts.expected.some((artifact) => artifact.semantic_key === 'fuzz.replay_fixture' && artifact.required === true));
+    assert.ok(workload.artifacts.expected.some((artifact) => artifact.semantic_key === 'fuzz.proof_index' && artifact.required === true));
+  }
+});
+
 test('Jetpack admin page coverage enumerates wp-admin menus with explicit skip reasons', () => {
   const admin = readFuzzManifest('jetpack-admin-page-coverage');
   const testCase = defaultCase(admin);


### PR DESCRIPTION
## Summary
- Refine Jetpack cron and sync queue fuzz contracts.
- Add product-specific hooks/actions, queue surfaces, safety classifications, connected-state blockers, replay fixture requirements, rollback expectations, and proof artifact expectations.

## Testing
- `node --test Automattic/jetpack/manifests/full-surface-coverage.test.mjs`
- `node scripts/lint-rig-packages.mjs`
- `node --test Automattic/jetpack/manifests/full-surface-coverage.test.mjs WordPress/gutenberg/tools/fuzz-coverage.test.mjs WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Jetpack fuzz manifest investigation, metadata updates, validation, and PR description drafting.
