### PR TITLE
Require generated WooCommerce fuzz contracts

### DIFF
--- a/woocommerce/woocommerce/bench/codebox-fuzz-suite-smoke.workload.json
+++ b/woocommerce/woocommerce/bench/codebox-fuzz-suite-smoke.workload.json
@@ -2,7 +2,7 @@
   "schema": "wp-codebox/wordpress-workload-run/v1",
   "wordpress_version": "latest",
   "runtime_env": {
-    "WP_CODEBOX_PUBLIC_CONTRACT_PROOF": "schema-only"
+    "WP_CODEBOX_PUBLIC_CONTRACT_PROOF": "generated-contract-only"
   },
   "before": [
     {
@@ -39,6 +39,6 @@
     "workload": "codebox-fuzz-suite-smoke",
     "contract": "wp-codebox/wordpress-workload-run/v1",
     "fuzz_suite": "${package.root}/manifests/codebox-fuzz-suite-smoke.json",
-    "proof_status": "schema_only_placeholder"
+    "proof_status": "contract_only_placeholder"
   }
 }

--- a/woocommerce/woocommerce/fuzz/codebox-fuzz-suite-smoke.json
+++ b/woocommerce/woocommerce/fuzz/codebox-fuzz-suite-smoke.json
@@ -10,7 +10,8 @@
   "operations": [
     "public-fuzz-suite-contract",
     "run-wordpress-workload-contract",
-    "schema-only-proof-placeholder"
+    "generated-route-inventory-contract",
+    "rest-db-query-attribution-contract"
   ],
   "case_budget": 1,
   "duration_budget_seconds": 60,
@@ -25,9 +26,18 @@
       "wp-codebox/wordpress-workload-run/v1",
       "wp-codebox/fuzz-suite-result/v1"
     ],
+    "required_primitive_contracts": [
+      "wordpress.inventory-rest-routes",
+      "wordpress.generate-rest-request-cases",
+      "wordpress.profile-rest-db-queries"
+    ],
     "readiness": {
       "level": "declared",
-      "coverage_contract": "Schema-level smoke path for WooCommerce through public WP Codebox fuzz-suite and run-wordpress-workload contracts. This does not claim full-surface proof until a real fuzz-suite-result artifact is captured."
+      "coverage_contract": "Schema-level public WP Codebox fuzz-suite handoff for WooCommerce generated REST route inventory, generated safe GET cases, and REST DB query attribution. This stays declared until non-local fuzz-suite-result artifacts prove the generated contracts executed.",
+      "upstream_blockers": [
+        "Public fuzz-suite execution must consume generated route inventory and request-case artifacts instead of static route fixtures.",
+        "REST DB query attribution must be emitted as reviewer-facing fuzz-suite-result artifacts before this can become executable or proven."
+      ]
     },
     "fixture": {
       "runtime": "wp-codebox",
@@ -58,7 +68,8 @@
       "operations": [
         "public-fuzz-suite-contract",
         "run-wordpress-workload-contract",
-        "schema-only-proof-placeholder"
+        "generated-route-inventory-contract",
+        "rest-db-query-attribution-contract"
       ],
       "artifacts": [
         {
@@ -107,7 +118,8 @@
     "operations": [
       "public-fuzz-suite-contract",
       "run-wordpress-workload-contract",
-      "schema-only-proof-placeholder"
+      "generated-route-inventory-contract",
+      "rest-db-query-attribution-contract"
     ]
   },
   "artifacts": {

--- a/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
+++ b/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
@@ -3,33 +3,48 @@
   "id": "woocommerce-codebox-fuzz-suite-smoke",
   "version": "1.0.0",
   "target": {
-    "kind": "rest",
-    "id": "woocommerce-store-api-cart",
-    "entrypoint": "/wc/store/v1/cart",
-    "label": "WooCommerce Store API cart read smoke",
+    "kind": "rest-generated-contract",
+    "id": "woocommerce-generated-rest-db-readiness",
+    "label": "WooCommerce generated REST and DB fuzz readiness contract",
     "metadata": {
       "component": "woocommerce",
-      "plugin": "woocommerce/woocommerce.php"
+      "plugin": "woocommerce/woocommerce.php",
+      "required_primitives": [
+        "wordpress.inventory-rest-routes",
+        "wordpress.generate-rest-request-cases",
+        "wordpress.profile-rest-db-queries"
+      ],
+      "source_manifests": [
+        "fuzz/woocommerce-rest-route-inventory.json",
+        "fuzz/generated-rest-request-cases.json",
+        "fuzz/rest-schema-query-attribution.json"
+      ]
     }
   },
   "cases": [
     {
-      "id": "woocommerce-store-api-cart-read-only",
-      "description": "Schema-level public Codebox fuzz-suite smoke case for a read-only WooCommerce Store API route.",
+      "id": "woocommerce-generated-rest-db-readiness-contract",
+      "description": "Schema-level public Codebox fuzz-suite contract for generated WooCommerce REST route inventory, generated safe GET cases, and REST DB query attribution. This is not a hand-picked route smoke case.",
       "input": {
-        "method": "GET",
-        "path": "/wc/store/v1/cart",
-        "params": {}
+        "generated_from": {
+          "route_inventory_artifact": "route_inventory",
+          "request_cases_artifact": "rest_request_cases",
+          "query_attribution_artifact": "rest_schema_query_attribution",
+          "safe_methods": ["GET"],
+          "namespaces": ["wc/v3", "wc/store/v1", "wc-admin", "wc-analytics"]
+        }
       },
       "metadata": {
         "safety_class": "read_only",
-        "proof_status": "placeholder"
+        "proof_status": "contract_only_placeholder",
+        "readiness_level": "declared"
       }
     }
   ],
   "metadata": {
     "component": "woocommerce",
     "contract": "wp-codebox/fuzz-suite/v1",
-    "proof_status": "schema_only_placeholder"
+    "proof_status": "contract_only_placeholder",
+    "readiness_level": "declared"
   }
 }

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -246,6 +246,14 @@ for (const { file, manifest } of fuzzManifests) {
 const codeboxSmokeManifest = fuzzManifests.find(({ manifest }) => manifest.id === 'codebox-fuzz-suite-smoke')?.manifest;
 assert.ok(codeboxSmokeManifest, 'codebox-fuzz-suite-smoke manifest is missing');
 assert.equal(codeboxSmokeManifest.metadata?.readiness?.level, 'declared', 'codebox smoke must not claim proven readiness without proof artifacts');
+assert.ok(codeboxSmokeManifest.operations.includes('generated-route-inventory-contract'), 'codebox smoke must depend on generated route inventory contracts');
+assert.ok(codeboxSmokeManifest.operations.includes('rest-db-query-attribution-contract'), 'codebox smoke must depend on REST DB query attribution contracts');
+assert.deepEqual(codeboxSmokeManifest.metadata?.required_primitive_contracts, [
+  'wordpress.inventory-rest-routes',
+  'wordpress.generate-rest-request-cases',
+  'wordpress.profile-rest-db-queries',
+]);
+assert.equal(codeboxSmokeManifest.metadata?.readiness?.upstream_blockers?.length, 2, 'codebox smoke declared readiness must name upstream blockers');
 assert.deepEqual(codeboxSmokeManifest.metadata?.public_codebox_contracts, [
   'wp-codebox/fuzz-suite/v1',
   'wp-codebox/wordpress-workload-run/v1',
@@ -256,6 +264,7 @@ assert.equal(codeboxSmokeManifest.artifacts.expected[0]?.proof_placeholder, true
 
 const codeboxWorkloadRun = readJson(packageRoot, 'bench/codebox-fuzz-suite-smoke.workload.json');
 assert.equal(codeboxWorkloadRun.schema, 'wp-codebox/wordpress-workload-run/v1');
+assert.equal(codeboxWorkloadRun.runtime_env?.WP_CODEBOX_PUBLIC_CONTRACT_PROOF, 'generated-contract-only');
 assert.ok(codeboxWorkloadRun.before.some((step) => step.command === 'wordpress.ensure-plugin-active'), 'codebox workload must activate WooCommerce');
 assert.ok(codeboxWorkloadRun.steps.some((step) => step.command === 'wp-codebox/run-fuzz-suite'), 'codebox workload must route through public run-fuzz-suite ability');
 assert.equal(codeboxWorkloadRun.artifacts[0]?.metadata?.schema, 'wp-codebox/fuzz-suite-result/v1');
@@ -263,10 +272,23 @@ assert.equal(codeboxWorkloadRun.artifacts[0]?.required, false, 'codebox workload
 
 const codeboxSuite = readJson(packageRoot, 'manifests/codebox-fuzz-suite-smoke.json');
 assert.equal(codeboxSuite.schema, 'wp-codebox/fuzz-suite/v1');
-assert.equal(codeboxSuite.target?.kind, 'rest');
-assert.equal(codeboxSuite.target?.entrypoint, '/wc/store/v1/cart');
-assert.equal(codeboxSuite.cases?.[0]?.input?.method, 'GET');
-assert.equal(codeboxSuite.cases?.[0]?.metadata?.proof_status, 'placeholder');
+assert.equal(codeboxSuite.target?.kind, 'rest-generated-contract');
+assert.equal(codeboxSuite.target?.entrypoint, undefined, 'codebox suite must not pin a hand-picked static REST route');
+assert.deepEqual(codeboxSuite.target?.metadata?.required_primitives, [
+  'wordpress.inventory-rest-routes',
+  'wordpress.generate-rest-request-cases',
+  'wordpress.profile-rest-db-queries',
+]);
+assert.deepEqual(codeboxSuite.target?.metadata?.source_manifests, [
+  'fuzz/woocommerce-rest-route-inventory.json',
+  'fuzz/generated-rest-request-cases.json',
+  'fuzz/rest-schema-query-attribution.json',
+]);
+assert.equal(codeboxSuite.cases?.[0]?.input?.generated_from?.route_inventory_artifact, 'route_inventory');
+assert.equal(codeboxSuite.cases?.[0]?.input?.generated_from?.request_cases_artifact, 'rest_request_cases');
+assert.equal(codeboxSuite.cases?.[0]?.input?.generated_from?.query_attribution_artifact, 'rest_schema_query_attribution');
+assert.equal(codeboxSuite.cases?.[0]?.metadata?.proof_status, 'contract_only_placeholder');
+assert.equal(codeboxSuite.metadata?.readiness_level, 'declared');
 
 const proofReadyContracts = {
   'rest-namespace-generated-cases': ['namespace-classification', 'generated-safe-get-cases', 'route-gap-attribution'],


### PR DESCRIPTION
## Summary
- replace the hand-picked WooCommerce Codebox fuzz smoke route with a generated REST/DB readiness contract
- declare required upstream primitives for REST route inventory, generated request cases, and REST DB query profiling
- keep readiness at `declared` and prevent the validator from accepting static route smoke coverage as production fuzz proof

## Testing
- `node "woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs"`
- `node "scripts/lint-rig-packages.mjs"`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Auditing WooCommerce fuzz readiness metadata, drafting the generated-contract slice, and running validation.