### PR TITLE
feat(studio): add Figma import proof rig

### DIFF
--- a/Automattic/studio/bench/studio-figma-ssi-import.bench.mjs
+++ b/Automattic/studio/bench/studio-figma-ssi-import.bench.mjs
@@ -1,0 +1,378 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const WORKLOAD_UTILS = process.env.HOMEBOY_NODEJS_WORKLOAD_UTILS;
+
+if (!WORKLOAD_UTILS) {
+  throw new Error('HOMEBOY_NODEJS_WORKLOAD_UTILS is required');
+}
+
+const {
+  artifactDir: nodeArtifactDir,
+  metric,
+  redactText,
+  runNode,
+  safeResult: nodeSafeResult,
+  setting,
+} = await import(WORKLOAD_UTILS);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(__dirname, '..');
+const defaultFixturePath = path.join(
+  packageRoot,
+  'fixtures',
+  'figma-to-wordpress-studio',
+  'basic-runner-request.json'
+);
+const defaultSsiPluginUrl = 'https://github.com/Automattic/static-site-importer/releases/latest/download/static-site-importer.zip';
+
+function artifactDir(name) {
+  return nodeArtifactDir(name, { sharedState: process.env.HOMEBOY_BENCH_SHARED_STATE });
+}
+
+function redact(text) {
+  return redactText(String(text || ''), { replacement: '[redacted]' });
+}
+
+function safeResult(result) {
+  return nodeSafeResult(result, { redaction: { replacement: '[redacted]' } });
+}
+
+function runStudio(args, options = {}) {
+  return runNode(['studio', ...args], { allowFailure: true, ...options });
+}
+
+function requestTitle(request) {
+  return String(
+    request.site_title ||
+      request.title ||
+      request.name ||
+      request?.figma?.name ||
+      request?.artifact_bundle?.files?.find((file) => file.path?.endsWith('metadata.json'))?.title ||
+      'Figma Studio Import'
+  );
+}
+
+function slugify(value) {
+  const slug = String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || 'figma-studio-import';
+}
+
+function phpString(value) {
+  return JSON.stringify(String(value));
+}
+
+function buildImportPhp(requestBase64) {
+  return `<?php
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+$payload = json_decode( base64_decode( ${phpString(requestBase64)} ), true );
+if ( ! is_array( $payload ) ) {
+    throw new RuntimeException( 'Figma runner request payload could not be decoded.' );
+}
+
+function homeboy_figma_studio_artifact_path( string $path, string $root ): string {
+    $path = str_replace( '\\\\', '/', $path );
+    $path = preg_replace( '#(^|/)\\.\\.(?=/|$)#', '', $path );
+    $path = preg_replace( '#[^A-Za-z0-9_./-]#', '-', (string) $path );
+    $path = trim( preg_replace( '#/+#', '/', (string) $path ), '/' );
+    $root = trim( str_replace( '\\\\', '/', $root ), '/' );
+    if ( '' !== $root && str_starts_with( $path, $root . '/' ) ) {
+        $path = substr( $path, strlen( $root ) + 1 );
+    }
+    return '' === $path ? '' : 'website/' . ltrim( $path, '/' );
+}
+
+function homeboy_figma_studio_artifact_from_bundle( array $bundle, array $payload ): array {
+    $root = isset( $bundle['root'] ) ? (string) $bundle['root'] : 'website/';
+    $files = array();
+    foreach ( isset( $bundle['files'] ) && is_array( $bundle['files'] ) ? $bundle['files'] : array() as $file ) {
+        if ( ! is_array( $file ) || ! isset( $file['path'] ) ) {
+            continue;
+        }
+        $path = homeboy_figma_studio_artifact_path( (string) $file['path'], $root );
+        if ( '' === $path ) {
+            continue;
+        }
+        $record = array( 'path' => $path );
+        if ( isset( $file['content_base64'] ) ) {
+            $record['content_base64'] = (string) $file['content_base64'];
+        } else {
+            $record['content'] = isset( $file['content'] ) ? (string) $file['content'] : '';
+        }
+        if ( isset( $file['mime_type'] ) ) {
+            $record['mime_type'] = (string) $file['mime_type'];
+        }
+        $files[] = $record;
+    }
+    if ( empty( $files ) ) {
+        throw new RuntimeException( 'Figma runner request did not include importable artifact files.' );
+    }
+    $paths = array_map( static fn( array $file ): string => (string) ( $file['path'] ?? '' ), $files );
+    $entrypoint = homeboy_figma_studio_artifact_path( isset( $bundle['entrypoint'] ) ? (string) $bundle['entrypoint'] : 'website/index.html', 'website' );
+    if ( '' === $entrypoint || ! in_array( $entrypoint, $paths, true ) ) {
+        $entrypoint = in_array( 'website/index.html', $paths, true ) ? 'website/index.html' : (string) reset( $paths );
+    }
+    return array(
+        'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
+        'root'       => 'website',
+        'entrypoint' => $entrypoint,
+        'files'      => $files,
+        'provenance' => array(
+            'source' => 'figma-to-wordpress-studio',
+            'schema' => isset( $payload['schema'] ) ? (string) $payload['schema'] : 'figma-to-wordpress-studio/runner-request/v1',
+        ),
+    );
+}
+
+$title = isset( $payload['site_title'] ) ? (string) $payload['site_title'] : ( isset( $payload['name'] ) ? (string) $payload['name'] : 'Figma Studio Import' );
+$slug = isset( $payload['slug'] ) ? (string) $payload['slug'] : sanitize_title( $title );
+
+if ( function_exists( 'static_site_importer_ability_import_figma' ) ) {
+    $result = static_site_importer_ability_import_figma( $payload );
+} else {
+    if ( ! function_exists( 'static_site_importer_ability_import_website_artifact' ) ) {
+        throw new RuntimeException( 'Static Site Importer website artifact import ability is unavailable.' );
+    }
+    if ( empty( $payload['artifact_bundle'] ) || ! is_array( $payload['artifact_bundle'] ) ) {
+        throw new RuntimeException( 'Static Site Importer Figma ability is unavailable and no artifact_bundle fallback was provided.' );
+    }
+    $result = static_site_importer_ability_import_website_artifact( array(
+        'artifact'        => homeboy_figma_studio_artifact_from_bundle( $payload['artifact_bundle'], $payload ),
+        'slug'            => $slug,
+        'name'            => $title,
+        'site_title'      => $title,
+        'activate'        => true,
+        'overwrite'       => true,
+        'source_metadata' => array(
+            'source' => 'figma-to-wordpress-studio',
+            'runner' => 'homeboy-rigs',
+        ),
+    ) );
+}
+
+update_option( 'figma_to_wordpress_studio_import_result', $result, false );
+
+if ( ! is_array( $result ) || empty( $result['success'] ) ) {
+    throw new RuntimeException( 'Static Site Importer import failed: ' . wp_json_encode( $result ) );
+}
+?>`;
+}
+
+function buildBlueprint(request, ssiPluginUrl) {
+  const requestBase64 = Buffer.from(JSON.stringify(request)).toString('base64');
+  return {
+    landingPage: '/',
+    preferredVersions: {
+      php: '8.4',
+      wp: 'latest',
+    },
+    features: {
+      networking: true,
+    },
+    steps: [
+      {
+        step: 'login',
+      },
+      {
+        step: 'installPlugin',
+        pluginData: {
+          resource: 'url',
+          url: ssiPluginUrl,
+        },
+        options: {
+          activate: true,
+          targetFolderName: 'static-site-importer',
+        },
+      },
+      {
+        step: 'runPHP',
+        code: buildImportPhp(requestBase64),
+      },
+    ],
+  };
+}
+
+function parseStatus(stdout) {
+  const jsonStart = String(stdout || '').indexOf('{');
+  if (jsonStart === -1) {
+    throw new Error(`studio site status did not emit JSON: ${redact(stdout).slice(0, 1000)}`);
+  }
+  const status = JSON.parse(String(stdout).slice(jsonStart));
+  if (!status.siteUrl) {
+    throw new Error(`studio site status missing siteUrl: ${redact(stdout).slice(0, 1000)}`);
+  }
+  return status;
+}
+
+async function readFixture(fixturePath) {
+  const request = JSON.parse(await readFile(fixturePath, 'utf8'));
+  if (!request || typeof request !== 'object') {
+    throw new Error(`Fixture did not decode to an object: ${fixturePath}`);
+  }
+  if (!request.artifact_bundle && !request.figma && !request.scenegraph) {
+    throw new Error(`Fixture must include artifact_bundle, figma, or scenegraph: ${fixturePath}`);
+  }
+  return request;
+}
+
+async function runRequired(label, args, options = {}) {
+  const result = await runStudio(args, options);
+  if (result.code !== 0) {
+    throw new Error(`${label} failed with exit ${result.code}: ${redact(result.stderr || result.stdout).slice(-4000)}`);
+  }
+  return result;
+}
+
+export default async function studioFigmaSsiImportBench() {
+  const fixturePath = setting('figma_studio_runner_request') || defaultFixturePath;
+  const ssiPluginUrl = setting('figma_studio_ssi_plugin_url') || defaultSsiPluginUrl;
+  const siteNameSetting = setting('figma_studio_site_name');
+  const artifactRoot = artifactDir('studio-figma-ssi-import-artifacts');
+  const runId = `figma-studio-import-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const runDir = path.join(artifactRoot, runId);
+  const sitesDir = path.join(artifactRoot, 'sites');
+  await mkdir(runDir, { recursive: true });
+  await mkdir(sitesDir, { recursive: true });
+
+  const request = await readFixture(fixturePath);
+  const siteName = siteNameSetting || `${requestTitle(request)} ${process.pid}`;
+  const sitePath = path.join(sitesDir, `${slugify(siteName)}-${Date.now()}`);
+  const requestArtifact = path.join(runDir, 'runner-request.json');
+  const blueprintPath = path.join(runDir, 'blueprint.json');
+  const progressPath = path.join(runDir, 'progress.json');
+  const resultPath = path.join(runDir, 'result.json');
+  const progress = { runId, fixturePath, siteName, sitePath, steps: [] };
+
+  async function recordStep(name, result, extra = {}) {
+    progress.steps.push({
+      name,
+      exit_code: result?.code ?? null,
+      elapsed_ms: metric(result?.elapsedMs),
+      stdout_tail: redact(result?.stdout).slice(-1000),
+      stderr_tail: redact(result?.stderr).slice(-1000),
+      recorded_at: new Date().toISOString(),
+      ...extra,
+    });
+    await writeFile(progressPath, `${JSON.stringify(progress, null, 2)}\n`);
+  }
+
+  await writeFile(requestArtifact, `${JSON.stringify(request, null, 2)}\n`);
+  await writeFile(blueprintPath, `${JSON.stringify(buildBlueprint(request, ssiPluginUrl), null, 2)}\n`);
+
+  const totalStarted = Date.now();
+  const preflight = await runRequired('studio preflight', ['site', 'create', '--help'], { timeoutMs: 60000 });
+  await recordStep('studio_site_create_help', preflight);
+
+  const create = await runRequired(
+    'studio site create from Figma import Blueprint',
+    [
+      'site',
+      'create',
+      '--name',
+      siteName,
+      '--path',
+      sitePath,
+      '--blueprint',
+      blueprintPath,
+      '--skip-browser',
+      '--skip-log-details',
+    ],
+    { timeoutMs: 600000 }
+  );
+  await recordStep('studio_site_create_blueprint', create);
+
+  const statusResult = await runRequired('studio site status', ['site', 'status', '--path', sitePath, '--format', 'json'], {
+    timeoutMs: 90000,
+  });
+  const status = parseStatus(statusResult.stdout);
+  await recordStep('studio_site_status', statusResult, { siteUrl: status.siteUrl });
+
+  const pluginCheck = await runRequired(
+    'static-site-importer plugin check',
+    ['--path', sitePath, 'wp', 'plugin', 'is-installed', 'static-site-importer'],
+    { timeoutMs: 90000 }
+  );
+  await recordStep('wp_plugin_is_installed_static_site_importer', pluginCheck);
+
+  const activeTheme = await runRequired('active theme check', ['--path', sitePath, 'wp', 'option', 'get', 'stylesheet'], {
+    timeoutMs: 90000,
+  });
+  await recordStep('wp_option_get_stylesheet', activeTheme, { stylesheet: activeTheme.stdout.trim() });
+
+  const importResult = await runRequired(
+    'SSI import result option check',
+    ['--path', sitePath, 'wp', 'option', 'get', 'figma_to_wordpress_studio_import_result', '--format=json'],
+    { timeoutMs: 90000 }
+  );
+  await recordStep('wp_option_get_import_result', importResult);
+
+  let importResultJson = null;
+  try {
+    importResultJson = JSON.parse(importResult.stdout);
+  } catch {
+    throw new Error(`Import result option was not JSON: ${redact(importResult.stdout).slice(0, 1000)}`);
+  }
+  if (!importResultJson?.success) {
+    throw new Error(`Import result option did not report success: ${redact(importResult.stdout).slice(0, 2000)}`);
+  }
+
+  const stop = await runStudio(['site', 'stop', '--path', sitePath], { timeoutMs: 90000 });
+  await recordStep('studio_site_stop', stop);
+
+  const totalElapsedMs = Date.now() - totalStarted;
+  const result = {
+    runId,
+    fixturePath,
+    siteName,
+    sitePath,
+    siteUrl: status.siteUrl,
+    ssiPluginUrl,
+    activeTheme: activeTheme.stdout.trim(),
+    importResult: importResultJson,
+    timings: {
+      studio_preflight_ms: preflight.elapsedMs,
+      site_create_ms: create.elapsedMs,
+      site_status_ms: statusResult.elapsedMs,
+      total_elapsed_ms: totalElapsedMs,
+    },
+    commands: {
+      preflight: safeResult(preflight),
+      create: safeResult(create),
+      status: safeResult(statusResult),
+      pluginCheck: safeResult(pluginCheck),
+      activeTheme: safeResult(activeTheme),
+      importResult: safeResult(importResult),
+      stop: safeResult(stop),
+    },
+    artifacts: {
+      request: requestArtifact,
+      blueprint: blueprintPath,
+      progress: progressPath,
+    },
+  };
+  await writeFile(resultPath, `${JSON.stringify(result, null, 2)}\n`);
+
+  return {
+    metrics: {
+      success_rate: 1,
+      elapsed_ms: totalElapsedMs,
+      site_create_ms: metric(create.elapsedMs),
+      site_status_ms: metric(statusResult.elapsedMs),
+      active_theme_present: activeTheme.stdout.trim() ? 1 : 0,
+      import_success: importResultJson?.success ? 1 : 0,
+    },
+    artifacts: {
+      raw_result: resultPath,
+      progress: progressPath,
+      blueprint: blueprintPath,
+      runner_request: requestArtifact,
+      site_path: sitePath,
+      site_url: status.siteUrl,
+    },
+  };
+}

--- a/Automattic/studio/fixtures/figma-to-wordpress-studio/basic-runner-request.json
+++ b/Automattic/studio/fixtures/figma-to-wordpress-studio/basic-runner-request.json
@@ -1,0 +1,54 @@
+{
+  "schema": "figma-to-wordpress-studio/runner-request/v1",
+  "source": {
+    "tool": "figma",
+    "nodeIds": ["homeboy-proof-frame"],
+    "exportedAt": "2026-06-24T00:00:00.000Z"
+  },
+  "goal": "Import Homeboy Studio Figma proof into WordPress using Static Site Importer inside a Studio-created site.",
+  "name": "Homeboy Figma Studio Proof",
+  "site_title": "Homeboy Figma Studio Proof",
+  "slug": "homeboy-figma-studio-proof",
+  "artifact_bundle": {
+    "schema": "figma-to-wordpress-studio/website-artifact-bundle/v1",
+    "root": "website/",
+    "entrypoint": "website/index.html",
+    "import_source": "figma-to-wordpress-studio",
+    "files": [
+      {
+        "path": "website/index.html",
+        "role": "html",
+        "mime_type": "text/html",
+        "content": "<!doctype html>\n<html lang=\"en\">\n<head>\n  <meta charset=\"utf-8\">\n  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n  <title>Homeboy Figma Studio Proof</title>\n  <link rel=\"stylesheet\" href=\"assets/styles.css\">\n</head>\n<body>\n  <main class=\"proof-shell\">\n    <section class=\"hero\">\n      <p class=\"eyebrow\">Figma to WordPress Studio</p>\n      <h1>Imported into a brand new Studio site</h1>\n      <p class=\"lede\">This fixture proves the local Studio CLI can create a fresh site, install Static Site Importer, import a generated website artifact, and activate the resulting theme.</p>\n      <a class=\"button\" href=\"#details\">Review proof details</a>\n    </section>\n    <section id=\"details\" class=\"cards\">\n      <article><h2>Studio</h2><p>Owns the new local WordPress site lifecycle.</p></article>\n      <article><h2>SSI</h2><p>Owns the artifact-to-theme import path.</p></article>\n      <article><h2>Figma</h2><p>Supplies the runner request payload.</p></article>\n    </section>\n  </main>\n</body>\n</html>\n"
+      },
+      {
+        "path": "website/assets/styles.css",
+        "role": "css",
+        "mime_type": "text/css",
+        "content": ":root { color-scheme: dark; --bg: #10131f; --panel: #1a2033; --ink: #f5f7fb; --muted: #aeb7cc; --accent: #9dff7a; --line: rgba(255,255,255,.14); }\n* { box-sizing: border-box; }\nbody { margin: 0; min-height: 100vh; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif; color: var(--ink); background: radial-gradient(circle at 20% 10%, rgba(157,255,122,.22), transparent 28rem), linear-gradient(135deg, #10131f 0%, #171a2a 100%); }\n.proof-shell { width: min(1120px, calc(100% - 40px)); margin: 0 auto; padding: 72px 0; }\n.hero { min-height: 58vh; display: grid; align-content: center; gap: 24px; }\n.eyebrow { margin: 0; color: var(--accent); text-transform: uppercase; letter-spacing: .18em; font-weight: 800; }\nh1 { max-width: 860px; margin: 0; font-size: clamp(3rem, 9vw, 7rem); line-height: .9; letter-spacing: -.07em; }\n.lede { max-width: 720px; margin: 0; color: var(--muted); font-size: clamp(1.1rem, 2vw, 1.35rem); line-height: 1.55; }\n.button { width: max-content; display: inline-flex; align-items: center; justify-content: center; min-height: 48px; padding: 0 22px; color: #10131f; background: var(--accent); border-radius: 999px; font-weight: 800; text-decoration: none; box-shadow: 0 18px 50px rgba(157,255,122,.25); }\n.cards { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 18px; }\n.cards article { padding: 24px; border: 1px solid var(--line); background: rgba(26,32,51,.72); border-radius: 24px; backdrop-filter: blur(18px); }\n.cards h2 { margin: 0 0 10px; font-size: 1.1rem; }\n.cards p { margin: 0; color: var(--muted); line-height: 1.5; }\n@media (max-width: 760px) { .proof-shell { width: min(100% - 28px, 1120px); padding: 40px 0; } .cards { grid-template-columns: 1fr; } }\n"
+      },
+      {
+        "path": "website/metadata.json",
+        "role": "metadata",
+        "mime_type": "application/json",
+        "content": "{\n  \"title\": \"Homeboy Figma Studio Proof\",\n  \"generatedAt\": \"2026-06-24T00:00:00.000Z\",\n  \"source\": \"homeboy-rigs\"\n}\n"
+      }
+    ]
+  },
+  "figma": {
+    "schema": "figma-to-wordpress-studio/scenegraph/v1",
+    "name": "Homeboy Figma Studio Proof",
+    "exportedAt": "2026-06-24T00:00:00.000Z",
+    "root": {
+      "id": "homeboy-proof-frame",
+      "name": "Homeboy Figma Studio Proof",
+      "type": "FRAME",
+      "visible": true,
+      "width": 1440,
+      "height": 1080,
+      "children": []
+    },
+    "nodes": [],
+    "assets": []
+  }
+}

--- a/Automattic/studio/rigs/studio-figma-to-wordpress-import/rig.json
+++ b/Automattic/studio/rigs/studio-figma-to-wordpress-import/rig.json
@@ -1,0 +1,48 @@
+{
+  "id": "studio-figma-to-wordpress-import",
+  "description": "Black-box proof rig for Figma to WordPress Studio imports. Uses the installed Studio CLI to create a brand new Studio site from a generated Blueprint, installs Static Site Importer during site creation, imports a Figma runner request fixture, and verifies the imported theme through public Studio/WP-CLI commands.",
+  "components": {
+    "studio": {
+      "path": "~/Developer/studio",
+      "branch": "dev/combined-fixes",
+      "extensions": {
+        "nodejs": {
+          "settings": {
+            "studio_bench_variant": "figma-to-wordpress-import"
+          }
+        }
+      }
+    }
+  },
+  "bench": {
+    "default_component": "studio"
+  },
+  "bench_workloads": {
+    "nodejs": [
+      {
+        "path": "${package.root}/bench/studio-figma-ssi-import.bench.mjs",
+        "port_range_size": 10
+      }
+    ]
+  },
+  "pipeline": {
+    "check": [
+      {
+        "kind": "check",
+        "label": "Studio CLI is available on PATH",
+        "command": "command -v studio >/dev/null 2>&1",
+        "expect_exit": 0
+      },
+      {
+        "kind": "check",
+        "label": "Figma import bench exists",
+        "file": "${package.root}/bench/studio-figma-ssi-import.bench.mjs"
+      },
+      {
+        "kind": "check",
+        "label": "Figma runner request fixture exists",
+        "file": "${package.root}/fixtures/figma-to-wordpress-studio/basic-runner-request.json"
+      }
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -87,7 +87,20 @@ GitHub Actions runs the package lint with PHP installed.
 
 `rigs/studio-combined/rig.json` is the Studio + Playground combined-fixes dev environment: forks rebased onto trunk, open PRs cherry-picked, Docker-compiled PHP-WASM glue, tarball server, and Studio CLI rewired to local tarballs.
 
-The rig declares the local tarball server port, touched component paths, and adopted Studio/Playground process patterns in `resources` so concurrent rig commands can see the same ownership assumptions that the pipeline uses. The fixed tarball port remains `9724` because Homeboy `http-static` services currently require an integer port in the rig spec.
+`studio-figma-to-wordpress-import` is the black-box Figma to WordPress Studio proof rig. It does not modify Studio. The workload uses the installed `studio` CLI from `PATH`, writes a temporary Blueprint, creates a brand new Studio site, installs Static Site Importer during site creation, imports a Figma runner request fixture, and verifies the imported theme plus SSI import result through Studio/WP-CLI commands.
+
+```bash
+homeboy rig check studio-figma-to-wordpress-import
+homeboy bench --rig studio-figma-to-wordpress-import --scenario studio-figma-ssi-import --iterations 1 --shared-state /tmp/studio-figma-ssi-import
+```
+
+Useful settings:
+
+- `figma_studio_runner_request=/path/to/runner-request.json` points the rig at a real Figma plugin payload instead of the checked-in fixture.
+- `figma_studio_ssi_plugin_url=https://.../static-site-importer.zip` pins the SSI package used by the generated Blueprint.
+- `figma_studio_site_name="Imported Figma Site"` overrides the generated Studio site name.
+
+`studio-combined` declares the local tarball server port, touched component paths, and adopted Studio/Playground process patterns in `resources` so concurrent rig commands can see the same ownership assumptions that the pipeline uses. The fixed tarball port remains `9724` because Homeboy `http-static` services currently require an integer port in the rig spec.
 
 ```bash
 homeboy rig check studio-combined


### PR DESCRIPTION
## Summary
- Add a black-box Studio rig for proving Figma-to-WordPress Studio imports without modifying Studio.
- Add a Node bench workload that creates a brand new Studio site from a generated Blueprint, installs Static Site Importer, imports a runner request fixture, and verifies the result through Studio/WP-CLI commands.
- Document the rig, workload command, and settings for real runner payloads and SSI plugin pinning.

## Testing
- `node --check Automattic/studio/bench/studio-figma-ssi-import.bench.mjs`
- JSON parse check for `Automattic/studio/rigs/studio-figma-to-wordpress-import/rig.json` and `Automattic/studio/fixtures/figma-to-wordpress-studio/basic-runner-request.json`
- `node scripts/lint-rig-packages.mjs`
- With patched Homeboy from Extra-Chill/homeboy#6359:
  - `cargo run --quiet -- rig check "/Users/chubes/Developer/homeboy-rigs@figma-to-wordpress-studio-rig/Automattic/studio" --id studio-figma-to-wordpress-import`
  - `cargo run --quiet -- rig install "/Users/chubes/Developer/homeboy-rigs@figma-to-wordpress-studio-rig/Automattic/studio" --id studio-figma-to-wordpress-import --reinstall`
  - `cargo run --quiet -- rig check studio-figma-to-wordpress-import`

## Notes
- This PR intentionally does not run the local bench workload. Local benchmarks are avoided on this Studio machine; the rig is ready for offloaded execution.
- Full local package `rig check --id` depends on Extra-Chill/homeboy#6359 because existing Homeboy parses unrelated sibling rigs before filtering by id.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the proof rig, workload, fixture, documentation, and validation workflow.