### PR TITLE
Keep SSI fixture matrix helpers package-local

### DIFF
--- a/WordPress/static-site-importer/bench/static-site-fixture-matrix.mjs
+++ b/WordPress/static-site-importer/bench/static-site-fixture-matrix.mjs
@@ -3,7 +3,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { runWpCodeboxRecipe } from '../../../shared/wp-codebox/recipe.mjs';
+import { runWpCodeboxRecipe } from '../shared/wp-codebox/recipe.mjs';
 import {
   buildFixtureMatrixRecipe,
   collectFixtureMatrixRunResults,

--- a/WordPress/static-site-importer/docs/generic-orchestration-contract.md
+++ b/WordPress/static-site-importer/docs/generic-orchestration-contract.md
@@ -6,7 +6,7 @@ surface and supplies all SSI policy from this package.
 
 ## Required Current Interfaces
 
-- `shared/wp-codebox/recipe.mjs` must expose `runWpCodeboxRecipe(options)`.
+- `${package.root}/shared/wp-codebox/recipe.mjs` must expose `runWpCodeboxRecipe(options)`.
 - `runWpCodeboxRecipe(options)` must accept `recipeFile`, `artifactsDir`,
   `outputFile`, and optional `wpCodeboxBin`.
 - WP Codebox recipes must accept schema `wp-codebox/workspace-recipe/v1`.

--- a/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
@@ -43,7 +43,7 @@
       {
         "kind": "command",
         "label": "WP Codebox CLI exists",
-        "command": "bash \"${package.root}/../../shared/wp-codebox/check-cli.sh\""
+        "command": "bash \"${package.root}/shared/wp-codebox/check-cli.sh\""
       },
       {
         "kind": "command",

--- a/WordPress/static-site-importer/shared/wp-codebox/check-cli.sh
+++ b/WordPress/static-site-importer/shared/wp-codebox/check-cli.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+wp_codebox_bin=${HOMEBOY_WP_CODEBOX_BIN:-${HOMEBOY_SETTINGS_WP_CODEBOX_BIN:-${WP_CODEBOX_BIN:-}}}
+
+case "$wp_codebox_bin" in
+	'~'/*) wp_codebox_bin="$HOME/${wp_codebox_bin#~/}" ;;
+esac
+
+if [ -n "$wp_codebox_bin" ]; then
+	test -f "$wp_codebox_bin" || {
+		printf '%s\n' "Configured WP Codebox CLI not found: $wp_codebox_bin" >&2
+		exit 1
+	}
+	exit 0
+fi
+
+command -v wp-codebox >/dev/null 2>&1 || {
+	printf '%s\n' 'Missing WP Codebox CLI. Install wp-codebox or set HOMEBOY_WP_CODEBOX_BIN, HOMEBOY_SETTINGS_WP_CODEBOX_BIN, or WP_CODEBOX_BIN.' >&2
+	exit 1
+}

--- a/WordPress/static-site-importer/shared/wp-codebox/recipe.mjs
+++ b/WordPress/static-site-importer/shared/wp-codebox/recipe.mjs
@@ -1,0 +1,36 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+function loadRecipeHelper() {
+  const explicit = process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
+  if (explicit) {
+    return require(explicit);
+  }
+
+  const manifestPath = process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST;
+  if (manifestPath) {
+    const manifestModule = require(manifestPath);
+    const manifest = typeof manifestModule.getWordPressHelperManifest === 'function'
+      ? manifestModule.getWordPressHelperManifest()
+      : manifestModule.WORDPRESS_HELPER_MANIFEST;
+    if (manifest?.extensionRoot) {
+      return require(path.join(manifest.extensionRoot, 'lib', 'wp-codebox-recipe-helper.js'));
+    }
+  }
+
+  return require('homeboy-extension-wordpress/wp-codebox-recipe-helper');
+}
+
+export function wpCodeboxBin(env = process.env) {
+  return loadRecipeHelper().wpCodeboxBin({ env });
+}
+
+export function wpCodeboxCommand(bin = wpCodeboxBin()) {
+  return loadRecipeHelper().wpCodeboxCommand(bin);
+}
+
+export async function runWpCodeboxRecipe(options) {
+  return loadRecipeHelper().runWpCodeboxRecipe(options);
+}


### PR DESCRIPTION
## Summary
- Move the SSI fixture matrix WP Codebox helper imports/checks inside the Static Site Importer rig package boundary.
- Add package-local WP Codebox helper wrappers so installed subpackages can run rig checks on Lab.

## Verification
- `git diff --check`
- Remote Lab failure before fix: `${package.root}/../../shared/wp-codebox/check-cli.sh` was missing in the installed SSI subpackage.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Diagnosing the Lab rig package boundary failure and drafting the package-local helper fix.
