### PR TITLE
Count nested REST batch response errors

### DIFF
--- a/woocommerce/woocommerce/bench/rest-product-batch-import.php
+++ b/woocommerce/woocommerce/bench/rest-product-batch-import.php
@@ -1069,7 +1069,7 @@ return function (): array {
 	$count_response_errors = static function ( array $response_items ): int {
 		$errors = 0;
 		foreach ( $response_items as $item ) {
-			if ( is_wp_error( $item ) || is_object( $item ) || ! ( is_array( $item ) && isset( $item['id'] ) ) || isset( $item['code'], $item['message'] ) ) {
+			if ( is_wp_error( $item ) || is_object( $item ) || ! is_array( $item ) || isset( $item['error'] ) || ! isset( $item['id'] ) || isset( $item['code'], $item['message'] ) ) {
 				++$errors;
 			}
 		}


### PR DESCRIPTION
## Summary
- Count WooCommerce REST batch items with nested `error` payloads as response errors.
- Keeps duplicate-SKU retry invariant aligned with the actual response shape observed in the fuzz artifact.

## Testing
- php -l woocommerce/woocommerce/bench/rest-product-batch-import.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the fuzz artifact and applying the workload counter fix.
