### PR TITLE
Generate Woo REST fuzz cases from routes

### DIFF
--- a/woocommerce/woocommerce/bench/generated-rest-request-cases.php
+++ b/woocommerce/woocommerce/bench/generated-rest-request-cases.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * WP Codebox-backed WooCommerce generated safe REST request workload.
+ *
+ * Generates GET-only request cases from the live REST route inventory, executes the
+ * bounded cases locally, and emits route coverage/gap artifacts for review.
+ */
+return function (): array {
+	$started = microtime( true );
+
+	if ( ! class_exists( 'WooCommerce' ) ) {
+		$woocommerce_entrypoint = WP_PLUGIN_DIR . '/woocommerce/woocommerce.php';
+		if ( ! file_exists( $woocommerce_entrypoint ) ) {
+			throw new RuntimeException( 'WooCommerce plugin entrypoint is not mounted.' );
+		}
+		require_once $woocommerce_entrypoint;
+	}
+
+	if ( ! class_exists( 'WooCommerce' ) || ! function_exists( 'WC' ) ) {
+		throw new RuntimeException( 'WooCommerce is not loaded.' );
+	}
+	if ( ! did_action( 'woocommerce_init' ) ) {
+		WC()->init();
+	}
+
+	$template_functions = WP_PLUGIN_DIR . '/woocommerce/includes/wc-template-functions.php';
+	if ( is_readable( $template_functions ) ) {
+		require_once $template_functions;
+	}
+
+	$run_id = 'generated-rest-request-cases-' . getmypid() . '-' . time();
+	$server = rest_get_server();
+	if ( class_exists( Automattic\WooCommerce\RestApi\Server::class ) ) {
+		Automattic\WooCommerce\RestApi\Server::instance()->register_rest_routes();
+	}
+
+	$routes = $server->get_routes();
+	ksort( $routes );
+
+	$classify_route = static function ( string $route ): string {
+		if ( preg_match( '#^/wc/store(?:/|$)#', $route ) ) {
+			return 'store_api';
+		}
+		if ( preg_match( '#^/wc/v\d+(?:/|$)#', $route ) ) {
+			return 'wc_rest_api';
+		}
+		if ( preg_match( '#^/wc-admin(?:/|$)#', $route ) ) {
+			return 'wc_admin_api';
+		}
+		if ( preg_match( '#^/wc-analytics(?:/|$)#', $route ) ) {
+			return 'wc_analytics_api';
+		}
+
+		return 'outside_scope';
+	};
+
+	$expected_statuses = static function ( string $surface, string $route ): array {
+		if ( 'store_api' === $surface ) {
+			if ( preg_match( '#^/wc/store(?:/v\d+)?/(products|cart|checkout|product-categories|product-collection-data|product-reviews|products/)#', $route ) ) {
+				return array( 200 );
+			}
+
+			return array( 200, 401, 403 );
+		}
+
+		return array( 200, 401, 403 );
+	};
+
+	$expected_outcome = static function ( string $surface, array $statuses ): string {
+		if ( 'store_api' === $surface && array( 200 ) === $statuses ) {
+			return 'public_read_success';
+		}
+
+		return 'bounded_read_or_auth_boundary';
+	};
+
+	$default_params = static function ( string $route ): array {
+		if ( preg_match( '#/(products|orders|customers|coupons|reviews|reports|categories|tags|attributes)(?:/|$)#', $route ) ) {
+			return array( 'per_page' => 1 );
+		}
+
+		return array();
+	};
+
+	$cases = array();
+	$skipped = array();
+	$namespace_counts = array(
+		'store_api'        => array( 'routes' => 0, 'covered' => 0, 'skipped' => 0 ),
+		'wc_rest_api'      => array( 'routes' => 0, 'covered' => 0, 'skipped' => 0 ),
+		'wc_admin_api'     => array( 'routes' => 0, 'covered' => 0, 'skipped' => 0 ),
+		'wc_analytics_api' => array( 'routes' => 0, 'covered' => 0, 'skipped' => 0 ),
+	);
+
+	foreach ( $routes as $route => $handlers ) {
+		$surface = $classify_route( $route );
+		if ( 'outside_scope' === $surface ) {
+			continue;
+		}
+
+		++$namespace_counts[ $surface ]['routes'];
+
+		if ( false !== strpos( $route, '(?P<' ) ) {
+			++$namespace_counts[ $surface ]['skipped'];
+			$skipped[] = array(
+				'path'        => $route,
+				'surface'     => $surface,
+				'reason_code' => 'dynamic_path_parameter',
+			);
+			continue;
+		}
+
+		$allows_get = false;
+		foreach ( $handlers as $handler ) {
+			foreach ( (array) ( $handler['methods'] ?? array() ) as $method => $enabled ) {
+				$method_name = is_string( $method ) ? $method : (string) $enabled;
+				if ( 'GET' === strtoupper( $method_name ) && $enabled ) {
+					$allows_get = true;
+				}
+			}
+		}
+
+		if ( ! $allows_get ) {
+			++$namespace_counts[ $surface ]['skipped'];
+			$skipped[] = array(
+				'path'        => $route,
+				'surface'     => $surface,
+				'reason_code' => 'no_safe_read_method',
+			);
+			continue;
+		}
+
+		$statuses = $expected_statuses( $surface, $route );
+		$cases[] = array(
+			'id'                => sanitize_key( trim( str_replace( '/', '-', $route ), '-' ) ),
+			'method'            => 'GET',
+			'path'              => $route,
+			'params'            => $default_params( $route ),
+			'capture_response'  => true,
+			'expected_statuses' => $statuses,
+			'metadata'          => array(
+				'surface'          => $surface,
+				'expected_outcome' => $expected_outcome( $surface, $statuses ),
+				'source'           => 'registered-rest-route-inventory',
+			),
+		);
+		++$namespace_counts[ $surface ]['covered'];
+	}
+
+	$responses = array();
+	foreach ( $cases as $case ) {
+		$request = new WP_REST_Request( $case['method'], $case['path'] );
+		foreach ( $case['params'] as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+
+		$response = rest_do_request( $request );
+		$status   = (int) $response->get_status();
+		$responses[] = array(
+			'id'              => $case['id'],
+			'path'            => $case['path'],
+			'method'          => $case['method'],
+			'surface'         => $case['metadata']['surface'],
+			'status'          => $status,
+			'expected_status' => in_array( $status, $case['expected_statuses'], true ),
+		);
+	}
+
+	$coverage_gap = array(
+		'schema'        => 'homeboy-rigs/woocommerce-rest-route-coverage-gap/v1',
+		'surface_type'  => 'rest',
+		'expected'      => $namespace_counts,
+		'covered'       => array_column( $cases, 'path' ),
+		'gaps'          => $skipped,
+		'status'        => empty( $skipped ) ? 'covered' : 'partial',
+		'evidence_refs' => array( 'artifact:rest_request_cases' ),
+	);
+
+	$summary = array(
+		'generated_case_count' => count( $cases ),
+		'skipped_route_count'  => count( $skipped ),
+		'response_count'       => count( $responses ),
+		'namespace_counts'     => $namespace_counts,
+		'total_elapsed_ms'     => ( microtime( true ) - $started ) * 1000,
+	);
+
+	$artifact_path = '';
+	$shared_state  = getenv( 'HOMEBOY_BENCH_SHARED_STATE' );
+	if ( $shared_state ) {
+		$artifact_dir = rtrim( $shared_state, '/' ) . '/generated-rest-request-cases';
+		wp_mkdir_p( $artifact_dir );
+		$artifact_path = $artifact_dir . '/' . $run_id . '.json';
+		file_put_contents(
+			$artifact_path,
+			wp_json_encode(
+				array(
+					'schema'              => 'homeboy/wordpress-rest-request-cases/v1',
+					'run_id'              => $run_id,
+					'woocommerce_version' => defined( 'WC_VERSION' ) ? WC_VERSION : '',
+					'generation'          => array(
+						'source'       => 'registered-rest-route-inventory',
+						'safe_methods' => array( 'GET' ),
+						'namespaces'    => array( 'wc/store*', 'wc/v*', 'wc-admin', 'wc-analytics' ),
+					),
+					'cases'               => $cases,
+					'responses'           => $responses,
+					'coverage_gap'        => $coverage_gap,
+					'metrics'             => $summary,
+				),
+				JSON_PRETTY_PRINT
+			) . "\n"
+		);
+	}
+
+	return array(
+		'metrics'   => $summary,
+		'metadata'  => array(
+			'runner'              => 'wp-codebox',
+			'workload'            => 'generated-rest-request-cases',
+			'coverage_shape'      => 'route-inventory-generated safe WooCommerce Store API, wc/v*, wc-admin, and wc-analytics GET request cases',
+			'status_contract'     => array(
+				'public_read_success'           => 'Expected 200 for read-only public Store API catalog/session routes.',
+				'bounded_read_or_auth_boundary' => 'Expected 200, 401, or 403 for bounded GET cases depending on route permissions.',
+			),
+			'coverage_gap_schema' => 'homeboy-rigs/woocommerce-rest-route-coverage-gap/v1',
+		),
+		'artifacts' => $artifact_path ? array( 'rest_request_cases' => array( 'path' => $artifact_path, 'kind' => 'json' ) ) : array(),
+	);
+};

--- a/woocommerce/woocommerce/fuzz/generated-rest-request-cases.json
+++ b/woocommerce/woocommerce/fuzz/generated-rest-request-cases.json
@@ -2,7 +2,7 @@
   "schema": "homeboy/fuzz-workload/v1",
   "id": "generated-rest-request-cases",
   "label": "Generated WooCommerce REST request cases",
-  "safety_class": "isolated_mutation",
+  "safety_class": "read_only",
   "surface_ids": [
     "woocommerce-rest-routes"
   ],
@@ -15,9 +15,13 @@
   "metadata": {
     "kind": "wordpress-plugin-fuzz",
     "wordpress_runner": "wp-codebox",
-    "workload_path": "${package.root}/bench/generated-rest-request-cases.workload.json",
+    "workload_path": "${package.root}/bench/generated-rest-request-cases.php",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report",
+    "readiness": {
+      "level": "executable",
+      "coverage_contract": "Generate bounded GET request cases from the live WooCommerce Store API, wc/v*, wc-admin, and wc-analytics route inventory, execute them locally, and emit response plus route coverage gap artifacts. This is executable but not proven until offloaded run artifacts are linked."
+    },
     "fixture": {
       "runtime": "wp-codebox",
       "scope": "disposable-wordpress",
@@ -32,8 +36,8 @@
   },
   "workload": {
     "runner": "wp-codebox",
-    "type": "json",
-    "path": "${package.root}/bench/generated-rest-request-cases.workload.json",
+    "type": "php",
+    "path": "${package.root}/bench/generated-rest-request-cases.php",
     "entry": "generated-rest-request-cases"
   },
   "cases": [
@@ -57,7 +61,7 @@
         }
       ],
       "metadata": {
-        "safety_class": "isolated_mutation"
+        "safety_class": "read_only"
       },
       "intent": {
         "schema": "homeboy/fuzz-workload-intent/v1",
@@ -67,8 +71,8 @@
         },
         "execute": {
           "workload_ref": "default",
-          "path": "${package.root}/bench/generated-rest-request-cases.workload.json",
-          "type": "json",
+          "path": "${package.root}/bench/generated-rest-request-cases.php",
+          "type": "php",
           "entry": "generated-rest-request-cases"
         },
         "collect": [

--- a/woocommerce/woocommerce/fuzz/performance-hotspots-artifact-summary.json
+++ b/woocommerce/woocommerce/fuzz/performance-hotspots-artifact-summary.json
@@ -26,11 +26,24 @@
     "workload_path": "${package.root}/bench/rest-db-query-profile.workload.json",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report",
+    "readiness": {
+      "level": "declared",
+      "coverage_contract": "Summarize WooCommerce checkout, cart, catalog, admin, and API hotspot artifacts by relative ranking with request attribution, query attribution, fixture scale, and run refs. This remains declared until real run artifacts produce the summary."
+    },
     "fixture": {
       "runtime": "wp-codebox",
       "scope": "disposable-wordpress",
       "component": "woocommerce",
       "activation": "woocommerce/woocommerce.php"
+    },
+    "artifact_schema": {
+      "schema": "homeboy/woocommerce-performance-hotspots-summary/v1",
+      "ranking": {
+        "mode": "relative",
+        "surfaces": ["checkout", "cart", "catalog", "admin", "api"],
+        "required_fields": ["rank", "surface", "relative_score", "request_attribution", "query_attribution", "fixture_scale", "run_refs"]
+      },
+      "threshold_policy": "relative_ranking_only"
     }
   },
   "target": {
@@ -122,7 +135,7 @@
   "proof_contracts": [
     {
       "id": "artifact-summary-expectations",
-      "description": "Artifact must summarize checkout/cart/catalog/admin/API timing, query counts, cache invalidation, transient growth, gateway compatibility, and external HTTP guardrail evidence without falling back to benchmark transcripts.",
+      "description": "Artifact must summarize checkout/cart/catalog/admin/API timing, query counts, cache invalidation, transient growth, gateway compatibility, and external HTTP guardrail evidence as relative rankings with request attribution, query attribution, fixture scale, and run refs, without hardcoded failure thresholds or benchmark transcript fallbacks.",
       "required_artifact": "performance_hotspots_summary"
     }
   ],

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.json
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.json
@@ -70,14 +70,19 @@
       "budget_manifest": "manifests/rest-route-budgets.json",
       "coverage_goal": "all_wc_v3_wc_store_wc_admin_routes_and_generated_safe_cases",
       "generated_request_cases": {
-        "workload": "bench/generated-rest-request-cases.workload.json",
+        "workload": "bench/generated-rest-request-cases.php",
         "status_contract": {
           "public_read_success": "Store API catalog GET cases should return 200.",
           "public_session_read_success": "Store API cart/checkout GET cases should return 200 without credentials.",
           "auth_boundary": "Woo REST and wc-admin GET cases intentionally run without credentials and should return 401 or 403; 2xx, 404, or 5xx statuses are actionable coverage failures."
         },
         "safe_methods": ["GET"],
-        "surfaces": ["store_api", "wc_rest_api", "wc_admin_api"],
+        "surfaces": ["store_api", "wc_rest_api", "wc_admin_api", "wc_analytics_api"],
+        "coverage_gap_artifact": {
+          "schema": "homeboy-rigs/woocommerce-rest-route-coverage-gap/v1",
+          "required_fields": ["surface_type", "expected", "covered", "gaps", "status", "evidence_refs"],
+          "skip_reason_codes": ["dynamic_path_parameter", "no_safe_read_method"]
+        },
         "permission_boundary_workload": "fuzz/rest-permission-boundary-matrix.json",
         "namespace_generated_cases_workload": "fuzz/rest-namespace-generated-cases.json",
         "schema_query_attribution_workload": "fuzz/rest-schema-query-attribution.json"
@@ -309,14 +314,14 @@
     },
     "generated-rest-request-cases": {
       "surface": "rest_api",
-      "coverage_shape": "generated safe WooCommerce Store API, REST API, and admin REST request cases with captured responses",
+      "coverage_shape": "route-inventory-generated safe WooCommerce Store API, wc/v*, wc-admin, and wc-analytics GET request cases with captured responses and route gap attribution",
       "safety": {
         "classification": "bounded_authenticated_read",
-        "notes": ["Uses explicit GET request cases against local WooCommerce routes", "Response capture is intended for reviewable route-contract evidence"]
+        "notes": ["Generates GET request cases from the registered local WooCommerce REST route inventory", "Skips dynamic path parameters and non-GET routes with explicit reason codes", "Response capture is intended for reviewable route-contract evidence"]
       },
       "artifact_expectations": {
-        "required": ["metadata", "captured REST responses"],
-        "optional": ["request case timing"]
+        "required": ["metadata", "generated REST request cases", "captured REST responses", "coverage gap artifact"],
+        "optional": ["request case timing", "skip reason rows"]
       }
     },
     "rest-db-query-profile": {

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -11,6 +11,8 @@ const packageRoot = path.join(__dirname, '..');
 const manifest = JSON.parse(readFileSync(path.join(__dirname, 'full-surface-coverage.json'), 'utf8'));
 const performanceRig = JSON.parse(readFileSync(path.join(packageRoot, 'rigs/woocommerce-performance/rig.json'), 'utf8'));
 const browserRig = JSON.parse(readFileSync(path.join(packageRoot, 'rigs/woocommerce-browser-coverage/rig.json'), 'utf8'));
+const generatedRestCases = JSON.parse(readFileSync(path.join(packageRoot, 'fuzz/generated-rest-request-cases.json'), 'utf8'));
+const performanceHotspots = JSON.parse(readFileSync(path.join(packageRoot, 'fuzz/performance-hotspots-artifact-summary.json'), 'utf8'));
 
 const workloadIdFromPath = (workloadPath) => path.basename(workloadPath, path.extname(workloadPath));
 
@@ -111,4 +113,50 @@ test('fuzz workload metadata does not fall back to benchmark transcripts', () =>
       `${workloadId} must not declare benchmark transcript fallback proof`
     );
   }
+});
+
+test('generated REST request cases are driven by route inventory coverage semantics', () => {
+  const contract = manifest.surfaces.rest_api.generated_request_cases;
+
+  assert.equal(contract.workload, 'bench/generated-rest-request-cases.php');
+  assert.deepEqual(contract.safe_methods, ['GET']);
+  assert.deepEqual(
+    new Set(contract.surfaces),
+    new Set(['store_api', 'wc_rest_api', 'wc_admin_api', 'wc_analytics_api'])
+  );
+  assert.equal(contract.coverage_gap_artifact.schema, 'homeboy-rigs/woocommerce-rest-route-coverage-gap/v1');
+  assert.deepEqual(
+    new Set(contract.coverage_gap_artifact.required_fields),
+    new Set(['surface_type', 'expected', 'covered', 'gaps', 'status', 'evidence_refs'])
+  );
+  assert.deepEqual(
+    new Set(contract.coverage_gap_artifact.skip_reason_codes),
+    new Set(['dynamic_path_parameter', 'no_safe_read_method'])
+  );
+
+  assert.equal(generatedRestCases.safety_class, 'read_only');
+  assert.equal(generatedRestCases.workload.type, 'php');
+  assert.equal(generatedRestCases.workload.path, '${package.root}/bench/generated-rest-request-cases.php');
+  assert.equal(generatedRestCases.cases[0].intent.execute.type, 'php');
+  assert.ok(
+    manifest.workloads['generated-rest-request-cases'].artifact_expectations.required.includes('coverage gap artifact'),
+    'generated REST workload must require the route coverage gap artifact'
+  );
+});
+
+test('performance hotspot summary contract uses relative ranking instead of hard thresholds', () => {
+  const artifactSchema = performanceHotspots.metadata.artifact_schema;
+
+  assert.equal(artifactSchema.schema, 'homeboy/woocommerce-performance-hotspots-summary/v1');
+  assert.equal(artifactSchema.ranking.mode, 'relative');
+  assert.deepEqual(
+    new Set(artifactSchema.ranking.surfaces),
+    new Set(['checkout', 'cart', 'catalog', 'admin', 'api'])
+  );
+  assert.deepEqual(
+    new Set(artifactSchema.ranking.required_fields),
+    new Set(['rank', 'surface', 'relative_score', 'request_attribution', 'query_attribution', 'fixture_scale', 'run_refs'])
+  );
+  assert.equal(artifactSchema.threshold_policy, 'relative_ranking_only');
+  assert.equal(performanceHotspots.thresholds, undefined, 'hotspot summary must not declare hardcoded thresholds');
 });


### PR DESCRIPTION
## Summary
- Declares executable WooCommerce REST fuzz workload/gap artifacts generated from routes.
- Updates generated request cases, hotspot summaries, full-surface coverage metadata, and coverage tests.
- This does not claim proven production execution until offloaded Homeboy artifacts exist.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 and OpenCode
- **Used for:** Pushing the existing cooked branch, inspecting repository state, and drafting this PR description.