### PR TITLE
Add Static Site Importer fixture matrix rig

### DIFF
--- a/WordPress/static-site-importer/README.md
+++ b/WordPress/static-site-importer/README.md
@@ -1,0 +1,32 @@
+# Static Site Importer Rigs
+
+`static-site-importer-fixture-matrix` is a product-level fixture matrix for Static
+Site Importer quality checks. It keeps SSI-specific defaults, fixture discovery,
+expected artifact names, and diagnostic grouping in this package while invoking
+generic Homeboy/Homeboy Extensions primitives for WP Codebox recipe execution.
+
+```bash
+homeboy rig check static-site-importer-fixture-matrix
+node WordPress/static-site-importer/bench/static-site-fixture-matrix.mjs \
+  --fixture-root WordPress/static-site-importer/fixtures \
+  --static-site-importer-path ~/Developer/static-site-importer
+```
+
+Add `--run` only in an approved non-local execution environment. The default
+command writes matrix, recipe, summary, result, and finding-packet artifacts
+without launching WP Codebox.
+
+## Generic Invocation
+
+The workload composes these generic surfaces:
+
+- Homeboy rig package discovery and `bench_workloads.nodejs` registration.
+- `shared/wp-codebox/check-cli.sh` for rig-level WP Codebox CLI availability.
+- `shared/wp-codebox/recipe.mjs` for Homeboy Extensions WP Codebox recipe
+  execution when `--run` is explicitly provided.
+- WP Codebox `workspace-recipe/v1` steps using generic `wordpress.wp-cli`
+  commands.
+
+SSI-specific behavior remains here: plugin slug/defaults, fixture artifact
+packing, `static-site-importer validate-in-codebox` command construction,
+artifact expectations, and diagnostic-to-repair grouping.

--- a/WordPress/static-site-importer/bench/static-site-fixture-matrix.mjs
+++ b/WordPress/static-site-importer/bench/static-site-fixture-matrix.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runWpCodeboxRecipe } from '../../../shared/wp-codebox/recipe.mjs';
+import {
+  buildFixtureMatrixRecipe,
+  collectFixtureMatrixRunResults,
+  createFixtureMatrix,
+  normalizeFixtureMatrixResult,
+  writeFixtureMatrixArtifacts,
+  writeFixtureMatrixResultArtifacts,
+} from '../lib/fixture-matrix.mjs';
+
+const DEFAULT_BATCH_SIZE = 10;
+const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const fixtureRoot = path.resolve(options.fixtureRoot || path.join(packageRoot, 'fixtures'));
+  const outputDirectory = path.resolve(options.outputDirectory || path.join(process.cwd(), 'artifacts', 'static-site-importer-fixture-matrix'));
+  const staticSiteImporterPath = options.staticSiteImporterPath || process.env.HOMEBOY_STATIC_SITE_IMPORTER_PATH || path.resolve(process.env.HOME || '.', 'Developer/static-site-importer');
+  const matrix = createFixtureMatrix({
+    id: options.id || `static-site-importer-fixture-matrix-${Date.now()}`,
+    fixture_root: fixtureRoot,
+    entrypoint: options.entrypoint || 'index.html',
+    maxDepth: options.maxDepth,
+  });
+  const written = writeFixtureMatrixArtifacts({ outputDirectory, matrix });
+  const recipe = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: outputDirectory,
+    playgroundArtifactsDirectory: options.playgroundArtifactsDirectory || '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix',
+    wordpressVersion: options.wordpressVersion,
+    staticSiteImporterPath,
+    staticSiteImporterPlugin: options.staticSiteImporterPlugin,
+    staticSiteImporterSlug: options.staticSiteImporterSlug,
+  });
+  const recipeFile = path.join(outputDirectory, 'wp-codebox-static-site-fixture-matrix-recipe.json');
+  fs.writeFileSync(recipeFile, `${JSON.stringify(recipe, null, 2)}\n`);
+
+  let runtime = null;
+  let runtimeError = null;
+  let collectedResult = written.result;
+  if (options.run) {
+    const batchSize = positiveInteger(options.batchSize, DEFAULT_BATCH_SIZE);
+    const batchRuns = [];
+    const batchResults = [];
+    for (const [batchIndex, fixtures] of chunk(matrix.fixtures, batchSize).entries()) {
+      const batchNumber = batchIndex + 1;
+      const batchSuffix = String(batchNumber).padStart(3, '0');
+      const batchMatrix = createFixtureMatrix({
+        id: `${matrix.id}-batch-${batchSuffix}`,
+        fixture_root: matrix.fixture_root,
+        entrypoint: matrix.entrypoint,
+        fixtures,
+      });
+      const batchRecipe = buildFixtureMatrixRecipe({
+        matrix: batchMatrix,
+        artifactsDirectory: outputDirectory,
+        playgroundArtifactsDirectory: options.playgroundArtifactsDirectory || '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix',
+        wordpressVersion: options.wordpressVersion,
+        staticSiteImporterPath,
+        staticSiteImporterPlugin: options.staticSiteImporterPlugin,
+        staticSiteImporterSlug: options.staticSiteImporterSlug,
+      });
+      const batchRecipeFile = path.join(outputDirectory, `wp-codebox-static-site-fixture-matrix-batch-${batchSuffix}.json`);
+      const outputFile = path.join(outputDirectory, `wp-codebox-output-batch-${batchSuffix}.json`);
+      fs.writeFileSync(batchRecipeFile, `${JSON.stringify(batchRecipe, null, 2)}\n`);
+
+      let batchRuntime = null;
+      let batchError = null;
+      try {
+        batchRuntime = await runWpCodeboxRecipe({
+          recipeFile: batchRecipeFile,
+          artifactsDir: outputDirectory,
+          outputFile,
+          wpCodeboxBin: options.wpCodeboxBin,
+        });
+      } catch (error) {
+        batchError = error;
+        batchRuntime = {
+          exitCode: error?.code ?? 1,
+          outputFile,
+          json: parseJsonText(error?.stdout),
+        };
+        runtimeError ||= error;
+      }
+      batchRuns.push({
+        batch: batchNumber,
+        fixture_count: fixtures.length,
+        recipe_file: batchRecipeFile,
+        output_file: outputFile,
+        exit_code: batchRuntime?.exitCode ?? 0,
+        error: batchError ? batchError.message : '',
+      });
+      batchResults.push(collectFixtureMatrixRunResults({
+        matrix: batchMatrix,
+        outputDirectory,
+        outputFile,
+        codeboxOutput: batchRuntime?.json,
+        codeboxError: batchError,
+      }));
+    }
+    collectedResult = normalizeFixtureMatrixResult({
+      matrix,
+      results: batchResults.flatMap((result) => result.fixtures),
+    });
+    runtime = {
+      exitCode: runtimeError ? (batchRuns.find((batch) => batch.exit_code)?.exit_code || 1) : 0,
+      batchSize,
+      batches: batchRuns,
+    };
+    writeFixtureMatrixResultArtifacts({ outputDirectory, matrix, result: collectedResult });
+  }
+
+  const summary = {
+    schema: 'homeboy-rigs/static-site-importer-fixture-matrix-cli-run/v1',
+    matrix_id: matrix.id,
+    fixture_root: matrix.fixture_root,
+    fixture_count: matrix.count,
+    output_directory: outputDirectory,
+    recipe_file: recipeFile,
+    artifact_refs: written.artifact_refs,
+    result_file: path.join(outputDirectory, 'static-site-fixture-matrix-result.json'),
+    result_summary: collectedResult.summary,
+    runtime: runtime ? runtimeSummary(runtime, runtimeError) : null,
+  };
+  fs.writeFileSync(path.join(outputDirectory, 'cli-run.json'), `${JSON.stringify(summary, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  if (runtimeError) {
+    process.exitCode = runtime.exitCode || 1;
+  }
+}
+
+function runtimeSummary(runtime, runtimeError) {
+  return {
+    exit_code: runtime.exitCode,
+    ...(runtime.batchSize ? { batch_size: runtime.batchSize } : {}),
+    ...(runtime.batches ? { batches: runtime.batches } : {}),
+    error: runtimeError ? runtimeError.message : '',
+  };
+}
+
+function parseArgs(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+    if (arg === '--run') {
+      options.run = true;
+      continue;
+    }
+    if (arg.startsWith('--')) {
+      const [rawKey, rawValue] = arg.slice(2).split('=');
+      const key = camelCase(rawKey);
+      const value = rawValue === undefined ? args[index + 1] : rawValue;
+      if (rawValue === undefined) {
+        index += 1;
+      }
+      options[key] = value;
+      continue;
+    }
+    if (!options.fixtureRoot) {
+      options.fixtureRoot = arg;
+    }
+  }
+  return options;
+}
+
+function chunk(items, size) {
+  const chunks = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseJsonText(text) {
+  try {
+    return text ? JSON.parse(text) : null;
+  } catch {
+    return null;
+  }
+}
+
+function camelCase(value) {
+  return value.replace(/-([a-z])/g, (_match, letter) => letter.toUpperCase());
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: static-site-fixture-matrix [fixture-root] [options]\n\nOptions:\n  --fixture-root <path>              Static-site fixture root. Defaults to this package's fixtures directory.\n  --output-directory <path>          Artifact output directory.\n  --static-site-importer-path <path> Static Site Importer checkout/plugin directory.\n  --static-site-importer-slug <slug> Plugin slug. Defaults to static-site-importer.\n  --static-site-importer-plugin <p>  Plugin activation file. Defaults to static-site-importer/static-site-importer.php.\n  --entrypoint <file>                Fixture entrypoint. Defaults to index.html.\n  --max-depth <n>                    Fixture discovery depth. Defaults to 2.\n  --wordpress-version <version>      WP Codebox WordPress version. Defaults to latest.\n  --batch-size <n>                   Fixtures per WP Codebox run when --run is used. Defaults to 10.\n  --run                             Execute WP Codebox recipes. Omit locally to only materialize artifacts.\n`);
+}
+
+await main();

--- a/WordPress/static-site-importer/docs/generic-orchestration-contract.md
+++ b/WordPress/static-site-importer/docs/generic-orchestration-contract.md
@@ -1,0 +1,51 @@
+# SSI Fixture Matrix Orchestration Contract
+
+This rig does not require unmerged Static Site Importer support in Homeboy or
+Homeboy Extensions. It calls the current generic WP Codebox recipe execution
+surface and supplies all SSI policy from this package.
+
+## Required Current Interfaces
+
+- `shared/wp-codebox/recipe.mjs` must expose `runWpCodeboxRecipe(options)`.
+- `runWpCodeboxRecipe(options)` must accept `recipeFile`, `artifactsDir`,
+  `outputFile`, and optional `wpCodeboxBin`.
+- WP Codebox recipes must accept schema `wp-codebox/workspace-recipe/v1`.
+- WP Codebox workflow steps must support `command: "wordpress.wp-cli"` with an
+  `args` entry containing a `command=...` WP-CLI string.
+- WP Codebox recipe inputs must support `extra_plugins` entries with `source`,
+  `slug`, and `activate`, plus `mounts` entries with `source`, `target`, and
+  `mode`.
+
+## SSI-Owned Inputs
+
+- Fixture root discovery starts at `--fixture-root`, defaults to an `index.html`
+  entrypoint, and descends two directory levels unless `--max-depth` is set.
+- The Static Site Importer plugin source is `--static-site-importer-path`.
+- The default plugin slug is `static-site-importer`.
+- The default activation file is
+  `static-site-importer/static-site-importer.php`.
+
+## SSI-Owned Artifacts
+
+- `matrix.json`: discovered fixture matrix.
+- `<fixture-id>/artifact.json`: Blocks Engine site artifact input for SSI.
+- `wp-codebox-static-site-fixture-matrix-recipe.json`: full matrix recipe.
+- `wp-codebox-static-site-fixture-matrix-batch-NNN.json`: batch recipes when
+  `--run` is used.
+- `static-site-fixture-matrix-result.json`: normalized fixture results.
+- `summary.json`: aggregate pass/fail/finding counts.
+- `finding-packets.json`: grouped diagnostics for repair fanout.
+- `cli-run.json`: command summary and runtime metadata.
+
+## Diagnostic Interpretation
+
+The rig classifies SSI validation payloads into product repair groups here rather
+than in generic Homeboy layers:
+
+- `button_style_loss` maps to `blocks-engine` transformer style parity.
+- `broken_svg` maps to `blocks-engine` SVG transformer parity.
+- `dropped_images` maps to `static-site-importer` asset materialization.
+- `invalid_block_content` maps to `blocks-engine` block validation parity.
+- `runtime_target_gap` maps to `blocks-engine` runtime DOM target parity.
+- Unclassified findings remain `static_site_import_quality` for SSI import
+  validation.

--- a/WordPress/static-site-importer/fixtures/simple-site/index.html
+++ b/WordPress/static-site-importer/fixtures/simple-site/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Simple SSI Fixture</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="site-shell">
+    <h1>Simple SSI Fixture</h1>
+    <p>This fixture proves matrix discovery and artifact packing without running a browser.</p>
+    <a class="button" href="/contact/">Contact</a>
+  </main>
+</body>
+</html>

--- a/WordPress/static-site-importer/fixtures/simple-site/style.css
+++ b/WordPress/static-site-importer/fixtures/simple-site/style.css
@@ -1,0 +1,14 @@
+.site-shell {
+  font-family: system-ui, sans-serif;
+  margin: 4rem auto;
+  max-width: 42rem;
+}
+
+.button {
+  background: #14532d;
+  border-radius: 999px;
+  color: #fff;
+  display: inline-block;
+  padding: 0.75rem 1rem;
+  text-decoration: none;
+}

--- a/WordPress/static-site-importer/lib/fixture-matrix.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix.mjs
@@ -1,0 +1,746 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const FIXTURE_MATRIX_SCHEMA = 'homeboy-rigs/static-site-importer-fixture-matrix/v1';
+export const FIXTURE_MATRIX_RESULT_SCHEMA = 'homeboy-rigs/static-site-importer-fixture-matrix-result/v1';
+export const WEBSITE_ARTIFACT_SCHEMA = 'blocks-engine/php-transformer/site-artifact/v1';
+
+const DEFAULT_ENTRYPOINT = 'website/index.html';
+const DEFAULT_IMPORTER_SLUG = 'static-site-importer';
+const DEFAULT_FINDING_GROUPS = {
+  button_style_loss: {
+    patterns: [/default gray button/i, /button.*gray/i, /button.*style/i],
+    candidate_repo: 'blocks-engine',
+    repair_mode: 'transformer-style-parity',
+  },
+  broken_svg: {
+    patterns: [/broken svg/i, /svg.*broken/i, /svg.*missing/i],
+    candidate_repo: 'blocks-engine',
+    repair_mode: 'svg-transformer-parity',
+  },
+  dropped_images: {
+    patterns: [/dropped image/i, /missing image/i, /image.*missing/i, /asset.*missing/i],
+    candidate_repo: 'static-site-importer',
+    repair_mode: 'asset-materialization',
+  },
+  invalid_block_content: {
+    patterns: [/unexpected or invalid content/i, /invalid block/i, /block validation/i],
+    candidate_repo: 'blocks-engine',
+    repair_mode: 'block-validation-parity',
+  },
+  runtime_target_gap: {
+    patterns: [/runtime_dependency_target_missing/i, /html_canvas_runtime_fallback/i, /canvas/i, /animation/i, /script target/i],
+    candidate_repo: 'blocks-engine',
+    repair_mode: 'runtime-dom-target-parity',
+  },
+};
+
+export function discoverFixtures(root, options = {}) {
+  const fixtureRoot = requiredDirectory(root || options.fixtureRoot || options.fixture_root, 'fixtureRoot');
+  const entrypoint = options.entrypoint || 'index.html';
+  const maxDepth = finiteNumber(options.maxDepth ?? options.max_depth, 2);
+  const fixtures = [];
+
+  visitFixtureDirectory(fixtureRoot, 0, maxDepth, (directory) => {
+    const entryPath = path.join(directory, entrypoint);
+    if (!fs.existsSync(entryPath) || !fs.statSync(entryPath).isFile()) {
+      return;
+    }
+
+    fixtures.push(normalizeFixture({ root: fixtureRoot, directory, entrypoint }));
+  });
+
+  return fixtures.sort((left, right) => left.id.localeCompare(right.id));
+}
+
+export function createFixtureMatrix(input = {}) {
+  const fixtures = normalizeArray(input.fixtures || discoverFixtures(input.fixture_root || input.fixtureRoot, input))
+    .map((fixture) => normalizeFixture(fixture));
+  return {
+    schema: FIXTURE_MATRIX_SCHEMA,
+    id: input.id || input.run_id || input.runId || 'static-site-importer-fixture-matrix',
+    fixture_root: input.fixture_root || input.fixtureRoot || fixtures[0]?.fixture_root || '',
+    entrypoint: input.entrypoint || 'index.html',
+    count: fixtures.length,
+    fixtures,
+    artifacts: {
+      result: input.result_artifact || input.resultArtifact || 'static-site-fixture-matrix-result.json',
+      summary: input.summary_artifact || input.summaryArtifact || 'summary.json',
+      findings: input.findings_artifact || input.findingsArtifact || 'finding-packets.json',
+    },
+  };
+}
+
+export function buildFixtureArtifact(fixture, options = {}) {
+  const normalized = normalizeFixture(fixture);
+  const files = collectFixtureFiles(normalized.directory, options);
+  const artifactFiles = files.map((file) => {
+    const payload = fs.readFileSync(file.absolute_path);
+    const artifactFile = {
+      path: `website/${file.relative_path}`,
+      source_path: file.absolute_path,
+      type: file.type,
+      bytes: file.bytes,
+    };
+    if (isTextPayloadType(file.type)) {
+      artifactFile.content = payload.toString('utf8');
+    } else {
+      artifactFile.content_base64 = payload.toString('base64');
+    }
+    return artifactFile;
+  });
+
+  return {
+    schema: WEBSITE_ARTIFACT_SCHEMA,
+    entrypoint: DEFAULT_ENTRYPOINT,
+    entry_path: DEFAULT_ENTRYPOINT,
+    files: artifactFiles,
+    summary: {
+      file_count: artifactFiles.length,
+      entry_path: DEFAULT_ENTRYPOINT,
+      has_css: artifactFiles.some((file) => file.path.endsWith('.css')),
+      has_js: artifactFiles.some((file) => file.path.endsWith('.js')),
+      has_images: artifactFiles.some((file) => isImagePath(file.path)),
+    },
+    source_metadata: {
+      fixture_id: normalized.id,
+      fixture_path: normalized.directory,
+      fixture_entrypoint: normalized.entrypoint,
+    },
+  };
+}
+
+export function buildFixtureMatrixRecipe(input = {}) {
+  const matrix = input.matrix || createFixtureMatrix(input);
+  const artifactsDirectory = input.artifactsDirectory || input.artifacts_directory || '/artifacts/static-site-importer-fixture-matrix';
+  const playgroundArtifactsDirectory = input.playgroundArtifactsDirectory || input.playground_artifacts_directory;
+  const commandArtifactsDirectory = playgroundArtifactsDirectory || artifactsDirectory;
+  const importer = normalizeStaticSiteImporterPlugin(input);
+  const mounts = normalizeArray(input.mounts);
+  const extraPlugins = [importer.extraPlugin, ...normalizeArray(input.extraPlugins || input.extra_plugins)];
+
+  if (playgroundArtifactsDirectory) {
+    mounts.push({
+      source: artifactsDirectory,
+      target: playgroundArtifactsDirectory,
+      mode: 'readwrite',
+    });
+  }
+
+  return {
+    schema: 'wp-codebox/workspace-recipe/v1',
+    runtime: {
+      wp: input.wordpressVersion || input.wordpress_version || 'latest',
+      blueprint: input.blueprint || {},
+    },
+    inputs: {
+      mounts,
+      extra_plugins: extraPlugins,
+    },
+    workflow: {
+      steps: [
+        importer.activationStep,
+        ...matrix.fixtures.map((fixture) => ({
+          command: 'wordpress.wp-cli',
+          args: [
+            `command=static-site-importer validate-in-codebox --artifact=${shellToken(path.join(commandArtifactsDirectory, fixture.id, 'artifact.json'))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --allow-missing-woocommerce --allow-failure`,
+          ],
+        })),
+      ],
+    },
+    artifacts: {
+      directory: artifactsDirectory,
+    },
+  };
+}
+
+export function normalizeStaticSiteImporterPlugin(input = {}) {
+  const source = requiredString(input.staticSiteImporterPath || input.static_site_importer_path, 'staticSiteImporterPath');
+  const slugValue = input.staticSiteImporterSlug || input.static_site_importer_slug || DEFAULT_IMPORTER_SLUG;
+  const pluginFile = input.staticSiteImporterPlugin || input.static_site_importer_plugin || `${slugValue}/${slugValue}.php`;
+  return {
+    extraPlugin: {
+      source,
+      slug: slugValue,
+      activate: true,
+    },
+    activationStep: {
+      command: 'wordpress.wp-cli',
+      args: [`command=plugin activate ${pluginFile}`],
+    },
+  };
+}
+
+export function normalizeFixtureMatrixResult(input = {}) {
+  const matrix = input.matrix || createFixtureMatrix(input);
+  const results = normalizeArray(input.results || input.fixture_results || input.fixtureResults).map(normalizeFixtureResult);
+  const resultByFixture = new Map(results.map((result) => [result.fixture_id, result]));
+  const fixtureResults = matrix.fixtures.map((fixture) => resultByFixture.get(fixture.id) || normalizeFixtureResult({ fixture_id: fixture.id, fixture_path: fixture.fixture_path, status: 'not_run' }));
+  const findings = fixtureResults.flatMap((result) => findingsForFixtureResult(result, { matrix }));
+  const grouped = groupFindings(findings);
+
+  return {
+    schema: FIXTURE_MATRIX_RESULT_SCHEMA,
+    matrix_id: matrix.id,
+    fixture_root: matrix.fixture_root,
+    summary: {
+      fixture_count: matrix.fixtures.length,
+      succeeded: fixtureResults.filter((result) => result.status === 'passed').length,
+      failed: fixtureResults.filter((result) => result.status === 'failed').length,
+      not_run: fixtureResults.filter((result) => result.status === 'not_run').length,
+      finding_count: findings.length,
+      groups: Object.fromEntries(Object.entries(grouped).map(([key, items]) => [key, items.length])),
+    },
+    fixtures: fixtureResults,
+    findings,
+    fanout_groups: Object.entries(grouped).map(([group_key, items], index) => ({ group_key, index, findings: items })),
+  };
+}
+
+export function collectFixtureMatrixRunResults(input = {}) {
+  const matrix = input.matrix || createFixtureMatrix(input);
+  const outputDirectory = requiredString(input.outputDirectory || input.output_directory, 'outputDirectory');
+  const codeboxOutput = input.codeboxOutput || input.codebox_output || readJsonFileIfExists(input.outputFile || input.output_file) || null;
+  const codeboxError = input.codeboxError || input.codebox_error || null;
+  const runtimePayloads = collectRuntimePayloads(codeboxOutput);
+  const results = matrix.fixtures.map((fixture) => {
+    const fixtureArtifactsDirectory = path.join(outputDirectory, fixture.id);
+    const payloads = [
+      ...runtimePayloads.filter((payload) => fixtureIdentity(payload) === fixture.id),
+      ...readFixturePayloadFiles(fixtureArtifactsDirectory),
+    ];
+    return normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError });
+  });
+
+  return normalizeFixtureMatrixResult({ matrix, results });
+}
+
+export function writeFixtureMatrixArtifacts(input = {}) {
+  const outputDirectory = requiredString(input.outputDirectory || input.output_directory, 'outputDirectory');
+  const matrix = input.matrix || createFixtureMatrix(input);
+  const result = input.result || normalizeFixtureMatrixResult({ ...input, matrix });
+
+  fs.mkdirSync(outputDirectory, { recursive: true });
+  for (const fixture of matrix.fixtures) {
+    const fixtureDirectory = path.join(outputDirectory, fixture.id);
+    fs.mkdirSync(fixtureDirectory, { recursive: true });
+    writeJsonFile(path.join(fixtureDirectory, 'artifact.json'), buildFixtureArtifact(fixture, input));
+  }
+
+  writeJsonFile(path.join(outputDirectory, 'matrix.json'), matrix);
+  writeFixtureMatrixResultArtifacts({ outputDirectory, matrix, result });
+
+  return {
+    matrix,
+    result,
+    artifact_refs: [
+      artifactRef('matrix', path.join(outputDirectory, 'matrix.json'), 'matrix'),
+      artifactRef('result', path.join(outputDirectory, 'static-site-fixture-matrix-result.json'), 'diagnostic'),
+      artifactRef('summary', path.join(outputDirectory, 'summary.json'), 'summary'),
+      artifactRef('finding-packets', path.join(outputDirectory, 'finding-packets.json'), 'diagnostic'),
+    ],
+  };
+}
+
+export function writeFixtureMatrixResultArtifacts(input = {}) {
+  const outputDirectory = requiredString(input.outputDirectory || input.output_directory, 'outputDirectory');
+  const matrix = input.matrix || createFixtureMatrix(input);
+  const result = input.result || normalizeFixtureMatrixResult({ ...input, matrix });
+  writeJsonFile(path.join(outputDirectory, 'static-site-fixture-matrix-result.json'), result);
+  writeJsonFile(path.join(outputDirectory, 'summary.json'), result.summary);
+  writeJsonFile(path.join(outputDirectory, 'finding-packets.json'), result.findings);
+  return result;
+}
+
+export function classifyStaticSiteFinding(input = {}) {
+  const haystack = [input.kind, input.code, input.category, input.message, input.reason, input.detail]
+    .filter(Boolean)
+    .join(' ');
+  for (const [group_key, group] of Object.entries(DEFAULT_FINDING_GROUPS)) {
+    if (group.patterns.some((pattern) => pattern.test(haystack))) {
+      return { group_key, candidate_repo: group.candidate_repo, repair_mode: group.repair_mode };
+    }
+  }
+  return {
+    group_key: DEFAULT_FINDING_GROUPS[input.group_key] ? input.group_key : 'static_site_import_quality',
+    candidate_repo: input.candidate_repo || 'static-site-importer',
+    repair_mode: input.repair_mode || 'import-validation',
+  };
+}
+
+function findingsForFixtureResult(result, context = {}) {
+  const diagnostics = normalizeArray(result.diagnostics || result.findings || result.messages);
+  const findings = diagnostics.map((diagnostic, index) => normalizeDiagnosticFinding(diagnostic, result, index));
+  if (result.status === 'failed' && findings.length === 0) {
+    findings.push(normalizeDiagnosticFinding({ kind: 'fixture_failed', message: result.error || 'Static-site fixture validation failed without a structured diagnostic.' }, result, 0));
+  }
+  if (context.matrix?.fixtures?.some((fixture) => fixture.id === result.fixture_id) && result.status === 'not_run') {
+    findings.push(normalizeDiagnosticFinding({ kind: 'fixture_not_run', message: 'Static-site fixture was discovered but did not produce a validation result.' }, result, 0));
+  }
+  return findings;
+}
+
+function normalizeDiagnosticFinding(diagnostic, result, index) {
+  const raw = diagnostic && typeof diagnostic === 'object' ? diagnostic : { message: String(diagnostic || '') };
+  const message = raw.message || raw.reason || raw.detail || raw.code || result.error || '';
+  const group = classifyStaticSiteFinding({ ...raw, message });
+  return {
+    id: raw.id || `${result.fixture_id || 'fixture'}:${group.group_key}:${index + 1}`,
+    kind: raw.kind || raw.code || 'static_site_fixture_diagnostic',
+    category: raw.category || group.group_key,
+    group_key: group.group_key,
+    severity: raw.severity || (result.status === 'failed' ? 'error' : 'warning'),
+    fixture_id: result.fixture_id || '',
+    path: raw.path || raw.source_path || result.fixture_path || '',
+    source_path: raw.source_path || raw.path || result.fixture_path || '',
+    selector: raw.selector || '',
+    reason: message,
+    repair_mode: raw.repair_mode || group.repair_mode,
+    candidate_repo: raw.candidate_repo || group.candidate_repo,
+    artifact_refs: normalizeArray(raw.artifact_refs),
+    raw,
+  };
+}
+
+function normalizeFixture(input) {
+  const directory = requiredDirectory(input.directory || input.path || input.fixture_path || input.fixturePath, 'fixture.directory');
+  const root = input.root || input.fixture_root || input.fixtureRoot || path.dirname(directory);
+  const relative = path.relative(path.resolve(root), path.resolve(directory));
+  const id = slug(input.id || input.slug || (relative && !relative.startsWith('..') ? relative : path.basename(directory)));
+  return {
+    id,
+    label: input.label || input.name || id,
+    directory,
+    fixture_path: directory,
+    fixture_root: root,
+    entrypoint: input.entrypoint || 'index.html',
+  };
+}
+
+function normalizeFixtureResult(input) {
+  let status = input.status || 'not_run';
+  if (!input.status && input.success === true) {
+    status = 'passed';
+  } else if (!input.status && input.success === false) {
+    status = 'failed';
+  }
+  return {
+    fixture_id: input.fixture_id || input.fixtureId || input.id || '',
+    fixture_path: input.fixture_path || input.fixturePath || input.path || '',
+    status,
+    success: status === 'passed',
+    error: input.error || input.message || '',
+    ssi_validation: input.ssi_validation || input.ssiValidation || null,
+    import_report: input.import_report || input.importReport || null,
+    quality_metrics: input.quality_metrics || input.qualityMetrics || {},
+    blocks_engine_diagnostics: normalizeArray(input.blocks_engine_diagnostics || input.blocksEngineDiagnostics),
+    invalid_block_counts: input.invalid_block_counts || input.invalidBlockCounts || {},
+    missing_assets: normalizeArray(input.missing_assets || input.missingAssets),
+    runtime_target_gaps: normalizeArray(input.runtime_target_gaps || input.runtimeTargetGaps),
+    diagnostics: normalizeArray(input.diagnostics || input.findings || input.messages),
+    artifact_refs: normalizeArray(input.artifact_refs || input.artifactRefs),
+    artifacts: input.artifacts || {},
+    raw: input,
+  };
+}
+
+function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError }) {
+  const merged = mergeObjects(payloads);
+  const diagnostics = collectFixtureDiagnostics(merged);
+  const error = firstString([
+    merged.error,
+    merged.message && isFailurePayload(merged) ? merged.message : '',
+    codeboxError && payloads.length === 0 ? codeboxError.message || String(codeboxError) : '',
+  ]);
+  const success = inferFixtureSuccess(merged, diagnostics, error, payloads.length);
+  return normalizeFixtureResult({
+    fixture_id: fixture.id,
+    fixture_path: fixture.fixture_path,
+    status: fixtureStatus(payloads.length, error, success),
+    success,
+    error,
+    ssi_validation: merged.ssi_validation || merged.ssiValidation || merged.validation || merged.static_site_importer || null,
+    import_report: merged.import_report || merged.importReport || merged.report || null,
+    quality_metrics: collectQualityMetrics(merged),
+    blocks_engine_diagnostics: collectBlocksEngineDiagnostics(merged),
+    invalid_block_counts: collectInvalidBlockCounts(merged),
+    missing_assets: collectMissingAssets(merged),
+    runtime_target_gaps: collectRuntimeTargetGaps(merged),
+    diagnostics,
+    artifact_refs: collectFixtureArtifactRefs(merged, fixtureArtifactsDirectory),
+    artifacts: merged.artifacts || {},
+    raw: { payloads },
+  });
+}
+
+function collectFixtureDiagnostics(payload) {
+  const diagnostics = [
+    ...normalizeArray(payload.diagnostics),
+    ...normalizeArray(payload.fixture_diagnostics?.diagnostics || payload.fixtureDiagnostics?.diagnostics),
+    ...normalizeArray(payload.findings),
+    ...normalizeArray(payload.messages),
+    ...normalizeArray(payload.errors),
+    ...normalizeArray(payload.warnings),
+    ...normalizeArray(payload.upstream_gaps || payload.upstreamGaps).map((gap) => ({ kind: 'upstream_gap', ...objectValue(gap), message: diagnosticMessage(gap) || gap.missing || 'Upstream capability gap detected.' })),
+    ...collectBlocksEngineDiagnostics(payload),
+    ...collectRuntimeTargetGaps(payload).map((gap) => ({ kind: 'runtime_target_gap', ...objectValue(gap), message: diagnosticMessage(gap) || 'Runtime target gap detected.' })),
+    ...collectMissingAssets(payload).map((asset) => ({ kind: missingAssetKind(asset), ...objectValue(asset), message: diagnosticMessage(asset) || 'Missing imported asset.' })),
+  ];
+  const invalidBlockCount = Object.values(collectInvalidBlockCounts(payload)).reduce((sum, value) => sum + numberValue(value), 0);
+  if (invalidBlockCount > 0) {
+    diagnostics.push({ kind: 'invalid_block_content', message: `${invalidBlockCount} invalid block${invalidBlockCount === 1 ? '' : 's'} reported by SSI validation.` });
+  }
+  return dedupeDiagnostics(diagnostics);
+}
+
+function dedupeDiagnostics(diagnostics) {
+  const seen = new Set();
+  return diagnostics.filter((diagnostic) => {
+    const normalized = objectValue(diagnostic);
+    const key = [normalized.kind || normalized.code || normalized.type || normalized.reason_code, normalized.message || normalized.reason, normalized.path || normalized.source_path, normalized.selector]
+      .map((part) => String(part || ''))
+      .join('\u0000');
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function collectFixtureArtifactRefs(payload, fixtureArtifactsDirectory) {
+  const refs = [...normalizeArray(payload.artifact_refs || payload.artifactRefs), ...normalizeArray(payload.artifacts?.refs)];
+  for (const [key, value] of Object.entries(payload.artifacts || {})) {
+    if (value && typeof value === 'object' && !Array.isArray(value) && (value.path || value.file || value.href)) {
+      refs.push({ artifact_id: key, kind: value.kind || key, ...value });
+    } else if (typeof value === 'string') {
+      refs.push({ artifact_id: key, kind: key, path: value });
+    }
+  }
+  for (const fileName of ['artifact.json', 'validation-result.json', 'import-report.json']) {
+    const filePath = path.join(fixtureArtifactsDirectory, fileName);
+    if (fs.existsSync(filePath)) {
+      refs.push(artifactRef(fileName.replace(/\.json$/, ''), filePath, fileName === 'artifact.json' ? 'input' : 'diagnostic'));
+    }
+  }
+  return refs;
+}
+
+function collectRuntimePayloads(value) {
+  const payloads = [];
+  visitRuntimePayloads(value, '', payloads, new Set());
+  return payloads;
+}
+
+function visitRuntimePayloads(value, inheritedFixtureId, payloads, seen) {
+  if (!value || typeof value !== 'object' || seen.has(value)) {
+    return;
+  }
+  seen.add(value);
+  const fixtureId = fixtureIdentity(value) || inheritedFixtureId;
+  if (fixtureId && hasPayloadData(value)) {
+    payloads.push({ fixture_id: fixtureId, ...value });
+  }
+  for (const key of ['stdout', 'stderr', 'output', 'result']) {
+    for (const parsed of parseJsonPayloadsFromText(value[key])) {
+      payloads.push({ fixture_id: fixtureId, ...parsed });
+    }
+  }
+  for (const child of Array.isArray(value) ? value : Object.values(value)) {
+    visitRuntimePayloads(child, fixtureId, payloads, seen);
+  }
+}
+
+function hasPayloadData(value) {
+  return ['status', 'success', 'ok', 'passed', 'error', 'diagnostics', 'findings', 'summary', 'artifacts', 'upstream_gaps', 'runtime_target_gaps', 'blocks_engine', 'import_report']
+    .some((key) => Object.hasOwn(value, key));
+}
+
+function readFixturePayloadFiles(directory) {
+  return ['validation-result.json', 'result.json', 'import-report.json', 'quality.json', 'blocks-engine-diagnostics.json']
+    .map((fileName) => readJsonFileIfExists(path.join(directory, fileName)))
+    .filter(Boolean);
+}
+
+function fixtureIdentity(payload) {
+  return payload?.fixture_id
+    || payload?.fixtureId
+    || payload?.fixture?.id
+    || payload?.fixture?.slug
+    || payload?.fixture_diagnostics?.fixture?.slug
+    || payload?.fixtureDiagnostics?.fixture?.slug
+    || payload?.request?.import_args?.slug
+    || payload?.request?.importArgs?.slug
+    || payload?.metadata?.fixture_id
+    || payload?.metadata?.fixtureId
+    || '';
+}
+
+function collectFixtureFiles(directory, options = {}) {
+  const maxFiles = finiteNumber(options.maxFiles ?? options.max_files, 1000);
+  const files = [];
+  const visit = (current) => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      if (entry.name === '.git' || entry.name === 'node_modules') {
+        continue;
+      }
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        visit(entryPath);
+        continue;
+      }
+      if (!entry.isFile()) {
+        continue;
+      }
+      const relativePath = path.relative(directory, entryPath).replace(/\\/g, '/');
+      const stat = fs.statSync(entryPath);
+      files.push({ relative_path: relativePath, absolute_path: entryPath, type: fileType(relativePath), bytes: stat.size });
+      if (files.length > maxFiles) {
+        throw new Error(`Fixture ${directory} has more than ${maxFiles} files.`);
+      }
+    }
+  };
+  visit(directory);
+  return files.sort((left, right) => left.relative_path.localeCompare(right.relative_path));
+}
+
+function visitFixtureDirectory(directory, depth, maxDepth, callback) {
+  callback(directory);
+  if (depth >= maxDepth) {
+    return;
+  }
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isDirectory() && entry.name !== '.git' && entry.name !== 'node_modules') {
+      visitFixtureDirectory(path.join(directory, entry.name), depth + 1, maxDepth, callback);
+    }
+  }
+}
+
+function collectQualityMetrics(payload) {
+  return compactObject({
+    ...(payload.quality_metrics || payload.qualityMetrics || {}),
+    ...(payload.quality || {}),
+    ...(payload.import_report?.report?.quality || payload.importReport?.report?.quality || payload.report?.quality || {}),
+  });
+}
+
+function collectInvalidBlockCounts(payload) {
+  const quality = collectQualityMetrics(payload);
+  return compactObject({
+    invalid_block_count: payload.invalid_block_count || payload.invalidBlockCount || quality.invalid_block_count,
+    invalid_blocks: payload.invalid_blocks || payload.invalidBlocks || quality.invalid_blocks,
+    editor_invalid_blocks: payload.editor_invalid_blocks || payload.editorInvalidBlocks || quality.editor_invalid_blocks,
+  });
+}
+
+function collectMissingAssets(payload) {
+  return [
+    ...normalizeArray(payload.missing_assets || payload.missingAssets),
+    ...normalizeArray(payload.dropped_images || payload.droppedImages),
+    ...normalizeArray(payload.import_report?.missing_assets || payload.importReport?.missing_assets),
+    ...normalizeArray(payload.report?.missing_assets),
+  ];
+}
+
+function collectRuntimeTargetGaps(payload) {
+  return [
+    ...normalizeArray(payload.runtime_target_gaps || payload.runtimeTargetGaps),
+    ...normalizeArray(payload.runtime_targets_missing || payload.runtimeTargetsMissing),
+    ...normalizeArray(payload.blocks_engine?.runtime_target_gaps || payload.blocksEngine?.runtimeTargetGaps),
+  ];
+}
+
+function collectBlocksEngineDiagnostics(payload) {
+  return [
+    ...normalizeArray(payload.blocks_engine_diagnostics || payload.blocksEngineDiagnostics),
+    ...normalizeArray(payload.blocks_engine?.diagnostics || payload.blocksEngine?.diagnostics),
+    ...normalizeArray(payload.transformer_diagnostics || payload.transformerDiagnostics),
+  ];
+}
+
+function groupFindings(findings) {
+  return findings.reduce((groups, finding) => {
+    const key = finding.group_key || 'static_site_import_quality';
+    groups[key] = groups[key] || [];
+    groups[key].push(finding);
+    return groups;
+  }, {});
+}
+
+function inferFixtureSuccess(payload, diagnostics, error, payloadCount) {
+  if (payload.success === true || payload.ok === true || payload.passed === true) {
+    return diagnostics.length === 0 && !error;
+  }
+  if (payload.success === false || payload.ok === false || payload.passed === false || payload.status === 'failed' || payload.status === 'error') {
+    return false;
+  }
+  if (payload.status === 'passed' || payload.status === 'success') {
+    return diagnostics.length === 0 && !error;
+  }
+  return payloadCount > 0 && diagnostics.length === 0 && !error;
+}
+
+function fixtureStatus(payloadCount, error, success) {
+  if (payloadCount === 0 && !error) {
+    return 'not_run';
+  }
+  return success ? 'passed' : 'failed';
+}
+
+function isFailurePayload(payload) {
+  return payload.success === false || payload.ok === false || payload.status === 'failed' || payload.status === 'error';
+}
+
+function fileType(filePath) {
+  const extension = path.extname(filePath).toLowerCase();
+  if (extension === '.html' || extension === '.htm') return 'text/html';
+  if (extension === '.css') return 'text/css';
+  if (extension === '.js' || extension === '.mjs') return 'application/javascript';
+  if (extension === '.svg') return 'image/svg+xml';
+  if (extension === '.png') return 'image/png';
+  if (extension === '.jpg' || extension === '.jpeg') return 'image/jpeg';
+  if (extension === '.webp') return 'image/webp';
+  return 'application/octet-stream';
+}
+
+function isImagePath(filePath) {
+  return /\.(png|jpe?g|gif|webp|svg)$/i.test(filePath);
+}
+
+function isTextPayloadType(type) {
+  return typeof type === 'string' && (type.startsWith('text/') || type === 'application/javascript' || type === 'application/json' || type === 'image/svg+xml');
+}
+
+function normalizeArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value === undefined || value === null || value === '') return [];
+  return [value];
+}
+
+function mergeObjects(values) {
+  return values.reduce((merged, value) => deepMerge(merged, value && typeof value === 'object' && !Array.isArray(value) ? value : {}), {});
+}
+
+function deepMerge(left, right) {
+  const output = { ...left };
+  for (const [key, value] of Object.entries(right)) {
+    if (Array.isArray(value)) {
+      output[key] = [...normalizeArray(output[key]), ...value];
+    } else if (value && typeof value === 'object' && !Array.isArray(value) && output[key] && typeof output[key] === 'object' && !Array.isArray(output[key])) {
+      output[key] = deepMerge(output[key], value);
+    } else if (value !== undefined && value !== null && value !== '') {
+      output[key] = value;
+    }
+  }
+  return output;
+}
+
+function compactObject(value) {
+  return Object.fromEntries(Object.entries(value || {}).filter(([, item]) => item !== undefined && item !== null && item !== ''));
+}
+
+function objectValue(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function numberValue(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function firstString(values) {
+  return values.map((value) => String(value || '').trim()).find(Boolean) || '';
+}
+
+function diagnosticMessage(value) {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return value?.message || value?.reason || value?.detail || value?.path || value?.target || value?.selector || '';
+}
+
+function missingAssetKind(value) {
+  const message = diagnosticMessage(value);
+  return /\.svg(?:\b|$)/i.test(message) ? 'broken_svg' : 'dropped_images';
+}
+
+function readJsonFileIfExists(filePath) {
+  if (!filePath || !fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+    return null;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    return {
+      status: 'failed',
+      error: `Unable to parse JSON artifact ${filePath}: ${error.message}`,
+      artifact_refs: [artifactRef('unparseable-json', filePath, 'diagnostic')],
+    };
+  }
+}
+
+function parseJsonPayloadsFromText(text) {
+  if (typeof text !== 'string' || !text.trim()) {
+    return [];
+  }
+  const payloads = [];
+  const trimmed = text.trim();
+  const candidates = new Set([trimmed, ...text.split(/\r?\n/).map((line) => line.trim())]);
+  const firstObject = trimmed.indexOf('{');
+  const lastObject = trimmed.lastIndexOf('}');
+  if (firstObject >= 0 && lastObject > firstObject) {
+    candidates.add(trimmed.slice(firstObject, lastObject + 1));
+  }
+  for (const candidate of candidates) {
+    if (!candidate || !candidate.startsWith('{')) continue;
+    try {
+      const parsed = JSON.parse(candidate);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        payloads.push(parsed);
+      }
+    } catch {
+      // WP-CLI output may mix human text and JSON; non-JSON lines are ignored.
+    }
+  }
+  return payloads;
+}
+
+function requiredString(value, name) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new TypeError(`${name} must be a non-empty string.`);
+  }
+  return value;
+}
+
+function requiredDirectory(value, name) {
+  const directory = requiredString(value, name);
+  if (!fs.existsSync(directory) || !fs.statSync(directory).isDirectory()) {
+    throw new Error(`${name} must be an existing directory: ${directory}`);
+  }
+  return path.resolve(directory);
+}
+
+function finiteNumber(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function writeJsonFile(filePath, payload) {
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function artifactRef(artifact_id, filePath, kind) {
+  return { schema: 'homeboy/artifact-ref/v1', artifact_id, kind, path: filePath };
+}
+
+function slug(value) {
+  return String(value || 'fixture')
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'fixture';
+}
+
+function shellToken(value) {
+  const text = String(value || '');
+  return /^[A-Za-z0-9_./:@=-]+$/.test(text) ? text : `'${text.replace(/'/g, "'\\''")}'`;
+}

--- a/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
@@ -1,0 +1,54 @@
+{
+  "id": "static-site-importer-fixture-matrix",
+  "description": "Static Site Importer fixture matrix workload that composes generic WP Codebox recipe orchestration while keeping SSI-specific fixture and diagnostic policy in homeboy-rigs.",
+  "components": {
+    "static-site-importer": {
+      "path": "~/Developer/static-site-importer",
+      "branch": "trunk"
+    }
+  },
+  "resources": {
+    "exclusive": [
+      "static-site-importer-fixture-matrix:${env.HOMEBOY_SETTINGS_STATIC_SITE_IMPORTER_FIXTURE_MATRIX_NAMESPACE}"
+    ],
+    "paths": [
+      "${components.static-site-importer.path}"
+    ]
+  },
+  "bench": {
+    "default_component": "static-site-importer",
+    "warmup_iterations": 0
+  },
+  "bench_workloads": {
+    "nodejs": [
+      "${package.root}/bench/static-site-fixture-matrix.mjs"
+    ]
+  },
+  "bench_profiles": {
+    "smoke": ["static-site-fixture-matrix"],
+    "fixture-matrix": ["static-site-fixture-matrix"]
+  },
+  "pipeline": {
+    "check": [
+      {
+        "kind": "requirement",
+        "label": "Static Site Importer checkout exists",
+        "file": "${components.static-site-importer.path}/static-site-importer.php",
+        "component": "static-site-importer",
+        "component_path_contains": "static-site-importer",
+        "remediation": "Pass homeboy bench --path /path/to/static-site-importer or update components.static-site-importer.path before running static-site-importer-fixture-matrix."
+      },
+      {
+        "kind": "command",
+        "label": "WP Codebox CLI exists",
+        "command": "bash \"${package.root}/../../shared/wp-codebox/check-cli.sh\""
+      },
+      {
+        "kind": "command",
+        "label": "Fixture matrix workload validates",
+        "command": "node \"${package.root}/tools/fixture-matrix.test.mjs\""
+      }
+    ],
+    "down": []
+  }
+}

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  buildFixtureMatrixRecipe,
+  classifyStaticSiteFinding,
+  createFixtureMatrix,
+  normalizeFixtureMatrixResult,
+  writeFixtureMatrixArtifacts,
+} from '../lib/fixture-matrix.mjs';
+
+const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const fixtureRoot = path.join(packageRoot, 'fixtures');
+
+test('discovers SSI fixtures and writes Blocks Engine site artifacts', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-fixture-matrix-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'test-matrix' });
+  const written = writeFixtureMatrixArtifacts({ outputDirectory, matrix });
+  const artifact = JSON.parse(readFileSync(path.join(outputDirectory, 'simple-site', 'artifact.json'), 'utf8'));
+
+  assert.equal(matrix.schema, 'homeboy-rigs/static-site-importer-fixture-matrix/v1');
+  assert.equal(matrix.count, 1);
+  assert.equal(matrix.fixtures[0].id, 'simple-site');
+  assert.equal(artifact.schema, 'blocks-engine/php-transformer/site-artifact/v1');
+  assert.ok(artifact.files.some((file) => file.path === 'website/index.html' && file.content.includes('Simple SSI Fixture')));
+  assert.ok(artifact.files.some((file) => file.path === 'website/style.css'));
+  assert.equal(written.result.summary.not_run, 1);
+});
+
+test('builds a generic WP Codebox recipe with SSI-owned plugin defaults', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'recipe-test' });
+  const recipe = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    playgroundArtifactsDirectory: '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+  });
+
+  assert.equal(recipe.schema, 'wp-codebox/workspace-recipe/v1');
+  assert.deepEqual(recipe.inputs.extra_plugins[0], {
+    source: '/tmp/static-site-importer',
+    slug: 'static-site-importer',
+    activate: true,
+  });
+  assert.equal(recipe.workflow.steps[0].command, 'wordpress.wp-cli');
+  assert.equal(recipe.workflow.steps[0].args[0], 'command=plugin activate static-site-importer/static-site-importer.php');
+  assert.match(recipe.workflow.steps[1].args[0], /static-site-importer validate-in-codebox/);
+  assert.match(recipe.workflow.steps[1].args[0], /--allow-failure/);
+});
+
+test('normalizes SSI diagnostics into product repair groups', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'diagnostic-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'failed',
+        diagnostics: [
+          { message: 'Dropped image asset during import' },
+          { message: 'Unexpected or invalid content in imported block' },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(result.summary.failed, 1);
+  assert.equal(result.summary.groups.dropped_images, 1);
+  assert.equal(result.summary.groups.invalid_block_content, 1);
+  assert.equal(classifyStaticSiteFinding({ message: 'canvas target missing' }).repair_mode, 'runtime-dom-target-parity');
+});


### PR DESCRIPTION
## Summary
- Adds a Static Site Importer fixture-matrix rig/workload package.
- Keeps SSI-specific fixture discovery, plugin defaults, expected artifacts, and diagnostic grouping in the rig layer.
- Builds generic WP Codebox recipes and documents the generic orchestration contract expected from Homeboy/Homeboy Extensions.

This is the product-level replacement for the closed Homeboy Extensions SSI fixture-matrix PRs.

## Testing
- `git diff --check`
- `node WordPress/static-site-importer/tools/fixture-matrix.test.mjs`
- `node scripts/lint-rig-packages.mjs`

## Notes
- Full `homeboy rig check static-site-importer-fixture-matrix` requires the new rig package to be installed/registered first.
- Runtime WP Codebox execution was not run locally.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting, refactoring, and verifying the rig/workload split.