### PR TITLE
Add WooCommerce REST batch import fuzz workload

### DIFF
--- a/woocommerce/woocommerce/fuzz/rest-product-batch-import.json
+++ b/woocommerce/woocommerce/fuzz/rest-product-batch-import.json
@@ -1,0 +1,121 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "rest-product-batch-import",
+  "label": "REST product batch import guardrails",
+  "safety_class": "isolated_mutation",
+  "surface_ids": [
+    "woocommerce-rest-products-batch",
+    "woocommerce-rest-product-variations-batch"
+  ],
+  "operations": [
+    "product-batch-create-update",
+    "variation-batch-create-update",
+    "lookup-pressure-guardrails",
+    "duplicate-meta-readback"
+  ],
+  "case_budget": 25,
+  "duration_budget_seconds": 1200,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/rest-product-batch-import.php",
+    "expected_artifact_role": "fuzz_report",
+    "expected_artifact_semantic_key": "fuzz.report",
+    "fixture": {
+      "runtime": "wp-codebox",
+      "scope": "disposable-wordpress",
+      "component": "woocommerce",
+      "activation": "woocommerce/woocommerce.php"
+    }
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "php",
+    "path": "${package.root}/bench/rest-product-batch-import.php",
+    "entry": "rest-product-batch-import"
+  },
+  "cases": [
+    {
+      "case_id": "rest-product-batch-import:default",
+      "surface_ids": [
+        "woocommerce-rest-products-batch",
+        "woocommerce-rest-product-variations-batch"
+      ],
+      "operations": [
+        "product-batch-create-update",
+        "variation-batch-create-update",
+        "lookup-pressure-guardrails",
+        "duplicate-meta-readback"
+      ],
+      "artifacts": [
+        {
+          "name": "raw_result",
+          "path": "rest-product-batch-import/raw_result.json",
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "isolated_mutation"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/rest-product-batch-import.php",
+          "type": "php",
+          "entry": "rest-product-batch-import"
+        },
+        "collect": [
+          {
+            "artifact": "raw_result"
+          }
+        ]
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 25,
+    "max_duration_seconds": 1200
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-rest-products-batch",
+      "woocommerce-rest-product-variations-batch"
+    ],
+    "operations": [
+      "product-batch-create-update",
+      "variation-batch-create-update",
+      "lookup-pressure-guardrails",
+      "duplicate-meta-readback"
+    ]
+  },
+  "proof_contracts": [
+    {
+      "id": "rest-product-batch-import-performance",
+      "description": "Artifact must include product and variation batch REST phase metrics, query buckets, side-effect guardrails, duplicate meta/readback checks, and focused phase pass/fail classification.",
+      "required_artifact": "raw_result"
+    }
+  ],
+  "artifacts": {
+    "expected": [
+      {
+        "name": "raw_result",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": true
+      }
+    ]
+  }
+}

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -80,6 +80,7 @@
       { "path": "${package.root}/fuzz/admin-page-coverage.json" },
       { "path": "${package.root}/fuzz/layered-nav-count-cache.json" },
       { "path": "${package.root}/fuzz/layered-nav-catalog-crawl.json" },
+      { "path": "${package.root}/fuzz/rest-product-batch-import.json" },
       { "path": "${package.root}/fuzz/woocommerce-rest-route-inventory.json" },
       { "path": "${package.root}/fuzz/generated-rest-request-cases.json" },
       { "path": "${package.root}/fuzz/rest-db-query-profile.json" },


### PR DESCRIPTION
## Summary
- add a normal fuzz manifest for the existing WooCommerce REST product batch import workload
- register it in the WooCommerce performance rig's fuzz workload list
- keeps #65591/#26029 coverage runnable through homeboy fuzz run instead of bench-only paths

## Verification
- homeboy fuzz list --rig woocommerce-performance --workload discovery saw rest-product-batch-import
- homeboy fuzz run --rig woocommerce-performance --workload rest-product-batch-import --run-id wc-rest-product-batch-import-trunk-20260623a --seed 1 --max-duration 20m --runner homeboy-lab --lab-only

## Evidence
- rest-product-batch-import: runner-artifact://homeboy-lab/wc-rest-product-batch-import-trunk-20260623a/35f548a5-5b7f-46a1-9fbb-613f5727c28a

## Notes
- The run status is pass, but the raw metrics include side_effect_invariant_failure_count=1. That should be handled by stronger fuzz gates in a follow-up so workload-reported invariant failures fail persisted runs.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** drafting the fuzz manifest, wiring it into the rig, and running verification