### PR TITLE
Count WP_Error batch response items

### DIFF
--- a/woocommerce/woocommerce/bench/rest-product-batch-import.php
+++ b/woocommerce/woocommerce/bench/rest-product-batch-import.php
@@ -1069,7 +1069,7 @@ return function (): array {
 	$count_response_errors = static function ( array $response_items ): int {
 		$errors = 0;
 		foreach ( $response_items as $item ) {
-			if ( is_array( $item ) && isset( $item['code'], $item['message'] ) ) {
+			if ( is_wp_error( $item ) || ( is_array( $item ) && isset( $item['code'], $item['message'] ) ) ) {
 				++$errors;
 			}
 		}


### PR DESCRIPTION
## Summary
- Count WP_Error objects as REST batch item errors in the WooCommerce batch import workload.
- Keeps the duplicate-SKU retry invariant aligned with WordPress REST batch responses that carry item failures as WP_Error objects.

## Testing
- php -l woocommerce/woocommerce/bench/rest-product-batch-import.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the duplicate-SKU retry invariant failure and drafting the workload counter fix.