### PR TITLE
Declare Woo DB API performance fuzzer profile

### DIFF
--- a/woocommerce/woocommerce/fuzz/codebox-fuzz-suite-smoke.json
+++ b/woocommerce/woocommerce/fuzz/codebox-fuzz-suite-smoke.json
@@ -29,15 +29,41 @@
     "required_primitive_contracts": [
       "wordpress.inventory-rest-routes",
       "wordpress.generate-rest-request-cases",
-      "wordpress.profile-rest-db-queries"
+      "wordpress.profile-rest-db-queries",
+      "wordpress.inventory-database",
+      "wordpress.attribute-rest-schema-queries",
+      "wordpress.summarize-performance-hotspots"
     ],
     "readiness": {
       "level": "declared",
-      "coverage_contract": "Schema-level public WP Codebox fuzz-suite handoff for WooCommerce generated REST route inventory, generated safe GET cases, and REST DB query attribution. This stays declared until non-local fuzz-suite-result artifacts prove the generated contracts executed.",
+      "coverage_contract": "Schema-level public WP Codebox fuzz-suite handoff for WooCommerce DB/API performance fuzzing using route inventory, generated safe GET cases, REST DB query profiling, database inventory, schema/query attribution, performance hotspot summary, and the full-surface gap report contract. This stays declared until non-local fuzz-suite-result artifacts prove the generated contracts executed.",
       "upstream_blockers": [
         "Public fuzz-suite execution must consume generated route inventory and request-case artifacts instead of static route fixtures.",
-        "REST DB query attribution must be emitted as reviewer-facing fuzz-suite-result artifacts before this can become executable or proven."
-      ]
+        "REST DB query attribution must be emitted as reviewer-facing fuzz-suite-result artifacts before this can become executable or proven.",
+        "Generic rollback-safe REST create/update/delete primitives must emit rollback artifacts before mutating DB/API cases can join the profile.",
+        "Coverage gap reporting currently comes from manifests/full-surface-coverage.json rather than a standalone executable gap-report workload."
+      ],
+      "crud": {
+        "create": {
+          "level": "declared",
+          "upstream_blocker": "No generic rollback-safe REST create primitive is declared for DB/API performance fuzzing."
+        },
+        "read": {
+          "level": "executable"
+        },
+        "update": {
+          "level": "declared",
+          "upstream_blocker": "No generic rollback-safe REST update primitive is declared for DB/API performance fuzzing."
+        },
+        "delete": {
+          "level": "declared",
+          "upstream_blocker": "No generic rollback-safe REST delete primitive is declared for DB/API performance fuzzing."
+        }
+      },
+      "mutation": {
+        "safety_boundary": "DB/API performance fuzzing remains read-only until isolated fixture mutation and rollback artifacts exist for REST create, update, and delete cases.",
+        "rollback_artifacts": []
+      }
     },
     "fixture": {
       "runtime": "wp-codebox",

--- a/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
+++ b/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
@@ -12,13 +12,33 @@
       "required_primitives": [
         "wordpress.inventory-rest-routes",
         "wordpress.generate-rest-request-cases",
-        "wordpress.profile-rest-db-queries"
+        "wordpress.profile-rest-db-queries",
+        "wordpress.inventory-database",
+        "wordpress.attribute-rest-schema-queries",
+        "wordpress.summarize-performance-hotspots"
       ],
       "source_manifests": [
         "fuzz/woocommerce-rest-route-inventory.json",
         "fuzz/generated-rest-request-cases.json",
-        "fuzz/rest-schema-query-attribution.json"
-      ]
+        "fuzz/rest-db-query-profile.json",
+        "fuzz/db-inventory.json",
+        "fuzz/rest-schema-query-attribution.json",
+        "fuzz/performance-hotspots-artifact-summary.json",
+        "manifests/db-api-performance-fuzzer-gap-report.json"
+      ],
+      "profile": {
+        "id": "db-api-performance-fuzzer",
+        "rig_profile": "rigs/woocommerce-performance/rig.json#fuzz_profiles.db-api-performance-fuzzer",
+        "workload_ids": [
+          "woocommerce-rest-route-inventory",
+          "generated-rest-request-cases",
+          "rest-db-query-profile",
+          "db-inventory",
+          "rest-schema-query-attribution",
+          "performance-hotspots-artifact-summary"
+        ],
+        "gap_report_manifest": "manifests/db-api-performance-fuzzer-gap-report.json"
+      }
     }
   },
   "cases": [

--- a/woocommerce/woocommerce/manifests/db-api-performance-fuzzer-gap-report.json
+++ b/woocommerce/woocommerce/manifests/db-api-performance-fuzzer-gap-report.json
@@ -1,0 +1,37 @@
+{
+  "schema": "homeboy-rigs/wordpress-coverage-gap-report-declaration/v1",
+  "id": "woocommerce-db-api-performance-fuzzer-gap-report",
+  "description": "Standalone declaration for the WooCommerce DB/API performance fuzzer gap report. This is declarative only and does not define an executable workload.",
+  "profile_id": "db-api-performance-fuzzer",
+  "source_gap_report": "manifests/full-surface-coverage.json#gap_report",
+  "semantic_key": "fuzz.report",
+  "inputs": [
+    "woocommerce-rest-route-inventory",
+    "generated-rest-request-cases",
+    "rest-db-query-profile",
+    "db-inventory",
+    "rest-schema-query-attribution",
+    "performance-hotspots-artifact-summary"
+  ],
+  "required_fields": [
+    "surface_type",
+    "expected",
+    "covered",
+    "gaps",
+    "status",
+    "evidence_refs"
+  ],
+  "compare": {
+    "rest": "registered WooCommerce routes minus generated safe request cases and schema/query attribution rows",
+    "database": "WooCommerce database inventory and REST DB query profiles minus route, table, option, transient, and lookup attribution rows",
+    "performance_hotspots": "declared WooCommerce performance hotspot focus areas minus hotspot summary evidence refs"
+  },
+  "readiness": {
+    "level": "declared",
+    "execution": "not_executable",
+    "upstream_blockers": [
+      "Coverage gap reporting currently comes from manifests/full-surface-coverage.json#gap_report rather than a standalone executable gap-report workload.",
+      "Public fuzz-suite execution must emit reviewer-facing fuzz-suite-result artifacts before this declaration can be proven."
+    ]
+  }
+}

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -113,6 +113,14 @@
       "db-inventory",
       "admin-page-coverage"
     ],
+    "db-api-performance-fuzzer": [
+      "woocommerce-rest-route-inventory",
+      "generated-rest-request-cases",
+      "rest-db-query-profile",
+      "db-inventory",
+      "rest-schema-query-attribution",
+      "performance-hotspots-artifact-summary"
+    ],
     "fuzzer": [
       "cart-session-overwrite-race",
       "checkout-concurrent-create-order",
@@ -161,6 +169,50 @@
       "performance-hotspots-artifact-summary",
       "woocommerce-external-http-guardrail"
     ]
+  },
+  "fuzz_profile_metadata": {
+    "db-api-performance-fuzzer": {
+      "description": "Focused WooCommerce DB/API performance fuzzer profile built only from declared REST inventory, generated REST cases, REST DB query profile, DB inventory, schema/query attribution, and performance hotspot summary workloads.",
+      "gap_report_manifest": "manifests/db-api-performance-fuzzer-gap-report.json",
+      "source_gap_report": "manifests/full-surface-coverage.json#gap_report",
+      "required_primitives": [
+        "wordpress.inventory-rest-routes",
+        "wordpress.generate-rest-request-cases",
+        "wordpress.profile-rest-db-queries",
+        "wordpress.inventory-database",
+        "wordpress.attribute-rest-schema-queries",
+        "wordpress.summarize-performance-hotspots"
+      ],
+      "readiness": {
+        "level": "declared",
+        "coverage_contract": "DB/API performance fuzzing is declared as a profile over existing WooCommerce fuzz workloads plus the full-surface gap report contract; it does not claim CRUD or mutating REST execution until upstream rollback-safe primitives exist.",
+        "crud": {
+          "create": {
+            "level": "declared",
+            "upstream_blocker": "No generic rollback-safe REST create primitive is declared for DB/API performance fuzzing."
+          },
+          "read": {
+            "level": "executable"
+          },
+          "update": {
+            "level": "declared",
+            "upstream_blocker": "No generic rollback-safe REST update primitive is declared for DB/API performance fuzzing."
+          },
+          "delete": {
+            "level": "declared",
+            "upstream_blocker": "No generic rollback-safe REST delete primitive is declared for DB/API performance fuzzing."
+          }
+        },
+        "mutation": {
+          "safety_boundary": "Profile execution is read-only until upstream provides isolated fixture mutation, rollback artifact, and delete-boundary primitives for REST CRUD cases.",
+          "rollback_artifacts": [],
+          "upstream_blockers": [
+            "Generic REST mutation runner must emit rollback artifacts before create/update/delete cases can join this profile.",
+            "Coverage gap reporting currently comes from manifests/full-surface-coverage.json rather than a standalone executable gap-report workload."
+          ]
+        }
+      }
+    }
   },
   "pipeline": {
     "check": [

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -20,6 +20,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
 const rig = readJson(packageRoot, 'rigs/woocommerce-performance/rig.json');
 const coverageManifest = readJson(packageRoot, 'manifests/full-surface-coverage.json');
+const dbApiPerformanceFuzzerGapReport = readJson(packageRoot, 'manifests/db-api-performance-fuzzer-gap-report.json');
 const targetInventory = readJson(packageRoot, 'manifests/target-inventory.json');
 const runtimeDependencyHelper = path.join(packageRoot, 'tools/prepare-runtime-dependency.sh');
 
@@ -106,6 +107,14 @@ const fullSurfaceFuzzIds = new Set(Object.entries(coverageManifest.coverage_prof
   .filter(([surface]) => surface !== 'browser_requests')
   .flatMap(([, workloadIds]) => workloadIds));
 const requiredArtifactWorkloadIds = fullSurfaceRequiredArtifactIds(coverageManifest);
+const dbApiPerformanceFuzzerWorkloadIds = [
+  'woocommerce-rest-route-inventory',
+  'generated-rest-request-cases',
+  'rest-db-query-profile',
+  'db-inventory',
+  'rest-schema-query-attribution',
+  'performance-hotspots-artifact-summary',
+];
 
 for (const workloadId of fullSurfaceFuzzIds) {
   assert.ok(declaredIds.has(workloadId), `${workloadId} full-surface coverage is not backed by a fuzz workload`);
@@ -253,8 +262,21 @@ assert.deepEqual(codeboxSmokeManifest.metadata?.required_primitive_contracts, [
   'wordpress.inventory-rest-routes',
   'wordpress.generate-rest-request-cases',
   'wordpress.profile-rest-db-queries',
+  'wordpress.inventory-database',
+  'wordpress.attribute-rest-schema-queries',
+  'wordpress.summarize-performance-hotspots',
 ]);
-assert.equal(codeboxSmokeManifest.metadata?.readiness?.upstream_blockers?.length, 2, 'codebox smoke declared readiness must name upstream blockers');
+assert.equal(codeboxSmokeManifest.metadata?.readiness?.upstream_blockers?.length, 4, 'codebox smoke declared readiness must name upstream blockers');
+assert.equal(codeboxSmokeManifest.metadata?.readiness?.crud?.read?.level, 'executable', 'DB/API profile read CRUD boundary must be executable');
+for (const operation of ['create', 'update', 'delete']) {
+  assert.equal(codeboxSmokeManifest.metadata?.readiness?.crud?.[operation]?.level, 'declared', `DB/API profile ${operation} CRUD boundary must be declared`);
+  assert.equal(typeof codeboxSmokeManifest.metadata?.readiness?.crud?.[operation]?.upstream_blocker, 'string', `DB/API profile ${operation} CRUD boundary must declare its upstream blocker`);
+}
+assert.match(
+  codeboxSmokeManifest.metadata?.readiness?.mutation?.safety_boundary || '',
+  /read-only until isolated fixture mutation/,
+  'DB/API profile mutation readiness must declare the read-only boundary'
+);
 assert.deepEqual(codeboxSmokeManifest.metadata?.public_codebox_contracts, [
   'wp-codebox/fuzz-suite/v1',
   'wp-codebox/wordpress-workload-run/v1',
@@ -279,12 +301,37 @@ assert.deepEqual(codeboxSuite.target?.metadata?.required_primitives, [
   'wordpress.inventory-rest-routes',
   'wordpress.generate-rest-request-cases',
   'wordpress.profile-rest-db-queries',
+  'wordpress.inventory-database',
+  'wordpress.attribute-rest-schema-queries',
+  'wordpress.summarize-performance-hotspots',
 ]);
 assert.deepEqual(codeboxSuite.target?.metadata?.source_manifests, [
   'fuzz/woocommerce-rest-route-inventory.json',
   'fuzz/generated-rest-request-cases.json',
+  'fuzz/rest-db-query-profile.json',
+  'fuzz/db-inventory.json',
   'fuzz/rest-schema-query-attribution.json',
+  'fuzz/performance-hotspots-artifact-summary.json',
+  'manifests/db-api-performance-fuzzer-gap-report.json',
 ]);
+assert.deepEqual(rig.fuzz_profiles?.['db-api-performance-fuzzer'], dbApiPerformanceFuzzerWorkloadIds, 'DB/API performance fuzzer profile workload ids drifted');
+assert.deepEqual(codeboxSuite.target?.metadata?.profile?.workload_ids, dbApiPerformanceFuzzerWorkloadIds, 'Codebox suite DB/API profile workload ids drifted');
+assert.equal(codeboxSuite.target?.metadata?.profile?.gap_report_manifest, 'manifests/db-api-performance-fuzzer-gap-report.json', 'Codebox suite must link the standalone DB/API gap report declaration');
+assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.gap_report_manifest, 'manifests/db-api-performance-fuzzer-gap-report.json', 'DB/API profile must link the standalone gap report declaration');
+assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.source_gap_report, 'manifests/full-surface-coverage.json#gap_report', 'DB/API profile must identify the source full-surface gap report');
+assert.equal(dbApiPerformanceFuzzerGapReport.schema, 'homeboy-rigs/wordpress-coverage-gap-report-declaration/v1', 'DB/API gap report declaration schema drifted');
+assert.equal(dbApiPerformanceFuzzerGapReport.id, 'woocommerce-db-api-performance-fuzzer-gap-report', 'DB/API gap report declaration id drifted');
+assert.equal(dbApiPerformanceFuzzerGapReport.profile_id, 'db-api-performance-fuzzer', 'DB/API gap report declaration must target the DB/API fuzzer profile');
+assert.equal(dbApiPerformanceFuzzerGapReport.source_gap_report, 'manifests/full-surface-coverage.json#gap_report', 'DB/API gap report declaration must point at the full-surface gap report source');
+assert.deepEqual(dbApiPerformanceFuzzerGapReport.inputs, dbApiPerformanceFuzzerWorkloadIds, 'DB/API gap report declaration inputs drifted');
+assert.equal(dbApiPerformanceFuzzerGapReport.readiness?.level, 'declared', 'DB/API gap report declaration readiness must stay declared');
+assert.equal(dbApiPerformanceFuzzerGapReport.readiness?.execution, 'not_executable', 'DB/API gap report declaration must not claim execution');
+assert.ok(dbApiPerformanceFuzzerGapReport.readiness?.upstream_blockers?.length > 0, 'DB/API gap report declaration must name upstream blockers');
+assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.readiness?.crud?.read?.level, 'executable', 'DB/API rig profile read CRUD boundary must be executable');
+for (const operation of ['create', 'update', 'delete']) {
+  assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.readiness?.crud?.[operation]?.level, 'declared', `DB/API rig profile ${operation} CRUD boundary must be declared`);
+  assert.equal(typeof rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.readiness?.crud?.[operation]?.upstream_blocker, 'string', `DB/API rig profile ${operation} CRUD boundary must declare its upstream blocker`);
+}
 assert.equal(codeboxSuite.cases?.[0]?.input?.generated_from?.route_inventory_artifact, 'route_inventory');
 assert.equal(codeboxSuite.cases?.[0]?.input?.generated_from?.request_cases_artifact, 'rest_request_cases');
 assert.equal(codeboxSuite.cases?.[0]?.input?.generated_from?.query_attribution_artifact, 'rest_schema_query_attribution');


### PR DESCRIPTION
## Summary
- add a focused WooCommerce DB/API performance fuzzer profile over existing fuzz workloads
- add a standalone declarative gap-report manifest for the DB/API profile
- keep CRUD mutation and gap-report execution blockers explicit instead of adding product-specific workaround execution

## Tests
- `node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs`
- `node woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs`
- `node --test woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs scripts/fuzz-manifest-helpers.test.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** adding the Woo DB/API fuzz profile declaration, standalone gap-report manifest, validation coverage, and running focused verification.
