### PR TITLE
Make SSI WP Codebox helper self-contained

### DIFF
--- a/WordPress/static-site-importer/shared/wp-codebox/recipe.mjs
+++ b/WordPress/static-site-importer/shared/wp-codebox/recipe.mjs
@@ -1,36 +1,75 @@
-import { createRequire } from 'node:module';
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
 import path from 'node:path';
+import { promisify } from 'node:util';
 
-const require = createRequire(import.meta.url);
-
-function loadRecipeHelper() {
-  const explicit = process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
-  if (explicit) {
-    return require(explicit);
-  }
-
-  const manifestPath = process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST;
-  if (manifestPath) {
-    const manifestModule = require(manifestPath);
-    const manifest = typeof manifestModule.getWordPressHelperManifest === 'function'
-      ? manifestModule.getWordPressHelperManifest()
-      : manifestModule.WORDPRESS_HELPER_MANIFEST;
-    if (manifest?.extensionRoot) {
-      return require(path.join(manifest.extensionRoot, 'lib', 'wp-codebox-recipe-helper.js'));
-    }
-  }
-
-  return require('homeboy-extension-wordpress/wp-codebox-recipe-helper');
-}
+const execFileAsync = promisify(execFile);
+const DEFAULT_MAX_BUFFER = 1024 * 1024 * 50;
 
 export function wpCodeboxBin(env = process.env) {
-  return loadRecipeHelper().wpCodeboxBin({ env });
+  return env.HOMEBOY_WP_CODEBOX_BIN
+    || env.HOMEBOY_SETTINGS_WP_CODEBOX_BIN
+    || env.WP_CODEBOX_BIN
+    || 'wp-codebox';
 }
 
 export function wpCodeboxCommand(bin = wpCodeboxBin()) {
-  return loadRecipeHelper().wpCodeboxCommand(bin);
+  if (/\.(?:js|cjs|mjs)$/.test(bin)) {
+    return { command: process.execPath, args: [bin] };
+  }
+
+  return { command: bin, args: [] };
 }
 
-export async function runWpCodeboxRecipe(options) {
-  return loadRecipeHelper().runWpCodeboxRecipe(options);
+export async function runWpCodeboxRecipe({
+  recipeFile,
+  artifactsDir,
+  outputFile,
+  recipeRunArgs = [],
+  maxBuffer = DEFAULT_MAX_BUFFER,
+  wpCodeboxBin: explicitWpCodeboxBin,
+  env = process.env,
+  cwd,
+} = {}) {
+  if (!recipeFile) {
+    throw new Error('runWpCodeboxRecipe requires recipeFile.');
+  }
+  if (!artifactsDir) {
+    throw new Error('runWpCodeboxRecipe requires artifactsDir.');
+  }
+
+  await fs.mkdir(artifactsDir, { recursive: true });
+  if (outputFile) {
+    await fs.mkdir(path.dirname(outputFile), { recursive: true });
+  }
+
+  const { command, args } = wpCodeboxCommand(explicitWpCodeboxBin || wpCodeboxBin(env));
+  const commandArgs = [
+    ...args,
+    'recipe-run',
+    '--recipe',
+    recipeFile,
+    '--artifacts',
+    artifactsDir,
+    ...recipeRunArgs,
+    '--json',
+  ];
+
+  try {
+    const result = await execFileAsync(command, commandArgs, { cwd, env, maxBuffer });
+    if (outputFile) {
+      await fs.writeFile(outputFile, result.stdout);
+    }
+    return { ...result, json: parseWpCodeboxJson(result.stdout) };
+  } catch (error) {
+    if (outputFile && typeof error?.stdout === 'string' && error.stdout) {
+      await fs.writeFile(outputFile, error.stdout);
+    }
+    throw error;
+  }
+}
+
+function parseWpCodeboxJson(stdout) {
+  const trimmed = String(stdout || '').trim();
+  return trimmed ? JSON.parse(trimmed) : null;
 }


### PR DESCRIPTION
## Summary
- Replace the SSI package-local WP Codebox recipe helper wrapper with a self-contained CLI runner.
- Removes the runtime dependency on `homeboy-extension-wordpress/wp-codebox-recipe-helper` when running the SSI fixture matrix through the Node.js extension.

## Verification
- `git diff --check`
- Lab evidence before fix: workload failed with `Cannot find module homeboy-extension-wordpress/wp-codebox-recipe-helper`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Diagnosing the package-local helper dependency failure and drafting the self-contained WP Codebox CLI wrapper.
