### PR TITLE
Refine Jetpack REST fuzz cases

### DIFF
--- a/Automattic/jetpack/bench/generated-rest-request-cases.workload.json
+++ b/Automattic/jetpack/bench/generated-rest-request-cases.workload.json
@@ -8,6 +8,9 @@
       "path": "/jetpack/v4/site",
       "capture-response": true,
       "permission_class": "authenticated_local",
+      "persona": "administrator",
+      "auth_required": true,
+      "mutating": false,
       "expected_statuses": [200, 401, 403]
     },
     {
@@ -16,6 +19,9 @@
       "path": "/jetpack/v4/modules",
       "capture-response": true,
       "permission_class": "authenticated_local",
+      "persona": "administrator",
+      "auth_required": true,
+      "mutating": false,
       "expected_statuses": [200, 401, 403]
     },
     {
@@ -24,6 +30,11 @@
       "path": "/jetpack/v4/modules/stats",
       "capture-response": true,
       "permission_class": "authenticated_local",
+      "persona": "administrator",
+      "auth_required": true,
+      "mutating": false,
+      "optional": true,
+      "skip_reason": "route_absent",
       "expected_statuses": [200, 401, 403, 404]
     },
     {
@@ -32,6 +43,9 @@
       "path": "/jetpack/v4/settings",
       "capture-response": true,
       "permission_class": "administrator_required",
+      "persona": "administrator",
+      "auth_required": true,
+      "mutating": false,
       "expected_statuses": [200, 401, 403]
     },
     {
@@ -40,6 +54,10 @@
       "path": "/jetpack/v4/connection",
       "capture-response": true,
       "permission_class": "connected_site_required",
+      "persona": "connected-site-placeholder",
+      "auth_required": true,
+      "mutating": false,
+      "skip_reason": "connected_required",
       "expected_statuses": [200, 401, 403, 404]
     },
     {
@@ -48,6 +66,10 @@
       "path": "/jetpack/v4/connection/status",
       "capture-response": true,
       "permission_class": "connected_site_required",
+      "persona": "connected-site-placeholder",
+      "auth_required": true,
+      "mutating": false,
+      "skip_reason": "connected_required",
       "expected_statuses": [200, 401, 403, 404]
     },
     {
@@ -56,6 +78,10 @@
       "path": "/wpcom/v2/publicize/services",
       "capture-response": true,
       "permission_class": "public_read_or_wpcom_dependent",
+      "persona": "anonymous",
+      "auth_required": false,
+      "mutating": false,
+      "skip_reason": "wpcom_dependent",
       "expected_statuses": [200, 401, 403, 404]
     },
     {
@@ -64,6 +90,11 @@
       "path": "/wpcom/v2/sites/example.wordpress.com/settings",
       "capture-response": true,
       "permission_class": "wpcom_dependent",
+      "persona": "connected-site-placeholder",
+      "auth_required": true,
+      "mutating": false,
+      "placeholder_parameters": { "site": "example.wordpress.com" },
+      "skip_reason": "credential_unavailable",
       "expected_statuses": [401, 403, 404],
       "boundary": "No live WordPress.com credentials are supplied in the fixture; forbidden or skipped is expected."
     }
@@ -73,6 +104,13 @@
     "workload": "generated-rest-request-cases",
     "coverage_shape": "generated safe Jetpack REST request cases",
     "manifest": "manifests/rest-route-coverage.json",
+    "method_allowlist": ["GET"],
+    "mutating_methods_allowed": false,
+    "real_wpcom_credentials_allowed": false,
+    "personas": ["anonymous", "administrator", "connected-site-placeholder"],
+    "skip_reason_codes": ["connected_required", "credential_unavailable", "route_absent", "wpcom_dependent"],
+    "required_artifacts": ["rest_request_cases", "rest_skip_reasons"],
+    "optional_artifacts": ["connected_site_response_samples", "wpcom_credentialed_response_samples"],
     "permission_classifications": ["public_read_or_wpcom_dependent", "authenticated_local", "administrator_required", "connected_site_required", "wpcom_dependent"]
   }
 }

--- a/Automattic/jetpack/fuzz/generated-rest-request-cases.json
+++ b/Automattic/jetpack/fuzz/generated-rest-request-cases.json
@@ -7,11 +7,30 @@
   "operations": ["generated-rest-case-plan", "request-case-execution"],
   "case_budget": 80,
   "duration_budget_seconds": 600,
-  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "workload_path": "${package.root}/bench/generated-rest-request-cases.workload.json", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report" },
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/generated-rest-request-cases.workload.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report",
+    "readiness": {
+      "level": "executable",
+      "coverage_contract": "Generated GET-only Jetpack REST request cases for local administrator, anonymous, connected-required, and WP.com-dependent permission boundaries.",
+      "upstream_blockers": [
+        "Connected-site and WP.com-dependent requests are classified as forbidden or skipped until durable connected fixture credentials are available."
+      ],
+      "crud": {
+        "create": { "level": "declared", "upstream_blocker": "safe connected-site mutation fixtures are not available" },
+        "read": { "level": "executable" },
+        "update": { "level": "declared", "upstream_blocker": "safe connected-site mutation fixtures are not available" },
+        "delete": { "level": "declared", "upstream_blocker": "safe connected-site mutation fixtures are not available" }
+      }
+    }
+  },
   "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
   "workload": { "runner": "wp-codebox", "type": "json", "path": "${package.root}/bench/generated-rest-request-cases.workload.json", "entry": "generated-rest-request-cases" },
-  "cases": [{ "case_id": "generated-rest-request-cases:default", "surface_ids": ["jetpack-rest-routes"], "operations": ["generated-rest-case-plan", "request-case-execution"], "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }], "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/generated-rest-request-cases.workload.json", "type=json"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=rest_request_cases"] }] }, "artifacts": [{ "name": "rest_request_cases", "path": "generated-rest-request-cases/rest_request_cases.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }], "metadata": { "safety_class": "read_only" } }],
+  "cases": [{ "case_id": "generated-rest-request-cases:default", "surface_ids": ["jetpack-rest-routes"], "operations": ["generated-rest-case-plan", "request-case-execution"], "inputs": { "methods": ["GET"], "personas": ["anonymous", "administrator", "connected-site-placeholder"], "skip_reason_codes": ["connected_required", "credential_unavailable", "route_absent", "wpcom_dependent"], "real_wpcom_credentials_allowed": false, "mutating_methods_allowed": false }, "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }], "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/generated-rest-request-cases.workload.json", "type=json"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=rest_request_cases"] }, { "command": "wordpress.collect-workload-result", "args": ["artifact=rest_skip_reasons"] }] }, "artifacts": [{ "name": "rest_request_cases", "path": "generated-rest-request-cases/rest_request_cases.json", "required": true, "metadata": { "semantic_key": "fuzz.report" } }, { "name": "rest_skip_reasons", "path": "generated-rest-request-cases/rest_skip_reasons.json", "required": true, "metadata": { "semantic_key": "fuzz.skip_reasons" } }], "metadata": { "safety_class": "read_only" } }],
   "limits": { "max_cases": 80, "max_duration_seconds": 600 },
   "coverage": { "surface_ids": ["jetpack-rest-routes"], "operations": ["generated-rest-case-plan", "request-case-execution"] },
-  "artifacts": { "expected": [{ "name": "rest_request_cases", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+  "artifacts": { "expected": [{ "name": "rest_request_cases", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": true }, { "name": "rest_skip_reasons", "role": "skip_reason_report", "semantic_key": "fuzz.skip_reasons", "required": true }] }
 }

--- a/Automattic/jetpack/fuzz/jetpack-rest-route-inventory.json
+++ b/Automattic/jetpack/fuzz/jetpack-rest-route-inventory.json
@@ -27,6 +27,12 @@
         "update": { "level": "declared", "upstream_blocker": "safe connected-site mutation fixtures are not available" },
         "delete": { "level": "declared", "upstream_blocker": "safe connected-site mutation fixtures are not available" }
       }
+    },
+    "target_selection": {
+      "route_namespace_allowlist": ["jetpack/v4", "wpcom/v2"],
+      "route_prefix_allowlist": ["/jetpack/v4/", "/wpcom/v2/"],
+      "excluded_route_families": ["wp/v2 core routes"],
+      "inventory_only": true
     }
   },
   "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
@@ -41,11 +47,12 @@
         "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/jetpack-rest-route-inventory.php", "type=php"] }],
         "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=route_inventory"] }]
       },
-      "artifacts": [{ "name": "route_inventory", "path": "jetpack-rest-route-inventory/route_inventory.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }],
+      "inputs": { "route_namespace_allowlist": ["jetpack/v4", "wpcom/v2"], "inventory_only": true, "execute_routes": false },
+      "artifacts": [{ "name": "route_inventory", "path": "jetpack-rest-route-inventory/route_inventory.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }, { "name": "route_namespace_counts", "path": "jetpack-rest-route-inventory/route_namespace_counts.json", "required": false, "metadata": { "semantic_key": "fuzz.rest.route_namespace_counts" } }],
       "metadata": { "safety_class": "read_only" }
     }
   ],
   "limits": { "max_cases": 1, "max_duration_seconds": 300 },
   "coverage": { "surface_ids": ["jetpack-rest-routes", "wordpress-rest-api"], "operations": ["route-discovery", "permission-boundary-classification"] },
-  "artifacts": { "expected": [{ "name": "route_inventory", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }] }
+  "artifacts": { "expected": [{ "name": "route_inventory", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }, { "name": "route_namespace_counts", "role": "coverage_summary", "semantic_key": "fuzz.rest.route_namespace_counts", "required": false }] }
 }

--- a/Automattic/jetpack/manifests/full-surface-coverage.test.mjs
+++ b/Automattic/jetpack/manifests/full-surface-coverage.test.mjs
@@ -95,6 +95,12 @@ test('Jetpack REST request cases cover namespaces and permission classes', () =>
   const casesById = new Map(generatedCases.rest_request_cases.map((restCase) => [restCase.id, restCase]));
 
   assert.deepEqual(new Set(routeCoverage.namespaces.map((entry) => entry.namespace)), new Set(['jetpack/v4', 'wpcom/v2']));
+  assert.deepEqual(new Set(routeCoverage.target_selection.route_namespace_allowlist), new Set(['jetpack/v4', 'wpcom/v2']));
+  assert.deepEqual(new Set(routeCoverage.target_selection.method_allowlist), new Set(['GET']));
+  assert.ok(routeCoverage.target_selection.excluded_methods.includes('POST'));
+  assert.ok(routeCoverage.artifact_expectations.required_for_executable.includes('rest_request_cases'));
+  assert.ok(routeCoverage.artifact_expectations.required_for_executable.includes('rest_skip_reasons'));
+  assert.ok(routeCoverage.artifact_expectations.optional_until_connected_fixture.includes('connected_site_response_samples'));
 
   for (const requiredCase of routeCoverage.required_generated_cases) {
     const generatedCase = casesById.get(requiredCase.id);
@@ -102,9 +108,33 @@ test('Jetpack REST request cases cover namespaces and permission classes', () =>
     assert.equal(generatedCase.method, requiredCase.method);
     assert.equal(generatedCase.path, requiredCase.path);
     assert.equal(generatedCase.permission_class, requiredCase.permission_class);
+    assert.equal(generatedCase.persona, requiredCase.persona);
+    assert.equal(generatedCase.mutating, false);
     assert.equal(typeof generatedCase.permission_class, 'string');
     assert.ok(Array.isArray(generatedCase.expected_statuses), `${requiredCase.id} needs explicit expected statuses`);
+    if (requiredCase.skip_reason) {
+      assert.equal(generatedCase.skip_reason, requiredCase.skip_reason);
+    }
   }
+
+  assert.equal(generatedCases.metadata.mutating_methods_allowed, false);
+  assert.equal(generatedCases.metadata.real_wpcom_credentials_allowed, false);
+  assert.ok(generatedCases.metadata.required_artifacts.includes('rest_request_cases'));
+  assert.ok(generatedCases.metadata.required_artifacts.includes('rest_skip_reasons'));
+});
+
+test('Jetpack generated REST fuzz manifest requires executable artifacts and skip reasons', () => {
+  const generatedRest = readFuzzManifest('generated-rest-request-cases');
+  const testCase = defaultCase(generatedRest);
+
+  assert.equal(generatedRest.metadata.readiness.level, 'executable');
+  assert.deepEqual(new Set(testCase.inputs.methods), new Set(['GET']));
+  assert.equal(testCase.inputs.real_wpcom_credentials_allowed, false);
+  assert.equal(testCase.inputs.mutating_methods_allowed, false);
+  assert.ok(testCase.inputs.skip_reason_codes.includes('connected_required'));
+  assert.ok(testCase.inputs.skip_reason_codes.includes('credential_unavailable'));
+  assert.ok(testCase.artifacts.every((artifact) => artifact.required === true));
+  assert.ok(generatedRest.artifacts.expected.every((artifact) => artifact.required === true));
 });
 
 test('Jetpack DB inventory declares module tables and options', () => {

--- a/Automattic/jetpack/manifests/rest-route-coverage.json
+++ b/Automattic/jetpack/manifests/rest-route-coverage.json
@@ -3,8 +3,31 @@
   "property": "Automattic/jetpack",
   "description": "Jetpack REST route inventory coverage shape for proof-ready API performance primitive adapters.",
   "namespaces": [
-    { "namespace": "jetpack/v4", "route_prefix": "/jetpack/v4/", "permission_class": "mixed_public_authenticated_and_connected" },
-    { "namespace": "wpcom/v2", "route_prefix": "/wpcom/v2/", "permission_class": "mixed_public_authenticated_and_wpcom_dependent" }
+    { "namespace": "jetpack/v4", "route_prefix": "/jetpack/v4/", "permission_class": "mixed_public_authenticated_and_connected", "target": "local Jetpack plugin routes" },
+    { "namespace": "wpcom/v2", "route_prefix": "/wpcom/v2/", "permission_class": "mixed_public_authenticated_and_wpcom_dependent", "target": "Jetpack-provided WordPress.com compatibility routes" }
+  ],
+  "target_selection": {
+    "plugin_slug": "jetpack",
+    "route_namespace_allowlist": ["jetpack/v4", "wpcom/v2"],
+    "route_prefix_allowlist": ["/jetpack/v4/", "/wpcom/v2/"],
+    "method_allowlist": ["GET"],
+    "excluded_methods": ["POST", "PUT", "PATCH", "DELETE"],
+    "excluded_route_families": ["wp/v2 core routes", "Jetpack routes requiring live WordPress.com OAuth mutation fixtures"],
+    "personas": [
+      { "id": "anonymous", "role": "none", "purpose": "permission-boundary denial and public read classification" },
+      { "id": "administrator", "role": "administrator", "purpose": "local authenticated read coverage for Jetpack admin surfaces" },
+      { "id": "connected-site-placeholder", "role": "administrator", "purpose": "declares connected-site requirement without supplying real WP.com credentials", "optional": true }
+    ]
+  },
+  "artifact_expectations": {
+    "required_for_executable": ["rest_request_cases", "rest_skip_reasons"],
+    "optional_until_connected_fixture": ["connected_site_response_samples", "wpcom_credentialed_response_samples"]
+  },
+  "skip_reason_codes": [
+    "connected_required",
+    "credential_unavailable",
+    "route_absent",
+    "wpcom_dependent"
   ],
   "route_prefixes": [
     "/jetpack/v4/",
@@ -48,14 +71,14 @@
     }
   ],
   "required_generated_cases": [
-    { "id": "jetpack-site", "method": "GET", "path": "/jetpack/v4/site", "permission_class": "authenticated_local" },
-    { "id": "jetpack-modules", "method": "GET", "path": "/jetpack/v4/modules", "permission_class": "authenticated_local" },
-    { "id": "jetpack-module-stats", "method": "GET", "path": "/jetpack/v4/modules/stats", "permission_class": "authenticated_local" },
-    { "id": "jetpack-settings", "method": "GET", "path": "/jetpack/v4/settings", "permission_class": "administrator_required" },
-    { "id": "jetpack-connection", "method": "GET", "path": "/jetpack/v4/connection", "permission_class": "connected_site_required" },
-    { "id": "jetpack-connection-status", "method": "GET", "path": "/jetpack/v4/connection/status", "permission_class": "connected_site_required" },
-    { "id": "wpcom-publicize-services", "method": "GET", "path": "/wpcom/v2/publicize/services", "permission_class": "public_read_or_wpcom_dependent" },
-    { "id": "wpcom-site-settings", "method": "GET", "path": "/wpcom/v2/sites/example.wordpress.com/settings", "permission_class": "wpcom_dependent", "placeholder_parameters": { "site": "example.wordpress.com" } }
+    { "id": "jetpack-site", "method": "GET", "path": "/jetpack/v4/site", "permission_class": "authenticated_local", "persona": "administrator" },
+    { "id": "jetpack-modules", "method": "GET", "path": "/jetpack/v4/modules", "permission_class": "authenticated_local", "persona": "administrator" },
+    { "id": "jetpack-module-stats", "method": "GET", "path": "/jetpack/v4/modules/stats", "permission_class": "authenticated_local", "persona": "administrator", "optional_if_module_absent": true, "skip_reason": "route_absent" },
+    { "id": "jetpack-settings", "method": "GET", "path": "/jetpack/v4/settings", "permission_class": "administrator_required", "persona": "administrator" },
+    { "id": "jetpack-connection", "method": "GET", "path": "/jetpack/v4/connection", "permission_class": "connected_site_required", "persona": "connected-site-placeholder", "skip_reason": "connected_required" },
+    { "id": "jetpack-connection-status", "method": "GET", "path": "/jetpack/v4/connection/status", "permission_class": "connected_site_required", "persona": "connected-site-placeholder", "skip_reason": "connected_required" },
+    { "id": "wpcom-publicize-services", "method": "GET", "path": "/wpcom/v2/publicize/services", "permission_class": "public_read_or_wpcom_dependent", "persona": "anonymous", "skip_reason": "wpcom_dependent" },
+    { "id": "wpcom-site-settings", "method": "GET", "path": "/wpcom/v2/sites/example.wordpress.com/settings", "permission_class": "wpcom_dependent", "persona": "connected-site-placeholder", "placeholder_parameters": { "site": "example.wordpress.com" }, "skip_reason": "credential_unavailable" }
   ],
   "future_primitives": [
     "route inventory",

--- a/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
+++ b/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
@@ -138,12 +138,37 @@ for (const { file, manifest } of fuzzManifests) {
 }
 
 assert.deepEqual(new Set(restRouteCoverage.namespaces.map((entry) => entry.namespace)), new Set(['jetpack/v4', 'wpcom/v2']), 'Jetpack REST namespaces drifted');
+assert.deepEqual(new Set(restRouteCoverage.target_selection.route_namespace_allowlist), new Set(['jetpack/v4', 'wpcom/v2']), 'Jetpack REST target namespace allowlist drifted');
+assert.deepEqual(new Set(restRouteCoverage.target_selection.method_allowlist), new Set(['GET']), 'Jetpack REST generated cases must stay GET-only');
+assert.ok(restRouteCoverage.target_selection.excluded_methods.includes('POST'), 'Jetpack REST mutating methods must remain excluded');
+assert.ok(restRouteCoverage.artifact_expectations.required_for_executable.includes('rest_request_cases'), 'Jetpack REST executable cases require request-case artifacts');
+assert.ok(restRouteCoverage.artifact_expectations.required_for_executable.includes('rest_skip_reasons'), 'Jetpack REST executable cases require skip-reason artifacts');
+assert.ok(restRouteCoverage.artifact_expectations.optional_until_connected_fixture.includes('connected_site_response_samples'), 'connected-site samples must remain optional until fixtures exist');
+assert.ok(restRouteCoverage.skip_reason_codes.includes('credential_unavailable'), 'Jetpack REST skip reasons must classify unavailable WP.com credentials');
 
 const generatedCaseIds = new Set(generatedRestCases.rest_request_cases.map((restCase) => restCase.id));
 for (const requiredCase of restRouteCoverage.required_generated_cases) {
+  const generatedCase = generatedRestCases.rest_request_cases.find((restCase) => restCase.id === requiredCase.id);
   assert.ok(generatedCaseIds.has(requiredCase.id), `generated REST cases missing ${requiredCase.id}`);
   assert.equal(typeof requiredCase.permission_class, 'string', `${requiredCase.id} must classify permission boundary`);
+  assert.equal(generatedCase.method, 'GET', `${requiredCase.id} generated request case must stay GET-only`);
+  assert.equal(generatedCase.mutating, false, `${requiredCase.id} generated request case must not claim mutating coverage`);
+  assert.equal(generatedCase.persona, requiredCase.persona, `${requiredCase.id} generated request case persona drifted`);
+  if (requiredCase.skip_reason) {
+    assert.equal(generatedCase.skip_reason, requiredCase.skip_reason, `${requiredCase.id} generated request case skip reason drifted`);
+  }
 }
+
+assert.equal(generatedRestCases.metadata.mutating_methods_allowed, false, 'Jetpack generated REST workload must not allow mutating methods');
+assert.equal(generatedRestCases.metadata.real_wpcom_credentials_allowed, false, 'Jetpack generated REST workload must not require real WP.com credentials');
+assert.ok(generatedRestCases.metadata.required_artifacts.includes('rest_request_cases'), 'Jetpack generated REST workload must require request-case artifact');
+assert.ok(generatedRestCases.metadata.required_artifacts.includes('rest_skip_reasons'), 'Jetpack generated REST workload must require skip-reason artifact');
+
+const generatedRestManifest = manifestFor('generated-rest-request-cases');
+assert.ok(generatedRestManifest.cases[0].inputs.skip_reason_codes.includes('connected_required'), 'generated REST fuzz manifest must declare connected skip reasons');
+assert.equal(generatedRestManifest.cases[0].inputs.real_wpcom_credentials_allowed, false, 'generated REST fuzz manifest must not allow real WP.com credentials');
+assert.equal(generatedRestManifest.cases[0].inputs.mutating_methods_allowed, false, 'generated REST fuzz manifest must not allow mutating methods');
+assert.ok(generatedRestManifest.cases[0].artifacts.every((artifact) => artifact.required === true), 'executable generated REST case artifacts must be required');
 
 const dbRun = dbInventory.run?.[0] || {};
 assert.equal(dbRun['include-options'], true, 'Jetpack DB inventory must include options');


### PR DESCRIPTION
## Summary
- Refine Jetpack REST fuzz route/request-case coverage.
- Add Jetpack-specific target selection, personas, skip reasons, and proof-ready artifact expectations.
- Keep mutating and credentialed WP.com paths blocked rather than overclaiming executable coverage.

## Testing
- `node Automattic/jetpack/tools/validate-fuzz-manifests.mjs`
- `node --test Automattic/jetpack/manifests/full-surface-coverage.test.mjs`
- `node --test scripts/lint-rig-packages.test.mjs`

## Notes
- Actual rig execution still needs a local/offloaded Jetpack checkout and reviewer-facing run artifacts.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Jetpack fuzz manifest investigation, metadata updates, validation, and PR description drafting.
