### PR TITLE
Count object REST batch response errors

### DIFF
--- a/woocommerce/woocommerce/bench/rest-product-batch-import.php
+++ b/woocommerce/woocommerce/bench/rest-product-batch-import.php
@@ -1069,7 +1069,7 @@ return function (): array {
 	$count_response_errors = static function ( array $response_items ): int {
 		$errors = 0;
 		foreach ( $response_items as $item ) {
-			if ( is_wp_error( $item ) || ( is_array( $item ) && isset( $item['code'], $item['message'] ) ) ) {
+			if ( is_wp_error( $item ) || is_object( $item ) || ( is_array( $item ) && isset( $item['code'], $item['message'] ) ) ) {
 				++$errors;
 			}
 		}


### PR DESCRIPTION
## Summary
- Treat object response items as REST batch errors in the WooCommerce batch import workload.
- Successful REST product batch items are arrays; this keeps duplicate-SKU retry accounting aligned with non-array failure payloads.

## Testing
- php -l woocommerce/woocommerce/bench/rest-product-batch-import.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the remaining duplicate-SKU retry counter gap and drafting the follow-up workload counter fix.