### PR TITLE
Return REST batch hotspot payload

### DIFF
--- a/woocommerce/woocommerce/bench/rest-product-batch-import.php
+++ b/woocommerce/woocommerce/bench/rest-product-batch-import.php
@@ -2442,6 +2442,7 @@ return function (): array {
 
 	return array(
 		'metrics'   => $summary,
+		'hotspots'  => $hotspots,
 		'metadata'  => array(
 			'runner'       => 'wp-codebox',
 			'workload'     => 'rest-product-batch-import',


### PR DESCRIPTION
## Summary
- Include the REST batch import `hotspots` envelope in the workload return payload.
- This makes the standardized hotspot schema visible in the normal WP Codebox fuzz artifact, not only in the optional raw file artifact.

## Testing
- php -l woocommerce/woocommerce/bench/rest-product-batch-import.php

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the missing artifact field and applying the return-payload export fix.
