### PR TITLE
Refine Jetpack admin fuzz coverage

### DIFF
--- a/Automattic/jetpack/fuzz/jetpack-admin-page-coverage.json
+++ b/Automattic/jetpack/fuzz/jetpack-admin-page-coverage.json
@@ -4,14 +4,344 @@
   "label": "Jetpack admin page coverage",
   "safety_class": "read_only",
   "surface_ids": ["jetpack-admin-pages", "wordpress-admin-pages"],
-  "operations": ["admin-page-discovery", "permission-boundary-classification", "query-attribution", "menu-page-enumeration", "destructive-skip-classification"],
+  "operations": [
+    "admin-page-discovery",
+    "permission-boundary-classification",
+    "query-attribution",
+    "menu-page-enumeration",
+    "destructive-skip-classification"
+  ],
   "case_budget": 40,
   "duration_budget_seconds": 600,
-  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "workload_path": "${package.root}/manifests/full-surface-coverage.json", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report" },
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/manifests/full-surface-coverage.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report",
+    "admin_target_contract": {
+      "product": "jetpack",
+      "discovery_sources": ["global_menu", "global_submenu", "registered_pages", "jetpack_admin_page_registry"],
+      "default_role": "administrator",
+      "default_capability": "manage_options",
+      "request_policy": {
+        "safe_methods": ["GET"],
+        "get_first": true,
+        "follow_redirects": false,
+        "submit_forms": false,
+        "mutating_methods_allowed": false,
+        "non_get_handling": "record_skipped_reason"
+      },
+      "skip_reasons": [
+        {
+          "code": "destructive_action",
+          "matches": ["action=delete", "action=remove", "action=trash", "action=reset"],
+          "reason": "Would delete, remove, trash, or reset local Jetpack data."
+        },
+        {
+          "code": "plugin_install_or_update",
+          "matches": ["action=install", "action=update", "update.php", "plugin-install.php"],
+          "reason": "Would install or update plugin code instead of observing admin rendering."
+        },
+        {
+          "code": "module_state_mutation",
+          "matches": ["action=activate", "action=deactivate", "module=", "activate-module", "deactivate-module"],
+          "reason": "Would alter Jetpack module state; module mutations belong to the module-state lane."
+        },
+        {
+          "code": "connection_mutation",
+          "matches": ["action=disconnect", "connect_url", "jetpack_reconnect", "jetpack_disconnect"],
+          "reason": "Would connect, reconnect, or disconnect a site from WordPress.com."
+        },
+        {
+          "code": "nonce_required",
+          "matches": ["_wpnonce=", "_ajax_nonce="],
+          "reason": "Nonce-bearing action URLs are classified instead of replayed."
+        },
+        {
+          "code": "credential_unavailable",
+          "matches": ["calypso", "wordpress.com", "wpcom"],
+          "reason": "Live WordPress.com credentials are not available in the local fixture."
+        },
+        {
+          "code": "capability_denied",
+          "matches": ["capability_mismatch"],
+          "reason": "The target requires a capability not held by the tested role."
+        },
+        {
+          "code": "external_service_required",
+          "matches": ["external_service", "oauth", "public-api.wordpress.com"],
+          "reason": "The target requires a live external service boundary."
+        },
+        {
+          "code": "unsupported_method",
+          "matches": ["POST", "PUT", "PATCH", "DELETE"],
+          "reason": "The admin coverage lane only performs GET requests."
+        }
+      ],
+      "page_targets": [
+        {
+          "id": "jetpack-dashboard",
+          "menu_slug": "jetpack",
+          "admin_path": "/wp-admin/admin.php?page=jetpack",
+          "hash_route": "#/dashboard",
+          "label": "Jetpack dashboard",
+          "required_capability": "manage_options",
+          "safe_methods": ["GET"],
+          "expected_states": ["connected", "disconnected"],
+          "proof_artifacts": ["admin_page_coverage", "admin_menu_enumeration", "admin_query_attribution"]
+        },
+        {
+          "id": "jetpack-connection",
+          "menu_slug": "jetpack#/connection",
+          "admin_path": "/wp-admin/admin.php?page=jetpack#/connection",
+          "hash_route": "#/connection",
+          "label": "Jetpack connection",
+          "required_capability": "manage_options",
+          "safe_methods": ["GET"],
+          "expected_states": ["connected", "disconnected"],
+          "destructive_skip_codes": ["connection_mutation", "credential_unavailable"],
+          "proof_artifacts": ["admin_page_coverage", "admin_skip_reasons"]
+        },
+        {
+          "id": "jetpack-settings-general",
+          "menu_slug": "jetpack#/settings",
+          "admin_path": "/wp-admin/admin.php?page=jetpack#/settings",
+          "hash_route": "#/settings",
+          "label": "Jetpack settings",
+          "required_capability": "manage_options",
+          "safe_methods": ["GET"],
+          "proof_artifacts": ["admin_page_coverage", "admin_query_attribution"]
+        },
+        {
+          "id": "jetpack-settings-performance",
+          "menu_slug": "jetpack#/settings?term=performance",
+          "admin_path": "/wp-admin/admin.php?page=jetpack#/settings?term=performance",
+          "hash_route": "#/settings?term=performance",
+          "label": "Jetpack performance settings",
+          "required_capability": "manage_options",
+          "safe_methods": ["GET"],
+          "proof_artifacts": ["admin_page_coverage", "admin_query_attribution"]
+        },
+        {
+          "id": "jetpack-settings-writing",
+          "menu_slug": "jetpack#/settings?term=writing",
+          "admin_path": "/wp-admin/admin.php?page=jetpack#/settings?term=writing",
+          "hash_route": "#/settings?term=writing",
+          "label": "Jetpack writing settings",
+          "required_capability": "manage_options",
+          "safe_methods": ["GET"],
+          "proof_artifacts": ["admin_page_coverage", "admin_query_attribution"]
+        },
+        {
+          "id": "jetpack-settings-sharing",
+          "menu_slug": "jetpack#/settings?term=sharing",
+          "admin_path": "/wp-admin/admin.php?page=jetpack#/settings?term=sharing",
+          "hash_route": "#/settings?term=sharing",
+          "label": "Jetpack sharing settings",
+          "required_capability": "manage_options",
+          "safe_methods": ["GET"],
+          "proof_artifacts": ["admin_page_coverage", "admin_query_attribution"]
+        },
+        {
+          "id": "jetpack-settings-discussion",
+          "menu_slug": "jetpack#/settings?term=discussion",
+          "admin_path": "/wp-admin/admin.php?page=jetpack#/settings?term=discussion",
+          "hash_route": "#/settings?term=discussion",
+          "label": "Jetpack discussion settings",
+          "required_capability": "manage_options",
+          "safe_methods": ["GET"],
+          "proof_artifacts": ["admin_page_coverage", "admin_query_attribution"]
+        },
+        {
+          "id": "jetpack-settings-security",
+          "menu_slug": "jetpack#/settings?term=security",
+          "admin_path": "/wp-admin/admin.php?page=jetpack#/settings?term=security",
+          "hash_route": "#/settings?term=security",
+          "label": "Jetpack security settings",
+          "required_capability": "manage_options",
+          "safe_methods": ["GET"],
+          "proof_artifacts": ["admin_page_coverage", "admin_query_attribution"]
+        },
+        {
+          "id": "jetpack-modules",
+          "menu_slug": "jetpack_modules",
+          "admin_path": "/wp-admin/admin.php?page=jetpack_modules",
+          "label": "Jetpack modules",
+          "required_capability": "manage_options",
+          "safe_methods": ["GET"],
+          "destructive_skip_codes": ["module_state_mutation", "nonce_required"],
+          "proof_artifacts": ["admin_page_coverage", "admin_menu_enumeration", "admin_skip_reasons"]
+        }
+      ],
+      "proof_artifact_expectations": [
+        {
+          "name": "admin_page_coverage",
+          "semantic_key": "fuzz.report",
+          "required_fields": ["target_id", "admin_path", "method", "status", "role", "required_capability", "state", "evidence_refs"]
+        },
+        {
+          "name": "admin_menu_enumeration",
+          "semantic_key": "fuzz.admin_menu_enumeration",
+          "required_fields": ["source", "menu_slug", "admin_path", "required_capability", "included"]
+        },
+        {
+          "name": "admin_skip_reasons",
+          "semantic_key": "fuzz.skip_reasons",
+          "required_fields": ["target_id", "skip_code", "matched_pattern", "reason"]
+        },
+        {
+          "name": "admin_query_attribution",
+          "semantic_key": "fuzz.admin_query_attribution",
+          "required_fields": ["target_id", "query_count", "slow_queries", "caller_summary"]
+        }
+      ]
+    }
+  },
   "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
-  "workload": { "runner": "wp-codebox", "type": "generic", "path": "${package.root}/manifests/full-surface-coverage.json", "entry": "wordpress-admin-page-coverage" },
-  "cases": [{ "case_id": "jetpack-admin-page-coverage:default", "surface_ids": ["jetpack-admin-pages", "wordpress-admin-pages"], "operations": ["admin-page-discovery", "permission-boundary-classification", "query-attribution", "menu-page-enumeration", "destructive-skip-classification"], "inputs": { "roles": ["administrator"], "menu_sources": ["global_menu", "global_submenu", "registered_pages", "jetpack_admin_page_registry"], "include_menu_slugs": ["jetpack", "jetpack#/dashboard", "jetpack#/connection", "jetpack#/settings", "jetpack#/settings?term=performance", "jetpack#/settings?term=writing", "jetpack#/settings?term=sharing", "jetpack#/settings?term=discussion", "jetpack#/settings?term=security", "jetpack_modules"], "safe_methods": ["GET"], "skip_url_patterns": ["action=delete", "action=install", "action=update", "action=activate", "action=deactivate", "action=disconnect", "_wpnonce="], "skip_reason_codes": ["destructive_action", "plugin_install_or_update", "module_state_mutation", "connection_mutation", "nonce_required", "credential_unavailable", "capability_denied", "external_service_required", "unsupported_method"] }, "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }], "action": [{ "command": "wordpress.fuzz-admin-pages", "args": ["safe_methods=GET", "max_pages=40", "enumerate_menus=true", "classify_skips=true"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=admin_page_coverage"] }] }, "artifacts": [{ "name": "admin_page_coverage", "path": "jetpack-admin-page-coverage/admin_page_coverage.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }, { "name": "admin_menu_enumeration", "path": "jetpack-admin-page-coverage/admin_menu_enumeration.json", "required": false, "metadata": { "semantic_key": "fuzz.admin_menu_enumeration" } }, { "name": "admin_skip_reasons", "path": "jetpack-admin-page-coverage/admin_skip_reasons.json", "required": false, "metadata": { "semantic_key": "fuzz.skip_reasons" } }], "metadata": { "safety_class": "read_only" } }],
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "generic",
+    "path": "${package.root}/manifests/full-surface-coverage.json",
+    "entry": "wordpress-admin-page-coverage"
+  },
+  "cases": [
+    {
+      "case_id": "jetpack-admin-page-coverage:default",
+      "surface_ids": ["jetpack-admin-pages", "wordpress-admin-pages"],
+      "operations": [
+        "admin-page-discovery",
+        "permission-boundary-classification",
+        "query-attribution",
+        "menu-page-enumeration",
+        "destructive-skip-classification"
+      ],
+      "metadata": { "safety_class": "read_only" },
+      "inputs": {
+        "roles": ["administrator"],
+        "capability_requirements": {
+          "default": "manage_options",
+          "per_target_field": "required_capability"
+        },
+        "menu_sources": ["global_menu", "global_submenu", "registered_pages", "jetpack_admin_page_registry"],
+        "include_menu_slugs": [
+          "jetpack",
+          "jetpack#/dashboard",
+          "jetpack#/connection",
+          "jetpack#/settings",
+          "jetpack#/settings?term=performance",
+          "jetpack#/settings?term=writing",
+          "jetpack#/settings?term=sharing",
+          "jetpack#/settings?term=discussion",
+          "jetpack#/settings?term=security",
+          "jetpack_modules"
+        ],
+        "page_targets_ref": "metadata.admin_target_contract.page_targets",
+        "safe_methods": ["GET"],
+        "get_first": true,
+        "submit_forms": false,
+        "follow_redirects": false,
+        "mutating_methods_allowed": false,
+        "skip_url_patterns": [
+          "action=delete",
+          "action=remove",
+          "action=trash",
+          "action=reset",
+          "action=install",
+          "action=update",
+          "action=activate",
+          "action=deactivate",
+          "action=disconnect",
+          "_wpnonce=",
+          "_ajax_nonce="
+        ],
+        "skip_reason_codes": [
+          "destructive_action",
+          "plugin_install_or_update",
+          "module_state_mutation",
+          "connection_mutation",
+          "nonce_required",
+          "credential_unavailable",
+          "capability_denied",
+          "external_service_required",
+          "unsupported_method"
+        ],
+        "proof_artifact_expectations_ref": "metadata.admin_target_contract.proof_artifact_expectations"
+      },
+      "phases": {
+        "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }],
+        "action": [
+          {
+            "command": "wordpress.fuzz-admin-pages",
+            "args": [
+              "safe_methods=GET",
+              "get_first=true",
+              "submit_forms=false",
+              "follow_redirects=false",
+              "max_pages=40",
+              "enumerate_menus=true",
+              "classify_skips=true",
+              "target_contract=metadata.admin_target_contract"
+            ]
+          }
+        ],
+        "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=admin_page_coverage"] }]
+      },
+      "artifacts": [
+        {
+          "name": "admin_page_coverage",
+          "path": "jetpack-admin-page-coverage/admin_page_coverage.json",
+          "required": false,
+          "metadata": { "semantic_key": "fuzz.report" }
+        },
+        {
+          "name": "admin_menu_enumeration",
+          "path": "jetpack-admin-page-coverage/admin_menu_enumeration.json",
+          "required": false,
+          "metadata": { "semantic_key": "fuzz.admin_menu_enumeration" }
+        },
+        {
+          "name": "admin_skip_reasons",
+          "path": "jetpack-admin-page-coverage/admin_skip_reasons.json",
+          "required": false,
+          "metadata": { "semantic_key": "fuzz.skip_reasons" }
+        },
+        {
+          "name": "admin_query_attribution",
+          "path": "jetpack-admin-page-coverage/admin_query_attribution.json",
+          "required": false,
+          "metadata": { "semantic_key": "fuzz.admin_query_attribution" }
+        }
+      ]
+    }
+  ],
   "limits": { "max_cases": 40, "max_duration_seconds": 600 },
-  "coverage": { "surface_ids": ["jetpack-admin-pages", "wordpress-admin-pages"], "operations": ["admin-page-discovery", "permission-boundary-classification", "query-attribution", "menu-page-enumeration", "destructive-skip-classification"] },
-  "artifacts": { "expected": [{ "name": "admin_page_coverage", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }, { "name": "admin_menu_enumeration", "role": "coverage_inventory", "semantic_key": "fuzz.admin_menu_enumeration", "required": false }, { "name": "admin_skip_reasons", "role": "safety_report", "semantic_key": "fuzz.skip_reasons", "required": false }] }
+  "coverage": {
+    "surface_ids": ["jetpack-admin-pages", "wordpress-admin-pages"],
+    "operations": [
+      "admin-page-discovery",
+      "permission-boundary-classification",
+      "query-attribution",
+      "menu-page-enumeration",
+      "destructive-skip-classification"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      { "name": "admin_page_coverage", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false },
+      {
+        "name": "admin_menu_enumeration",
+        "role": "coverage_inventory",
+        "semantic_key": "fuzz.admin_menu_enumeration",
+        "required": false
+      },
+      { "name": "admin_skip_reasons", "role": "safety_report", "semantic_key": "fuzz.skip_reasons", "required": false },
+      {
+        "name": "admin_query_attribution",
+        "role": "query_attribution",
+        "semantic_key": "fuzz.admin_query_attribution",
+        "required": false
+      }
+    ]
+  }
 }

--- a/Automattic/jetpack/manifests/full-surface-coverage.json
+++ b/Automattic/jetpack/manifests/full-surface-coverage.json
@@ -192,7 +192,7 @@
         "classification": "bounded_authenticated_read",
         "notes": ["GET-only admin visits with explicit skips for destructive/update/install screens", "Per-role and per-page limits bound request volume"]
       },
-      "artifact_expectations": { "required": ["metrics", "admin_page_coverage json artifact", "admin menu enumeration artifact", "admin skip reason artifact"], "optional": ["request logs"] }
+      "artifact_expectations": { "required": ["metrics", "admin_page_coverage json artifact", "admin menu enumeration artifact", "admin skip reason artifact", "admin query attribution artifact"], "optional": ["request logs"] }
     },
     "jetpack-module-state-matrix": {
       "surface": "modules",

--- a/Automattic/jetpack/manifests/full-surface-coverage.test.mjs
+++ b/Automattic/jetpack/manifests/full-surface-coverage.test.mjs
@@ -162,16 +162,51 @@ test('Jetpack admin page coverage enumerates wp-admin menus with explicit skip r
   const admin = readFuzzManifest('jetpack-admin-page-coverage');
   const testCase = defaultCase(admin);
   const inputs = testCase.inputs;
+  const targetContract = admin.metadata.admin_target_contract;
 
   assert.ok(inputs.menu_sources.includes('global_menu'));
   assert.ok(inputs.menu_sources.includes('global_submenu'));
   assert.ok(inputs.include_menu_slugs.includes('jetpack'));
   assert.ok(inputs.include_menu_slugs.includes('jetpack_modules'));
   assert.ok(inputs.include_menu_slugs.includes('jetpack#/settings?term=performance'));
+  assert.equal(targetContract.product, 'jetpack');
+  assert.equal(targetContract.default_capability, 'manage_options');
+  assert.equal(targetContract.request_policy.get_first, true);
+  assert.deepEqual(targetContract.request_policy.safe_methods, ['GET']);
+  assert.equal(targetContract.request_policy.mutating_methods_allowed, false);
   assert.ok(inputs.skip_reason_codes.includes('destructive_action'));
   assert.ok(inputs.skip_reason_codes.includes('credential_unavailable'));
   assert.ok(testCase.artifacts.some((artifact) => artifact.metadata?.semantic_key === 'fuzz.admin_menu_enumeration'));
   assert.ok(testCase.artifacts.some((artifact) => artifact.metadata?.semantic_key === 'fuzz.skip_reasons'));
+});
+
+test('Jetpack admin page coverage declares product-specific page targets and proof artifacts', () => {
+  const admin = readFuzzManifest('jetpack-admin-page-coverage');
+  const targetContract = admin.metadata.admin_target_contract;
+  const targetsById = new Map(targetContract.page_targets.map((target) => [target.id, target]));
+  const skipReasonsByCode = new Map(targetContract.skip_reasons.map((skipReason) => [skipReason.code, skipReason]));
+  const proofArtifactsByName = new Map(targetContract.proof_artifact_expectations.map((artifact) => [artifact.name, artifact]));
+
+  assert.ok(targetsById.has('jetpack-dashboard'));
+  assert.ok(targetsById.has('jetpack-connection'));
+  assert.ok(targetsById.has('jetpack-settings-performance'));
+  assert.ok(targetsById.has('jetpack-modules'));
+
+  for (const target of targetContract.page_targets) {
+    assert.equal(target.required_capability, 'manage_options', `${target.id} must declare its capability requirement`);
+    assert.deepEqual(target.safe_methods, ['GET'], `${target.id} must stay GET-only`);
+    assert.ok(target.admin_path.startsWith('/wp-admin/admin.php?page='), `${target.id} needs a concrete admin.php target`);
+    assert.ok(target.proof_artifacts.includes('admin_page_coverage'), `${target.id} needs page coverage proof`);
+  }
+
+  assert.equal(targetsById.get('jetpack-connection').hash_route, '#/connection');
+  assert.ok(targetsById.get('jetpack-connection').destructive_skip_codes.includes('connection_mutation'));
+  assert.ok(targetsById.get('jetpack-modules').destructive_skip_codes.includes('module_state_mutation'));
+  assert.ok(skipReasonsByCode.get('module_state_mutation').reason.includes('module-state lane'));
+  assert.ok(skipReasonsByCode.get('connection_mutation').reason.includes('WordPress.com'));
+  assert.ok(proofArtifactsByName.get('admin_page_coverage').required_fields.includes('required_capability'));
+  assert.ok(proofArtifactsByName.get('admin_skip_reasons').required_fields.includes('matched_pattern'));
+  assert.ok(proofArtifactsByName.get('admin_query_attribution').required_fields.includes('caller_summary'));
 });
 
 test('Jetpack public frontend coverage declares module routes, request classes, and state skips', () => {


### PR DESCRIPTION
## Summary
- Refine Jetpack admin page fuzz coverage metadata.
- Add explicit admin targets, capability requirements, GET-only semantics, destructive-action skip reasons, and proof artifact expectations.

## Testing
- `node scripts/lint-rig-packages.mjs Automattic/jetpack`
- `node --test Automattic/jetpack/manifests/full-surface-coverage.test.mjs`
- `node --test scripts/fuzz-manifest-helpers.test.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Jetpack fuzz manifest investigation, metadata updates, validation, and PR description drafting.
