### PR TITLE
Fix SSI fixture matrix workload schema

### DIFF
--- a/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
@@ -21,7 +21,9 @@
   },
   "bench_workloads": {
     "nodejs": [
-      "${package.root}/bench/static-site-fixture-matrix.mjs"
+      {
+        "path": "${package.root}/bench/static-site-fixture-matrix.mjs"
+      }
     ]
   },
   "bench_profiles": {


### PR DESCRIPTION
## Summary
- Wrap the Static Site Importer fixture matrix node workload in the current rig `WorkloadSpec` object shape.
- Allows `homeboy rig install` to parse the merged fixture matrix rig package.

## Verification
- `git diff --check`
- Install failure before fix: `invalid type: string "${package.root}/bench/static-site-fixture-matrix.mjs", expected struct WorkloadSpec`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Diagnosing the rig install schema mismatch and drafting the minimal fix.
