### PR TITLE
Prepare WooCommerce runtime dependencies for fuzz

### DIFF
--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -161,6 +161,24 @@
     ],
     "up": [],
     "bench_prepare": [],
+    "fuzz_prepare": [
+      {
+        "kind": "requirement",
+        "label": "WooCommerce Composer package autoloader exists or can be prepared",
+        "file": "${components.woocommerce.path}/vendor/autoload_packages.php",
+        "prepare_command": "bash \"${package.root}/tools/prepare-runtime-dependency.sh\" composer \"${components.woocommerce.path}\"",
+        "prepare_phases": ["fuzz_prepare"],
+        "remediation": "Install Composer on the runner, then run: homeboy rig up woocommerce-performance"
+      },
+      {
+        "kind": "requirement",
+        "label": "WooCommerce generated feature config exists or can be prepared",
+        "file": "${components.woocommerce.path}/includes/react-admin/feature-config.php",
+        "prepare_command": "bash \"${package.root}/tools/prepare-runtime-dependency.sh\" feature-config \"${components.woocommerce.path}\"",
+        "prepare_phases": ["fuzz_prepare"],
+        "remediation": "Ensure PHP is available, then run: homeboy rig up woocommerce-performance"
+      }
+    ],
     "down": []
   }
 }

--- a/woocommerce/woocommerce/tools/prepare-runtime-dependency.sh
+++ b/woocommerce/woocommerce/tools/prepare-runtime-dependency.sh
@@ -10,10 +10,12 @@ if [ -z "$task" ] || [ -z "$woocommerce_component_source" ]; then
 fi
 
 woocommerce_plugin_source="$woocommerce_component_source"
-if [ -n "${HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT:-}" ]; then
-  woocommerce_plugin_source="$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT"
-  if [ -n "${HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH:-}" ]; then
-    woocommerce_plugin_source="$woocommerce_plugin_source/$HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH"
+woocommerce_source_root="${HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT:-${HOMEBOY_SETTINGS_COMPONENTS_WOOCOMMERCE_EXTENSIONS_WORDPRESS_WP_CODEBOX_SOURCE_ROOT:-}}"
+woocommerce_source_subpath="${HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_SUBPATH:-${HOMEBOY_SETTINGS_COMPONENTS_WOOCOMMERCE_EXTENSIONS_WORDPRESS_WP_CODEBOX_SOURCE_SUBPATH:-}}"
+if [ -n "$woocommerce_source_root" ]; then
+  woocommerce_plugin_source="$woocommerce_source_root"
+  if [ -n "$woocommerce_source_subpath" ]; then
+    woocommerce_plugin_source="$woocommerce_plugin_source/$woocommerce_source_subpath"
   fi
 fi
 
@@ -32,7 +34,6 @@ case "$task" in
     fi
     ;;
   admin-assets)
-    woocommerce_source_root="${HOMEBOY_SETTINGS_WP_CODEBOX_SOURCE_ROOT:-}"
     if [ -z "$woocommerce_source_root" ]; then
       woocommerce_source_root=$(cd "$woocommerce_component_source/../.." && pwd)
     fi


### PR DESCRIPTION
## Summary
- add a WooCommerce fuzz_prepare pipeline for Composer package autoloading and generated feature config
- teach the Woo runtime dependency script to use the configured monorepo source root/subpath when fuzz runs materialize plugin-only workspaces
- keeps checkout/layered-nav fuzz activation working against fresh Woo trunk source checkouts

## Verification
- homeboy fuzz run --rig woocommerce-performance --workload checkout-shipping-cache --run-id wc-checkout-shipping-cache-trunk-20260623i --seed 1 --max-duration 20m --runner homeboy-lab --lab-only
- homeboy fuzz run --rig woocommerce-performance --workload layered-nav-count-cache --run-id wc-layered-nav-count-cache-trunk-20260623a --seed 1 --max-duration 20m --runner homeboy-lab --lab-only

## Evidence
- checkout-shipping-cache: runner-artifact://homeboy-lab/wc-checkout-shipping-cache-trunk-20260623i/f3a2d33d-6c91-452b-9d67-91a18fc4b6a1
- layered-nav-count-cache: runner-artifact://homeboy-lab/wc-layered-nav-count-cache-trunk-20260623a/eb4fe5b8-42a2-48de-811d-7a1f3b14cd9b

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** diagnosing Woo fuzz runtime preparation failures, drafting the rig/script updates, and running verification