### PR TITLE
Add SSI generated artifact intake

### DIFF
--- a/WordPress/static-site-importer/README.md
+++ b/WordPress/static-site-importer/README.md
@@ -12,6 +12,20 @@ node WordPress/static-site-importer/bench/static-site-fixture-matrix.mjs \
   --static-site-importer-path ~/Developer/static-site-importer
 ```
 
+Generated/static artifact roots can be normalized into matrix fixtures first:
+
+```bash
+node WordPress/static-site-importer/tools/artifact-intake.mjs \
+  --artifact-root /path/to/generated-artifacts \
+  --fixture-root /tmp/ssi-fixtures \
+  --manifest /tmp/ssi-fixtures/intake.json
+
+node WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs \
+  --artifact-root /path/to/generated-artifacts \
+  --output-directory /tmp/ssi-matrix \
+  --static-site-importer-path ~/Developer/static-site-importer
+```
+
 Add `--run` only in an approved non-local execution environment. The default
 command writes matrix, recipe, summary, result, and finding-packet artifacts
 without launching WP Codebox.
@@ -30,3 +44,18 @@ The workload composes these generic surfaces:
 SSI-specific behavior remains here: plugin slug/defaults, fixture artifact
 packing, `static-site-importer validate-in-codebox` command construction,
 artifact expectations, and diagnostic-to-repair grouping.
+
+## Generated Artifact Intake Contract
+
+`--artifact-root` accepts any directory containing one or more generated static
+site artifacts. Discovery is structural, not fixture-specific:
+
+- A directory with `index.html` becomes one fixture.
+- A directory with `website/index.html` becomes one fixture from `website/`.
+- A directory with `artifact.json`, `website-artifact.json`, or
+  `static-site-candidate.json` containing `files[].path` entries under
+  `website/` becomes one materialized fixture.
+
+The bridge writes normal fixture directories under the requested fixture root,
+then the existing matrix path discovers them and writes `<fixture-id>/artifact.json`
+for SSI validation.

--- a/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
+++ b/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
@@ -5,6 +5,7 @@ import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { runWpCodeboxRecipe } from '../shared/wp-codebox/recipe.mjs';
+import { materializeGeneratedArtifactFixtures } from '../lib/artifact-intake.mjs';
 import {
   buildFixtureMatrixRecipe,
   collectFixtureMatrixRunResults,
@@ -65,8 +66,16 @@ export default async function runFixtureMatrixBench() {
 }
 
 async function runFixtureMatrix(options) {
-  const fixtureRoot = path.resolve(options.fixtureRoot || path.join(packageRoot, 'fixtures'));
   const outputDirectory = path.resolve(options.outputDirectory || path.join(process.cwd(), 'artifacts', 'static-site-importer-fixture-matrix'));
+  const intake = options.artifactRoot
+    ? materializeGeneratedArtifactFixtures({
+      artifactRoot: path.resolve(options.artifactRoot),
+      fixtureRoot: path.resolve(options.fixtureRoot || path.join(outputDirectory, 'intake-fixtures')),
+      entrypoint: options.entrypoint || 'index.html',
+      maxDepth: options.maxDepth,
+    })
+    : null;
+  const fixtureRoot = path.resolve(intake?.fixture_root || options.fixtureRoot || path.join(packageRoot, 'fixtures'));
   const staticSiteImporterPath = options.staticSiteImporterPath || process.env.HOMEBOY_STATIC_SITE_IMPORTER_PATH || process.cwd();
   ensureComposerDependencies(staticSiteImporterPath);
   const matrix = createFixtureMatrix({
@@ -168,6 +177,7 @@ async function runFixtureMatrix(options) {
     matrix_id: matrix.id,
     fixture_root: matrix.fixture_root,
     fixture_count: matrix.count,
+    intake,
     output_directory: outputDirectory,
     recipe_file: recipeFile,
     artifact_refs: written.artifact_refs,
@@ -242,6 +252,7 @@ function optionsFromEnv(env = process.env) {
     staticSiteImporterPlugin: benchEnv.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PLUGIN || env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PLUGIN,
     entrypoint: benchEnv.SSI_FIXTURE_MATRIX_ENTRYPOINT || env.SSI_FIXTURE_MATRIX_ENTRYPOINT,
     maxDepth: benchEnv.SSI_FIXTURE_MATRIX_MAX_DEPTH || env.SSI_FIXTURE_MATRIX_MAX_DEPTH,
+    artifactRoot: benchEnv.SSI_FIXTURE_MATRIX_ARTIFACT_ROOT || env.SSI_FIXTURE_MATRIX_ARTIFACT_ROOT,
     wordpressVersion: benchEnv.SSI_FIXTURE_MATRIX_WORDPRESS_VERSION || env.SSI_FIXTURE_MATRIX_WORDPRESS_VERSION,
     batchSize: benchEnv.SSI_FIXTURE_MATRIX_BATCH_SIZE || env.SSI_FIXTURE_MATRIX_BATCH_SIZE,
     run: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_RUN) || isTruthy(env.SSI_FIXTURE_MATRIX_RUN),

--- a/WordPress/static-site-importer/docs/generic-orchestration-contract.md
+++ b/WordPress/static-site-importer/docs/generic-orchestration-contract.md
@@ -20,6 +20,8 @@ surface and supplies all SSI policy from this package.
 
 - Fixture root discovery starts at `--fixture-root`, defaults to an `index.html`
   entrypoint, and descends two directory levels unless `--max-depth` is set.
+- Generated artifact intake starts at `--artifact-root` and materializes
+  structural candidates into a normal fixture root before matrix discovery.
 - The Static Site Importer plugin source is `--static-site-importer-path`.
 - The default plugin slug is `static-site-importer`.
 - The default activation file is
@@ -28,6 +30,8 @@ surface and supplies all SSI policy from this package.
 ## SSI-Owned Artifacts
 
 - `matrix.json`: discovered fixture matrix.
+- `intake`: optional `cli-run.json` summary section describing generated
+  artifact roots materialized into matrix-compatible fixtures.
 - `<fixture-id>/artifact.json`: Blocks Engine site artifact input for SSI.
 - `wp-codebox-static-site-fixture-matrix-recipe.json`: full matrix recipe.
 - `wp-codebox-static-site-fixture-matrix-batch-NNN.json`: batch recipes when

--- a/WordPress/static-site-importer/lib/artifact-intake.mjs
+++ b/WordPress/static-site-importer/lib/artifact-intake.mjs
@@ -1,0 +1,192 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DEFAULT_ENTRYPOINT = 'index.html';
+const DEFAULT_MAX_DEPTH = 3;
+
+export function materializeGeneratedArtifactFixtures(input = {}) {
+  const artifactRoot = requiredDirectory(input.artifactRoot || input.artifact_root, 'artifactRoot');
+  const fixtureRoot = path.resolve(requiredString(input.fixtureRoot || input.fixture_root, 'fixtureRoot'));
+  const entrypoint = input.entrypoint || DEFAULT_ENTRYPOINT;
+  const maxDepth = finiteNumber(input.maxDepth ?? input.max_depth, DEFAULT_MAX_DEPTH);
+  const candidates = discoverGeneratedArtifacts(artifactRoot, { entrypoint, maxDepth });
+  const fixtures = [];
+
+  fs.mkdirSync(fixtureRoot, { recursive: true });
+  for (const [index, candidate] of candidates.entries()) {
+    const fixtureId = uniqueFixtureId(candidate.id || path.basename(candidate.source), fixtures, index + 1);
+    const fixtureDirectory = path.join(fixtureRoot, fixtureId);
+    fs.rmSync(fixtureDirectory, { recursive: true, force: true });
+    fs.mkdirSync(fixtureDirectory, { recursive: true });
+
+    if (candidate.kind === 'website_artifact') {
+      materializeWebsiteArtifact(candidate.payload, fixtureDirectory);
+    } else {
+      copyDirectory(candidate.source, fixtureDirectory);
+      const discoveredEntry = candidate.entrypoint || entrypoint;
+      if (discoveredEntry !== entrypoint && fs.existsSync(path.join(fixtureDirectory, discoveredEntry))) {
+        fs.copyFileSync(path.join(fixtureDirectory, discoveredEntry), path.join(fixtureDirectory, entrypoint));
+      }
+    }
+
+    fixtures.push({
+      id: fixtureId,
+      directory: fixtureDirectory,
+      fixture_path: fixtureDirectory,
+      fixture_root: fixtureRoot,
+      entrypoint,
+      source: candidate.source,
+      source_kind: candidate.kind,
+    });
+  }
+
+  return {
+    schema: 'homeboy-rigs/static-site-importer-generated-artifact-intake/v1',
+    artifact_root: artifactRoot,
+    fixture_root: fixtureRoot,
+    entrypoint,
+    count: fixtures.length,
+    fixtures,
+  };
+}
+
+export function discoverGeneratedArtifacts(root, options = {}) {
+  const artifactRoot = requiredDirectory(root, 'artifactRoot');
+  const entrypoint = options.entrypoint || DEFAULT_ENTRYPOINT;
+  const maxDepth = finiteNumber(options.maxDepth ?? options.max_depth, DEFAULT_MAX_DEPTH);
+  const candidates = [];
+
+  visitDirectories(artifactRoot, 0, maxDepth, (directory) => {
+    const artifact = readWebsiteArtifact(directory);
+    if (artifact) {
+      candidates.push({
+        kind: 'website_artifact',
+        source: artifact.path,
+        payload: artifact.payload,
+        id: artifact.payload?.metadata?.site || path.basename(directory),
+      });
+      return false;
+    }
+
+    if (fs.existsSync(path.join(directory, entrypoint))) {
+      candidates.push({ kind: 'static_directory', source: directory, entrypoint, id: path.basename(directory) });
+      return false;
+    }
+
+    const websiteDirectory = path.join(directory, 'website');
+    if (fs.existsSync(path.join(websiteDirectory, entrypoint))) {
+      candidates.push({ kind: 'website_directory', source: websiteDirectory, entrypoint, id: path.basename(directory) });
+      return false;
+    }
+
+    return true;
+  });
+
+  return candidates.sort((left, right) => left.source.localeCompare(right.source));
+}
+
+function readWebsiteArtifact(directory) {
+  for (const name of ['artifact.json', 'website-artifact.json', 'static-site-candidate.json']) {
+    const filePath = path.join(directory, name);
+    if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+      continue;
+    }
+    try {
+      const payload = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      if (Array.isArray(payload?.files) && payload.files.some((file) => file.path === 'website/index.html')) {
+        return { path: filePath, payload };
+      }
+    } catch {
+      // Non-JSON files with these names are not website artifact candidates.
+    }
+  }
+  return null;
+}
+
+function materializeWebsiteArtifact(artifact, fixtureDirectory) {
+  for (const file of artifact.files || []) {
+    if (!file?.path || !file.path.startsWith('website/')) {
+      continue;
+    }
+    const relativePath = file.path.slice('website/'.length);
+    if (!relativePath || relativePath.includes('..')) {
+      continue;
+    }
+    const destination = path.join(fixtureDirectory, relativePath);
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    if (typeof file.content === 'string') {
+      fs.writeFileSync(destination, file.content);
+    } else if (typeof file.content_base64 === 'string') {
+      fs.writeFileSync(destination, Buffer.from(file.content_base64, 'base64'));
+    }
+  }
+}
+
+function copyDirectory(source, destination) {
+  for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
+    if (entry.name === '.git' || entry.name === 'node_modules') {
+      continue;
+    }
+    const sourcePath = path.join(source, entry.name);
+    const destinationPath = path.join(destination, entry.name);
+    if (entry.isDirectory()) {
+      fs.mkdirSync(destinationPath, { recursive: true });
+      copyDirectory(sourcePath, destinationPath);
+    } else if (entry.isFile()) {
+      fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+      fs.copyFileSync(sourcePath, destinationPath);
+    }
+  }
+}
+
+function visitDirectories(directory, depth, maxDepth, callback) {
+  const shouldDescend = callback(directory) !== false;
+  if (!shouldDescend || depth >= maxDepth) {
+    return;
+  }
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isDirectory() && entry.name !== '.git' && entry.name !== 'node_modules') {
+      visitDirectories(path.join(directory, entry.name), depth + 1, maxDepth, callback);
+    }
+  }
+}
+
+function uniqueFixtureId(value, existingFixtures, fallback) {
+  const base = slug(value || `fixture-${fallback}`);
+  const existing = new Set(existingFixtures.map((fixture) => fixture.id));
+  if (!existing.has(base)) {
+    return base;
+  }
+  let suffix = 2;
+  while (existing.has(`${base}-${suffix}`)) {
+    suffix += 1;
+  }
+  return `${base}-${suffix}`;
+}
+
+function requiredString(value, name) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new TypeError(`${name} must be a non-empty string.`);
+  }
+  return value;
+}
+
+function requiredDirectory(value, name) {
+  const directory = path.resolve(requiredString(value, name));
+  if (!fs.existsSync(directory) || !fs.statSync(directory).isDirectory()) {
+    throw new Error(`${name} must be an existing directory: ${directory}`);
+  }
+  return directory;
+}
+
+function finiteNumber(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function slug(value) {
+  return String(value || 'fixture')
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'fixture';
+}

--- a/WordPress/static-site-importer/tools/artifact-intake.mjs
+++ b/WordPress/static-site-importer/tools/artifact-intake.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import { materializeGeneratedArtifactFixtures } from '../lib/artifact-intake.mjs';
+
+const options = parseArgs(process.argv.slice(2));
+if (options.help) {
+  printHelp();
+  process.exit(0);
+}
+
+const result = materializeGeneratedArtifactFixtures(options);
+if (options.manifest) {
+  fs.writeFileSync(options.manifest, `${JSON.stringify(result, null, 2)}\n`);
+}
+process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+function parseArgs(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+    if (arg.startsWith('--')) {
+      const [rawKey, rawValue] = arg.slice(2).split('=');
+      const value = rawValue === undefined ? args[index + 1] : rawValue;
+      if (rawValue === undefined) {
+        index += 1;
+      }
+      options[camelCase(rawKey)] = value;
+      continue;
+    }
+    if (!options.artifactRoot) {
+      options.artifactRoot = arg;
+    } else if (!options.fixtureRoot) {
+      options.fixtureRoot = arg;
+    }
+  }
+  return options;
+}
+
+function camelCase(value) {
+  return value.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node WordPress/static-site-importer/tools/artifact-intake.mjs --artifact-root <dir> --fixture-root <dir> [--manifest <file>]\n\nMaterializes generated static-site artifacts into SSI fixture-matrix directories.\n`);
+}

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -11,6 +11,7 @@ import {
   normalizeFixtureMatrixResult,
   writeFixtureMatrixArtifacts,
 } from '../lib/fixture-matrix.mjs';
+import { materializeGeneratedArtifactFixtures } from '../lib/artifact-intake.mjs';
 
 const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const fixtureRoot = path.join(packageRoot, 'fixtures');
@@ -71,4 +72,29 @@ test('normalizes SSI diagnostics into product repair groups', () => {
   assert.equal(result.summary.groups.dropped_images, 1);
   assert.equal(result.summary.groups.invalid_block_content, 1);
   assert.equal(classifyStaticSiteFinding({ message: 'canvas target missing' }).repair_mode, 'runtime-dom-target-parity');
+});
+
+test('materializes generated artifact roots into matrix-compatible fixtures', () => {
+  const sourceRoot = mkdtempSync(path.join(tmpdir(), 'ssi-generated-artifacts-'));
+  const fixtureOutput = mkdtempSync(path.join(tmpdir(), 'ssi-generated-fixtures-'));
+  mkdirSync(path.join(sourceRoot, 'static-sites', 'alpha', 'assets'), { recursive: true });
+  writeFileSync(path.join(sourceRoot, 'static-sites', 'alpha', 'index.html'), '<h1>Alpha</h1>');
+  writeFileSync(path.join(sourceRoot, 'static-sites', 'alpha', 'assets', 'style.css'), 'body { color: black; }');
+  mkdirSync(path.join(sourceRoot, 'artifact-candidate'), { recursive: true });
+  writeFileSync(path.join(sourceRoot, 'artifact-candidate', 'artifact.json'), JSON.stringify({
+    schema: 'blocks-engine/php-transformer/site-artifact/v1',
+    metadata: { site: 'Beta Site' },
+    files: [
+      { path: 'website/index.html', content: '<h1>Beta</h1>' },
+      { path: 'website/assets/style.css', content: 'body { color: blue; }' },
+    ],
+  }));
+
+  const intake = materializeGeneratedArtifactFixtures({ artifactRoot: sourceRoot, fixtureRoot: fixtureOutput });
+  const matrix = createFixtureMatrix({ fixture_root: intake.fixture_root });
+
+  assert.equal(intake.count, 2);
+  assert.deepEqual(matrix.fixtures.map((fixture) => fixture.id), ['alpha', 'beta-site']);
+  assert.equal(readFileSync(path.join(fixtureOutput, 'alpha', 'index.html'), 'utf8'), '<h1>Alpha</h1>');
+  assert.equal(readFileSync(path.join(fixtureOutput, 'beta-site', 'index.html'), 'utf8'), '<h1>Beta</h1>');
 });


### PR DESCRIPTION
## Summary
- Add a generic generated-artifact intake helper for SSI fixture matrix runs.
- Support static directories, website/ directories, and website artifact JSON payloads without fixture-specific code.
- Wire the matrix bench to accept --artifact-root and document the intake contract.

## Verification
- node --test WordPress/static-site-importer/tools/fixture-matrix.test.mjs
- node WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs --fixture-root WordPress/static-site-importer/fixtures --output-directory /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/ssi-matrix-fixture-check --static-site-importer-path /Users/chubes/Developer/static-site-importer@run-ssi-matrix-current-main-20260625
- node WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs --artifact-root /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/ssi-generated-root --output-directory /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/ssi-matrix-intake-check --static-site-importer-path /Users/chubes/Developer/static-site-importer@run-ssi-matrix-current-main-20260625

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, tests, documentation, and verification.