### PR TITLE
Refine Jetpack connection fuzz fixtures

### DIFF
--- a/Automattic/jetpack/fuzz/jetpack-connected-disconnected-fixtures.json
+++ b/Automattic/jetpack/fuzz/jetpack-connected-disconnected-fixtures.json
@@ -7,11 +7,73 @@
   "operations": ["connected-fixture-state", "disconnected-fixture-state", "token-placeholder-serialization", "skip-reason-classification"],
   "case_budget": 80,
   "duration_budget_seconds": 900,
-  "metadata": { "kind": "wordpress-plugin-fuzz", "wordpress_runner": "wp-codebox", "workload_path": "${package.root}/manifests/full-surface-coverage.json", "expected_artifact_role": "fuzz_report", "expected_artifact_semantic_key": "fuzz.report", "fixture_states": ["connected", "disconnected"], "mutation_policy": "snapshot_connection_options_restore_after_assert", "artifact_expectations": { "required": ["connected_fixture_rows", "disconnected_fixture_rows", "token_placeholder_serialization", "skip_reason_rows"], "optional": ["module_state_diffs", "sync_queue_diffs"] } },
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/manifests/full-surface-coverage.json",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report",
+    "fixture_states": ["connected", "disconnected"],
+    "fixture_state_contract": {
+      "connected": {
+        "description": "Synthetic local connected-site shape with placeholder blog/user IDs and fake token material only.",
+        "required_options": ["jetpack_options", "jetpack_private_options", "jetpack_active_modules"],
+        "expected_connection_state": "locally_connected_without_wpcom_sandbox",
+        "allowed_secret_values": ["__JETPACK_FAKE_BLOG_TOKEN__", "__JETPACK_FAKE_USER_TOKEN__"],
+        "expected_skip_reasons": ["credential_unavailable", "external_service_required"],
+        "network_calls_allowed": false
+      },
+      "disconnected": {
+        "description": "Clean local disconnected-site shape with connection options absent or reset to empty defaults.",
+        "required_absent_options": ["jetpack_private_options.blog_token", "jetpack_private_options.user_tokens"],
+        "expected_connection_state": "disconnected_without_wpcom_sandbox",
+        "expected_skip_reasons": ["connection_required", "disconnected_expected"],
+        "network_calls_allowed": false
+      }
+    },
+    "fake_token_policy": {
+      "real_wpcom_credentials_allowed": false,
+      "real_tokens_allowed": false,
+      "placeholder_tokens_only": true,
+      "redact_token_fields": ["blog_token", "user_token", "token", "secret", "access_token"],
+      "redaction_placeholder": "[redacted:jetpack-fixture-token]",
+      "artifact_must_not_contain_patterns": ["Bearer ", "token_secret", "oauth_token_secret", "public-api.wordpress.com/rest/v1.1/me"]
+    },
+    "wpcom_sandbox_blockers": [
+      "No WP.com OAuth application, sandbox blog, or service account is provisioned for this fixture lane.",
+      "Connected behavior that requires public-api.wordpress.com must be reported as a skip, not exercised with live credentials.",
+      "The Jetpack external HTTP guardrail owns network blocking proof for this lane."
+    ],
+    "module_availability_expectations": {
+      "available_in_both_states": ["shortcodes", "markdown", "widget-visibility"],
+      "connected_fixture_may_enable": ["stats", "publicize", "related-posts", "protect"],
+      "requires_connected_or_wpcom_service": ["stats", "publicize", "protect"],
+      "unavailable_reason": "credential_unavailable"
+    },
+    "reset_contract": {
+      "snapshot_before_mutation": true,
+      "restore_original_values": true,
+      "rollback_required": true,
+      "reset_after_each_state": true,
+      "option_patterns": ["jetpack_options", "jetpack_private_options", "jetpack_active_modules", "jetpack_sync_settings_*"],
+      "transient_patterns": ["jetpack_%", "jp_%"],
+      "failure_policy": "fail_if_fixture_state_leaks_after_assert"
+    },
+    "mutation_policy": "snapshot_connection_options_restore_after_assert",
+    "artifact_expectations": {
+      "required": ["connected_fixture_rows", "disconnected_fixture_rows", "token_placeholder_serialization", "skip_reason_rows", "rollback_reset_rows", "redaction_rows"],
+      "optional": ["module_state_diffs", "sync_queue_diffs"]
+    },
+    "proof_artifact_expectations": {
+      "connection_fixture_matrix": ["state", "connection_state", "option_snapshot_hash", "module_expectations", "skip_reasons"],
+      "connection_skip_reasons": ["state", "surface", "reason_code", "blocked_by_wpcom_sandbox"],
+      "connection_reset_report": ["state", "restored_options", "restored_transients", "leaked_keys", "passed"]
+    }
+  },
   "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
   "workload": { "runner": "wp-codebox", "type": "generic", "path": "${package.root}/manifests/full-surface-coverage.json", "entry": "jetpack-connected-disconnected-fixtures" },
-  "cases": [{ "case_id": "jetpack-connected-disconnected-fixtures:default", "surface_ids": ["jetpack-connection", "jetpack-modules", "jetpack-sync", "wordpress-options"], "operations": ["connected-fixture-state", "disconnected-fixture-state", "token-placeholder-serialization", "skip-reason-classification"], "inputs": { "states": ["connected", "disconnected"], "fixture_states": ["connected", "disconnected"], "connection_options": ["jetpack_options", "jetpack_private_options", "jetpack_active_modules", "jetpack_sync_settings_sync_wait_time"], "fixture_options": ["jetpack_options", "jetpack_private_options", "jetpack_active_modules", "jetpack_sync_settings_*"], "real_wpcom_credentials_allowed": false, "secret_placeholders_only": true, "restore_original_values": true, "rollback_required": true, "skip_reason_codes": ["credential_unavailable", "external_service_required", "connection_required", "disconnected_expected", "connected_required", "destructive_action", "unsupported_fixture"] }, "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }], "action": [{ "command": "wordpress.fuzz-plugin-connection-fixtures", "args": ["states=connected,disconnected", "secret_placeholders_only=true", "restore_original_values=true", "rollback_required=true", "classify_skips=true"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=connection_fixture_matrix"] }] }, "artifacts": [{ "name": "connection_fixture_matrix", "path": "jetpack-connected-disconnected-fixtures/connection_fixture_matrix.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }, { "name": "connection_skip_reasons", "path": "jetpack-connected-disconnected-fixtures/connection_skip_reasons.json", "required": false, "metadata": { "semantic_key": "fuzz.skip_reasons" } }], "metadata": { "safety_class": "isolated_mutation", "mutation_policy": "snapshot_connection_options_restore_after_assert" } }],
+  "cases": [{ "case_id": "jetpack-connected-disconnected-fixtures:default", "surface_ids": ["jetpack-connection", "jetpack-modules", "jetpack-sync", "wordpress-options"], "operations": ["connected-fixture-state", "disconnected-fixture-state", "token-placeholder-serialization", "skip-reason-classification"], "inputs": { "states": ["connected", "disconnected"], "fixture_states": ["connected", "disconnected"], "explicit_fixture_states": { "connected": "synthetic_placeholder_connection_without_wpcom_sandbox", "disconnected": "clean_local_disconnect_without_wpcom_sandbox" }, "connection_options": ["jetpack_options", "jetpack_private_options", "jetpack_active_modules", "jetpack_sync_settings_sync_wait_time"], "fixture_options": ["jetpack_options", "jetpack_private_options", "jetpack_active_modules", "jetpack_sync_settings_*"], "redact_option_fields": ["blog_token", "user_token", "token", "secret", "access_token"], "allowed_fake_tokens": ["__JETPACK_FAKE_BLOG_TOKEN__", "__JETPACK_FAKE_USER_TOKEN__"], "real_wpcom_credentials_allowed": false, "real_tokens_allowed": false, "network_calls_allowed": false, "wpcom_sandbox_required": false, "secret_placeholders_only": true, "restore_original_values": true, "reset_after_each_state": true, "rollback_required": true, "module_availability_expectations": { "available_in_both_states": ["shortcodes", "markdown", "widget-visibility"], "connected_fixture_may_enable": ["stats", "publicize", "related-posts", "protect"], "requires_connected_or_wpcom_service": ["stats", "publicize", "protect"] }, "skip_reason_codes": ["credential_unavailable", "external_service_required", "connection_required", "disconnected_expected", "connected_required", "destructive_action", "unsupported_fixture"] }, "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }], "action": [{ "command": "wordpress.fuzz-plugin-connection-fixtures", "args": ["states=connected,disconnected", "secret_placeholders_only=true", "restore_original_values=true", "rollback_required=true", "classify_skips=true"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=connection_fixture_matrix"] }] }, "artifacts": [{ "name": "connection_fixture_matrix", "path": "jetpack-connected-disconnected-fixtures/connection_fixture_matrix.json", "required": false, "metadata": { "semantic_key": "fuzz.report" } }, { "name": "connection_skip_reasons", "path": "jetpack-connected-disconnected-fixtures/connection_skip_reasons.json", "required": false, "metadata": { "semantic_key": "fuzz.skip_reasons" } }, { "name": "connection_reset_report", "path": "jetpack-connected-disconnected-fixtures/connection_reset_report.json", "required": false, "metadata": { "semantic_key": "fuzz.rollback_report" } }], "metadata": { "safety_class": "isolated_mutation", "mutation_policy": "snapshot_connection_options_restore_after_assert" } }],
   "limits": { "max_cases": 80, "max_duration_seconds": 900 },
   "coverage": { "surface_ids": ["jetpack-connection", "jetpack-modules", "jetpack-sync", "wordpress-options"], "operations": ["connected-fixture-state", "disconnected-fixture-state", "token-placeholder-serialization", "skip-reason-classification"] },
-  "artifacts": { "expected": [{ "name": "connection_fixture_matrix", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }, { "name": "connection_skip_reasons", "role": "safety_report", "semantic_key": "fuzz.skip_reasons", "required": false }] }
+  "artifacts": { "expected": [{ "name": "connection_fixture_matrix", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": false }, { "name": "connection_skip_reasons", "role": "safety_report", "semantic_key": "fuzz.skip_reasons", "required": false }, { "name": "connection_reset_report", "role": "rollback_report", "semantic_key": "fuzz.rollback_report", "required": false }] }
 }

--- a/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
+++ b/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
@@ -198,9 +198,10 @@ assertBoundary('jetpack-cron-sync-actions', {
 });
 assertBoundary('jetpack-connected-disconnected-fixtures', {
   safetyClass: 'isolated_mutation',
-  operations: ['connected-fixture-state', 'disconnected-fixture-state', 'token-placeholder-serialization'],
-  inputs: { real_wpcom_credentials_allowed: false, secret_placeholders_only: true, restore_original_values: true, rollback_required: true },
+  operations: ['connected-fixture-state', 'disconnected-fixture-state', 'token-placeholder-serialization', 'skip-reason-classification'],
+  inputs: { real_wpcom_credentials_allowed: false, real_tokens_allowed: false, network_calls_allowed: false, wpcom_sandbox_required: false, secret_placeholders_only: true, restore_original_values: true, reset_after_each_state: true, rollback_required: true },
 });
+assertConnectedDisconnectedFixtureContract();
 
 const moduleInventory = manifestFor('jetpack-module-option-table-inventory');
 assert.equal(moduleInventory.safety_class, 'read_only', 'Jetpack module inventory must remain read-only');
@@ -322,4 +323,50 @@ function assertArtifactContains(manifest, artifactName, expectedFields) {
     assert.ok(caseArtifact.metadata?.contains?.includes(field), `${manifest.id} case artifact ${artifactName} must contain ${field}`);
     assert.ok(expectedArtifact.contains?.includes(field), `${manifest.id} expected artifact ${artifactName} must contain ${field}`);
   }
+}
+
+function assertConnectedDisconnectedFixtureContract() {
+  const manifest = manifestFor('jetpack-connected-disconnected-fixtures');
+  const runnerCase = manifest.cases[0];
+  const metadata = manifest.metadata || {};
+  const states = new Set(['connected', 'disconnected']);
+
+  assert.deepEqual(new Set(metadata.fixture_states), states, 'Jetpack connection fixture metadata states drifted');
+  assert.deepEqual(new Set(runnerCase.inputs?.fixture_states), states, 'Jetpack connection fixture input states drifted');
+  assert.deepEqual(new Set(Object.keys(metadata.fixture_state_contract || {})), states, 'Jetpack connection fixture state contract must describe both states');
+  assert.deepEqual(new Set(Object.keys(runnerCase.inputs?.explicit_fixture_states || {})), states, 'Jetpack connection fixture inputs must name both explicit fixture states');
+
+  assert.equal(metadata.fixture_state_contract.connected.network_calls_allowed, false, 'Connected fixture contract must not allow network calls');
+  assert.equal(metadata.fixture_state_contract.disconnected.network_calls_allowed, false, 'Disconnected fixture contract must not allow network calls');
+  assert.equal(metadata.fake_token_policy?.real_wpcom_credentials_allowed, false, 'Connection fixture must forbid real WP.com credentials');
+  assert.equal(metadata.fake_token_policy?.real_tokens_allowed, false, 'Connection fixture must forbid real tokens');
+  assert.equal(metadata.fake_token_policy?.placeholder_tokens_only, true, 'Connection fixture must use placeholder tokens only');
+  assert.ok(metadata.fake_token_policy.redact_token_fields.includes('blog_token'), 'Connection fixture must redact blog_token fields');
+  assert.ok(metadata.fake_token_policy.redact_token_fields.includes('user_token'), 'Connection fixture must redact user_token fields');
+  assert.ok(metadata.fake_token_policy.artifact_must_not_contain_patterns.includes('Bearer '), 'Connection fixture must forbid bearer-token artifacts');
+  assert.ok(runnerCase.inputs.allowed_fake_tokens.every((token) => token.startsWith('__JETPACK_FAKE_')), 'Connection fixture fake tokens must be obvious placeholders');
+
+  assert.ok(Array.isArray(metadata.wpcom_sandbox_blockers) && metadata.wpcom_sandbox_blockers.length >= 2, 'Connection fixture must declare WP.com sandbox blockers');
+  assert.ok(metadata.wpcom_sandbox_blockers.some((blocker) => blocker.includes('No WP.com OAuth')), 'Connection fixture must document missing WP.com OAuth sandbox');
+  assert.ok(runnerCase.inputs.skip_reason_codes.includes('credential_unavailable'), 'Connection fixture must classify credential skips');
+  assert.ok(runnerCase.inputs.skip_reason_codes.includes('external_service_required'), 'Connection fixture must classify external service skips');
+  assert.ok(runnerCase.inputs.skip_reason_codes.includes('connection_required'), 'Connection fixture must classify connection-required skips');
+
+  assert.ok(metadata.module_availability_expectations.available_in_both_states.includes('shortcodes'), 'Connection fixture must document state-independent modules');
+  assert.ok(metadata.module_availability_expectations.requires_connected_or_wpcom_service.includes('stats'), 'Connection fixture must document WP.com-dependent modules');
+  assert.ok(runnerCase.inputs.module_availability_expectations.requires_connected_or_wpcom_service.includes('publicize'), 'Connection fixture inputs must preserve module availability expectations');
+
+  assert.equal(metadata.reset_contract.snapshot_before_mutation, true, 'Connection fixture must snapshot before mutation');
+  assert.equal(metadata.reset_contract.restore_original_values, true, 'Connection fixture must restore original values');
+  assert.equal(metadata.reset_contract.rollback_required, true, 'Connection fixture must require rollback');
+  assert.equal(metadata.reset_contract.reset_after_each_state, true, 'Connection fixture must reset after each state');
+  assert.ok(metadata.reset_contract.option_patterns.includes('jetpack_private_options'), 'Connection fixture reset contract must include private options');
+  assert.ok(metadata.artifact_expectations.required.includes('rollback_reset_rows'), 'Connection fixture must require rollback reset artifact rows');
+  assert.ok(metadata.artifact_expectations.required.includes('redaction_rows'), 'Connection fixture must require redaction artifact rows');
+
+  assert.ok(runnerCase.artifacts.some((artifact) => artifact.name === 'connection_reset_report' && artifact.metadata?.semantic_key === 'fuzz.rollback_report'), 'Connection fixture must declare a reset report case artifact');
+  assert.ok(manifest.artifacts.expected.some((artifact) => artifact.name === 'connection_reset_report' && artifact.semantic_key === 'fuzz.rollback_report'), 'Connection fixture must declare a reset report expected artifact');
+  assert.ok(metadata.proof_artifact_expectations.connection_fixture_matrix.includes('module_expectations'), 'Connection fixture proof matrix must include module expectations');
+  assert.ok(metadata.proof_artifact_expectations.connection_skip_reasons.includes('blocked_by_wpcom_sandbox'), 'Connection fixture skip proof must include WP.com blocker status');
+  assert.ok(metadata.proof_artifact_expectations.connection_reset_report.includes('leaked_keys'), 'Connection fixture reset proof must include leaked key checks');
 }


### PR DESCRIPTION
## Summary
- Refine Jetpack connected/disconnected fixture contracts.
- Add fixture states, fake-token/redaction policy, WP.com sandbox blockers, module availability expectations, rollback/reset requirements, and proof artifact expectations.

## Testing
- `node Automattic/jetpack/tools/validate-fuzz-manifests.mjs`
- `node --test scripts/fuzz-manifest-helpers.test.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Jetpack fuzz manifest investigation, metadata updates, validation, and PR description drafting.
