### PR TITLE
Sample REST DB profile hook hotspots

### DIFF
--- a/woocommerce/woocommerce/bench/rest-db-query-profile.workload.json
+++ b/woocommerce/woocommerce/bench/rest-db-query-profile.workload.json
@@ -16,6 +16,17 @@
         { "id": "woocommerce-store-cart", "method": "GET", "path": "/wc/store/v1/cart" },
         { "id": "woocommerce-v3-products", "method": "GET", "path": "/wc/v3/products", "params": { "per_page": 1 } }
       ]
+    },
+    {
+      "type": "hook-hotspot-sampler",
+      "metric-prefix": "wp_hook_hotspot",
+      "sampleLimit": 50,
+      "hookLimit": 100,
+      "rest_request_cases": [
+        { "id": "woocommerce-store-products-hooks", "method": "GET", "path": "/wc/store/v1/products", "params": { "per_page": 1 } },
+        { "id": "woocommerce-store-cart-hooks", "method": "GET", "path": "/wc/store/v1/cart" },
+        { "id": "woocommerce-v3-products-hooks", "method": "GET", "path": "/wc/v3/products", "params": { "per_page": 1 } }
+      ]
     }
   ],
   "metadata": {


### PR DESCRIPTION
## Summary
- Add a `hook-hotspot-sampler` step to the Woo REST DB query profile workload.
- Captures hook counts and hook hotspot samples for the same Store API / REST API request set used by query profiling.

## Testing
- node -e "JSON.parse(require('fs').readFileSync('woocommerce/woocommerce/bench/rest-db-query-profile.workload.json','utf8')); console.log('ok')"

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Wiring the generic WP Codebox hook sampler into the Woo REST DB profile workload.
