### PR TITLE
Stabilize Woo fuzz readiness inventory

### DIFF
--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -168,6 +168,31 @@ The rig exposes `smoke`, `fuzzer`, and `full-surface` `fuzz_profiles` for fleet
 orchestration. These profiles only group existing fuzz workload declarations;
 they do not change readiness levels or convert declarations into proof.
 
+The `full-surface` profile also links discovery manifests for route families,
+Woo blocks, admin action families, and DB/API hotspot artifact IO through
+`fuzz_profile_metadata` and the generated `manifests/target-inventory.json`.
+Those manifests are inventory contracts, not new executable workload IDs. The
+validator allows explicit external discovery references, such as the browser
+coverage rig, while rejecting drift from declared Woo fuzz workloads.
+
+The Woo DB/API fuzz progression is split into two focused profiles:
+
+- `db-api-performance-fuzzer` groups read-only REST route inventory, generated
+  safe request cases, REST DB query profiling, DB inventory, schema/query
+  attribution, gap reporting, and hotspot summary declarations. Create, update,
+  and delete stay declared until upstream rollback-safe REST mutation primitives
+  emit rollback artifacts.
+- `product-rest-crud-fuzzer` makes product and variation batch create/update plus
+  readback executable through `rest-product-batch-import`. Delete remains blocked
+  on the same upstream rollback-safe delete primitive and delete-boundary artifact
+  contract.
+
+The hotspot and coverage aggregation workloads intentionally keep
+`homeboy.artifact-postprocess` as a runner blocker. Do not shim aggregation in
+the rig: Homeboy/Homeboy Extensions must bind `args.helper`, `args.action`,
+`args.input`, `args.output`, and `args.parameters`, then collect the declared
+`fuzz.report` artifact before those contracts can become executable.
+
 The declared full-surface fuzz proof is API/DB/admin/server coverage plus the
 issue-focused checkout/catalog workloads above. Browser request and performance
 summary fuzz manifests are proof-ready declarations until a `homeboy fuzz run`

--- a/woocommerce/woocommerce/fuzz/rest-product-batch-import.json
+++ b/woocommerce/woocommerce/fuzz/rest-product-batch-import.json
@@ -21,6 +21,33 @@
     "workload_path": "${package.root}/bench/rest-product-batch-import.php",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report",
+    "readiness": {
+      "level": "executable",
+      "profile": "product-rest-crud-fuzzer",
+      "execution": "wp-codebox-isolated-mutation",
+      "coverage_contract": "Executes isolated WooCommerce product and variation batch create/update cases with synthetic fixture readback; delete remains declared until upstream rollback-safe delete primitives emit rollback artifacts.",
+      "crud": {
+        "create": {
+          "level": "executable",
+          "safety_class": "isolated_mutation",
+          "fixture_scope": "synthetic_products_attributes_terms_and_variations"
+        },
+        "read": {
+          "level": "executable",
+          "safety_class": "read_only",
+          "fixture_scope": "synthetic_product_readback"
+        },
+        "update": {
+          "level": "executable",
+          "safety_class": "isolated_mutation",
+          "fixture_scope": "synthetic_products_attributes_terms_and_variations"
+        },
+        "delete": {
+          "level": "declared",
+          "upstream_blocker": "The current workload exercises batch create/update and readback guardrails only; delete coverage waits for an upstream rollback-safe REST delete primitive and delete-boundary artifact contract."
+        }
+      }
+    },
     "fixture": {
       "runtime": "wp-codebox",
       "scope": "disposable-wordpress",
@@ -101,6 +128,10 @@
       "duplicate-meta-readback"
     ]
   },
+  "route_families": [
+    "wc/v3/products/batch",
+    "wc/v3/products/<product_id>/variations/batch"
+  ],
   "proof_contracts": [
     {
       "id": "rest-product-batch-import-performance",

--- a/woocommerce/woocommerce/manifests/admin-action-inventory.json
+++ b/woocommerce/woocommerce/manifests/admin-action-inventory.json
@@ -1,0 +1,42 @@
+{
+  "schema": "homeboy-rigs/woocommerce-admin-action-inventory/v1",
+  "id": "woocommerce-admin-action-inventory",
+  "description": "Declared inventory of WooCommerce admin AJAX/action fuzz surfaces with fixture requirements and skip reasons for production-readiness review.",
+  "owner_profile": "full-surface",
+  "owned_by": {
+    "workloads": ["admin-page-coverage", "woocommerce-external-http-guardrail"],
+    "profiles": ["full-surface"]
+  },
+  "action_families": [
+    {
+      "id": "admin-menu-get-pages",
+      "fixture_requirements": ["administrator user", "shop_manager user", "WooCommerce active"],
+      "readiness": "executable_get_only",
+      "workload": "admin-page-coverage",
+      "skip_reasons": ["unsafe_query_arg_action", "unsafe_query_arg_delete", "setup_or_onboarding_screen"]
+    },
+    {
+      "id": "wc-ajax-frontend-actions",
+      "fixture_requirements": ["synthetic cart", "synthetic product"],
+      "readiness": "declared_browser_request_inventory_only",
+      "workload": "frontend-rendering-request-coverage",
+      "skip_reasons": ["destructive_cart_or_checkout_mutation", "payment_submission"]
+    },
+    {
+      "id": "marketplace-and-webhook-http-actions",
+      "fixture_requirements": ["external HTTP guardrail", "allowlist policy"],
+      "readiness": "executable_guardrail_probe",
+      "workload": "woocommerce-external-http-guardrail",
+      "skip_reasons": ["live_credentials_required", "external_side_effect_blocked"]
+    }
+  ],
+  "skip_reason_codes": [
+    "unsafe_query_arg_action",
+    "unsafe_query_arg_delete",
+    "setup_or_onboarding_screen",
+    "destructive_cart_or_checkout_mutation",
+    "payment_submission",
+    "live_credentials_required",
+    "external_side_effect_blocked"
+  ]
+}

--- a/woocommerce/woocommerce/manifests/block-inventory-rendering-fuzz.json
+++ b/woocommerce/woocommerce/manifests/block-inventory-rendering-fuzz.json
@@ -1,0 +1,28 @@
+{
+  "schema": "homeboy-rigs/woocommerce-block-inventory-rendering-fuzz/v1",
+  "id": "woocommerce-block-inventory-rendering-fuzz",
+  "description": "Declared WooCommerce block inventory and rendering fuzz scope for storefront/product/cart/checkout block surfaces. Execution should use generic WordPress block inventory/rendering primitives when available.",
+  "owner_profile": "full-surface",
+  "fixture_requirements": ["shop page", "single product", "cart with synthetic product", "checkout page without payment submission"],
+  "block_name_prefixes": ["woocommerce/"],
+  "frontend_contexts": ["shop", "product", "cart", "checkout"],
+  "owned_by": {
+    "workloads": ["frontend-rendering-request-coverage", "woocommerce-browser-coverage"],
+    "profiles": ["full-surface"]
+  },
+  "readiness": {
+    "inventory": "declared_requires_generic_block_inventory_artifact",
+    "rendering": "partial_via_frontend_browser_request_coverage",
+    "mutation": "blocked_not_a_block_editor_mutation_workload"
+  },
+  "skip_reasons": [
+    {
+      "scope": "checkout_submit_blocks",
+      "reason_code": "destructive_or_payment_submission"
+    },
+    {
+      "scope": "editor_block_mutation",
+      "reason_code": "missing_generic_block_editor_mutation_primitive"
+    }
+  ]
+}

--- a/woocommerce/woocommerce/manifests/db-api-hotspot-artifact-io.json
+++ b/woocommerce/woocommerce/manifests/db-api-hotspot-artifact-io.json
@@ -1,0 +1,77 @@
+{
+  "schema": "homeboy-rigs/woocommerce-db-api-hotspot-artifact-io/v1",
+  "id": "woocommerce-db-api-hotspot-artifact-io",
+  "description": "Expected input artifact map and sample output schema for future Homeboy artifact postprocess of WooCommerce DB/API hotspot evidence.",
+  "owner_profile": "db-api-performance-fuzzer",
+  "postprocess_command": "homeboy.artifact-postprocess",
+  "readiness": {
+    "level": "declared",
+    "upstream_blocker": "Homeboy/Homeboy Extensions must bind artifact-postprocess helper/action/input/output/parameters before this IO contract becomes executable."
+  },
+  "expected_inputs": [
+    {
+      "workload_id": "woocommerce-rest-route-inventory",
+      "artifact_name": "route_inventory",
+      "schema": "homeboy/wordpress-rest-route-inventory/v1",
+      "required": true,
+      "consumed_fields": ["routes", "namespace_counts"]
+    },
+    {
+      "workload_id": "generated-rest-request-cases",
+      "artifact_name": "rest_request_cases",
+      "schema": "homeboy/wordpress-rest-request-cases/v1",
+      "required": true,
+      "consumed_fields": ["cases", "coverage_gap"]
+    },
+    {
+      "workload_id": "rest-db-query-profile",
+      "artifact_name": "rest_db_query_profile",
+      "schema": "homeboy/wordpress-rest-db-query-profile/v1",
+      "required": true,
+      "consumed_fields": ["route_profiles", "query_samples", "metrics"]
+    },
+    {
+      "workload_id": "db-inventory",
+      "artifact_name": "db_inventory",
+      "schema": "homeboy/wordpress-db-inventory/v1",
+      "required": true,
+      "consumed_fields": ["tables", "row_counts", "indexes"]
+    },
+    {
+      "workload_id": "rest-schema-query-attribution",
+      "artifact_name": "rest_schema_query_attribution",
+      "schema": "homeboy/woocommerce-rest-schema-query-attribution/v1",
+      "required": true,
+      "consumed_fields": ["routes", "tables", "query_families"]
+    },
+    {
+      "workload_id": "performance-hotspots-artifact-summary",
+      "artifact_name": "performance_hotspots_summary",
+      "schema": "homeboy/woocommerce-performance-hotspots-summary/v1",
+      "required": false,
+      "consumed_fields": ["ranking", "evidence_refs"]
+    }
+  ],
+  "sample_output": {
+    "schema": "homeboy/woocommerce-performance-hotspots-summary/v1",
+    "ranking": [
+      {
+        "rank": 1,
+        "surface": "api",
+        "relative_score": 42.5,
+        "request_attribution": "GET /wc/v3/products",
+        "query_attribution": [
+          {
+            "table": "wp_wc_product_meta_lookup",
+            "query_family": "product_lookup_read",
+            "sample_count": 3
+          }
+        ],
+        "fixture_scale": "synthetic_product_catalog",
+        "run_refs": ["artifact:rest-db-query-profile.json"]
+      }
+    ],
+    "threshold_policy": "relative_ranking_only",
+    "evidence_refs": ["artifact:rest-db-query-profile.json"]
+  }
+}

--- a/woocommerce/woocommerce/manifests/rest-crud-route-family-catalog.json
+++ b/woocommerce/woocommerce/manifests/rest-crud-route-family-catalog.json
@@ -1,0 +1,119 @@
+{
+  "schema": "homeboy-rigs/woocommerce-rest-crud-route-family-catalog/v1",
+  "id": "woocommerce-rest-crud-route-family-catalog",
+  "description": "WooCommerce REST CRUD route-family catalog for production fuzzing readiness. This manifest declares fixture needs, executable status, skipped dynamic/non-GET coverage, and owning workloads/profiles without adding runner behavior.",
+  "owner_profile": "product-rest-crud-fuzzer",
+  "route_families": [
+    {
+      "id": "products-collection",
+      "namespace": "wc/v3",
+      "routes": ["/wc/v3/products"],
+      "resources": ["product"],
+      "fixture_requirements": ["synthetic simple products", "synthetic variable products", "attributes and terms", "unique SKU/title/slug inputs"],
+      "owned_by": {
+        "workloads": ["generated-rest-request-cases", "rest-schema-query-attribution", "rest-product-batch-import"],
+        "profiles": ["product-rest-crud-fuzzer", "full-surface"]
+      },
+      "readiness": {
+        "create": "executable_via_batch_import",
+        "read": "executable_via_generated_get_cases",
+        "update": "executable_via_batch_import",
+        "delete": "blocked_requires_rollback_safe_delete_primitive"
+      },
+      "skipped_coverage": [
+        {
+          "scope": "non_get_collection_mutations_outside_batch",
+          "reason_code": "owned_by_batch_import_workload"
+        },
+        {
+          "scope": "delete",
+          "reason_code": "missing_rollback_safe_delete_primitive"
+        }
+      ]
+    },
+    {
+      "id": "products-batch",
+      "namespace": "wc/v3",
+      "routes": ["/wc/v3/products/batch"],
+      "resources": ["product"],
+      "fixture_requirements": ["synthetic catalog products", "unique SKU/title/slug inputs", "image import disabled unless explicitly configured"],
+      "owned_by": {
+        "workloads": ["rest-product-batch-import"],
+        "profiles": ["product-rest-crud-fuzzer", "full-surface"]
+      },
+      "readiness": {
+        "create": "executable_isolated_mutation",
+        "read": "executable_readback_guardrail",
+        "update": "executable_isolated_mutation",
+        "delete": "declared_blocked"
+      },
+      "skipped_coverage": [
+        {
+          "scope": "delete",
+          "reason_code": "current_workload_does_not_execute_delete"
+        }
+      ]
+    },
+    {
+      "id": "product-variations-batch",
+      "namespace": "wc/v3",
+      "routes": ["/wc/v3/products/<product_id>/variations/batch"],
+      "resources": ["product_variation"],
+      "fixture_requirements": ["parent variable product", "attributes and terms", "variation payload matrix"],
+      "owned_by": {
+        "workloads": ["rest-product-batch-import"],
+        "profiles": ["product-rest-crud-fuzzer", "full-surface"]
+      },
+      "readiness": {
+        "create": "executable_isolated_mutation",
+        "read": "executable_readback_guardrail",
+        "update": "executable_isolated_mutation",
+        "delete": "declared_blocked"
+      },
+      "skipped_coverage": [
+        {
+          "scope": "dynamic_parent_id_discovery",
+          "reason_code": "fixture_owned_dynamic_path_parameter"
+        },
+        {
+          "scope": "delete",
+          "reason_code": "current_workload_does_not_execute_delete"
+        }
+      ]
+    },
+    {
+      "id": "product-attributes-and-terms",
+      "namespace": "wc/v3",
+      "routes": ["/wc/v3/products/attributes", "/wc/v3/products/attributes/<attribute_id>/terms"],
+      "resources": ["product_attribute", "product_attribute_term"],
+      "fixture_requirements": ["synthetic attributes", "synthetic terms", "dynamic attribute id from fixture setup"],
+      "owned_by": {
+        "workloads": ["rest-product-batch-import", "generated-rest-request-cases"],
+        "profiles": ["product-rest-crud-fuzzer", "full-surface"]
+      },
+      "readiness": {
+        "create": "executable_as_fixture_setup",
+        "read": "partial_dynamic_get_cases",
+        "update": "declared_fixture_owned",
+        "delete": "blocked_requires_rollback_safe_delete_primitive"
+      },
+      "skipped_coverage": [
+        {
+          "scope": "dynamic_attribute_term_paths",
+          "reason_code": "dynamic_path_parameter"
+        },
+        {
+          "scope": "delete",
+          "reason_code": "missing_rollback_safe_delete_primitive"
+        }
+      ]
+    }
+  ],
+  "skip_reason_codes": [
+    "dynamic_path_parameter",
+    "fixture_owned_dynamic_path_parameter",
+    "missing_rollback_safe_delete_primitive",
+    "current_workload_does_not_execute_delete",
+    "owned_by_batch_import_workload"
+  ]
+}

--- a/woocommerce/woocommerce/manifests/target-inventory.json
+++ b/woocommerce/woocommerce/manifests/target-inventory.json
@@ -11,7 +11,61 @@
   },
   "source_manifests": {
     "full_surface": "manifests/full-surface-coverage.json",
-    "rig": "rigs/woocommerce-performance/rig.json"
+    "rig": "rigs/woocommerce-performance/rig.json",
+    "rest_crud_route_family_catalog": "manifests/rest-crud-route-family-catalog.json",
+    "block_inventory_rendering_fuzz": "manifests/block-inventory-rendering-fuzz.json",
+    "admin_action_inventory": "manifests/admin-action-inventory.json",
+    "db_api_hotspot_artifact_io": "manifests/db-api-hotspot-artifact-io.json"
+  },
+  "discovery_manifests": {
+    "rest_route_families": {
+      "manifest": "manifests/rest-crud-route-family-catalog.json",
+      "owner_profile": "product-rest-crud-fuzzer",
+      "readiness": "declared_inventory",
+      "route_family_ids": [
+        "products-collection",
+        "products-batch",
+        "product-variations-batch",
+        "product-attributes-and-terms"
+      ]
+    },
+    "blocks": {
+      "manifest": "manifests/block-inventory-rendering-fuzz.json",
+      "owner_profile": "full-surface",
+      "readiness": {
+        "inventory": "declared_requires_generic_block_inventory_artifact",
+        "rendering": "partial_via_frontend_browser_request_coverage",
+        "mutation": "blocked_not_a_block_editor_mutation_workload"
+      },
+      "owned_by": {
+        "workloads": [
+          "frontend-rendering-request-coverage",
+          "woocommerce-browser-coverage"
+        ],
+        "profiles": [
+          "full-surface"
+        ]
+      }
+    },
+    "admin_actions": {
+      "manifest": "manifests/admin-action-inventory.json",
+      "owner_profile": "full-surface",
+      "readiness": "declared_inventory",
+      "action_family_ids": [
+        "admin-menu-get-pages",
+        "wc-ajax-frontend-actions",
+        "marketplace-and-webhook-http-actions"
+      ]
+    },
+    "db_api_hotspots": {
+      "manifest": "manifests/db-api-hotspot-artifact-io.json",
+      "owner_profile": "db-api-performance-fuzzer",
+      "readiness": {
+        "level": "declared",
+        "upstream_blocker": "Homeboy/Homeboy Extensions must bind artifact-postprocess helper/action/input/output/parameters before this IO contract becomes executable."
+      },
+      "postprocess_command": "homeboy.artifact-postprocess"
+    }
   },
   "inventory_primitives": {
     "rest_routes": {
@@ -251,7 +305,8 @@
         "transient_growth",
         "gateway_compatibility",
         "external_http_guardrail"
-      ]
+      ],
+      "artifact_io_manifest": "manifests/db-api-hotspot-artifact-io.json"
     }
   },
   "declared_fuzz_workloads": [

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -123,6 +123,13 @@
       "coverage-gap-report",
       "performance-hotspots-artifact-summary"
     ],
+    "product-rest-crud-fuzzer": [
+      "rest-product-batch-import",
+      "woocommerce-rest-route-inventory",
+      "generated-rest-request-cases",
+      "rest-schema-query-attribution",
+      "coverage-gap-report"
+    ],
     "fuzzer": [
       "cart-session-overwrite-race",
       "checkout-concurrent-create-order",
@@ -175,6 +182,20 @@
     ]
   },
   "fuzz_profile_metadata": {
+    "full-surface": {
+      "description": "WooCommerce full-surface fuzz inventory. Discovery manifests extend the executable fuzz workload list with declared REST route-family, block, admin action, and DB/API hotspot artifact contracts without claiming additional runner coverage.",
+      "target_inventory_manifest": "manifests/target-inventory.json",
+      "discovery_manifests": {
+        "rest_route_families": "manifests/rest-crud-route-family-catalog.json",
+        "blocks": "manifests/block-inventory-rendering-fuzz.json",
+        "admin_actions": "manifests/admin-action-inventory.json",
+        "db_api_hotspots": "manifests/db-api-hotspot-artifact-io.json"
+      },
+      "readiness": {
+        "level": "declared_inventory",
+        "coverage_contract": "These manifests are inventory and artifact contracts only. Executable coverage remains limited to workload ids declared in fuzz_workloads.wordpress and grouped by fuzz_profiles. Browser-only scenarios and future artifact-postprocess outputs stay non-executable until upstream runner support emits reviewer-facing artifacts."
+      }
+    },
     "db-api-performance-fuzzer": {
       "description": "Focused WooCommerce DB/API performance fuzzer profile built only from declared REST inventory, generated REST cases, REST DB query profile, DB inventory, schema/query attribution, and performance hotspot summary workloads.",
       "gap_report_manifest": "manifests/db-api-performance-fuzzer-gap-report.json",
@@ -215,6 +236,35 @@
             "Generic REST mutation runner must emit rollback artifacts before create/update/delete cases can join this profile.",
             "Generic REST mutation runner must emit delete-boundary rollback artifacts before mutating CRUD cases can join this profile."
           ]
+        }
+      }
+    },
+    "product-rest-crud-fuzzer": {
+      "description": "Focused WooCommerce product REST CRUD fuzzing profile for batch create/update/readback readiness, with delete explicitly blocked until upstream rollback-safe delete primitives land.",
+      "route_family_catalog_manifest": "manifests/rest-crud-route-family-catalog.json",
+      "hotspot_artifact_contract_manifest": "manifests/db-api-hotspot-artifact-io.json",
+      "readiness": {
+        "level": "partially_executable",
+        "crud": {
+          "create": {
+            "level": "executable",
+            "workload": "rest-product-batch-import",
+            "safety_class": "isolated_mutation"
+          },
+          "read": {
+            "level": "executable",
+            "workloads": ["generated-rest-request-cases", "rest-schema-query-attribution"],
+            "safety_class": "read_only"
+          },
+          "update": {
+            "level": "executable",
+            "workload": "rest-product-batch-import",
+            "safety_class": "isolated_mutation"
+          },
+          "delete": {
+            "level": "declared",
+            "upstream_blocker": "Generic rollback-safe REST delete primitive and delete-boundary rollback artifact contract are not available to this profile."
+          }
         }
       }
     }

--- a/woocommerce/woocommerce/tools/generate-target-inventory.mjs
+++ b/woocommerce/woocommerce/tools/generate-target-inventory.mjs
@@ -11,6 +11,10 @@ const packageRoot = path.join(__dirname, '..');
 
 const rig = readJson(packageRoot, 'rigs/woocommerce-performance/rig.json');
 const coverage = readJson(packageRoot, 'manifests/full-surface-coverage.json');
+const restCrudRouteFamilyCatalog = readJson(packageRoot, 'manifests/rest-crud-route-family-catalog.json');
+const blockInventoryRenderingFuzz = readJson(packageRoot, 'manifests/block-inventory-rendering-fuzz.json');
+const adminActionInventory = readJson(packageRoot, 'manifests/admin-action-inventory.json');
+const dbApiHotspotArtifactIo = readJson(packageRoot, 'manifests/db-api-hotspot-artifact-io.json');
 
 const declaredWorkloads = [...declaredFuzzIds(rig)].sort();
 
@@ -28,6 +32,36 @@ const inventory = {
   source_manifests: {
     full_surface: 'manifests/full-surface-coverage.json',
     rig: 'rigs/woocommerce-performance/rig.json',
+    rest_crud_route_family_catalog: 'manifests/rest-crud-route-family-catalog.json',
+    block_inventory_rendering_fuzz: 'manifests/block-inventory-rendering-fuzz.json',
+    admin_action_inventory: 'manifests/admin-action-inventory.json',
+    db_api_hotspot_artifact_io: 'manifests/db-api-hotspot-artifact-io.json',
+  },
+  discovery_manifests: {
+    rest_route_families: {
+      manifest: 'manifests/rest-crud-route-family-catalog.json',
+      owner_profile: restCrudRouteFamilyCatalog.owner_profile,
+      readiness: 'declared_inventory',
+      route_family_ids: restCrudRouteFamilyCatalog.route_families.map((family) => family.id),
+    },
+    blocks: {
+      manifest: 'manifests/block-inventory-rendering-fuzz.json',
+      owner_profile: blockInventoryRenderingFuzz.owner_profile,
+      readiness: blockInventoryRenderingFuzz.readiness,
+      owned_by: blockInventoryRenderingFuzz.owned_by,
+    },
+    admin_actions: {
+      manifest: 'manifests/admin-action-inventory.json',
+      owner_profile: adminActionInventory.owner_profile,
+      readiness: 'declared_inventory',
+      action_family_ids: adminActionInventory.action_families.map((family) => family.id),
+    },
+    db_api_hotspots: {
+      manifest: 'manifests/db-api-hotspot-artifact-io.json',
+      owner_profile: dbApiHotspotArtifactIo.owner_profile,
+      readiness: dbApiHotspotArtifactIo.readiness,
+      postprocess_command: dbApiHotspotArtifactIo.postprocess_command,
+    },
   },
   inventory_primitives: {
     rest_routes: {
@@ -97,8 +131,8 @@ const inventory = {
       query_attribution_fields: ['request_case_id', 'route', 'method', 'query_type', 'table', 'stack_summary', 'caller_summary'],
     },
     blocks: {
-      block_name_prefixes: ['woocommerce/'],
-      frontend_contexts: ['shop', 'product', 'cart', 'checkout'],
+      block_name_prefixes: blockInventoryRenderingFuzz.block_name_prefixes,
+      frontend_contexts: blockInventoryRenderingFuzz.frontend_contexts,
       required_sections: ['registered_blocks', 'rendered_blocks', 'block_assets', 'block_rest_requests', 'block_query_profiles'],
     },
     options_transients: {
@@ -110,6 +144,7 @@ const inventory = {
       workloads: coverage.coverage_profiles['full-surface'].performance_hotspots,
       focus_areas: ['checkout', 'cart_session', 'catalog_layered_navigation', 'admin_dashboard', 'rest_api', 'cache_invalidation', 'external_http'],
       required_sections: ['request_timing', 'query_counts', 'cache_invalidation', 'transient_growth', 'gateway_compatibility', 'external_http_guardrail'],
+      artifact_io_manifest: 'manifests/db-api-hotspot-artifact-io.json',
     },
   },
   declared_fuzz_workloads: declaredWorkloads,

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -21,6 +21,10 @@ const packageRoot = path.join(__dirname, '..');
 const rig = readJson(packageRoot, 'rigs/woocommerce-performance/rig.json');
 const coverageManifest = readJson(packageRoot, 'manifests/full-surface-coverage.json');
 const dbApiPerformanceFuzzerGapReport = readJson(packageRoot, 'manifests/db-api-performance-fuzzer-gap-report.json');
+const restCrudRouteFamilyCatalog = readJson(packageRoot, 'manifests/rest-crud-route-family-catalog.json');
+const dbApiHotspotArtifactIo = readJson(packageRoot, 'manifests/db-api-hotspot-artifact-io.json');
+const blockInventoryRenderingFuzz = readJson(packageRoot, 'manifests/block-inventory-rendering-fuzz.json');
+const adminActionInventory = readJson(packageRoot, 'manifests/admin-action-inventory.json');
 const targetInventory = readJson(packageRoot, 'manifests/target-inventory.json');
 const coverageGapReportWorkload = readJson(packageRoot, 'bench/coverage-gap-report.workload.json');
 const performanceHotspotsWorkload = readJson(packageRoot, 'bench/performance-hotspots-artifact-summary.workload.json');
@@ -120,6 +124,16 @@ const dbApiPerformanceFuzzerWorkloadIds = [
   'performance-hotspots-artifact-summary',
 ];
 const dbApiPerformanceFuzzerGapReportInputIds = dbApiPerformanceFuzzerWorkloadIds.filter((workloadId) => workloadId !== 'coverage-gap-report');
+const externalDiscoveryWorkloadIds = new Set([
+  'woocommerce-browser-coverage',
+]);
+
+function assertDeclaredOrExternalDiscoveryWorkload(workloadId, context) {
+  assert.ok(
+    declaredIds.has(workloadId) || externalDiscoveryWorkloadIds.has(workloadId),
+    `${context} references unknown workload ${workloadId}`
+  );
+}
 
 function assertArtifactPostprocessWorkload(workload, { id, action, artifactName, schema }) {
   assert.equal(workload.schema, 'wp-codebox/wordpress-workload-run/v1', `${id} must use the upstream workload-run envelope`);
@@ -176,6 +190,21 @@ assert.equal(targetInventory.schema, 'homeboy-rigs/wordpress-target-inventory/v1
 assert.equal(targetInventory.runtime?.runner, 'wp-codebox', 'target inventory must run through WP Codebox');
 assert.equal(targetInventory.runtime?.activation, 'woocommerce/woocommerce.php', 'target inventory must activate WooCommerce');
 assert.deepEqual(new Set(targetInventory.declared_fuzz_workloads), expectedFuzzIds, 'target inventory declared fuzz workloads drifted');
+assert.deepEqual(targetInventory.source_manifests, {
+  full_surface: 'manifests/full-surface-coverage.json',
+  rig: 'rigs/woocommerce-performance/rig.json',
+  rest_crud_route_family_catalog: 'manifests/rest-crud-route-family-catalog.json',
+  block_inventory_rendering_fuzz: 'manifests/block-inventory-rendering-fuzz.json',
+  admin_action_inventory: 'manifests/admin-action-inventory.json',
+  db_api_hotspot_artifact_io: 'manifests/db-api-hotspot-artifact-io.json',
+}, 'target inventory source manifests drifted');
+assert.deepEqual(rig.fuzz_profile_metadata?.['full-surface']?.discovery_manifests, {
+  rest_route_families: 'manifests/rest-crud-route-family-catalog.json',
+  blocks: 'manifests/block-inventory-rendering-fuzz.json',
+  admin_actions: 'manifests/admin-action-inventory.json',
+  db_api_hotspots: 'manifests/db-api-hotspot-artifact-io.json',
+}, 'full-surface profile discovery manifests drifted');
+assert.equal(rig.fuzz_profile_metadata?.['full-surface']?.readiness?.level, 'declared_inventory', 'full-surface discovery manifests must stay declared inventory');
 
 const requiredTargetSurfaces = new Set([
   'rest_routes',
@@ -378,11 +407,69 @@ assert.equal(dbApiPerformanceFuzzerGapReport.readiness?.level, 'declared', 'DB/A
 assert.equal(dbApiPerformanceFuzzerGapReport.readiness?.execution, 'artifact_aggregation', 'DB/API gap report workload must use artifact aggregation execution');
 assert.ok(dbApiPerformanceFuzzerGapReport.readiness?.upstream_blockers?.length > 0, 'DB/API gap report declaration must name upstream blockers');
 assert.ok(dbApiPerformanceFuzzerGapReport.readiness.upstream_blockers.some((blocker) => blocker.includes('args.helper')), 'DB/API gap report declaration must list the missing upstream artifact-postprocess fields');
+assert.equal(dbApiHotspotArtifactIo.schema, 'homeboy-rigs/woocommerce-db-api-hotspot-artifact-io/v1', 'DB/API hotspot artifact IO schema drifted');
+assert.equal(dbApiHotspotArtifactIo.postprocess_command, 'homeboy.artifact-postprocess', 'DB/API hotspot artifact IO must use upstream artifact-postprocess');
+assert.equal(dbApiHotspotArtifactIo.readiness?.level, 'declared', 'DB/API hotspot artifact IO must stay declared until artifact-postprocess binding lands');
+assert.deepEqual(new Set(dbApiHotspotArtifactIo.expected_inputs.map((input) => input.workload_id)), new Set(dbApiPerformanceFuzzerGapReportInputIds), 'DB/API hotspot artifact IO inputs drifted');
+assert.equal(dbApiHotspotArtifactIo.sample_output?.schema, 'homeboy/woocommerce-performance-hotspots-summary/v1', 'DB/API hotspot sample output schema drifted');
+assert.equal(dbApiHotspotArtifactIo.sample_output?.threshold_policy, 'relative_ranking_only', 'DB/API hotspot sample output must use relative ranking');
 assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.readiness?.crud?.read?.level, 'executable', 'DB/API rig profile read CRUD boundary must be executable');
 for (const operation of ['create', 'update', 'delete']) {
   assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.readiness?.crud?.[operation]?.level, 'declared', `DB/API rig profile ${operation} CRUD boundary must be declared`);
   assert.equal(typeof rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.readiness?.crud?.[operation]?.upstream_blocker, 'string', `DB/API rig profile ${operation} CRUD boundary must declare its upstream blocker`);
 }
+
+const productCrudProfileIds = ['rest-product-batch-import', 'woocommerce-rest-route-inventory', 'generated-rest-request-cases', 'rest-schema-query-attribution', 'coverage-gap-report'];
+assert.deepEqual(rig.fuzz_profiles?.['product-rest-crud-fuzzer'], productCrudProfileIds, 'product REST CRUD fuzzer profile workload ids drifted');
+assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.route_family_catalog_manifest, 'manifests/rest-crud-route-family-catalog.json', 'product REST CRUD profile must link the route-family catalog');
+assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.hotspot_artifact_contract_manifest, 'manifests/db-api-hotspot-artifact-io.json', 'product REST CRUD profile must link the hotspot artifact IO contract');
+assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.create?.level, 'executable', 'product REST CRUD create readiness must be executable');
+assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.update?.level, 'executable', 'product REST CRUD update readiness must be executable');
+assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.delete?.level, 'declared', 'product REST CRUD delete readiness must be declared/blocked by upstream');
+assert.equal(typeof rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.delete?.upstream_blocker, 'string', 'product REST CRUD delete readiness must name upstream blocker');
+
+const productBatchManifest = fuzzManifests.find(({ manifest }) => manifest.id === 'rest-product-batch-import')?.manifest;
+assert.equal(productBatchManifest.metadata?.readiness?.profile, 'product-rest-crud-fuzzer', 'product batch import readiness profile drifted');
+assert.equal(productBatchManifest.metadata?.readiness?.level, 'executable', 'product batch import create/update readiness must be executable');
+assert.equal(productBatchManifest.metadata?.readiness?.crud?.create?.level, 'executable', 'product batch import create readiness must be executable');
+assert.equal(productBatchManifest.metadata?.readiness?.crud?.update?.level, 'executable', 'product batch import update readiness must be executable');
+assert.equal(productBatchManifest.metadata?.readiness?.crud?.delete?.level, 'declared', 'product batch import delete readiness must remain declared/blocked');
+assert.ok(productBatchManifest.route_families.includes('wc/v3/products/batch'), 'product batch import must list products batch route family');
+assert.ok(productBatchManifest.route_families.includes('wc/v3/products/<product_id>/variations/batch'), 'product batch import must list variations batch route family');
+
+assert.equal(restCrudRouteFamilyCatalog.schema, 'homeboy-rigs/woocommerce-rest-crud-route-family-catalog/v1', 'REST CRUD route-family catalog schema drifted');
+assert.equal(restCrudRouteFamilyCatalog.owner_profile, 'product-rest-crud-fuzzer', 'REST CRUD route-family catalog owner profile drifted');
+assert.ok(restCrudRouteFamilyCatalog.route_families.length >= 4, 'REST CRUD route-family catalog must cover product collection, batch, variations, and attributes/terms');
+assert.deepEqual(targetInventory.discovery_manifests?.rest_route_families?.route_family_ids, restCrudRouteFamilyCatalog.route_families.map((family) => family.id), 'target inventory REST route-family discovery ids drifted');
+for (const family of restCrudRouteFamilyCatalog.route_families) {
+  assert.ok(Array.isArray(family.fixture_requirements) && family.fixture_requirements.length > 0, `${family.id} must declare fixture requirements`);
+  assert.ok(Array.isArray(family.owned_by?.workloads) && family.owned_by.workloads.length > 0, `${family.id} must declare owning workloads`);
+  for (const workloadId of family.owned_by.workloads) {
+    assert.ok(declaredIds.has(workloadId), `${family.id} owner workload ${workloadId} must be declared`);
+  }
+  assert.ok(family.readiness?.delete, `${family.id} must declare delete readiness`);
+}
+
+assert.equal(blockInventoryRenderingFuzz.schema, 'homeboy-rigs/woocommerce-block-inventory-rendering-fuzz/v1', 'block inventory/rendering fuzz schema drifted');
+assert.ok(blockInventoryRenderingFuzz.block_name_prefixes.includes('woocommerce/'), 'block inventory/rendering fuzz must target WooCommerce blocks');
+assert.ok(blockInventoryRenderingFuzz.frontend_contexts.includes('checkout'), 'block inventory/rendering fuzz must include checkout context');
+assert.equal(blockInventoryRenderingFuzz.readiness?.rendering, 'partial_via_frontend_browser_request_coverage', 'block rendering readiness drifted');
+assert.deepEqual(targetInventory.targets.blocks.block_name_prefixes, blockInventoryRenderingFuzz.block_name_prefixes, 'target inventory block prefixes must come from block inventory manifest');
+assert.deepEqual(targetInventory.targets.blocks.frontend_contexts, blockInventoryRenderingFuzz.frontend_contexts, 'target inventory block contexts must come from block inventory manifest');
+assert.deepEqual(targetInventory.discovery_manifests?.blocks?.readiness, blockInventoryRenderingFuzz.readiness, 'target inventory block discovery readiness drifted');
+for (const workloadId of blockInventoryRenderingFuzz.owned_by.workloads) {
+  assertDeclaredOrExternalDiscoveryWorkload(workloadId, 'block inventory discovery');
+}
+
+assert.equal(adminActionInventory.schema, 'homeboy-rigs/woocommerce-admin-action-inventory/v1', 'admin action inventory schema drifted');
+assert.ok(adminActionInventory.action_families.some((family) => family.id === 'admin-menu-get-pages' && family.readiness === 'executable_get_only'), 'admin action inventory must include executable GET-only admin menu coverage');
+assert.ok(adminActionInventory.skip_reason_codes.includes('payment_submission'), 'admin action inventory must classify payment submission skips');
+assert.deepEqual(targetInventory.discovery_manifests?.admin_actions?.action_family_ids, adminActionInventory.action_families.map((family) => family.id), 'target inventory admin action discovery ids drifted');
+for (const family of adminActionInventory.action_families) {
+  assertDeclaredOrExternalDiscoveryWorkload(family.workload, `admin action ${family.id}`);
+}
+assert.deepEqual(targetInventory.discovery_manifests?.db_api_hotspots?.readiness, dbApiHotspotArtifactIo.readiness, 'target inventory DB/API hotspot discovery readiness drifted');
+assert.equal(targetInventory.targets.performance_hotspots.artifact_io_manifest, 'manifests/db-api-hotspot-artifact-io.json', 'target inventory must link DB/API hotspot artifact IO manifest');
 assert.equal(codeboxSuite.cases?.[0]?.input?.generated_from?.route_inventory_artifact, 'route_inventory');
 assert.equal(codeboxSuite.cases?.[0]?.input?.generated_from?.request_cases_artifact, 'rest_request_cases');
 assert.equal(codeboxSuite.cases?.[0]?.input?.generated_from?.query_attribution_artifact, 'rest_schema_query_attribution');


### PR DESCRIPTION
## Summary
- Add readiness metadata and profile wiring for Woo product batch REST fuzzing.
- Add Woo REST CRUD route-family catalog for DB/API fuzz progression.
- Add hotspot artifact input/output manifest for future aggregation.
- Add Woo block inventory/rendering and admin action inventory manifests.
- Wire new manifests into target inventory generation and validation without claiming premature executable coverage.

## Verification
- `node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs`
- `node scripts/lint-rig-packages.mjs`
- `node scripts/lint-rig-packages.mjs --strict-fuzz-readiness`
- `git diff --check`
- `git diff --cached --check`

## Stack context
This is the product-level WooCommerce fuzz readiness slice. It deliberately keeps rollback-safe mutation and artifact postprocess as upstream blockers instead of shimming around them. Related upstream PRs:
- WP Codebox: https://github.com/Automattic/wp-codebox/pull/1509
- Homeboy Extensions: https://github.com/Extra-Chill/homeboy-extensions/pull/1817
- Homeboy core: https://github.com/Extra-Chill/homeboy/pull/6243

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing Woo fuzz readiness manifests, validators, docs, verification, and PR preparation.