### PR TITLE
Wire Woo DB/API fuzzer artifact workloads

### DIFF
--- a/woocommerce/woocommerce/bench/coverage-gap-report.workload.json
+++ b/woocommerce/woocommerce/bench/coverage-gap-report.workload.json
@@ -1,0 +1,52 @@
+{
+  "schema": "wp-codebox/wordpress-workload-run/v1",
+  "id": "coverage-gap-report",
+  "steps": [
+    {
+      "command": "homeboy.artifact-postprocess",
+      "args": {
+        "helper": "${package.root}/tools/db-api-fuzzer-artifacts.mjs",
+        "action": "coverage-gap-report",
+        "input": {
+          "type": "artifact-root",
+          "path": "${artifacts.root}",
+          "artifact_globs": ["**/*.json"],
+          "max_bytes": 1048576
+        },
+        "output": {
+          "artifact": "coverage_gap_report",
+          "path": "coverage-gap-report/coverage_gap_report.json",
+          "kind": "json",
+          "contentType": "application/json",
+          "schema": "homeboy-rigs/wordpress-coverage-gap-report/v1",
+          "semantic_key": "fuzz.report",
+          "required_fields": ["surface_type", "expected", "covered", "gaps", "status", "evidence_refs"]
+        },
+        "parameters": {
+          "metric_prefix": "coverage_gap_report"
+        }
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "name": "coverage_gap_report",
+      "path": "coverage-gap-report/coverage_gap_report.json",
+      "kind": "json",
+      "contentType": "application/json",
+      "required": true,
+      "metadata": {
+        "schema": "homeboy-rigs/wordpress-coverage-gap-report/v1",
+        "semantic_key": "fuzz.report"
+      }
+    }
+  ],
+  "metadata": {
+    "runner": "wp-codebox",
+    "workload": "coverage-gap-report",
+    "runner_support_status": "requires-upstream-binding",
+    "missing_upstream_contract": "WP Codebox/Homeboy Extensions must bind homeboy.artifact-postprocess steps with args.helper, args.action, args.input, args.output, and args.parameters exactly as declared here.",
+    "coverage_shape": "Executable coverage gap report over available WooCommerce DB/API fuzzer artifacts",
+    "manifest": "manifests/db-api-performance-fuzzer-gap-report.json"
+  }
+}

--- a/woocommerce/woocommerce/bench/performance-hotspots-artifact-summary.workload.json
+++ b/woocommerce/woocommerce/bench/performance-hotspots-artifact-summary.workload.json
@@ -1,0 +1,56 @@
+{
+  "schema": "wp-codebox/wordpress-workload-run/v1",
+  "id": "performance-hotspots-artifact-summary",
+  "steps": [
+    {
+      "command": "homeboy.artifact-postprocess",
+      "args": {
+        "helper": "${package.root}/tools/db-api-fuzzer-artifacts.mjs",
+        "action": "performance-hotspots-summary",
+        "input": {
+          "type": "artifact-root",
+          "path": "${artifacts.root}",
+          "artifact_globs": ["**/*.json"],
+          "max_bytes": 1048576
+        },
+        "output": {
+          "artifact": "performance_hotspots_summary",
+          "path": "performance-hotspots-artifact-summary/performance_hotspots_summary.json",
+          "kind": "json",
+          "contentType": "application/json",
+          "schema": "homeboy/woocommerce-performance-hotspots-summary/v1",
+          "semantic_key": "fuzz.report",
+          "ranking": {
+            "mode": "relative",
+            "required_fields": ["rank", "surface", "relative_score", "request_attribution", "query_attribution", "fixture_scale", "run_refs"]
+          }
+        },
+        "parameters": {
+          "metric_prefix": "performance_hotspots_summary",
+          "maxQuerySamples": 50
+        }
+      }
+    }
+  ],
+  "artifacts": [
+    {
+      "name": "performance_hotspots_summary",
+      "path": "performance-hotspots-artifact-summary/performance_hotspots_summary.json",
+      "kind": "json",
+      "contentType": "application/json",
+      "required": true,
+      "metadata": {
+        "schema": "homeboy/woocommerce-performance-hotspots-summary/v1",
+        "semantic_key": "fuzz.report"
+      }
+    }
+  ],
+  "metadata": {
+    "runner": "wp-codebox",
+    "workload": "performance-hotspots-artifact-summary",
+    "runner_support_status": "requires-upstream-binding",
+    "missing_upstream_contract": "WP Codebox/Homeboy Extensions must bind homeboy.artifact-postprocess steps with args.helper, args.action, args.input, args.output, and args.parameters exactly as declared here.",
+    "coverage_shape": "Executable relative hotspot ranking over available WooCommerce performance and DB/API run artifacts",
+    "manifest": "manifests/full-surface-coverage.json"
+  }
+}

--- a/woocommerce/woocommerce/bench/rest-db-query-profile.workload.json
+++ b/woocommerce/woocommerce/bench/rest-db-query-profile.workload.json
@@ -9,24 +9,16 @@
     {
       "type": "rest-db-query-profiler",
       "metric-prefix": "rest_db_query_profile",
+      "rest_request_cases_source": {
+        "type": "artifact",
+        "schema": "homeboy/wordpress-rest-request-cases/v1",
+        "artifact_globs": ["generated-rest-request-cases/*.json"],
+        "maxRouteCases": 80,
+        "maxArtifactBytes": 1048576
+      },
       "sampleLimit": 50,
       "queryLengthLimit": 500,
-      "rest_request_cases": [
-        { "id": "woocommerce-store-products", "method": "GET", "path": "/wc/store/v1/products", "params": { "per_page": 1 } },
-        { "id": "woocommerce-store-cart", "method": "GET", "path": "/wc/store/v1/cart" },
-        { "id": "woocommerce-v3-products", "method": "GET", "path": "/wc/v3/products", "params": { "per_page": 1 } }
-      ]
-    },
-    {
-      "type": "hook-hotspot-sampler",
-      "metric-prefix": "wp_hook_hotspot",
-      "sampleLimit": 50,
-      "hookLimit": 100,
-      "rest_request_cases": [
-        { "id": "woocommerce-store-products-hooks", "method": "GET", "path": "/wc/store/v1/products", "params": { "per_page": 1 } },
-        { "id": "woocommerce-store-cart-hooks", "method": "GET", "path": "/wc/store/v1/cart" },
-        { "id": "woocommerce-v3-products-hooks", "method": "GET", "path": "/wc/v3/products", "params": { "per_page": 1 } }
-      ]
+      "fallback_policy": "require_generated_rest_request_cases_artifact"
     }
   ],
   "metadata": {

--- a/woocommerce/woocommerce/fuzz/codebox-fuzz-suite-smoke.json
+++ b/woocommerce/woocommerce/fuzz/codebox-fuzz-suite-smoke.json
@@ -32,7 +32,8 @@
       "wordpress.profile-rest-db-queries",
       "wordpress.inventory-database",
       "wordpress.attribute-rest-schema-queries",
-      "wordpress.summarize-performance-hotspots"
+      "wordpress.summarize-performance-hotspots",
+      "wordpress.coverage-gap-report"
     ],
     "readiness": {
       "level": "declared",
@@ -41,7 +42,7 @@
         "Public fuzz-suite execution must consume generated route inventory and request-case artifacts instead of static route fixtures.",
         "REST DB query attribution must be emitted as reviewer-facing fuzz-suite-result artifacts before this can become executable or proven.",
         "Generic rollback-safe REST create/update/delete primitives must emit rollback artifacts before mutating DB/API cases can join the profile.",
-        "Coverage gap reporting currently comes from manifests/full-surface-coverage.json rather than a standalone executable gap-report workload."
+        "Public fuzz-suite proof must include reviewer-facing coverage gap report and hotspot summary artifacts before this contract can become proven."
       ],
       "crud": {
         "create": {

--- a/woocommerce/woocommerce/fuzz/coverage-gap-report.json
+++ b/woocommerce/woocommerce/fuzz/coverage-gap-report.json
@@ -1,0 +1,116 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "coverage-gap-report",
+  "label": "WooCommerce DB/API coverage gap report",
+  "safety_class": "read_only",
+  "surface_ids": [
+    "woocommerce-rest-routes",
+    "wordpress-database-queries",
+    "woocommerce-api-performance"
+  ],
+  "operations": [
+    "coverage-gap-report"
+  ],
+  "case_budget": 1,
+  "duration_budget_seconds": 120,
+  "metadata": {
+    "kind": "wordpress-plugin-fuzz",
+    "wordpress_runner": "wp-codebox",
+    "workload_path": "${package.root}/bench/coverage-gap-report.workload.json",
+    "expected_artifact_role": "fuzz_report",
+      "expected_artifact_semantic_key": "fuzz.report",
+      "readiness": {
+        "level": "declared",
+        "coverage_contract": "Read available WooCommerce DB/API fuzzer run artifacts and emit a generic coverage gap report with expected, covered, gaps, status, and evidence refs. The workload uses the forward-compatible homeboy.artifact-postprocess command shape; executable readiness requires the upstream runner binding for that command. Mutating CRUD remains out of scope until rollback-safe primitives exist.",
+        "upstream_blockers": [
+          "WP Codebox/Homeboy Extensions must bind homeboy.artifact-postprocess steps with args.helper, args.action, args.input, args.output, and args.parameters.",
+          "The runner must pass an artifact root for prior workload outputs and collect the declared fuzz.report JSON artifact."
+        ]
+      },
+    "fixture": {
+      "runtime": "wp-codebox",
+      "scope": "disposable-wordpress",
+      "component": "woocommerce",
+      "activation": "woocommerce/woocommerce.php"
+    }
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "woocommerce",
+    "component": "woocommerce"
+  },
+  "workload": {
+    "runner": "wp-codebox",
+    "type": "json",
+    "path": "${package.root}/bench/coverage-gap-report.workload.json",
+    "entry": "coverage-gap-report"
+  },
+  "cases": [
+    {
+      "case_id": "coverage-gap-report:default",
+      "surface_ids": [
+        "woocommerce-rest-routes",
+        "wordpress-database-queries",
+        "woocommerce-api-performance"
+      ],
+      "operations": [
+        "coverage-gap-report"
+      ],
+      "artifacts": [
+        {
+          "name": "coverage_gap_report",
+          "path": "coverage-gap-report/coverage_gap_report.json",
+          "required": true,
+          "metadata": {
+            "semantic_key": "fuzz.report"
+          }
+        }
+      ],
+      "metadata": {
+        "safety_class": "read_only"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "woocommerce/woocommerce.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/coverage-gap-report.workload.json",
+          "type": "json",
+          "entry": "coverage-gap-report"
+        },
+        "collect": [
+          {
+            "artifact": "coverage_gap_report"
+          }
+        ]
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 1,
+    "max_duration_seconds": 120
+  },
+  "coverage": {
+    "surface_ids": [
+      "woocommerce-rest-routes",
+      "wordpress-database-queries",
+      "woocommerce-api-performance"
+    ],
+    "operations": [
+      "coverage-gap-report"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      {
+        "name": "coverage_gap_report",
+        "role": "fuzz_report",
+        "semantic_key": "fuzz.report",
+        "required": true
+      }
+    ]
+  }
+}

--- a/woocommerce/woocommerce/fuzz/performance-hotspots-artifact-summary.json
+++ b/woocommerce/woocommerce/fuzz/performance-hotspots-artifact-summary.json
@@ -2,7 +2,7 @@
   "schema": "homeboy/fuzz-workload/v1",
   "id": "performance-hotspots-artifact-summary",
   "label": "WooCommerce performance hotspots artifact summary",
-  "safety_class": "isolated_mutation",
+  "safety_class": "read_only",
   "surface_ids": [
     "woocommerce-checkout-performance",
     "woocommerce-cart-session-performance",
@@ -23,12 +23,16 @@
   "metadata": {
     "kind": "wordpress-plugin-fuzz",
     "wordpress_runner": "wp-codebox",
-    "workload_path": "${package.root}/bench/rest-db-query-profile.workload.json",
+    "workload_path": "${package.root}/bench/performance-hotspots-artifact-summary.workload.json",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report",
     "readiness": {
       "level": "declared",
-      "coverage_contract": "Summarize WooCommerce checkout, cart, catalog, admin, and API hotspot artifacts by relative ranking with request attribution, query attribution, fixture scale, and run refs. This remains declared until real run artifacts produce the summary."
+      "coverage_contract": "Summarize available WooCommerce checkout, cart, catalog, admin, and API hotspot artifacts by relative ranking with request attribution, query attribution, fixture scale, and run refs. The workload uses the forward-compatible homeboy.artifact-postprocess command shape; executable readiness requires the upstream runner binding for that command. Proven status still requires reviewer-facing run artifacts produced by offloaded workloads.",
+      "upstream_blockers": [
+        "WP Codebox/Homeboy Extensions must bind homeboy.artifact-postprocess steps with args.helper, args.action, args.input, args.output, and args.parameters.",
+        "The runner must pass an artifact root for prior workload outputs and collect the declared fuzz.report JSON artifact."
+      ]
     },
     "fixture": {
       "runtime": "wp-codebox",
@@ -54,7 +58,7 @@
   "workload": {
     "runner": "wp-codebox",
     "type": "json",
-    "path": "${package.root}/bench/rest-db-query-profile.workload.json",
+    "path": "${package.root}/bench/performance-hotspots-artifact-summary.workload.json",
     "entry": "performance-hotspots-artifact-summary"
   },
   "cases": [
@@ -86,7 +90,7 @@
         }
       ],
       "metadata": {
-        "safety_class": "isolated_mutation"
+        "safety_class": "read_only"
       },
       "intent": {
         "schema": "homeboy/fuzz-workload-intent/v1",
@@ -96,7 +100,7 @@
         },
         "execute": {
           "workload_ref": "default",
-          "path": "${package.root}/bench/rest-db-query-profile.workload.json",
+          "path": "${package.root}/bench/performance-hotspots-artifact-summary.workload.json",
           "type": "json",
           "entry": "performance-hotspots-artifact-summary",
           "parameters": {

--- a/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
+++ b/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
@@ -15,7 +15,8 @@
         "wordpress.profile-rest-db-queries",
         "wordpress.inventory-database",
         "wordpress.attribute-rest-schema-queries",
-        "wordpress.summarize-performance-hotspots"
+        "wordpress.summarize-performance-hotspots",
+        "wordpress.coverage-gap-report"
       ],
       "source_manifests": [
         "fuzz/woocommerce-rest-route-inventory.json",
@@ -23,6 +24,7 @@
         "fuzz/rest-db-query-profile.json",
         "fuzz/db-inventory.json",
         "fuzz/rest-schema-query-attribution.json",
+        "fuzz/coverage-gap-report.json",
         "fuzz/performance-hotspots-artifact-summary.json",
         "manifests/db-api-performance-fuzzer-gap-report.json"
       ],
@@ -35,6 +37,7 @@
           "rest-db-query-profile",
           "db-inventory",
           "rest-schema-query-attribution",
+          "coverage-gap-report",
           "performance-hotspots-artifact-summary"
         ],
         "gap_report_manifest": "manifests/db-api-performance-fuzzer-gap-report.json"

--- a/woocommerce/woocommerce/manifests/db-api-performance-fuzzer-gap-report.json
+++ b/woocommerce/woocommerce/manifests/db-api-performance-fuzzer-gap-report.json
@@ -1,8 +1,10 @@
 {
-  "schema": "homeboy-rigs/wordpress-coverage-gap-report-declaration/v1",
+  "schema": "homeboy-rigs/wordpress-coverage-gap-report-workload/v1",
   "id": "woocommerce-db-api-performance-fuzzer-gap-report",
-  "description": "Standalone declaration for the WooCommerce DB/API performance fuzzer gap report. This is declarative only and does not define an executable workload.",
+  "description": "Declared WooCommerce DB/API performance fuzzer gap report workload over available fuzz/run artifacts, ready to become executable when the generic artifact-postprocess runner binding lands.",
   "profile_id": "db-api-performance-fuzzer",
+  "workload": "fuzz/coverage-gap-report.json",
+  "workload_config": "bench/coverage-gap-report.workload.json",
   "source_gap_report": "manifests/full-surface-coverage.json#gap_report",
   "semantic_key": "fuzz.report",
   "inputs": [
@@ -28,9 +30,10 @@
   },
   "readiness": {
     "level": "declared",
-    "execution": "not_executable",
+    "execution": "artifact_aggregation",
     "upstream_blockers": [
-      "Coverage gap reporting currently comes from manifests/full-surface-coverage.json#gap_report rather than a standalone executable gap-report workload.",
+      "WP Codebox/Homeboy Extensions must bind homeboy.artifact-postprocess steps with args.helper, args.action, args.input, args.output, and args.parameters.",
+      "The runner must pass an artifact root for prior workload outputs and collect the declared fuzz.report JSON artifact.",
       "Public fuzz-suite execution must emit reviewer-facing fuzz-suite-result artifacts before this declaration can be proven."
     ]
   }

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.json
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.json
@@ -48,7 +48,7 @@
       "surface_type": "database",
       "surface_id": "database",
       "coverage_goal": "WooCommerce database inventory, REST query profile, lookup table, option, transient, and attribution coverage",
-      "workload_ids": ["db-inventory", "rest-db-query-profile", "rest-schema-query-attribution", "action-scheduler-lookup-table-coverage", "options-transients-coverage"],
+      "workload_ids": ["db-inventory", "rest-db-query-profile", "rest-schema-query-attribution", "coverage-gap-report", "action-scheduler-lookup-table-coverage", "options-transients-coverage"],
       "artifact_schemas": ["homeboy/wordpress-db-inventory/v1", "homeboy/wordpress-rest-db-query-profile/v1", "homeboy/woocommerce-options-transients-coverage/v1"]
     }
   },
@@ -157,7 +157,7 @@
   "coverage_profiles": {
     "full-surface": {
       "rest_api": ["woocommerce-rest-route-inventory", "generated-rest-request-cases", "rest-permission-boundary-matrix", "rest-namespace-generated-cases", "rest-schema-query-attribution"],
-      "database": ["db-inventory", "rest-db-query-profile", "rest-schema-query-attribution", "action-scheduler-lookup-table-coverage"],
+      "database": ["db-inventory", "rest-db-query-profile", "rest-schema-query-attribution", "coverage-gap-report", "action-scheduler-lookup-table-coverage"],
       "server_requests": ["woocommerce-external-http-guardrail"],
       "authenticated_admin_pages": ["admin-page-coverage"],
       "permission_boundaries": ["rest-permission-boundary-matrix"],
@@ -382,6 +382,18 @@
       "artifact_expectations": {
         "required": ["metrics", "schema/query attribution artifact"],
         "optional": ["route-to-table samples", "query family summaries"]
+      }
+    },
+    "coverage-gap-report": {
+      "surface": "database",
+      "coverage_shape": "Executable generic coverage gap report over WooCommerce DB/API fuzzer artifacts",
+      "safety": {
+        "classification": "read_only_inventory",
+        "notes": ["Reads available fuzz/run artifacts from the isolated runner artifact directory", "Does not execute or mutate REST, database, order, product, payment, or customer state"]
+      },
+      "artifact_expectations": {
+        "required": ["coverage gap report artifact"],
+        "optional": ["artifact evidence refs", "skipped oversized artifact rows"]
       }
     },
     "action-scheduler-lookup-table-coverage": {

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -13,6 +13,10 @@ const performanceRig = JSON.parse(readFileSync(path.join(packageRoot, 'rigs/wooc
 const browserRig = JSON.parse(readFileSync(path.join(packageRoot, 'rigs/woocommerce-browser-coverage/rig.json'), 'utf8'));
 const generatedRestCases = JSON.parse(readFileSync(path.join(packageRoot, 'fuzz/generated-rest-request-cases.json'), 'utf8'));
 const performanceHotspots = JSON.parse(readFileSync(path.join(packageRoot, 'fuzz/performance-hotspots-artifact-summary.json'), 'utf8'));
+const restDbQueryProfileWorkload = JSON.parse(readFileSync(path.join(packageRoot, 'bench/rest-db-query-profile.workload.json'), 'utf8'));
+const coverageGapReport = JSON.parse(readFileSync(path.join(packageRoot, 'fuzz/coverage-gap-report.json'), 'utf8'));
+const coverageGapReportWorkload = JSON.parse(readFileSync(path.join(packageRoot, 'bench/coverage-gap-report.workload.json'), 'utf8'));
+const performanceHotspotsWorkload = JSON.parse(readFileSync(path.join(packageRoot, 'bench/performance-hotspots-artifact-summary.workload.json'), 'utf8'));
 
 const workloadIdFromPath = (workloadPath) => path.basename(workloadPath, path.extname(workloadPath));
 
@@ -159,4 +163,89 @@ test('performance hotspot summary contract uses relative ranking instead of hard
   );
   assert.equal(artifactSchema.threshold_policy, 'relative_ranking_only');
   assert.equal(performanceHotspots.thresholds, undefined, 'hotspot summary must not declare hardcoded thresholds');
+});
+
+test('REST DB query profile consumes generated request case artifacts with caps', () => {
+  const profilerSteps = restDbQueryProfileWorkload.run.filter((step) => (
+    step.type === 'rest-db-query-profiler'
+  ));
+
+  assert.equal(profilerSteps.length, 1);
+  for (const step of profilerSteps) {
+    assert.equal(step.rest_request_cases, undefined, `${step.type} must not fall back to hard-coded route cases`);
+    assert.equal(step.rest_request_cases_source.type, 'artifact');
+    assert.equal(step.rest_request_cases_source.schema, 'homeboy/wordpress-rest-request-cases/v1');
+    assert.deepEqual(step.rest_request_cases_source.artifact_globs, ['generated-rest-request-cases/*.json']);
+    assert.equal(step.rest_request_cases_source.maxRouteCases, 80);
+    assert.equal(step.rest_request_cases_source.maxArtifactBytes, 1048576);
+    assert.equal(step.sampleLimit, 50);
+    assert.equal(step.fallback_policy, 'require_generated_rest_request_cases_artifact');
+  }
+});
+
+function assertArtifactPostprocessWorkloadContract(workload, { id, action, artifact, outputPath, schema }) {
+  assert.equal(workload.schema, 'wp-codebox/wordpress-workload-run/v1', `${id} workload must use the generic workload-run contract`);
+  assert.equal(workload.id, id, `${id} workload id drifted`);
+  assert.equal(workload.steps?.length, 1, `${id} must declare one artifact postprocess step`);
+  assert.equal(workload.steps[0].command, 'homeboy.artifact-postprocess', `${id} must use the generic artifact postprocess command`);
+  assert.equal(workload.steps[0].type, undefined, `${id} must not invent an unsupported step type`);
+  assert.equal(workload.steps[0].runner_support_status, undefined, `${id} runner support status belongs in metadata, not the executable step`);
+
+  const args = workload.steps[0].args;
+  assert.equal(args.helper, '${package.root}/tools/db-api-fuzzer-artifacts.mjs', `${id} helper drifted`);
+  assert.equal(args.action, action, `${id} action drifted`);
+  assert.deepEqual(args.input, {
+    type: 'artifact-root',
+    path: '${artifacts.root}',
+    artifact_globs: ['**/*.json'],
+    max_bytes: 1048576,
+  }, `${id} input artifact binding drifted`);
+  assert.equal(args.output.artifact, artifact, `${id} output artifact drifted`);
+  assert.equal(args.output.path, outputPath, `${id} output path drifted`);
+  assert.equal(args.output.kind, 'json', `${id} output kind drifted`);
+  assert.equal(args.output.contentType, 'application/json', `${id} output contentType drifted`);
+  assert.equal(args.output.schema, schema, `${id} output schema drifted`);
+  assert.equal(args.output.semantic_key, 'fuzz.report', `${id} semantic key drifted`);
+
+  assert.deepEqual(workload.artifacts?.[0], {
+    name: artifact,
+    path: outputPath,
+    kind: 'json',
+    contentType: 'application/json',
+    required: true,
+    metadata: {
+      schema,
+      semantic_key: 'fuzz.report',
+    },
+  }, `${id} collected artifact declaration drifted`);
+  assert.equal(workload.metadata?.runner_support_status, 'requires-upstream-binding', `${id} must stay declared until upstream binds this command`);
+  assert.match(workload.metadata?.missing_upstream_contract || '', /args\.helper, args\.action, args\.input, args\.output, and args\.parameters/, `${id} must document missing upstream fields`);
+}
+
+test('coverage gap and hotspot reports declare the generic artifact postprocess contract', () => {
+  assert.equal(coverageGapReport.metadata.readiness.level, 'declared');
+  assert.equal(coverageGapReport.workload.path, '${package.root}/bench/coverage-gap-report.workload.json');
+  assert.equal(coverageGapReport.workload.type, 'json');
+  assert.equal(coverageGapReport.safety_class, 'read_only');
+  assert.equal(coverageGapReport.artifacts.expected[0].name, 'coverage_gap_report');
+  assertArtifactPostprocessWorkloadContract(coverageGapReportWorkload, {
+    id: 'coverage-gap-report',
+    action: 'coverage-gap-report',
+    artifact: 'coverage_gap_report',
+    outputPath: 'coverage-gap-report/coverage_gap_report.json',
+    schema: 'homeboy-rigs/wordpress-coverage-gap-report/v1',
+  });
+
+  assert.equal(performanceHotspots.metadata.readiness.level, 'declared');
+  assert.equal(performanceHotspots.workload.path, '${package.root}/bench/performance-hotspots-artifact-summary.workload.json');
+  assert.equal(performanceHotspots.workload.type, 'json');
+  assert.equal(performanceHotspots.safety_class, 'read_only');
+  assert.equal(performanceHotspots.artifacts.expected[0].name, 'performance_hotspots_summary');
+  assertArtifactPostprocessWorkloadContract(performanceHotspotsWorkload, {
+    id: 'performance-hotspots-artifact-summary',
+    action: 'performance-hotspots-summary',
+    artifact: 'performance_hotspots_summary',
+    outputPath: 'performance-hotspots-artifact-summary/performance_hotspots_summary.json',
+    schema: 'homeboy/woocommerce-performance-hotspots-summary/v1',
+  });
 });

--- a/woocommerce/woocommerce/manifests/target-inventory.json
+++ b/woocommerce/woocommerce/manifests/target-inventory.json
@@ -18,83 +18,265 @@
       "command": "wordpress.inventory-rest-routes",
       "status": "preferred",
       "artifact_schema": "homeboy/wordpress-rest-route-inventory/v1",
-      "workload_ids": ["woocommerce-rest-route-inventory", "generated-rest-request-cases", "rest-permission-boundary-matrix", "rest-namespace-generated-cases", "rest-schema-query-attribution"]
+      "workload_ids": [
+        "woocommerce-rest-route-inventory",
+        "generated-rest-request-cases",
+        "rest-permission-boundary-matrix",
+        "rest-namespace-generated-cases",
+        "rest-schema-query-attribution"
+      ]
     },
     "admin_pages": {
       "command": "wordpress.fuzz-admin-pages",
       "status": "preferred",
       "artifact_schema": "homeboy-rigs/woocommerce-admin-page-coverage/v1",
-      "workload_ids": ["admin-page-coverage"]
+      "workload_ids": [
+        "admin-page-coverage"
+      ]
     },
     "frontend_pages": {
       "command": "wordpress.trace-browser-coverage",
       "status": "preferred",
       "artifact_schema": "wp-codebox/browser-request-coverage/v1",
-      "workload_ids": ["frontend-rendering-request-coverage"]
+      "workload_ids": [
+        "frontend-rendering-request-coverage"
+      ]
     },
     "database": {
       "command": "wordpress.inventory-database",
       "status": "preferred",
       "artifact_schema": "homeboy/wordpress-db-inventory/v1",
-      "workload_ids": ["db-inventory", "rest-db-query-profile", "rest-schema-query-attribution", "action-scheduler-lookup-table-coverage"]
+      "workload_ids": [
+        "db-inventory",
+        "rest-db-query-profile",
+        "rest-schema-query-attribution",
+        "coverage-gap-report",
+        "action-scheduler-lookup-table-coverage"
+      ]
     },
     "blocks": {
       "command": "wordpress.inventory-blocks",
       "status": "preferred",
       "artifact_schema": "homeboy/wordpress-block-inventory/v1",
-      "workload_ids": ["frontend-rendering-request-coverage"]
+      "workload_ids": [
+        "frontend-rendering-request-coverage"
+      ]
     },
     "options_transients": {
       "command": "wordpress.inventory-options-transients",
       "status": "preferred",
       "artifact_schema": "homeboy/woocommerce-options-transients-coverage/v1",
-      "workload_ids": ["options-transients-coverage", "action-scheduler-lookup-table-coverage", "rollback-safe-options-transients-mutations"]
+      "workload_ids": [
+        "options-transients-coverage",
+        "action-scheduler-lookup-table-coverage",
+        "rollback-safe-options-transients-mutations"
+      ]
     },
     "performance_hotspots": {
       "command": "wordpress.summarize-performance-hotspots",
       "status": "preferred",
       "artifact_schema": "homeboy/woocommerce-performance-hotspots-summary/v1",
-      "workload_ids": ["performance-hotspots-artifact-summary"]
+      "workload_ids": [
+        "performance-hotspots-artifact-summary"
+      ]
     }
   },
   "targets": {
     "rest_routes": {
-      "namespaces": ["wc/v1", "wc/v2", "wc/v3", "wc/store/v1", "wc/store/v2", "wc-admin", "wc-analytics"],
-      "required_sections": ["routes", "namespaces", "permission_boundaries", "generated_safe_get_cases", "query_attribution"],
-      "gap_report_sections": ["routes_without_generated_cases", "routes_without_permission_boundary_cases", "routes_without_query_attribution"]
+      "namespaces": [
+        "wc/v1",
+        "wc/v2",
+        "wc/v3",
+        "wc/store/v1",
+        "wc/store/v2",
+        "wc-admin",
+        "wc-analytics"
+      ],
+      "required_sections": [
+        "routes",
+        "namespaces",
+        "permission_boundaries",
+        "generated_safe_get_cases",
+        "query_attribution"
+      ],
+      "gap_report_sections": [
+        "routes_without_generated_cases",
+        "routes_without_permission_boundary_cases",
+        "routes_without_query_attribution"
+      ]
     },
     "admin_pages": {
-      "sources": ["global $menu", "global $submenu"],
-      "roles": ["administrator", "shop_manager"],
-      "safe_methods": ["GET"],
-      "skip_reason_codes": ["creation_install_update_or_export_screen", "unsafe_query_arg_action", "unsafe_query_arg_action2", "unsafe_query_arg_delete", "unsafe_query_arg_trash", "unsafe_query_arg_untrash", "unsafe_query_arg_activate", "unsafe_query_arg_deactivate", "setup_or_onboarding_screen", "role_unavailable", "permission_boundary"],
-      "required_sections": ["contract", "targets", "visits", "skipped", "request_logs", "query_attribution", "metrics"]
+      "sources": [
+        "global $menu",
+        "global $submenu"
+      ],
+      "roles": [
+        "administrator",
+        "shop_manager"
+      ],
+      "safe_methods": [
+        "GET"
+      ],
+      "skip_reason_codes": [
+        "creation_install_update_or_export_screen",
+        "unsafe_query_arg_action",
+        "unsafe_query_arg_action2",
+        "unsafe_query_arg_delete",
+        "unsafe_query_arg_trash",
+        "unsafe_query_arg_untrash",
+        "unsafe_query_arg_activate",
+        "unsafe_query_arg_deactivate",
+        "setup_or_onboarding_screen",
+        "role_unavailable",
+        "permission_boundary"
+      ],
+      "required_sections": [
+        "contract",
+        "targets",
+        "visits",
+        "skipped",
+        "request_logs",
+        "query_attribution",
+        "metrics"
+      ]
     },
     "frontend_pages": {
-      "scenarios": ["shop", "product", "cart", "checkout", "orders_admin", "products_admin", "analytics_admin"],
-      "required_sections": ["pages", "requests", "assets", "xhr_fetch", "console", "errors", "skipped_destructive_actions"],
-      "gap_report_sections": ["pages_without_request_coverage", "scenarios_without_artifacts", "unexpected_failed_requests"]
+      "scenarios": [
+        "shop",
+        "product",
+        "cart",
+        "checkout",
+        "orders_admin",
+        "products_admin",
+        "analytics_admin"
+      ],
+      "required_sections": [
+        "pages",
+        "requests",
+        "assets",
+        "xhr_fetch",
+        "console",
+        "errors",
+        "skipped_destructive_actions"
+      ],
+      "gap_report_sections": [
+        "pages_without_request_coverage",
+        "scenarios_without_artifacts",
+        "unexpected_failed_requests"
+      ]
     },
     "database": {
-      "table_prefixes": ["woocommerce_", "wc_", "actionscheduler_"],
-      "required_sections": ["tables", "columns", "indexes", "row_counts", "query_profiles"],
-      "query_attribution_fields": ["request_case_id", "route", "method", "query_type", "table", "stack_summary", "caller_summary"]
+      "table_prefixes": [
+        "woocommerce_",
+        "wc_",
+        "actionscheduler_"
+      ],
+      "required_sections": [
+        "tables",
+        "columns",
+        "indexes",
+        "row_counts",
+        "query_profiles"
+      ],
+      "query_attribution_fields": [
+        "request_case_id",
+        "route",
+        "method",
+        "query_type",
+        "table",
+        "stack_summary",
+        "caller_summary"
+      ]
     },
     "blocks": {
-      "block_name_prefixes": ["woocommerce/"],
-      "frontend_contexts": ["shop", "product", "cart", "checkout"],
-      "required_sections": ["registered_blocks", "rendered_blocks", "block_assets", "block_rest_requests", "block_query_profiles"]
+      "block_name_prefixes": [
+        "woocommerce/"
+      ],
+      "frontend_contexts": [
+        "shop",
+        "product",
+        "cart",
+        "checkout"
+      ],
+      "required_sections": [
+        "registered_blocks",
+        "rendered_blocks",
+        "block_assets",
+        "block_rest_requests",
+        "block_query_profiles"
+      ]
     },
     "options_transients": {
-      "option_prefixes": ["woocommerce_", "woocommerce-", "wc_", "_wc_", "_woocommerce_"],
-      "transient_prefixes": ["_transient_wc_", "_transient_timeout_wc_", "_site_transient_wc_", "_site_transient_timeout_wc_", "_transient_woocommerce_", "_transient_timeout_woocommerce_"],
-      "required_sections": ["options", "transients", "autoloaded_options", "action_scheduler", "lookup_tables", "rollback_mutations"]
+      "option_prefixes": [
+        "woocommerce_",
+        "woocommerce-",
+        "wc_",
+        "_wc_",
+        "_woocommerce_"
+      ],
+      "transient_prefixes": [
+        "_transient_wc_",
+        "_transient_timeout_wc_",
+        "_site_transient_wc_",
+        "_site_transient_timeout_wc_",
+        "_transient_woocommerce_",
+        "_transient_timeout_woocommerce_"
+      ],
+      "required_sections": [
+        "options",
+        "transients",
+        "autoloaded_options",
+        "action_scheduler",
+        "lookup_tables",
+        "rollback_mutations"
+      ]
     },
     "performance_hotspots": {
-      "workloads": ["performance-hotspots-artifact-summary"],
-      "focus_areas": ["checkout", "cart_session", "catalog_layered_navigation", "admin_dashboard", "rest_api", "cache_invalidation", "external_http"],
-      "required_sections": ["request_timing", "query_counts", "cache_invalidation", "transient_growth", "gateway_compatibility", "external_http_guardrail"]
+      "workloads": [
+        "performance-hotspots-artifact-summary"
+      ],
+      "focus_areas": [
+        "checkout",
+        "cart_session",
+        "catalog_layered_navigation",
+        "admin_dashboard",
+        "rest_api",
+        "cache_invalidation",
+        "external_http"
+      ],
+      "required_sections": [
+        "request_timing",
+        "query_counts",
+        "cache_invalidation",
+        "transient_growth",
+        "gateway_compatibility",
+        "external_http_guardrail"
+      ]
     }
   },
-  "declared_fuzz_workloads": ["action-scheduler-lookup-table-coverage", "admin-page-coverage", "cart-session-overwrite-race", "checkout-concurrent-create-order", "checkout-gateway-compatibility-matrix", "checkout-shipping-cache", "codebox-fuzz-suite-smoke", "db-inventory", "frontend-rendering-request-coverage", "generated-rest-request-cases", "layered-nav-catalog-crawl", "layered-nav-count-cache", "options-transients-coverage", "performance-hotspots-artifact-summary", "rest-db-query-profile", "rest-namespace-generated-cases", "rest-permission-boundary-matrix", "rest-product-batch-import", "rest-schema-query-attribution", "rollback-safe-options-transients-mutations", "woocommerce-external-http-guardrail", "woocommerce-rest-route-inventory"]
+  "declared_fuzz_workloads": [
+    "action-scheduler-lookup-table-coverage",
+    "admin-page-coverage",
+    "cart-session-overwrite-race",
+    "checkout-concurrent-create-order",
+    "checkout-gateway-compatibility-matrix",
+    "checkout-shipping-cache",
+    "codebox-fuzz-suite-smoke",
+    "coverage-gap-report",
+    "db-inventory",
+    "frontend-rendering-request-coverage",
+    "generated-rest-request-cases",
+    "layered-nav-catalog-crawl",
+    "layered-nav-count-cache",
+    "options-transients-coverage",
+    "performance-hotspots-artifact-summary",
+    "rest-db-query-profile",
+    "rest-namespace-generated-cases",
+    "rest-permission-boundary-matrix",
+    "rest-product-batch-import",
+    "rest-schema-query-attribution",
+    "rollback-safe-options-transients-mutations",
+    "woocommerce-external-http-guardrail",
+    "woocommerce-rest-route-inventory"
+  ]
 }

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -87,6 +87,7 @@
       { "path": "${package.root}/fuzz/rest-permission-boundary-matrix.json" },
       { "path": "${package.root}/fuzz/rest-namespace-generated-cases.json" },
       { "path": "${package.root}/fuzz/rest-schema-query-attribution.json" },
+      { "path": "${package.root}/fuzz/coverage-gap-report.json" },
       { "path": "${package.root}/fuzz/action-scheduler-lookup-table-coverage.json" },
       { "path": "${package.root}/fuzz/options-transients-coverage.json" },
       { "path": "${package.root}/fuzz/rollback-safe-options-transients-mutations.json" },
@@ -119,6 +120,7 @@
       "rest-db-query-profile",
       "db-inventory",
       "rest-schema-query-attribution",
+      "coverage-gap-report",
       "performance-hotspots-artifact-summary"
     ],
     "fuzzer": [
@@ -137,6 +139,7 @@
       "rest-permission-boundary-matrix",
       "rest-namespace-generated-cases",
       "rest-schema-query-attribution",
+      "coverage-gap-report",
       "action-scheduler-lookup-table-coverage",
       "options-transients-coverage",
       "rollback-safe-options-transients-mutations",
@@ -161,6 +164,7 @@
       "rest-permission-boundary-matrix",
       "rest-namespace-generated-cases",
       "rest-schema-query-attribution",
+      "coverage-gap-report",
       "action-scheduler-lookup-table-coverage",
       "options-transients-coverage",
       "rollback-safe-options-transients-mutations",
@@ -181,7 +185,8 @@
         "wordpress.profile-rest-db-queries",
         "wordpress.inventory-database",
         "wordpress.attribute-rest-schema-queries",
-        "wordpress.summarize-performance-hotspots"
+        "wordpress.summarize-performance-hotspots",
+        "wordpress.coverage-gap-report"
       ],
       "readiness": {
         "level": "declared",
@@ -208,7 +213,7 @@
           "rollback_artifacts": [],
           "upstream_blockers": [
             "Generic REST mutation runner must emit rollback artifacts before create/update/delete cases can join this profile.",
-            "Coverage gap reporting currently comes from manifests/full-surface-coverage.json rather than a standalone executable gap-report workload."
+            "Generic REST mutation runner must emit delete-boundary rollback artifacts before mutating CRUD cases can join this profile."
           ]
         }
       }

--- a/woocommerce/woocommerce/tools/db-api-fuzzer-artifacts.mjs
+++ b/woocommerce/woocommerce/tools/db-api-fuzzer-artifacts.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+import { mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const coverageGapSchema = 'homeboy-rigs/wordpress-coverage-gap-report/v1';
+export const hotspotSummarySchema = 'homeboy/woocommerce-performance-hotspots-summary/v1';
+export const artifactPostprocessCommand = 'homeboy.artifact-postprocess';
+const supportedCommands = new Set(['coverage-gap-report', 'performance-hotspots-summary']);
+
+export function readArtifactTree(root, { maxArtifactBytes = 1024 * 1024 } = {}) {
+  const artifacts = [];
+  const visit = (current) => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        visit(entryPath);
+        continue;
+      }
+
+      if (!entry.isFile() || !entry.name.endsWith('.json')) {
+        continue;
+      }
+
+      const size = statSync(entryPath).size;
+      if (size > maxArtifactBytes) {
+        artifacts.push({ path: entryPath, skipped: true, reason: 'artifact_size_limit', size });
+        continue;
+      }
+
+      artifacts.push({ path: entryPath, size, json: JSON.parse(readFileSync(entryPath, 'utf8')) });
+    }
+  };
+
+  visit(root);
+  return artifacts;
+}
+
+export function extractRestRequestCases(artifacts, { maxRouteCases = 80 } = {}) {
+  return artifacts
+    .filter((artifact) => artifact.json?.schema === 'homeboy/wordpress-rest-request-cases/v1')
+    .flatMap((artifact) => (artifact.json.cases || []).map((requestCase) => ({
+      id: requestCase.id,
+      method: requestCase.method,
+      path: requestCase.path,
+      params: requestCase.params || {},
+      source_artifact: artifact.path,
+      surface: requestCase.metadata?.surface,
+    })))
+    .slice(0, maxRouteCases);
+}
+
+export function buildCoverageGapReport(artifacts) {
+  const evidenceRefs = [];
+  const expectedRoutes = new Set();
+  const coveredRoutes = new Set();
+  const explainedGapRoutes = new Set();
+  const gaps = [];
+
+  for (const artifact of artifacts) {
+    if (artifact.skipped) {
+      gaps.push({ artifact: artifact.path, reason_code: artifact.reason, size: artifact.size });
+      continue;
+    }
+
+    const json = artifact.json;
+    if (!json || typeof json !== 'object') {
+      continue;
+    }
+
+    if (Array.isArray(json.routes)) {
+      evidenceRefs.push(`artifact:${path.basename(artifact.path)}`);
+      for (const route of json.routes) {
+        if (route?.path) {
+          expectedRoutes.add(route.path);
+        }
+      }
+    }
+
+    if (json.schema === 'homeboy/wordpress-rest-request-cases/v1') {
+      evidenceRefs.push(`artifact:${path.basename(artifact.path)}`);
+      for (const requestCase of json.cases || []) {
+        if (requestCase?.path) {
+          coveredRoutes.add(requestCase.path);
+        }
+      }
+      for (const gap of json.coverage_gap?.gaps || []) {
+        if (gap?.path) {
+          explainedGapRoutes.add(gap.path);
+        }
+        gaps.push(gap);
+      }
+    }
+  }
+
+  for (const route of expectedRoutes) {
+    if (!coveredRoutes.has(route) && !explainedGapRoutes.has(route)) {
+      gaps.push({ path: route, reason_code: 'missing_generated_request_case' });
+    }
+  }
+
+  return {
+    schema: coverageGapSchema,
+    surface_type: 'rest',
+    expected: { rest_routes: expectedRoutes.size },
+    covered: [...coveredRoutes].sort(),
+    gaps: gaps.sort((a, b) => String(a.path || a.artifact || '').localeCompare(String(b.path || b.artifact || ''))),
+    status: gaps.length === 0 ? 'covered' : 'partial',
+    evidence_refs: [...new Set(evidenceRefs)].sort(),
+  };
+}
+
+export function buildPerformanceHotspotsSummary(artifacts, { maxQuerySamples = 50 } = {}) {
+  const candidates = [];
+
+  for (const artifact of artifacts) {
+    if (artifact.skipped || !artifact.json || typeof artifact.json !== 'object') {
+      continue;
+    }
+
+    const json = artifact.json;
+    const workload = json.metadata?.workload || json.workload || path.basename(path.dirname(artifact.path)) || 'unknown';
+    const surface = classifySurface(workload, json);
+    const metrics = json.metrics || {};
+    const querySamples = json.query_samples || json.samples || json.queries || [];
+    const queryCount = Number(metrics.query_count ?? metrics.total_query_count ?? querySamples.length ?? 0);
+    const elapsedMs = Number(metrics.total_elapsed_ms ?? metrics.elapsed_ms ?? metrics.duration_ms ?? 0);
+    const relativeScore = queryCount + elapsedMs / 1000;
+
+    if (relativeScore <= 0) {
+      continue;
+    }
+
+    candidates.push({
+      surface,
+      relative_score: relativeScore,
+      request_attribution: json.route || json.request || json.metadata?.coverage_shape || workload,
+      query_attribution: querySamples.slice(0, maxQuerySamples),
+      fixture_scale: json.fixture_scale || metrics.fixture_scale || json.metadata?.fixture_scale || 'unknown',
+      run_refs: [json.run_id ? `run:${json.run_id}` : `artifact:${path.basename(artifact.path)}`],
+    });
+  }
+
+  candidates.sort((a, b) => b.relative_score - a.relative_score);
+
+  return {
+    schema: hotspotSummarySchema,
+    ranking: candidates.map((candidate, index) => ({
+      rank: index + 1,
+      ...candidate,
+    })),
+    threshold_policy: 'relative_ranking_only',
+    evidence_refs: candidates.flatMap((candidate) => candidate.run_refs),
+  };
+}
+
+function classifySurface(workload, json) {
+  const haystack = `${workload} ${json.metadata?.coverage_shape || ''}`.toLowerCase();
+  if (haystack.includes('checkout')) return 'checkout';
+  if (haystack.includes('cart')) return 'cart';
+  if (haystack.includes('catalog') || haystack.includes('layered')) return 'catalog';
+  if (haystack.includes('admin')) return 'admin';
+  return 'api';
+}
+
+export function writeJsonArtifact(outputPath, payload) {
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+export function normalizeArtifactPostprocessStep(step) {
+  if (!step || typeof step !== 'object' || Array.isArray(step)) {
+    throw new Error('Artifact postprocess step must be an object');
+  }
+  if (step.command !== artifactPostprocessCommand) {
+    throw new Error(`Unsupported artifact postprocess command: ${step.command}`);
+  }
+
+  const args = step.args;
+  if (!args || typeof args !== 'object' || Array.isArray(args)) {
+    throw new Error('Artifact postprocess step requires args');
+  }
+  if (typeof args.helper !== 'string' || args.helper.trim() === '') {
+    throw new Error('Artifact postprocess args.helper must be a non-empty string');
+  }
+  if (!supportedCommands.has(args.action)) {
+    throw new Error(`Unsupported artifact postprocess action: ${args.action}`);
+  }
+
+  const input = args.input;
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('Artifact postprocess args.input must be an object');
+  }
+  if (input.type !== 'artifact-root') {
+    throw new Error(`Unsupported artifact postprocess input type: ${input.type}`);
+  }
+  if (typeof input.path !== 'string' || input.path.trim() === '') {
+    throw new Error('Artifact postprocess args.input.path must be a non-empty string');
+  }
+  if (!Array.isArray(input.artifact_globs) || input.artifact_globs.length === 0) {
+    throw new Error('Artifact postprocess args.input.artifact_globs must be a non-empty array');
+  }
+
+  const output = args.output;
+  if (!output || typeof output !== 'object' || Array.isArray(output)) {
+    throw new Error('Artifact postprocess args.output must be an object');
+  }
+  for (const field of ['artifact', 'path', 'kind', 'contentType', 'schema', 'semantic_key']) {
+    if (typeof output[field] !== 'string' || output[field].trim() === '') {
+      throw new Error(`Artifact postprocess args.output.${field} must be a non-empty string`);
+    }
+  }
+  if (output.kind !== 'json') {
+    throw new Error(`Unsupported artifact postprocess output kind: ${output.kind}`);
+  }
+  if (output.contentType !== 'application/json') {
+    throw new Error(`Unsupported artifact postprocess output contentType: ${output.contentType}`);
+  }
+
+  return {
+    command: args.action,
+    inputRoot: input.path,
+    outputPath: output.path,
+    maxArtifactBytes: input.max_bytes ?? 1024 * 1024,
+    maxQuerySamples: args.parameters?.maxQuerySamples ?? 50,
+    outputSchema: output.schema,
+  };
+}
+
+export function buildArtifactPostprocessPayload(step, { inputRoot } = {}) {
+  const contract = normalizeArtifactPostprocessStep(step);
+  const artifacts = readArtifactTree(inputRoot || contract.inputRoot, {
+    maxArtifactBytes: contract.maxArtifactBytes,
+  });
+  const payload = contract.command === 'coverage-gap-report'
+    ? buildCoverageGapReport(artifacts)
+    : buildPerformanceHotspotsSummary(artifacts, { maxQuerySamples: contract.maxQuerySamples });
+
+  if (payload.schema !== contract.outputSchema) {
+    throw new Error(`Artifact postprocess output schema mismatch: expected ${contract.outputSchema}, received ${payload.schema}`);
+  }
+
+  return payload;
+}
+
+export function writeArtifactPostprocessPayload(step, { inputRoot, outputPath } = {}) {
+  const contract = normalizeArtifactPostprocessStep(step);
+  const payload = buildArtifactPostprocessPayload(step, { inputRoot });
+  writeJsonArtifact(outputPath || contract.outputPath, payload);
+  return payload;
+}
+
+async function main() {
+  const [command, inputRoot, outputPath] = process.argv.slice(2);
+  if (command === 'artifact-postprocess') {
+    if (!inputRoot) {
+      throw new Error('Usage: db-api-fuzzer-artifacts.mjs artifact-postprocess <step-json> [input-root] [output-json]');
+    }
+    const step = JSON.parse(readFileSync(inputRoot, 'utf8'));
+    writeArtifactPostprocessPayload(step, { inputRoot: outputPath, outputPath: process.argv[5] });
+    return;
+  }
+
+  if (!command || !inputRoot || !outputPath) {
+    throw new Error('Usage: db-api-fuzzer-artifacts.mjs <coverage-gap-report|performance-hotspots-summary> <artifact-root> <output-json>');
+  }
+  if (!supportedCommands.has(command)) {
+    throw new Error(`Unsupported command: ${command}`);
+  }
+
+  const artifacts = readArtifactTree(inputRoot);
+  const payload = command === 'coverage-gap-report'
+    ? buildCoverageGapReport(artifacts)
+    : buildPerformanceHotspotsSummary(artifacts);
+  writeJsonArtifact(outputPath, payload);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/woocommerce/woocommerce/tools/db-api-fuzzer-artifacts.test.mjs
+++ b/woocommerce/woocommerce/tools/db-api-fuzzer-artifacts.test.mjs
@@ -1,0 +1,187 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  artifactPostprocessCommand,
+  buildArtifactPostprocessPayload,
+  buildCoverageGapReport,
+  buildPerformanceHotspotsSummary,
+  extractRestRequestCases,
+  normalizeArtifactPostprocessStep,
+  readArtifactTree,
+} from './db-api-fuzzer-artifacts.mjs';
+
+function writeJson(root, relativePath, payload) {
+  const targetPath = path.join(root, relativePath);
+  mkdirSync(path.dirname(targetPath), { recursive: true });
+  writeFileSync(targetPath, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+test('coverage gap report is derived from route inventory and generated request case artifacts', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'woo-db-api-gap-'));
+
+  writeJson(root, 'woocommerce-rest-route-inventory/routes.json', {
+    routes: [
+      { path: '/wc/store/v1/products' },
+      { path: '/wc/store/v1/cart' },
+    ],
+  });
+  writeJson(root, 'generated-rest-request-cases/cases.json', {
+    schema: 'homeboy/wordpress-rest-request-cases/v1',
+    cases: [
+      { id: 'products', method: 'GET', path: '/wc/store/v1/products', params: { per_page: 1 } },
+    ],
+    coverage_gap: {
+      gaps: [
+        { path: '/wc/store/v1/cart', reason_code: 'dynamic_path_parameter' },
+      ],
+    },
+  });
+
+  const artifacts = readArtifactTree(root);
+  const report = buildCoverageGapReport(artifacts);
+
+  assert.equal(report.schema, 'homeboy-rigs/wordpress-coverage-gap-report/v1');
+  assert.equal(report.surface_type, 'rest');
+  assert.deepEqual(report.expected, { rest_routes: 2 });
+  assert.deepEqual(report.covered, ['/wc/store/v1/products']);
+  assert.equal(report.status, 'partial');
+  assert.deepEqual(report.gaps, [{ path: '/wc/store/v1/cart', reason_code: 'dynamic_path_parameter' }]);
+  assert.ok(report.evidence_refs.includes('artifact:cases.json'));
+});
+
+test('generated REST request cases are capped when consumed by DB/API profilers', () => {
+  const artifacts = [
+    {
+      path: '/artifacts/generated-rest-request-cases/cases.json',
+      json: {
+        schema: 'homeboy/wordpress-rest-request-cases/v1',
+        cases: [
+          { id: 'a', method: 'GET', path: '/wc/store/v1/products' },
+          { id: 'b', method: 'GET', path: '/wc/store/v1/cart' },
+        ],
+      },
+    },
+  ];
+
+  assert.deepEqual(
+    extractRestRequestCases(artifacts, { maxRouteCases: 1 }),
+    [{ id: 'a', method: 'GET', path: '/wc/store/v1/products', params: {}, source_artifact: '/artifacts/generated-rest-request-cases/cases.json', surface: undefined }]
+  );
+});
+
+test('performance hotspot summary ranks available artifacts relatively', () => {
+  const artifacts = [
+    {
+      path: '/artifacts/rest-db-query-profile/profile.json',
+      json: {
+        run_id: 'api-run',
+        metadata: { workload: 'rest-db-query-profile', coverage_shape: 'REST API profile' },
+        metrics: { total_query_count: 12, total_elapsed_ms: 2500 },
+        query_samples: [{ table: 'wp_wc_orders', query_type: 'select' }],
+      },
+    },
+    {
+      path: '/artifacts/checkout-shipping-cache/profile.json',
+      json: {
+        run_id: 'checkout-run',
+        metadata: { workload: 'checkout-shipping-cache', coverage_shape: 'checkout shipping cache profile' },
+        metrics: { total_query_count: 20, total_elapsed_ms: 1000 },
+      },
+    },
+  ];
+
+  const summary = buildPerformanceHotspotsSummary(artifacts);
+
+  assert.equal(summary.schema, 'homeboy/woocommerce-performance-hotspots-summary/v1');
+  assert.equal(summary.threshold_policy, 'relative_ranking_only');
+  assert.equal(summary.ranking[0].rank, 1);
+  assert.equal(summary.ranking[0].surface, 'checkout');
+  assert.ok(summary.ranking[0].relative_score > summary.ranking[1].relative_score);
+  assert.deepEqual(Object.keys(summary.ranking[0]).sort(), [
+    'fixture_scale',
+    'query_attribution',
+    'rank',
+    'relative_score',
+    'request_attribution',
+    'run_refs',
+    'surface',
+  ]);
+});
+
+test('generic artifact postprocess contract drives coverage gap output', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'woo-db-api-contract-gap-'));
+  writeJson(root, 'woocommerce-rest-route-inventory/routes.json', {
+    routes: [{ path: '/wc/store/v1/products' }],
+  });
+  writeJson(root, 'generated-rest-request-cases/cases.json', {
+    schema: 'homeboy/wordpress-rest-request-cases/v1',
+    cases: [{ id: 'products', method: 'GET', path: '/wc/store/v1/products' }],
+  });
+
+  const step = {
+    command: artifactPostprocessCommand,
+    args: {
+      helper: '${package.root}/tools/db-api-fuzzer-artifacts.mjs',
+      action: 'coverage-gap-report',
+      input: {
+        type: 'artifact-root',
+        path: root,
+        artifact_globs: ['**/*.json'],
+        max_bytes: 1048576,
+      },
+      output: {
+        artifact: 'coverage_gap_report',
+        path: 'coverage-gap-report/coverage_gap_report.json',
+        kind: 'json',
+        contentType: 'application/json',
+        schema: 'homeboy-rigs/wordpress-coverage-gap-report/v1',
+        semantic_key: 'fuzz.report',
+        required_fields: ['surface_type', 'expected', 'covered', 'gaps', 'status', 'evidence_refs'],
+      },
+      parameters: {
+        metric_prefix: 'coverage_gap_report',
+      },
+    },
+  };
+
+  assert.equal(normalizeArtifactPostprocessStep(step).command, 'coverage-gap-report');
+  assert.equal(buildArtifactPostprocessPayload(step).status, 'covered');
+});
+
+test('generic artifact postprocess contract rejects invented commands and incomplete output bindings', () => {
+  assert.throws(
+    () => normalizeArtifactPostprocessStep({ command: 'artifact-postprocess', args: {} }),
+    /Unsupported artifact postprocess command: artifact-postprocess/
+  );
+
+  assert.throws(
+    () => normalizeArtifactPostprocessStep({
+      command: artifactPostprocessCommand,
+      args: {
+        helper: '${package.root}/tools/db-api-fuzzer-artifacts.mjs',
+        action: 'coverage-gap-report',
+        input: { type: 'artifact-root', path: '/tmp/artifacts', artifact_globs: ['**/*.json'] },
+        output: { artifact: 'coverage_gap_report', path: 'coverage-gap-report/coverage_gap_report.json', kind: 'json' },
+      },
+    }),
+    /args\.output\.contentType must be a non-empty string/
+  );
+});
+
+test('CLI rejects unsupported artifact commands', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'woo-db-api-cli-'));
+  const result = spawnSync(process.execPath, [
+    fileURLToPath(new URL('./db-api-fuzzer-artifacts.mjs', import.meta.url)),
+    'unknown-command',
+    root,
+    path.join(root, 'out.json'),
+  ], { encoding: 'utf8' });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Unsupported command: unknown-command/);
+});

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -22,6 +22,8 @@ const rig = readJson(packageRoot, 'rigs/woocommerce-performance/rig.json');
 const coverageManifest = readJson(packageRoot, 'manifests/full-surface-coverage.json');
 const dbApiPerformanceFuzzerGapReport = readJson(packageRoot, 'manifests/db-api-performance-fuzzer-gap-report.json');
 const targetInventory = readJson(packageRoot, 'manifests/target-inventory.json');
+const coverageGapReportWorkload = readJson(packageRoot, 'bench/coverage-gap-report.workload.json');
+const performanceHotspotsWorkload = readJson(packageRoot, 'bench/performance-hotspots-artifact-summary.workload.json');
 const runtimeDependencyHelper = path.join(packageRoot, 'tools/prepare-runtime-dependency.sh');
 
 assertFullSurfaceCoverageManifest(coverageManifest, { file: 'WooCommerce full-surface coverage' });
@@ -34,6 +36,7 @@ const expectedFuzzIds = new Set([
   'checkout-gateway-compatibility-matrix',
   'checkout-shipping-cache',
   'codebox-fuzz-suite-smoke',
+  'coverage-gap-report',
   'db-inventory',
   'frontend-rendering-request-coverage',
   'generated-rest-request-cases',
@@ -65,7 +68,7 @@ const requiredProofContracts = new Map([
 
 const fuzzManifests = collectFuzzManifests(packageRoot);
 
-assert.equal(fuzzManifests.length, 22, 'expected 22 WooCommerce fuzz manifests');
+assert.equal(fuzzManifests.length, 23, 'expected 23 WooCommerce fuzz manifests');
 assert.ok(existsSync(runtimeDependencyHelper), 'WooCommerce runtime dependency prep helper must exist');
 
 const declaredIds = declaredFuzzIds(rig);
@@ -113,8 +116,51 @@ const dbApiPerformanceFuzzerWorkloadIds = [
   'rest-db-query-profile',
   'db-inventory',
   'rest-schema-query-attribution',
+  'coverage-gap-report',
   'performance-hotspots-artifact-summary',
 ];
+const dbApiPerformanceFuzzerGapReportInputIds = dbApiPerformanceFuzzerWorkloadIds.filter((workloadId) => workloadId !== 'coverage-gap-report');
+
+function assertArtifactPostprocessWorkload(workload, { id, action, artifactName, schema }) {
+  assert.equal(workload.schema, 'wp-codebox/wordpress-workload-run/v1', `${id} must use the upstream workload-run envelope`);
+  assert.equal(workload.id, id, `${id} workload id drifted`);
+  assert.equal(workload.steps?.length, 1, `${id} must declare one generic artifact-postprocess step`);
+  assert.equal(workload.steps[0].command, 'homeboy.artifact-postprocess', `${id} must use the generic artifact-postprocess command`);
+  assert.equal(workload.steps[0].type, undefined, `${id} must not invent unsupported step types`);
+
+  const args = workload.steps[0].args;
+  assert.equal(args.helper, '${package.root}/tools/db-api-fuzzer-artifacts.mjs', `${id} helper drifted`);
+  assert.equal(args.action, action, `${id} action drifted`);
+  assert.deepEqual(args.input, {
+    type: 'artifact-root',
+    path: '${artifacts.root}',
+    artifact_globs: ['**/*.json'],
+    max_bytes: 1048576,
+  }, `${id} input artifact root contract drifted`);
+  assert.equal(args.output.artifact, artifactName, `${id} output artifact name drifted`);
+  assert.equal(args.output.kind, 'json', `${id} output kind drifted`);
+  assert.equal(args.output.contentType, 'application/json', `${id} output contentType drifted`);
+  assert.equal(args.output.schema, schema, `${id} output schema drifted`);
+  assert.equal(args.output.semantic_key, 'fuzz.report', `${id} output semantic key drifted`);
+  assert.equal(workload.artifacts?.[0]?.name, artifactName, `${id} collected artifact name drifted`);
+  assert.equal(workload.artifacts?.[0]?.required, true, `${id} collected artifact must be required`);
+  assert.equal(workload.metadata?.runner_support_status, 'requires-upstream-binding', `${id} must stay blocked until upstream binds homeboy.artifact-postprocess`);
+  assert.match(workload.metadata?.missing_upstream_contract || '', /args\.helper, args\.action, args\.input, args\.output, and args\.parameters/, `${id} must document exact missing upstream fields`);
+}
+
+assertArtifactPostprocessWorkload(coverageGapReportWorkload, {
+  id: 'coverage-gap-report',
+  action: 'coverage-gap-report',
+  artifactName: 'coverage_gap_report',
+  schema: 'homeboy-rigs/wordpress-coverage-gap-report/v1',
+});
+
+assertArtifactPostprocessWorkload(performanceHotspotsWorkload, {
+  id: 'performance-hotspots-artifact-summary',
+  action: 'performance-hotspots-summary',
+  artifactName: 'performance_hotspots_summary',
+  schema: 'homeboy/woocommerce-performance-hotspots-summary/v1',
+});
 
 for (const workloadId of fullSurfaceFuzzIds) {
   assert.ok(declaredIds.has(workloadId), `${workloadId} full-surface coverage is not backed by a fuzz workload`);
@@ -265,6 +311,7 @@ assert.deepEqual(codeboxSmokeManifest.metadata?.required_primitive_contracts, [
   'wordpress.inventory-database',
   'wordpress.attribute-rest-schema-queries',
   'wordpress.summarize-performance-hotspots',
+  'wordpress.coverage-gap-report',
 ]);
 assert.equal(codeboxSmokeManifest.metadata?.readiness?.upstream_blockers?.length, 4, 'codebox smoke declared readiness must name upstream blockers');
 assert.equal(codeboxSmokeManifest.metadata?.readiness?.crud?.read?.level, 'executable', 'DB/API profile read CRUD boundary must be executable');
@@ -304,6 +351,7 @@ assert.deepEqual(codeboxSuite.target?.metadata?.required_primitives, [
   'wordpress.inventory-database',
   'wordpress.attribute-rest-schema-queries',
   'wordpress.summarize-performance-hotspots',
+  'wordpress.coverage-gap-report',
 ]);
 assert.deepEqual(codeboxSuite.target?.metadata?.source_manifests, [
   'fuzz/woocommerce-rest-route-inventory.json',
@@ -311,6 +359,7 @@ assert.deepEqual(codeboxSuite.target?.metadata?.source_manifests, [
   'fuzz/rest-db-query-profile.json',
   'fuzz/db-inventory.json',
   'fuzz/rest-schema-query-attribution.json',
+  'fuzz/coverage-gap-report.json',
   'fuzz/performance-hotspots-artifact-summary.json',
   'manifests/db-api-performance-fuzzer-gap-report.json',
 ]);
@@ -319,14 +368,16 @@ assert.deepEqual(codeboxSuite.target?.metadata?.profile?.workload_ids, dbApiPerf
 assert.equal(codeboxSuite.target?.metadata?.profile?.gap_report_manifest, 'manifests/db-api-performance-fuzzer-gap-report.json', 'Codebox suite must link the standalone DB/API gap report declaration');
 assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.gap_report_manifest, 'manifests/db-api-performance-fuzzer-gap-report.json', 'DB/API profile must link the standalone gap report declaration');
 assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.source_gap_report, 'manifests/full-surface-coverage.json#gap_report', 'DB/API profile must identify the source full-surface gap report');
-assert.equal(dbApiPerformanceFuzzerGapReport.schema, 'homeboy-rigs/wordpress-coverage-gap-report-declaration/v1', 'DB/API gap report declaration schema drifted');
-assert.equal(dbApiPerformanceFuzzerGapReport.id, 'woocommerce-db-api-performance-fuzzer-gap-report', 'DB/API gap report declaration id drifted');
-assert.equal(dbApiPerformanceFuzzerGapReport.profile_id, 'db-api-performance-fuzzer', 'DB/API gap report declaration must target the DB/API fuzzer profile');
-assert.equal(dbApiPerformanceFuzzerGapReport.source_gap_report, 'manifests/full-surface-coverage.json#gap_report', 'DB/API gap report declaration must point at the full-surface gap report source');
-assert.deepEqual(dbApiPerformanceFuzzerGapReport.inputs, dbApiPerformanceFuzzerWorkloadIds, 'DB/API gap report declaration inputs drifted');
-assert.equal(dbApiPerformanceFuzzerGapReport.readiness?.level, 'declared', 'DB/API gap report declaration readiness must stay declared');
-assert.equal(dbApiPerformanceFuzzerGapReport.readiness?.execution, 'not_executable', 'DB/API gap report declaration must not claim execution');
+assert.equal(dbApiPerformanceFuzzerGapReport.schema, 'homeboy-rigs/wordpress-coverage-gap-report-workload/v1', 'DB/API gap report workload schema drifted');
+assert.equal(dbApiPerformanceFuzzerGapReport.id, 'woocommerce-db-api-performance-fuzzer-gap-report', 'DB/API gap report workload id drifted');
+assert.equal(dbApiPerformanceFuzzerGapReport.profile_id, 'db-api-performance-fuzzer', 'DB/API gap report workload must target the DB/API fuzzer profile');
+assert.equal(dbApiPerformanceFuzzerGapReport.source_gap_report, 'manifests/full-surface-coverage.json#gap_report', 'DB/API gap report workload must point at the full-surface gap report source');
+assert.equal(dbApiPerformanceFuzzerGapReport.workload, 'fuzz/coverage-gap-report.json', 'DB/API gap report workload must link the executable fuzz workload');
+assert.deepEqual(dbApiPerformanceFuzzerGapReport.inputs, dbApiPerformanceFuzzerGapReportInputIds, 'DB/API gap report workload inputs drifted');
+assert.equal(dbApiPerformanceFuzzerGapReport.readiness?.level, 'declared', 'DB/API gap report workload readiness must stay declared until upstream binds artifact-postprocess');
+assert.equal(dbApiPerformanceFuzzerGapReport.readiness?.execution, 'artifact_aggregation', 'DB/API gap report workload must use artifact aggregation execution');
 assert.ok(dbApiPerformanceFuzzerGapReport.readiness?.upstream_blockers?.length > 0, 'DB/API gap report declaration must name upstream blockers');
+assert.ok(dbApiPerformanceFuzzerGapReport.readiness.upstream_blockers.some((blocker) => blocker.includes('args.helper')), 'DB/API gap report declaration must list the missing upstream artifact-postprocess fields');
 assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.readiness?.crud?.read?.level, 'executable', 'DB/API rig profile read CRUD boundary must be executable');
 for (const operation of ['create', 'update', 'delete']) {
   assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.readiness?.crud?.[operation]?.level, 'declared', `DB/API rig profile ${operation} CRUD boundary must be declared`);


### PR DESCRIPTION
## Summary
- make the Woo DB/API profile consume generated REST request case artifacts for DB profiling
- add coverage-gap and performance-hotspot artifact workload contracts using the generic artifact-postprocess shape
- add a Woo artifact helper for coverage gap and relative hotspot summaries
- keep mutating CRUD explicitly gated until rollback-safe upstream primitives are available

## Dependencies
- Homeboy hotspot contract: https://github.com/Extra-Chill/homeboy/pull/6213
- WP Codebox artifact-postprocess primitive: https://github.com/Automattic/wp-codebox/pull/1497
- Homeboy Extensions runtime adapter: https://github.com/Extra-Chill/homeboy-extensions/pull/1810

## Testing
- node tools/validate-fuzz-manifests.mjs
- node --test manifests/full-surface-coverage.test.mjs tools/db-api-fuzzer-artifacts.test.mjs
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Drafting/stabilizing the Woo DB/API fuzzer artifact workloads, helper contracts, manifest validation, and targeted tests.