### PR TITLE
Add SSI finding packet comparison helper

### DIFF
--- a/WordPress/static-site-importer/README.md
+++ b/WordPress/static-site-importer/README.md
@@ -16,6 +16,22 @@ Add `--run` only in an approved non-local execution environment. The default
 command writes matrix, recipe, summary, result, and finding-packet artifacts
 without launching WP Codebox.
 
+Compare two fixture-matrix finding-packet artifacts without requiring Homeboy run
+state:
+
+```bash
+node WordPress/static-site-importer/tools/compare-finding-packets.mjs \
+  --base /path/to/main/finding-packets.json \
+  --candidate /path/to/candidate/finding-packets.json \
+  --base-label current-main \
+  --candidate-label candidate \
+  --top 20
+```
+
+The comparison reports signed count deltas by repair bucket, `group_key`, kind,
+fixture, candidate repo, and selector family. Positive deltas mean the candidate
+has more findings in that group; negative deltas mean fewer findings.
+
 ## Generic Invocation
 
 The workload composes these generic surfaces:

--- a/WordPress/static-site-importer/tools/compare-finding-packets.mjs
+++ b/WordPress/static-site-importer/tools/compare-finding-packets.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_TOP = 15;
+const DIMENSIONS = [
+  ['bucket', 'bucket'],
+  ['group_key', 'group_key'],
+  ['kind', 'kind'],
+  ['fixture_id', 'fixture_id'],
+  ['candidate_repo', 'candidate_repo'],
+  ['selector_family', 'selector_family'],
+];
+
+const isCli = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isCli) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      printHelp();
+    } else {
+      const summary = compareFindingPacketFiles(options);
+      process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+    }
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+export function compareFindingPacketFiles(options = {}) {
+  const baseFile = requiredString(options.base, '--base');
+  const candidateFile = requiredString(options.candidate, '--candidate');
+  return compareFindingPackets({
+    base: readJsonFile(baseFile),
+    candidate: readJsonFile(candidateFile),
+    base_label: options.baseLabel || options.base_label || path.basename(baseFile),
+    candidate_label: options.candidateLabel || options.candidate_label || path.basename(candidateFile),
+    top: options.top,
+  });
+}
+
+export function compareFindingPackets(input = {}) {
+  const top = positiveInteger(input.top, DEFAULT_TOP);
+  const baseFindings = normalizeFindingPackets(input.base);
+  const candidateFindings = normalizeFindingPackets(input.candidate);
+  const dimensions = Object.fromEntries(DIMENSIONS.map(([key, field]) => [
+    key,
+    topDeltas(countBy(baseFindings, field), countBy(candidateFindings, field), top),
+  ]));
+
+  return {
+    schema: 'homeboy-rigs/finding-packet-comparison/v1',
+    base_label: input.base_label || input.baseLabel || 'base',
+    candidate_label: input.candidate_label || input.candidateLabel || 'candidate',
+    top,
+    totals: {
+      base: baseFindings.length,
+      candidate: candidateFindings.length,
+      delta: candidateFindings.length - baseFindings.length,
+    },
+    dimensions,
+  };
+}
+
+export function normalizeFindingPackets(input) {
+  const findings = unwrapFindings(input);
+  return findings.map((finding) => normalizeFinding(finding));
+}
+
+export function selectorFamily(selector) {
+  const value = String(selector || '').trim();
+  if (!value) {
+    return '(none)';
+  }
+
+  const firstToken = value.split(/\s+|\s*[>+~]\s*/).find(Boolean) || value;
+  if (firstToken.startsWith('#')) {
+    return `id:${firstToken.slice(1).split(/[:.#[\]]/)[0] || '(unknown)'}`;
+  }
+  if (firstToken.startsWith('.')) {
+    return `class:${firstToken.slice(1).split(/[:.#[\]]/)[0] || '(unknown)'}`;
+  }
+  if (firstToken.startsWith('[')) {
+    return `attr:${firstToken.slice(1).split(/[=\]]/)[0] || '(unknown)'}`;
+  }
+
+  return firstToken.split(/[:.#[\]]/)[0] || firstToken;
+}
+
+function normalizeFinding(finding) {
+  const raw = finding && typeof finding === 'object' ? finding : { reason: String(finding || '') };
+  const rawPayload = raw.raw && typeof raw.raw === 'object' ? raw.raw : {};
+  const groupKey = stringValue(raw.group_key || rawPayload.group_key || raw.category || rawPayload.category, '(missing)');
+  const bucket = stringValue(raw.repair_bucket || rawPayload.repair_bucket || groupKey, '(missing)');
+  const selector = stringValue(raw.selector || rawPayload.selector, '');
+  return {
+    bucket,
+    group_key: groupKey,
+    kind: stringValue(raw.kind || raw.code || raw.type || rawPayload.kind || rawPayload.code || rawPayload.type, '(missing)'),
+    fixture_id: stringValue(raw.fixture_id || rawPayload.fixture_id || raw.fixture || rawPayload.fixture, '(missing)'),
+    candidate_repo: stringValue(raw.candidate_repo || rawPayload.candidate_repo || raw.owner || rawPayload.owner, '(missing)'),
+    selector,
+    selector_family: selectorFamily(selector),
+  };
+}
+
+function unwrapFindings(input) {
+  if (Array.isArray(input)) {
+    return input;
+  }
+  if (!input || typeof input !== 'object') {
+    return [];
+  }
+  if (Array.isArray(input.findings)) {
+    return input.findings;
+  }
+  if (Array.isArray(input.packets)) {
+    return input.packets;
+  }
+  if (Array.isArray(input.fanout_groups)) {
+    return input.fanout_groups.flatMap((group) => Array.isArray(group.findings) ? group.findings : []);
+  }
+  return [];
+}
+
+function countBy(findings, field) {
+  const counts = new Map();
+  for (const finding of findings) {
+    const key = finding[field] || '(missing)';
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+  return counts;
+}
+
+function topDeltas(baseCounts, candidateCounts, top) {
+  const keys = new Set([...baseCounts.keys(), ...candidateCounts.keys()]);
+  return [...keys].map((key) => {
+    const base = baseCounts.get(key) || 0;
+    const candidate = candidateCounts.get(key) || 0;
+    return { key, base, candidate, delta: candidate - base };
+  })
+    .filter((row) => row.delta !== 0)
+    .sort((left, right) => Math.abs(right.delta) - Math.abs(left.delta) || right.delta - left.delta || left.key.localeCompare(right.key))
+    .slice(0, top);
+}
+
+function parseArgs(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+    if (arg.startsWith('--')) {
+      const [rawKey, rawValue] = arg.slice(2).split('=');
+      const value = rawValue === undefined ? args[index + 1] : rawValue;
+      if (rawValue === undefined) {
+        index += 1;
+      }
+      options[camelCase(rawKey)] = value;
+      continue;
+    }
+    if (!options.base) {
+      options.base = arg;
+    } else if (!options.candidate) {
+      options.candidate = arg;
+    }
+  }
+  return options;
+}
+
+function printHelp() {
+  process.stdout.write(`Compare finding-packet JSON artifacts and summarize count deltas.\n\nUsage:\n  node WordPress/static-site-importer/tools/compare-finding-packets.mjs --base base.json --candidate candidate.json [--top 20]\n\nOptions:\n  --base <file>             Baseline finding-packets JSON file.\n  --candidate <file>        Candidate finding-packets JSON file.\n  --base-label <label>      Label for the baseline run.\n  --candidate-label <label> Label for the candidate run.\n  --top <count>             Number of rows per dimension. Default: ${DEFAULT_TOP}.\n`);
+}
+
+function readJsonFile(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function requiredString(value, label) {
+  if (!value || typeof value !== 'string') {
+    throw new Error(`Missing required ${label}. Run with --help for usage.`);
+  }
+  return value;
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function stringValue(value, fallback) {
+  if (value === undefined || value === null || value === '') {
+    return fallback;
+  }
+  return String(value);
+}
+
+function camelCase(value) {
+  return value.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+}

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -5,6 +5,10 @@ import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import {
+  compareFindingPackets,
+  selectorFamily,
+} from './compare-finding-packets.mjs';
+import {
   buildFixtureMatrixRecipe,
   classifyStaticSiteFinding,
   createFixtureMatrix,
@@ -71,4 +75,31 @@ test('normalizes SSI diagnostics into product repair groups', () => {
   assert.equal(result.summary.groups.dropped_images, 1);
   assert.equal(result.summary.groups.invalid_block_content, 1);
   assert.equal(classifyStaticSiteFinding({ message: 'canvas target missing' }).repair_mode, 'runtime-dom-target-parity');
+});
+
+test('compares finding packet deltas by repair dimensions', () => {
+  const summary = compareFindingPackets({
+    base_label: 'main',
+    candidate_label: 'candidate',
+    top: 5,
+    base: [
+      { kind: 'unsupported_html_fallback', group_key: 'static_site_import_quality', repair_bucket: 'runtime_target_gap', fixture_id: 'hero-site', candidate_repo: 'blocks-engine', selector: 'script:nth-of-type(1)' },
+      { kind: 'document_metadata_routed', group_key: 'dropped_images', repair_bucket: 'dropped_images', fixture_id: 'shop-site', candidate_repo: 'static-site-importer', selector: '.gallery img' },
+    ],
+    candidate: [
+      { kind: 'document_metadata_routed', group_key: 'dropped_images', repair_bucket: 'dropped_images', fixture_id: 'shop-site', candidate_repo: 'static-site-importer', selector: '.gallery img' },
+      { kind: 'document_metadata_routed', group_key: 'dropped_images', repair_bucket: 'dropped_images', fixture_id: 'portfolio-site', candidate_repo: 'static-site-importer', selector: '.gallery img' },
+      { kind: 'invalid_block_content', group_key: 'invalid_block_content', repair_bucket: 'invalid_block_content', fixture_id: 'portfolio-site', candidate_repo: 'blocks-engine', selector: '#hero .cta' },
+    ],
+  });
+
+  assert.deepEqual(summary.totals, { base: 2, candidate: 3, delta: 1 });
+  assert.deepEqual(summary.dimensions.bucket.slice(0, 2), [
+    { key: 'dropped_images', base: 1, candidate: 2, delta: 1 },
+    { key: 'invalid_block_content', base: 0, candidate: 1, delta: 1 },
+  ]);
+  assert.ok(summary.dimensions.bucket.some((row) => row.key === 'runtime_target_gap' && row.delta === -1));
+  assert.deepEqual(summary.dimensions.fixture_id[0], { key: 'portfolio-site', base: 0, candidate: 2, delta: 2 });
+  assert.equal(selectorFamily('script:nth-of-type(1)'), 'script');
+  assert.equal(selectorFamily('#hero .cta'), 'id:hero');
 });


### PR DESCRIPTION
## Summary
- Add a file-based SSI finding-packet comparison helper for fixture matrix artifacts.
- Summarize signed deltas by repair bucket, group_key, kind, fixture_id, candidate_repo, and selector family.
- Document usage and cover the comparison behavior in the existing fixture matrix test entrypoint.

## Verification
- `node WordPress/static-site-importer/tools/fixture-matrix.test.mjs`
- `node WordPress/static-site-importer/tools/compare-finding-packets.mjs --base /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/ssi-finding-packets-0.1.15.json --candidate /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/ssi-finding-packets.json --base-label current-main-c6d54b3e --candidate-label candidate-9fefaa83 --top 5`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the comparison helper, tests, documentation, and verification commands.