### PR TITLE
Count non-product REST batch response items

### DIFF
--- a/woocommerce/woocommerce/bench/rest-product-batch-import.php
+++ b/woocommerce/woocommerce/bench/rest-product-batch-import.php
@@ -1069,7 +1069,7 @@ return function (): array {
 	$count_response_errors = static function ( array $response_items ): int {
 		$errors = 0;
 		foreach ( $response_items as $item ) {
-			if ( is_wp_error( $item ) || is_object( $item ) || ( is_array( $item ) && isset( $item['code'], $item['message'] ) ) ) {
+			if ( is_wp_error( $item ) || is_object( $item ) || ! ( is_array( $item ) && isset( $item['id'] ) ) || isset( $item['code'], $item['message'] ) ) {
 				++$errors;
 			}
 		}


### PR DESCRIPTION
## Summary
- Treat REST batch response items without a product id as errors in the Woo batch import workload.
- This matches the success shape for product create/update responses and keeps duplicate-SKU retry accounting from accepting empty failure payloads as successes.

## Testing
- php -l woocommerce/woocommerce/bench/rest-product-batch-import.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the remaining duplicate-SKU retry accounting gap and drafting the success-shape counter fix.