### PR TITLE
feat(woocommerce): require fuzz proof bundle metadata

### DIFF
--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -201,13 +201,24 @@ export function assertFuzzReadinessMetadata(manifest, { file = manifest.id } = {
   const readiness = manifest.metadata?.readiness;
   assert.ok(readiness && typeof readiness === 'object' && !Array.isArray(readiness), `${file} requires metadata.readiness`);
 
-  assert.ok(fuzzReadinessLevels.has(readiness.level), `${file} metadata.readiness.level must be declared, executable, or proven`);
+  assertFuzzReadinessLevel(readiness.level, `${file} metadata.readiness.level`);
   assert.equal(typeof readiness.coverage_contract, 'string', `${file} metadata.readiness.coverage_contract must describe the declared contract`);
   assert.notEqual(readiness.coverage_contract.trim(), '', `${file} metadata.readiness.coverage_contract must describe the declared contract`);
+
+  if (readiness.proof_refs !== undefined) {
+    assertStringArray(readiness.proof_refs, `${file} metadata.readiness.proof_refs`);
+    for (const proofRef of readiness.proof_refs) {
+      assertReviewerFacingRef(proofRef, `${file} metadata.readiness.proof_refs`);
+    }
+  }
 
   if (readiness.level === 'proven') {
     assert.ok(Array.isArray(readiness.proof_refs) && readiness.proof_refs.length > 0, `${file} proven readiness requires proof_refs`);
     assertFuzzProofBundle(readiness.proof_bundle, manifest, { file });
+  }
+
+  if (readiness.proof_bundle_requirements !== undefined) {
+    assertFuzzProofBundleRequirements(readiness.proof_bundle_requirements, { file });
   }
 
   if (readiness.upstream_blockers !== undefined) {
@@ -313,12 +324,44 @@ export function assertFuzzCrudReadiness(crud, { file } = {}) {
 
   for (const operation of fuzzCrudOperations) {
     assert.ok(crud[operation] && typeof crud[operation] === 'object' && !Array.isArray(crud[operation]), `${file} metadata.readiness.crud.${operation} must be an object`);
-    assert.ok(fuzzReadinessLevels.has(crud[operation].level), `${file} metadata.readiness.crud.${operation}.level must be declared, executable, or proven`);
+    assertFuzzReadinessLevel(crud[operation].level, `${file} metadata.readiness.crud.${operation}.level`);
 
     if (crud[operation].upstream_blocker !== undefined) {
       assert.equal(typeof crud[operation].upstream_blocker, 'string', `${file} metadata.readiness.crud.${operation}.upstream_blocker must be a string`);
       assert.notEqual(crud[operation].upstream_blocker.trim(), '', `${file} metadata.readiness.crud.${operation}.upstream_blocker must be non-empty`);
     }
+  }
+}
+
+export function assertFuzzReadinessLevel(level, label) {
+  assert.ok(fuzzReadinessLevels.has(level), `${label} must be declared, executable, or proven`);
+}
+
+export function assertExecutableCrudMutationSafety(readiness, { file } = {}) {
+  const executableMutations = ['create', 'update', 'delete'].filter((operation) => ['executable', 'proven'].includes(readiness?.crud?.[operation]?.level));
+  if (executableMutations.length === 0) {
+    return;
+  }
+
+  assert.ok(readiness.mutation, `${file} executable CRUD mutation readiness requires metadata.readiness.mutation`);
+  assertFuzzMutationReadiness(readiness.mutation, { file });
+  assert.ok(readiness.mutation.rollback_artifacts.length > 0, `${file} executable CRUD mutation readiness requires rollback_artifacts`);
+
+  for (const operation of executableMutations) {
+    const safetyClass = readiness.crud[operation].safety_class;
+    assert.ok(
+      ['isolated_mutation', 'synthetic_checkout_mutation', 'bounded_catalog_fixture_mutation', 'bounded_admin_fixture_mutation'].includes(safetyClass),
+      `${file} executable CRUD ${operation} requires an isolated mutation safety_class`
+    );
+  }
+}
+
+export function assertFuzzProofBundleRequirements(requirements, { file } = {}) {
+  assert.ok(requirements && typeof requirements === 'object' && !Array.isArray(requirements), `${file} metadata.readiness.proof_bundle_requirements must be an object`);
+  assertStringArray(requirements.required_refs, `${file} metadata.readiness.proof_bundle_requirements.required_refs`);
+  assertStringArray(requirements.required_artifacts, `${file} metadata.readiness.proof_bundle_requirements.required_artifacts`);
+  if (requirements.status !== undefined) {
+    assert.equal(requirements.status, 'required_before_proven', `${file} metadata.readiness.proof_bundle_requirements.status must be required_before_proven`);
   }
 }
 

--- a/scripts/fuzz-manifest-helpers.test.mjs
+++ b/scripts/fuzz-manifest-helpers.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  assertExecutableCrudMutationSafety,
   assertFuzzReadinessMetadata,
   assertGenericFuzzManifest,
   assertJetpackFuzzManifestReadinessContract,
@@ -266,6 +267,39 @@ test('assertFuzzReadinessMetadata accepts declared CRUD and isolated mutation co
   }), { file: 'product-fuzz.json' }));
 });
 
+test('assertExecutableCrudMutationSafety accepts executable isolated mutations with rollback artifacts', () => {
+  assert.doesNotThrow(() => assertExecutableCrudMutationSafety({
+    crud: {
+      create: { level: 'executable', safety_class: 'isolated_mutation' },
+      read: { level: 'executable' },
+      update: { level: 'declared', upstream_blocker: 'not available' },
+      delete: { level: 'declared', upstream_blocker: 'not available' },
+    },
+    mutation: {
+      safety_boundary: 'Runs only against disposable fixtures and emits rollback artifacts.',
+      rollback_artifacts: ['raw_result'],
+    },
+  }, { file: 'product-fuzz.json' }));
+});
+
+test('assertExecutableCrudMutationSafety rejects executable mutations without rollback artifacts', () => {
+  assert.throws(
+    () => assertExecutableCrudMutationSafety({
+      crud: {
+        create: { level: 'executable', safety_class: 'isolated_mutation' },
+        read: { level: 'executable' },
+        update: { level: 'declared', upstream_blocker: 'not available' },
+        delete: { level: 'declared', upstream_blocker: 'not available' },
+      },
+      mutation: {
+        safety_boundary: 'Runs only against disposable fixtures.',
+        rollback_artifacts: [],
+      },
+    }, { file: 'product-fuzz.json' }),
+    /requires rollback_artifacts/
+  );
+});
+
 test('assertFuzzReadinessMetadata accepts proven readiness with proof bundle linkage', () => {
   assert.doesNotThrow(() => assertFuzzReadinessMetadata(fuzzManifest({
     metadata: {
@@ -335,6 +369,28 @@ test('assertFuzzReadinessMetadata rejects local proof bundle refs', () => {
       },
     }), { file: 'product-fuzz.json' }),
     /must not use local URLs/
+  );
+});
+
+test('assertFuzzReadinessMetadata rejects local proof refs', () => {
+  assert.throws(
+    () => assertFuzzReadinessMetadata(fuzzManifest({
+      metadata: {
+        workload_path: '${package.root}/bench/product.workload.json',
+        readiness: {
+          level: 'proven',
+          coverage_contract: 'Product API CRUD coverage.',
+          proof_refs: ['/Users/chris/artifacts/product-fuzz.json'],
+          proof_bundle: {
+            artifact_refs: ['https://github.com/example/product/issues/123#issuecomment-456'],
+            run_ids: ['run:product-fuzz-proof'],
+            gap_reports: ['https://github.com/example/product/issues/124'],
+            fuzz_result_artifacts: ['report'],
+          },
+        },
+      },
+    }), { file: 'product-fuzz.json' }),
+    /must be reviewer-facing refs/
   );
 });
 

--- a/woocommerce/woocommerce/fuzz/cart-session-overwrite-race.json
+++ b/woocommerce/woocommerce/fuzz/cart-session-overwrite-race.json
@@ -23,13 +23,15 @@
       "coverage_contract": "WP Codebox can execute the cart/session overwrite race workload and emit the cart-session race artifact contract; reviewer-facing proof links are still required before marking this proven.",
       "crud": {
         "create": {
-          "level": "executable"
+          "level": "executable",
+          "safety_class": "isolated_mutation"
         },
         "read": {
           "level": "executable"
         },
         "update": {
-          "level": "executable"
+          "level": "executable",
+          "safety_class": "isolated_mutation"
         },
         "delete": {
           "level": "declared",

--- a/woocommerce/woocommerce/fuzz/checkout-concurrent-create-order.json
+++ b/woocommerce/woocommerce/fuzz/checkout-concurrent-create-order.json
@@ -50,7 +50,8 @@
       },
       "crud": {
         "create": {
-          "level": "proven"
+          "level": "proven",
+          "safety_class": "isolated_mutation"
         },
         "read": {
           "level": "executable"

--- a/woocommerce/woocommerce/fuzz/checkout-gateway-compatibility-matrix.json
+++ b/woocommerce/woocommerce/fuzz/checkout-gateway-compatibility-matrix.json
@@ -25,7 +25,8 @@
       "coverage_contract": "WP Codebox can execute the checkout gateway compatibility matrix and emit gateway readiness, dependency classification, and create-order idempotency observations; reviewer-facing proof links are still required before marking this proven.",
       "crud": {
         "create": {
-          "level": "executable"
+          "level": "executable",
+          "safety_class": "isolated_mutation"
         },
         "read": {
           "level": "executable"

--- a/woocommerce/woocommerce/fuzz/codebox-fuzz-suite-smoke.json
+++ b/woocommerce/woocommerce/fuzz/codebox-fuzz-suite-smoke.json
@@ -44,6 +44,20 @@
         "Generic rollback-safe REST create/update/delete primitives must emit rollback artifacts before mutating DB/API cases can join the profile.",
         "Public fuzz-suite proof must include reviewer-facing coverage gap report and hotspot summary artifacts before this contract can become proven."
       ],
+      "proof_bundle_requirements": {
+        "status": "required_before_proven",
+        "required_refs": [
+          "reviewer-facing wp-codebox fuzz-suite run id",
+          "reviewer-facing wp-codebox/fuzz-suite-result artifact ref",
+          "reviewer-facing coverage gap report artifact ref",
+          "reviewer-facing performance hotspot summary artifact ref"
+        ],
+        "required_artifacts": [
+          "codebox_fuzz_suite_result",
+          "coverage_gap_report",
+          "performance_hotspots_summary"
+        ]
+      },
       "crud": {
         "create": {
           "level": "declared",

--- a/woocommerce/woocommerce/fuzz/rest-product-batch-import.json
+++ b/woocommerce/woocommerce/fuzz/rest-product-batch-import.json
@@ -30,6 +30,18 @@
         "Reviewer-facing fuzz run artifacts and rollback/gap reports are required before proven status.",
         "Rollback-safe REST delete primitives and delete-boundary artifacts are required before delete coverage can execute."
       ],
+      "proof_bundle_requirements": {
+        "status": "required_before_proven",
+        "required_refs": [
+          "reviewer-facing rest-product-batch-import run id",
+          "reviewer-facing raw_result artifact ref",
+          "reviewer-facing product REST CRUD coverage gap report artifact ref"
+        ],
+        "required_artifacts": [
+          "raw_result",
+          "coverage_gap_report"
+        ]
+      },
       "crud": {
         "create": {
           "level": "executable",

--- a/woocommerce/woocommerce/fuzz/rollback-safe-options-transients-mutations.json
+++ b/woocommerce/woocommerce/fuzz/rollback-safe-options-transients-mutations.json
@@ -26,13 +26,15 @@
       "coverage_contract": "WP Codebox can execute rollback-safe WooCommerce option/transient mutations and emit rollback, transient-growth, and skipped-sensitive-option artifacts before any proof claim.",
       "crud": {
         "create": {
-          "level": "executable"
+          "level": "executable",
+          "safety_class": "isolated_mutation"
         },
         "read": {
           "level": "executable"
         },
         "update": {
-          "level": "executable"
+          "level": "executable",
+          "safety_class": "isolated_mutation"
         },
         "delete": {
           "level": "declared",

--- a/woocommerce/woocommerce/manifests/admin-action-inventory.json
+++ b/woocommerce/woocommerce/manifests/admin-action-inventory.json
@@ -11,21 +11,21 @@
     {
       "id": "admin-menu-get-pages",
       "fixture_requirements": ["administrator user", "shop_manager user", "WooCommerce active"],
-      "readiness": "executable_get_only",
+      "readiness": { "level": "executable", "via": "safe GET-only admin-page-coverage" },
       "workload": "admin-page-coverage",
       "skip_reasons": ["unsafe_query_arg_action", "unsafe_query_arg_delete", "setup_or_onboarding_screen"]
     },
     {
       "id": "wc-ajax-frontend-actions",
       "fixture_requirements": ["synthetic cart", "synthetic product"],
-      "readiness": "declared_browser_request_inventory_only",
+      "readiness": { "level": "declared", "upstream_blocker": "browser request inventory artifacts are required before action coverage is executable" },
       "workload": "frontend-rendering-request-coverage",
       "skip_reasons": ["destructive_cart_or_checkout_mutation", "payment_submission"]
     },
     {
       "id": "marketplace-and-webhook-http-actions",
       "fixture_requirements": ["external HTTP guardrail", "allowlist policy"],
-      "readiness": "executable_guardrail_probe",
+      "readiness": { "level": "executable", "via": "woocommerce-external-http-guardrail" },
       "workload": "woocommerce-external-http-guardrail",
       "skip_reasons": ["live_credentials_required", "external_side_effect_blocked"]
     }

--- a/woocommerce/woocommerce/manifests/block-inventory-rendering-fuzz.json
+++ b/woocommerce/woocommerce/manifests/block-inventory-rendering-fuzz.json
@@ -11,9 +11,18 @@
     "profiles": ["full-surface"]
   },
   "readiness": {
-    "inventory": "declared_requires_generic_block_inventory_artifact",
-    "rendering": "partial_via_frontend_browser_request_coverage",
-    "mutation": "blocked_not_a_block_editor_mutation_workload"
+    "inventory": {
+      "level": "declared",
+      "upstream_blocker": "generic WordPress block inventory artifact is required before inventory coverage is executable"
+    },
+    "rendering": {
+      "level": "executable",
+      "via": "frontend-rendering-request-coverage"
+    },
+    "mutation": {
+      "level": "declared",
+      "upstream_blocker": "this profile is not a block editor mutation workload"
+    }
   },
   "skip_reasons": [
     {

--- a/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
+++ b/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
@@ -41,6 +41,20 @@
           "performance-hotspots-artifact-summary"
         ],
         "gap_report_manifest": "manifests/db-api-performance-fuzzer-gap-report.json"
+      },
+      "proof_bundle_requirements": {
+        "status": "required_before_proven",
+        "required_refs": [
+          "reviewer-facing wp-codebox fuzz-suite run id",
+          "reviewer-facing wp-codebox/fuzz-suite-result artifact ref",
+          "reviewer-facing coverage gap report artifact ref",
+          "reviewer-facing performance hotspot summary artifact ref"
+        ],
+        "required_artifacts": [
+          "codebox_fuzz_suite_result",
+          "coverage_gap_report",
+          "performance_hotspots_summary"
+        ]
       }
     }
   },
@@ -68,6 +82,7 @@
     "component": "woocommerce",
     "contract": "wp-codebox/fuzz-suite/v1",
     "proof_status": "contract_only_placeholder",
-    "readiness_level": "declared"
+    "readiness_level": "declared",
+    "public_result_contract": "wp-codebox/fuzz-suite-result/v1"
   }
 }

--- a/woocommerce/woocommerce/manifests/db-api-hotspot-artifact-io.json
+++ b/woocommerce/woocommerce/manifests/db-api-hotspot-artifact-io.json
@@ -4,8 +4,23 @@
   "description": "Expected input artifact map and sample output schema for future Homeboy artifact postprocess of WooCommerce DB/API hotspot evidence.",
   "owner_profile": "db-api-performance-fuzzer",
   "postprocess_command": "homeboy.artifact-postprocess",
+  "generic_upstream_contracts": [
+    "homeboy.artifact-postprocess",
+    "wp-codebox/wordpress-workload-run/v1",
+    "homeboy/woocommerce-performance-hotspots-summary/v1"
+  ],
   "readiness": {
     "level": "declared",
+    "proof_bundle_requirements": {
+      "status": "required_before_proven",
+      "required_refs": [
+        "reviewer-facing artifact-postprocess run id",
+        "reviewer-facing performance hotspot summary artifact ref"
+      ],
+      "required_artifacts": [
+        "performance_hotspots_summary"
+      ]
+    },
     "upstream_blocker": "Homeboy/Homeboy Extensions must bind artifact-postprocess helper/action/input/output/parameters before this IO contract becomes executable."
   },
   "expected_inputs": [

--- a/woocommerce/woocommerce/manifests/db-api-performance-fuzzer-gap-report.json
+++ b/woocommerce/woocommerce/manifests/db-api-performance-fuzzer-gap-report.json
@@ -6,6 +6,11 @@
   "workload": "fuzz/coverage-gap-report.json",
   "workload_config": "bench/coverage-gap-report.workload.json",
   "source_gap_report": "manifests/full-surface-coverage.json#gap_report",
+  "generic_upstream_contracts": [
+    "homeboy.artifact-postprocess",
+    "wp-codebox/wordpress-workload-run/v1",
+    "homeboy-rigs/wordpress-coverage-gap-report/v1"
+  ],
   "semantic_key": "fuzz.report",
   "inputs": [
     "woocommerce-rest-route-inventory",
@@ -31,6 +36,16 @@
   "readiness": {
     "level": "declared",
     "execution": "artifact_aggregation",
+    "proof_bundle_requirements": {
+      "status": "required_before_proven",
+      "required_refs": [
+        "reviewer-facing artifact-postprocess run id",
+        "reviewer-facing coverage gap report artifact ref"
+      ],
+      "required_artifacts": [
+        "coverage_gap_report"
+      ]
+    },
     "upstream_blockers": [
       "WP Codebox/Homeboy Extensions must bind homeboy.artifact-postprocess steps with args.helper, args.action, args.input, args.output, and args.parameters.",
       "The runner must pass an artifact root for prior workload outputs and collect the declared fuzz.report JSON artifact.",

--- a/woocommerce/woocommerce/manifests/rest-crud-route-family-catalog.json
+++ b/woocommerce/woocommerce/manifests/rest-crud-route-family-catalog.json
@@ -15,10 +15,10 @@
         "profiles": ["product-rest-crud-fuzzer", "full-surface"]
       },
       "readiness": {
-        "create": "executable_via_batch_import",
-        "read": "executable_via_generated_get_cases",
-        "update": "executable_via_batch_import",
-        "delete": "blocked_requires_rollback_safe_delete_primitive"
+        "create": { "level": "executable", "via": "rest-product-batch-import" },
+        "read": { "level": "executable", "via": "generated-rest-request-cases" },
+        "update": { "level": "executable", "via": "rest-product-batch-import" },
+        "delete": { "level": "declared", "upstream_blocker": "rollback-safe REST delete primitive and delete-boundary rollback artifacts are unavailable" }
       },
       "skipped_coverage": [
         {
@@ -42,10 +42,10 @@
         "profiles": ["product-rest-crud-fuzzer", "full-surface"]
       },
       "readiness": {
-        "create": "executable_isolated_mutation",
-        "read": "executable_readback_guardrail",
-        "update": "executable_isolated_mutation",
-        "delete": "declared_blocked"
+        "create": { "level": "executable", "via": "isolated_mutation" },
+        "read": { "level": "executable", "via": "readback_guardrail" },
+        "update": { "level": "executable", "via": "isolated_mutation" },
+        "delete": { "level": "declared", "upstream_blocker": "current workload does not execute delete" }
       },
       "skipped_coverage": [
         {
@@ -65,10 +65,10 @@
         "profiles": ["product-rest-crud-fuzzer", "full-surface"]
       },
       "readiness": {
-        "create": "executable_isolated_mutation",
-        "read": "executable_readback_guardrail",
-        "update": "executable_isolated_mutation",
-        "delete": "declared_blocked"
+        "create": { "level": "executable", "via": "isolated_mutation" },
+        "read": { "level": "executable", "via": "readback_guardrail" },
+        "update": { "level": "executable", "via": "isolated_mutation" },
+        "delete": { "level": "declared", "upstream_blocker": "current workload does not execute delete" }
       },
       "skipped_coverage": [
         {
@@ -92,10 +92,10 @@
         "profiles": ["product-rest-crud-fuzzer", "full-surface"]
       },
       "readiness": {
-        "create": "executable_as_fixture_setup",
-        "read": "partial_dynamic_get_cases",
-        "update": "declared_fixture_owned",
-        "delete": "blocked_requires_rollback_safe_delete_primitive"
+        "create": { "level": "executable", "via": "fixture_setup" },
+        "read": { "level": "declared", "upstream_blocker": "dynamic attribute and term path cases require generated fixture-owned path parameter artifacts" },
+        "update": { "level": "declared", "upstream_blocker": "update is fixture-owned and lacks standalone rollback artifact proof" },
+        "delete": { "level": "declared", "upstream_blocker": "rollback-safe REST delete primitive and delete-boundary rollback artifacts are unavailable" }
       },
       "skipped_coverage": [
         {

--- a/woocommerce/woocommerce/manifests/target-inventory.json
+++ b/woocommerce/woocommerce/manifests/target-inventory.json
@@ -21,7 +21,10 @@
     "rest_route_families": {
       "manifest": "manifests/rest-crud-route-family-catalog.json",
       "owner_profile": "product-rest-crud-fuzzer",
-      "readiness": "declared_inventory",
+      "readiness": {
+        "level": "declared",
+        "coverage_contract": "REST route-family discovery is a Woo-owned inventory contract; executable/proven status requires the owning fuzz workloads to emit reviewer-facing artifacts."
+      },
       "route_family_ids": [
         "products-collection",
         "products-batch",
@@ -33,9 +36,18 @@
       "manifest": "manifests/block-inventory-rendering-fuzz.json",
       "owner_profile": "full-surface",
       "readiness": {
-        "inventory": "declared_requires_generic_block_inventory_artifact",
-        "rendering": "partial_via_frontend_browser_request_coverage",
-        "mutation": "blocked_not_a_block_editor_mutation_workload"
+        "inventory": {
+          "level": "declared",
+          "upstream_blocker": "generic WordPress block inventory artifact is required before inventory coverage is executable"
+        },
+        "rendering": {
+          "level": "executable",
+          "via": "frontend-rendering-request-coverage"
+        },
+        "mutation": {
+          "level": "declared",
+          "upstream_blocker": "this profile is not a block editor mutation workload"
+        }
       },
       "owned_by": {
         "workloads": [
@@ -50,7 +62,10 @@
     "admin_actions": {
       "manifest": "manifests/admin-action-inventory.json",
       "owner_profile": "full-surface",
-      "readiness": "declared_inventory",
+      "readiness": {
+        "level": "declared",
+        "coverage_contract": "Admin action discovery is a Woo-owned inventory contract; executable/proven status requires the owning safe admin fuzz workloads to emit reviewer-facing artifacts."
+      },
       "action_family_ids": [
         "admin-menu-get-pages",
         "wc-ajax-frontend-actions",
@@ -62,6 +77,16 @@
       "owner_profile": "db-api-performance-fuzzer",
       "readiness": {
         "level": "declared",
+        "proof_bundle_requirements": {
+          "status": "required_before_proven",
+          "required_refs": [
+            "reviewer-facing artifact-postprocess run id",
+            "reviewer-facing performance hotspot summary artifact ref"
+          ],
+          "required_artifacts": [
+            "performance_hotspots_summary"
+          ]
+        },
         "upstream_blocker": "Homeboy/Homeboy Extensions must bind artifact-postprocess helper/action/input/output/parameters before this IO contract becomes executable."
       },
       "postprocess_command": "homeboy.artifact-postprocess"

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -192,7 +192,7 @@
         "db_api_hotspots": "manifests/db-api-hotspot-artifact-io.json"
       },
       "readiness": {
-        "level": "declared_inventory",
+        "level": "declared",
         "coverage_contract": "These manifests are inventory and artifact contracts only. Executable coverage remains limited to workload ids declared in fuzz_workloads.wordpress and grouped by fuzz_profiles. Browser-only scenarios and future artifact-postprocess outputs stay non-executable until upstream runner support emits reviewer-facing artifacts."
       }
     },
@@ -212,6 +212,23 @@
       "readiness": {
         "level": "declared",
         "coverage_contract": "DB/API performance fuzzing is declared as a profile over existing WooCommerce fuzz workloads plus the full-surface gap report contract; it does not claim CRUD or mutating REST execution until upstream rollback-safe primitives exist.",
+        "proof_bundle_requirements": {
+          "status": "required_before_proven",
+          "required_refs": [
+            "reviewer-facing run ids from wp-codebox/fuzz-suite-result/v1 outputs",
+            "reviewer-facing coverage gap report artifact refs",
+            "reviewer-facing performance hotspot summary artifact refs"
+          ],
+          "required_artifacts": [
+            "route_inventory",
+            "rest_request_cases",
+            "rest_db_query_profile",
+            "db_inventory",
+            "rest_schema_query_attribution",
+            "coverage_gap_report",
+            "performance_hotspots_summary"
+          ]
+        },
         "crud": {
           "create": {
             "level": "declared",
@@ -244,7 +261,19 @@
       "route_family_catalog_manifest": "manifests/rest-crud-route-family-catalog.json",
       "hotspot_artifact_contract_manifest": "manifests/db-api-hotspot-artifact-io.json",
       "readiness": {
-        "level": "partially_executable",
+        "level": "executable",
+        "coverage_contract": "Product REST CRUD fuzzing can execute isolated create/update plus readback through rest-product-batch-import. Delete remains declared until rollback-safe delete primitives and delete-boundary rollback artifacts exist; proven status requires reviewer-facing run artifacts and gap reports.",
+        "proof_bundle_requirements": {
+          "status": "required_before_proven",
+          "required_refs": [
+            "reviewer-facing run id for rest-product-batch-import",
+            "reviewer-facing coverage gap report artifact ref"
+          ],
+          "required_artifacts": [
+            "raw_result",
+            "coverage_gap_report"
+          ]
+        },
         "crud": {
           "create": {
             "level": "executable",
@@ -265,6 +294,10 @@
             "level": "declared",
             "upstream_blocker": "Generic rollback-safe REST delete primitive and delete-boundary rollback artifact contract are not available to this profile."
           }
+        },
+        "mutation": {
+          "safety_boundary": "Executable product create/update cases run only inside disposable WP Codebox fixtures and must emit rollback/readback details in raw_result before any proof claim.",
+          "rollback_artifacts": ["raw_result"]
         }
       }
     }

--- a/woocommerce/woocommerce/tools/generate-target-inventory.mjs
+++ b/woocommerce/woocommerce/tools/generate-target-inventory.mjs
@@ -41,7 +41,10 @@ const inventory = {
     rest_route_families: {
       manifest: 'manifests/rest-crud-route-family-catalog.json',
       owner_profile: restCrudRouteFamilyCatalog.owner_profile,
-      readiness: 'declared_inventory',
+      readiness: {
+        level: 'declared',
+        coverage_contract: 'REST route-family discovery is a Woo-owned inventory contract; executable/proven status requires the owning fuzz workloads to emit reviewer-facing artifacts.',
+      },
       route_family_ids: restCrudRouteFamilyCatalog.route_families.map((family) => family.id),
     },
     blocks: {
@@ -53,7 +56,10 @@ const inventory = {
     admin_actions: {
       manifest: 'manifests/admin-action-inventory.json',
       owner_profile: adminActionInventory.owner_profile,
-      readiness: 'declared_inventory',
+      readiness: {
+        level: 'declared',
+        coverage_contract: 'Admin action discovery is a Woo-owned inventory contract; executable/proven status requires the owning safe admin fuzz workloads to emit reviewer-facing artifacts.',
+      },
       action_family_ids: adminActionInventory.action_families.map((family) => family.id),
     },
     db_api_hotspots: {

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -5,7 +5,10 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
+  assertExecutableCrudMutationSafety,
   assertFullSurfaceCoverageManifest,
+  assertFuzzProofBundleRequirements,
+  assertFuzzReadinessLevel,
   assertGenericFuzzManifest,
   collectFuzzManifests,
   declaredBenchProfileIds,
@@ -128,6 +131,19 @@ const externalDiscoveryWorkloadIds = new Set([
   'woocommerce-browser-coverage',
 ]);
 
+function assertProfileReadiness(readiness, context) {
+  assert.ok(readiness && typeof readiness === 'object' && !Array.isArray(readiness), `${context} requires readiness metadata`);
+  assertFuzzReadinessLevel(readiness.level, `${context}.level`);
+  assert.equal(typeof readiness.coverage_contract, 'string', `${context}.coverage_contract must describe the contract`);
+  assert.notEqual(readiness.coverage_contract.trim(), '', `${context}.coverage_contract must not be empty`);
+  if (readiness.proof_bundle_requirements !== undefined) {
+    assertFuzzProofBundleRequirements(readiness.proof_bundle_requirements, { file: context });
+  }
+  if (readiness.crud !== undefined) {
+    assertExecutableCrudMutationSafety(readiness, { file: context });
+  }
+}
+
 function assertDeclaredOrExternalDiscoveryWorkload(workloadId, context) {
   assert.ok(
     declaredIds.has(workloadId) || externalDiscoveryWorkloadIds.has(workloadId),
@@ -204,7 +220,8 @@ assert.deepEqual(rig.fuzz_profile_metadata?.['full-surface']?.discovery_manifest
   admin_actions: 'manifests/admin-action-inventory.json',
   db_api_hotspots: 'manifests/db-api-hotspot-artifact-io.json',
 }, 'full-surface profile discovery manifests drifted');
-assert.equal(rig.fuzz_profile_metadata?.['full-surface']?.readiness?.level, 'declared_inventory', 'full-surface discovery manifests must stay declared inventory');
+assertProfileReadiness(rig.fuzz_profile_metadata?.['full-surface']?.readiness, 'fuzz_profile_metadata.full-surface.readiness');
+assert.equal(rig.fuzz_profile_metadata?.['full-surface']?.readiness?.level, 'declared', 'full-surface discovery manifests must stay declared');
 
 const requiredTargetSurfaces = new Set([
   'rest_routes',
@@ -272,6 +289,7 @@ for (const { file, manifest } of fuzzManifests) {
   assert.equal(manifest.metadata?.fixture?.scope, 'disposable-wordpress', `${manifest.id} fixture scope must be disposable-wordpress`);
   assert.equal(manifest.metadata?.fixture?.component, 'woocommerce', `${manifest.id} fixture component must be woocommerce`);
   assert.equal(manifest.metadata?.fixture?.activation, 'woocommerce/woocommerce.php', `${manifest.id} fixture activation must be woocommerce/woocommerce.php`);
+  assertExecutableCrudMutationSafety(manifest.metadata?.readiness, { file: manifest.id });
 
   if (manifest.metadata?.readiness?.level === 'proven') {
     const proofBundle = manifest.metadata.readiness.proof_bundle;
@@ -331,6 +349,7 @@ for (const { file, manifest } of fuzzManifests) {
 const codeboxSmokeManifest = fuzzManifests.find(({ manifest }) => manifest.id === 'codebox-fuzz-suite-smoke')?.manifest;
 assert.ok(codeboxSmokeManifest, 'codebox-fuzz-suite-smoke manifest is missing');
 assert.equal(codeboxSmokeManifest.metadata?.readiness?.level, 'declared', 'codebox smoke must not claim proven readiness without proof artifacts');
+assertFuzzProofBundleRequirements(codeboxSmokeManifest.metadata?.readiness?.proof_bundle_requirements, { file: 'codebox-fuzz-suite-smoke readiness' });
 assert.ok(codeboxSmokeManifest.operations.includes('generated-route-inventory-contract'), 'codebox smoke must depend on generated route inventory contracts');
 assert.ok(codeboxSmokeManifest.operations.includes('rest-db-query-attribution-contract'), 'codebox smoke must depend on REST DB query attribution contracts');
 assert.deepEqual(codeboxSmokeManifest.metadata?.required_primitive_contracts, [
@@ -395,8 +414,11 @@ assert.deepEqual(codeboxSuite.target?.metadata?.source_manifests, [
 assert.deepEqual(rig.fuzz_profiles?.['db-api-performance-fuzzer'], dbApiPerformanceFuzzerWorkloadIds, 'DB/API performance fuzzer profile workload ids drifted');
 assert.deepEqual(codeboxSuite.target?.metadata?.profile?.workload_ids, dbApiPerformanceFuzzerWorkloadIds, 'Codebox suite DB/API profile workload ids drifted');
 assert.equal(codeboxSuite.target?.metadata?.profile?.gap_report_manifest, 'manifests/db-api-performance-fuzzer-gap-report.json', 'Codebox suite must link the standalone DB/API gap report declaration');
+assertFuzzProofBundleRequirements(codeboxSuite.target?.metadata?.proof_bundle_requirements, { file: 'codebox suite metadata proof bundle requirements' });
+assert.equal(codeboxSuite.metadata?.public_result_contract, 'wp-codebox/fuzz-suite-result/v1', 'Codebox suite must declare the public fuzz-suite result contract');
 assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.gap_report_manifest, 'manifests/db-api-performance-fuzzer-gap-report.json', 'DB/API profile must link the standalone gap report declaration');
 assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.source_gap_report, 'manifests/full-surface-coverage.json#gap_report', 'DB/API profile must identify the source full-surface gap report');
+assertProfileReadiness(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.readiness, 'fuzz_profile_metadata.db-api-performance-fuzzer.readiness');
 assert.equal(dbApiPerformanceFuzzerGapReport.schema, 'homeboy-rigs/wordpress-coverage-gap-report-workload/v1', 'DB/API gap report workload schema drifted');
 assert.equal(dbApiPerformanceFuzzerGapReport.id, 'woocommerce-db-api-performance-fuzzer-gap-report', 'DB/API gap report workload id drifted');
 assert.equal(dbApiPerformanceFuzzerGapReport.profile_id, 'db-api-performance-fuzzer', 'DB/API gap report workload must target the DB/API fuzzer profile');
@@ -405,11 +427,23 @@ assert.equal(dbApiPerformanceFuzzerGapReport.workload, 'fuzz/coverage-gap-report
 assert.deepEqual(dbApiPerformanceFuzzerGapReport.inputs, dbApiPerformanceFuzzerGapReportInputIds, 'DB/API gap report workload inputs drifted');
 assert.equal(dbApiPerformanceFuzzerGapReport.readiness?.level, 'declared', 'DB/API gap report workload readiness must stay declared until upstream binds artifact-postprocess');
 assert.equal(dbApiPerformanceFuzzerGapReport.readiness?.execution, 'artifact_aggregation', 'DB/API gap report workload must use artifact aggregation execution');
+assert.deepEqual(dbApiPerformanceFuzzerGapReport.generic_upstream_contracts, [
+  'homeboy.artifact-postprocess',
+  'wp-codebox/wordpress-workload-run/v1',
+  'homeboy-rigs/wordpress-coverage-gap-report/v1',
+], 'DB/API gap report must link generic upstream artifact contracts');
+assertFuzzProofBundleRequirements(dbApiPerformanceFuzzerGapReport.readiness?.proof_bundle_requirements, { file: 'db-api-performance-fuzzer-gap-report readiness' });
 assert.ok(dbApiPerformanceFuzzerGapReport.readiness?.upstream_blockers?.length > 0, 'DB/API gap report declaration must name upstream blockers');
 assert.ok(dbApiPerformanceFuzzerGapReport.readiness.upstream_blockers.some((blocker) => blocker.includes('args.helper')), 'DB/API gap report declaration must list the missing upstream artifact-postprocess fields');
 assert.equal(dbApiHotspotArtifactIo.schema, 'homeboy-rigs/woocommerce-db-api-hotspot-artifact-io/v1', 'DB/API hotspot artifact IO schema drifted');
 assert.equal(dbApiHotspotArtifactIo.postprocess_command, 'homeboy.artifact-postprocess', 'DB/API hotspot artifact IO must use upstream artifact-postprocess');
 assert.equal(dbApiHotspotArtifactIo.readiness?.level, 'declared', 'DB/API hotspot artifact IO must stay declared until artifact-postprocess binding lands');
+assert.deepEqual(dbApiHotspotArtifactIo.generic_upstream_contracts, [
+  'homeboy.artifact-postprocess',
+  'wp-codebox/wordpress-workload-run/v1',
+  'homeboy/woocommerce-performance-hotspots-summary/v1',
+], 'DB/API hotspot artifact IO must link generic upstream artifact contracts');
+assertFuzzProofBundleRequirements(dbApiHotspotArtifactIo.readiness?.proof_bundle_requirements, { file: 'db-api-hotspot-artifact-io readiness' });
 assert.deepEqual(new Set(dbApiHotspotArtifactIo.expected_inputs.map((input) => input.workload_id)), new Set(dbApiPerformanceFuzzerGapReportInputIds), 'DB/API hotspot artifact IO inputs drifted');
 assert.equal(dbApiHotspotArtifactIo.sample_output?.schema, 'homeboy/woocommerce-performance-hotspots-summary/v1', 'DB/API hotspot sample output schema drifted');
 assert.equal(dbApiHotspotArtifactIo.sample_output?.threshold_policy, 'relative_ranking_only', 'DB/API hotspot sample output must use relative ranking');
@@ -423,6 +457,7 @@ const productCrudProfileIds = ['rest-product-batch-import', 'woocommerce-rest-ro
 assert.deepEqual(rig.fuzz_profiles?.['product-rest-crud-fuzzer'], productCrudProfileIds, 'product REST CRUD fuzzer profile workload ids drifted');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.route_family_catalog_manifest, 'manifests/rest-crud-route-family-catalog.json', 'product REST CRUD profile must link the route-family catalog');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.hotspot_artifact_contract_manifest, 'manifests/db-api-hotspot-artifact-io.json', 'product REST CRUD profile must link the hotspot artifact IO contract');
+assertProfileReadiness(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness, 'fuzz_profile_metadata.product-rest-crud-fuzzer.readiness');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.create?.level, 'executable', 'product REST CRUD create readiness must be executable');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.update?.level, 'executable', 'product REST CRUD update readiness must be executable');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.delete?.level, 'declared', 'product REST CRUD delete readiness must be declared/blocked by upstream');
@@ -448,12 +483,17 @@ for (const family of restCrudRouteFamilyCatalog.route_families) {
     assert.ok(declaredIds.has(workloadId), `${family.id} owner workload ${workloadId} must be declared`);
   }
   assert.ok(family.readiness?.delete, `${family.id} must declare delete readiness`);
+  for (const operation of ['create', 'read', 'update', 'delete']) {
+    assertFuzzReadinessLevel(family.readiness?.[operation]?.level, `${family.id} ${operation} readiness level`);
+  }
 }
 
 assert.equal(blockInventoryRenderingFuzz.schema, 'homeboy-rigs/woocommerce-block-inventory-rendering-fuzz/v1', 'block inventory/rendering fuzz schema drifted');
 assert.ok(blockInventoryRenderingFuzz.block_name_prefixes.includes('woocommerce/'), 'block inventory/rendering fuzz must target WooCommerce blocks');
 assert.ok(blockInventoryRenderingFuzz.frontend_contexts.includes('checkout'), 'block inventory/rendering fuzz must include checkout context');
-assert.equal(blockInventoryRenderingFuzz.readiness?.rendering, 'partial_via_frontend_browser_request_coverage', 'block rendering readiness drifted');
+assert.equal(blockInventoryRenderingFuzz.readiness?.inventory?.level, 'declared', 'block inventory readiness drifted');
+assert.equal(blockInventoryRenderingFuzz.readiness?.rendering?.level, 'executable', 'block rendering readiness drifted');
+assert.equal(blockInventoryRenderingFuzz.readiness?.mutation?.level, 'declared', 'block mutation readiness drifted');
 assert.deepEqual(targetInventory.targets.blocks.block_name_prefixes, blockInventoryRenderingFuzz.block_name_prefixes, 'target inventory block prefixes must come from block inventory manifest');
 assert.deepEqual(targetInventory.targets.blocks.frontend_contexts, blockInventoryRenderingFuzz.frontend_contexts, 'target inventory block contexts must come from block inventory manifest');
 assert.deepEqual(targetInventory.discovery_manifests?.blocks?.readiness, blockInventoryRenderingFuzz.readiness, 'target inventory block discovery readiness drifted');
@@ -462,11 +502,12 @@ for (const workloadId of blockInventoryRenderingFuzz.owned_by.workloads) {
 }
 
 assert.equal(adminActionInventory.schema, 'homeboy-rigs/woocommerce-admin-action-inventory/v1', 'admin action inventory schema drifted');
-assert.ok(adminActionInventory.action_families.some((family) => family.id === 'admin-menu-get-pages' && family.readiness === 'executable_get_only'), 'admin action inventory must include executable GET-only admin menu coverage');
+assert.ok(adminActionInventory.action_families.some((family) => family.id === 'admin-menu-get-pages' && family.readiness?.level === 'executable'), 'admin action inventory must include executable GET-only admin menu coverage');
 assert.ok(adminActionInventory.skip_reason_codes.includes('payment_submission'), 'admin action inventory must classify payment submission skips');
 assert.deepEqual(targetInventory.discovery_manifests?.admin_actions?.action_family_ids, adminActionInventory.action_families.map((family) => family.id), 'target inventory admin action discovery ids drifted');
 for (const family of adminActionInventory.action_families) {
   assertDeclaredOrExternalDiscoveryWorkload(family.workload, `admin action ${family.id}`);
+  assertFuzzReadinessLevel(family.readiness?.level, `admin action ${family.id} readiness level`);
 }
 assert.deepEqual(targetInventory.discovery_manifests?.db_api_hotspots?.readiness, dbApiHotspotArtifactIo.readiness, 'target inventory DB/API hotspot discovery readiness drifted');
 assert.equal(targetInventory.targets.performance_hotspots.artifact_io_manifest, 'manifests/db-api-hotspot-artifact-io.json', 'target inventory must link DB/API hotspot artifact IO manifest');


### PR DESCRIPTION
## Summary
- Normalize Woo fuzz readiness toward declared/executable/proven.
- Add explicit proof-bundle requirements for DB/API, CRUD, hotspot summary, and Codebox fuzz-suite outputs.
- Strengthen validators for proof refs, local-only refs, missing bundles, and unsafe CRUD mutation declarations.
- Regenerate the Woo target inventory without fabricating production proof.

## Verification
- node --test scripts/fuzz-manifest-helpers.test.mjs
- cd woocommerce/woocommerce && node --test tools/db-api-fuzzer-artifacts.test.mjs
- cd woocommerce/woocommerce && node tools/validate-fuzz-manifests.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode task subagents
- **Used for:** Auditing Woo fuzz proof readiness, drafting manifest and validator changes, adding focused tests, and preparing the PR.