### PR TITLE
Inline Woo REST cases for DB profile workload

### DIFF
--- a/woocommerce/woocommerce/bench/rest-db-query-profile.workload.json
+++ b/woocommerce/woocommerce/bench/rest-db-query-profile.workload.json
@@ -9,16 +9,114 @@
     {
       "type": "rest-db-query-profiler",
       "metric-prefix": "rest_db_query_profile",
-      "rest_request_cases_source": {
-        "type": "artifact",
-        "schema": "homeboy/wordpress-rest-request-cases/v1",
-        "artifact_globs": ["generated-rest-request-cases/*.json"],
-        "maxRouteCases": 80,
-        "maxArtifactBytes": 1048576
-      },
+      "rest_request_cases": [
+        {
+          "id": "woocommerce-store-products",
+          "method": "GET",
+          "path": "/wc/store/v1/products",
+          "params": { "per_page": 1 },
+          "capture-response": true,
+          "metadata": { "surface": "store_api", "expected_statuses": [200], "expected_outcome": "public_read_success" }
+        },
+        {
+          "id": "woocommerce-store-product-categories",
+          "method": "GET",
+          "path": "/wc/store/v1/products/categories",
+          "params": { "per_page": 1 },
+          "capture-response": true,
+          "metadata": { "surface": "store_api", "expected_statuses": [200], "expected_outcome": "public_read_success" }
+        },
+        {
+          "id": "woocommerce-store-product-tags",
+          "method": "GET",
+          "path": "/wc/store/v1/products/tags",
+          "params": { "per_page": 1 },
+          "capture-response": true,
+          "metadata": { "surface": "store_api", "expected_statuses": [200], "expected_outcome": "public_read_success" }
+        },
+        {
+          "id": "woocommerce-store-product-attributes",
+          "method": "GET",
+          "path": "/wc/store/v1/products/attributes",
+          "capture-response": true,
+          "metadata": { "surface": "store_api", "expected_statuses": [200], "expected_outcome": "public_read_success" }
+        },
+        {
+          "id": "woocommerce-store-product-reviews",
+          "method": "GET",
+          "path": "/wc/store/v1/products/reviews",
+          "params": { "per_page": 1 },
+          "capture-response": true,
+          "metadata": { "surface": "store_api", "expected_statuses": [200], "expected_outcome": "public_read_success" }
+        },
+        {
+          "id": "woocommerce-store-product-collection-data",
+          "method": "GET",
+          "path": "/wc/store/v1/products/collection-data",
+          "capture-response": true,
+          "metadata": { "surface": "store_api", "expected_statuses": [200], "expected_outcome": "public_read_success" }
+        },
+        {
+          "id": "woocommerce-store-cart",
+          "method": "GET",
+          "path": "/wc/store/v1/cart",
+          "capture-response": true,
+          "metadata": { "surface": "store_api", "expected_statuses": [200], "expected_outcome": "public_session_read_success" }
+        },
+        {
+          "id": "woocommerce-store-checkout",
+          "method": "GET",
+          "path": "/wc/store/v1/checkout",
+          "capture-response": true,
+          "metadata": { "surface": "store_api", "expected_statuses": [200], "expected_outcome": "public_session_read_success" }
+        },
+        {
+          "id": "woocommerce-v3-products",
+          "method": "GET",
+          "path": "/wc/v3/products",
+          "params": { "per_page": 1 },
+          "capture-response": true,
+          "metadata": { "surface": "wc_rest_api", "expected_statuses": [401, 403], "expected_outcome": "auth_boundary" }
+        },
+        {
+          "id": "woocommerce-v3-orders",
+          "method": "GET",
+          "path": "/wc/v3/orders",
+          "params": { "per_page": 1 },
+          "capture-response": true,
+          "metadata": { "surface": "wc_rest_api", "expected_statuses": [401, 403], "expected_outcome": "auth_boundary" }
+        },
+        {
+          "id": "woocommerce-v3-payment-gateways",
+          "method": "GET",
+          "path": "/wc/v3/payment_gateways",
+          "capture-response": true,
+          "metadata": { "surface": "wc_rest_api", "expected_statuses": [401, 403], "expected_outcome": "auth_boundary" }
+        },
+        {
+          "id": "woocommerce-v3-reports",
+          "method": "GET",
+          "path": "/wc/v3/reports",
+          "capture-response": true,
+          "metadata": { "surface": "wc_rest_api", "expected_statuses": [401, 403], "expected_outcome": "auth_boundary" }
+        },
+        {
+          "id": "woocommerce-v3-system-status",
+          "method": "GET",
+          "path": "/wc/v3/system_status",
+          "capture-response": true,
+          "metadata": { "surface": "wc_rest_api", "expected_statuses": [401, 403], "expected_outcome": "auth_boundary" }
+        },
+        {
+          "id": "woocommerce-admin-options",
+          "method": "GET",
+          "path": "/wc-admin/options",
+          "capture-response": true,
+          "metadata": { "surface": "wc_admin_api", "expected_statuses": [401, 403], "expected_outcome": "auth_boundary" }
+        }
+      ],
       "sampleLimit": 50,
-      "queryLengthLimit": 500,
-      "fallback_policy": "require_generated_rest_request_cases_artifact"
+      "queryLengthLimit": 500
     }
   ],
   "metadata": {


### PR DESCRIPTION
## Summary
- Make the Woo REST DB query profile workload self-contained by inlining bounded REST request cases.
- Remove the hard dependency on a prior `generated-rest-request-cases` artifact for this workload.
- Preserve the same safe read/auth-boundary route set used by the generated REST request cases workload.

## Testing
- `node -e "JSON.parse(require('node:fs').readFileSync('woocommerce/woocommerce/bench/rest-db-query-profile.workload.json','utf8')); console.log('json ok')"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the missing artifact dependency in the Woo DB profile workload and converting the workload to a self-contained executable shape.
