### PR TITLE
Generate Woo REST cases before DB profiling

### DIFF
--- a/woocommerce/woocommerce/bench/generated-rest-request-cases.php
+++ b/woocommerce/woocommerce/bench/generated-rest-request-cases.php
@@ -184,7 +184,7 @@ return function (): array {
 	);
 
 	$artifact_path = '';
-	$shared_state  = getenv( 'HOMEBOY_BENCH_SHARED_STATE' );
+	$shared_state  = getenv( 'WP_CODEBOX_BENCH_SHARED_STATE' );
 	if ( $shared_state ) {
 		$artifact_dir = rtrim( $shared_state, '/' ) . '/generated-rest-request-cases';
 		wp_mkdir_p( $artifact_dir );

--- a/woocommerce/woocommerce/bench/rest-db-query-profile.workload.json
+++ b/woocommerce/woocommerce/bench/rest-db-query-profile.workload.json
@@ -7,6 +7,10 @@
       "code": "$template_functions = WP_PLUGIN_DIR . '/woocommerce/includes/wc-template-functions.php'; if (!is_readable($template_functions)) { throw new RuntimeException('WooCommerce template functions are required for Store API product responses.'); } require_once $template_functions; return array('metadata' => array('woocommerce_template_functions_loaded' => function_exists('wc_get_quantity_input_args')));"
     },
     {
+      "type": "php",
+      "file": "bench/generated-rest-request-cases.php"
+    },
+    {
       "type": "rest-db-query-profiler",
       "metric-prefix": "rest_db_query_profile",
       "rest_request_cases_source": {


### PR DESCRIPTION
## Summary
- run the generated REST request case workload before the DB query profiler
- write generated case artifacts through the Codebox-owned WP_CODEBOX_BENCH_SHARED_STATE directory
- keep the DB profiler on the generated artifact source contract instead of hard-coded route cases

## Dependency
- Depends on https://github.com/Automattic/wp-codebox/pull/1519 for wordpress.bench artifact-source resolution.
- Supersedes the inline-case approach in #445.

## Testing
- node scripts/lint-rig-packages.mjs
- node --test woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the contract failure, implementing the workload/env update, and running validation.