### PR TITLE
Measure Jetpack fuzz performance observation

### DIFF
--- a/Automattic/jetpack/fuzz/jetpack-performance-observation.json
+++ b/Automattic/jetpack/fuzz/jetpack-performance-observation.json
@@ -144,6 +144,15 @@
           "max_external_http_attempts",
           "max_sync_queue_delta"
         ],
+        "product_budgets": {
+          "max_rest_p95_duration_ms": 750,
+          "max_admin_p95_duration_ms": 1200,
+          "max_public_frontend_p95_duration_ms": 1000,
+          "max_queries_per_rest_case": 75,
+          "max_assets_per_public_request": 35,
+          "max_external_http_attempts": 0,
+          "max_sync_queue_delta": 0
+        },
         "hotspot_classes": [
           "slow-rest-route",
           "slow-admin-screen",

--- a/Automattic/jetpack/fuzz/jetpack-performance-observation.json
+++ b/Automattic/jetpack/fuzz/jetpack-performance-observation.json
@@ -175,10 +175,55 @@
         ],
         "action": [
           {
+            "command": "wordpress.run-workload",
+            "args": [
+              "path=${package.root}/bench/rest-db-query-profile.workload.json",
+              "type=json",
+              "artifact=rest_db_query_profile"
+            ]
+          },
+          {
+            "command": "wordpress.fuzz-admin-pages",
+            "args": [
+              "safe_methods=GET",
+              "get_first=true",
+              "submit_forms=false",
+              "follow_redirects=false",
+              "max_pages=40",
+              "enumerate_menus=true",
+              "classify_skips=true"
+            ]
+          },
+          {
+            "command": "wordpress.trace-browser-coverage",
+            "args": [
+              "surface=jetpack-public-modules",
+              "states=connected,disconnected",
+              "classify_skips=true",
+              "artifact=public_module_frontend_coverage"
+            ]
+          },
+          {
+            "command": "wordpress.ensure-external-http-guardrail",
+            "args": [
+              "allowlist=public-api.wordpress.com",
+              "block_network=true"
+            ]
+          },
+          {
+            "command": "wordpress.run-workload",
+            "args": [
+              "path=${package.root}/bench/jetpack-external-http-guardrail.php",
+              "type=php",
+              "artifact=external_http_guardrail"
+            ]
+          },
+          {
             "command": "wordpress.summarize-fuzz-artifacts",
             "args": [
               "surface=jetpack-performance",
-              "include=timing,queries,assets,sync,http,skips"
+              "include=timing,queries,assets,sync,http,skips",
+              "artifact=jetpack_performance_observation,jetpack_performance_surface_summary"
             ]
           }
         ],
@@ -192,6 +237,30 @@
         ]
       },
       "artifacts": [
+        {
+          "name": "rest_db_query_profile",
+          "path": "jetpack-performance-observation/rest_db_query_profile.json",
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.rest_db_query_profile"
+          }
+        },
+        {
+          "name": "public_module_frontend_coverage",
+          "path": "jetpack-performance-observation/public_module_frontend_coverage.json",
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.browser_request_coverage"
+          }
+        },
+        {
+          "name": "external_http_guardrail",
+          "path": "jetpack-performance-observation/external_http_guardrail.json",
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.external_http_guardrail"
+          }
+        },
         {
           "name": "jetpack_performance_observation",
           "path": "jetpack-performance-observation/jetpack_performance_observation.json",

--- a/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
+++ b/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
@@ -4,6 +4,7 @@
   "components": {
     "jetpack": {
       "path": "~/Developer/jetpack/projects/plugins/jetpack",
+      "checkout_root": "~/Developer/jetpack",
       "branch": "trunk",
       "extensions": {
         "wordpress": {


### PR DESCRIPTION
## Summary

- Declare the Jetpack checkout root so Lab materializes the monorepo root for Composer path repositories.
- Enforce Jetpack fuzz readiness contracts.
- Wire `jetpack-performance-observation` to run measurable inputs before summarizing performance.
- Declare Jetpack performance observation budgets for generic measured summary comparison.

## Validation

- `homeboy --force-hot --allow-local-hot rig check jetpack-api-route-inventory`
- `homeboy fuzz run jetpack --rig jetpack-api-route-inventory --workload jetpack-performance-observation --runner homeboy-lab --lab-only --allow-dirty-lab-workspace --run-id jetpack-performance-observation-20260623-measure5`

## Evidence

- Final measured fuzz run: `jetpack-performance-observation-20260623-measure5`
- Evidence artifact: `runner-artifact://homeboy-lab/jetpack-performance-observation-20260623-measure5/e6d6a4d4-da3f-4606-ad1e-35ee20efc62c`
- Observed metrics: REST requests `6`, DB queries `0`, browser requests `5`, admin targets `40`, external HTTP attempts `2`.
- Exceeded budget: `max_external_http_attempts` observed `2`, budget `0`.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Wiring Jetpack fuzz workloads, validating rig behavior on Lab, and extracting measured performance evidence.
