### PR TITLE
Default SSI matrix plugin path to component checkout

### DIFF
--- a/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
+++ b/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
@@ -66,7 +66,7 @@ export default async function runFixtureMatrixBench() {
 async function runFixtureMatrix(options) {
   const fixtureRoot = path.resolve(options.fixtureRoot || path.join(packageRoot, 'fixtures'));
   const outputDirectory = path.resolve(options.outputDirectory || path.join(process.cwd(), 'artifacts', 'static-site-importer-fixture-matrix'));
-  const staticSiteImporterPath = options.staticSiteImporterPath || process.env.HOMEBOY_STATIC_SITE_IMPORTER_PATH || path.resolve(process.env.HOME || '.', 'Developer/static-site-importer');
+  const staticSiteImporterPath = options.staticSiteImporterPath || process.env.HOMEBOY_STATIC_SITE_IMPORTER_PATH || process.cwd();
   const matrix = createFixtureMatrix({
     id: options.id || `static-site-importer-fixture-matrix-${Date.now()}`,
     fixture_root: fixtureRoot,


### PR DESCRIPTION
## Summary
- Defaults the SSI fixture matrix plugin source path to the current component checkout.
- Removes the need for hard-coded runner-side plugin paths when Lab materializes a dynamic workspace.

## Verification
- `git diff --check`
- Failure before fix: WP Codebox recipe validation reported missing `$.inputs.extra_plugins[0].source` for `/home/chubes/Developer/static-site-importer-matrix-0-1-15`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Diagnosing Lab recipe path validation and drafting the minimal workload default fix.
