### PR TITLE
Allow SSI matrix to use local Blocks Engine transformer

### DIFF
--- a/WordPress/static-site-importer/README.md
+++ b/WordPress/static-site-importer/README.md
@@ -7,9 +7,10 @@ generic Homeboy/Homeboy Extensions primitives for WP Codebox recipe execution.
 
 ```bash
 homeboy rig check static-site-importer-fixture-matrix
-node WordPress/static-site-importer/bench/static-site-fixture-matrix.mjs \
+node WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs \
   --fixture-root WordPress/static-site-importer/fixtures \
-  --static-site-importer-path ~/Developer/static-site-importer
+  --static-site-importer-path ~/Developer/static-site-importer \
+  --blocks-engine-php-transformer-path ~/Developer/blocks-engine
 ```
 
 Generated/static artifact roots can be normalized into matrix fixtures first:
@@ -29,6 +30,12 @@ node WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs \
 Add `--run` only in an approved non-local execution environment. The default
 command writes matrix, recipe, summary, result, and finding-packet artifacts
 without launching WP Codebox.
+
+Use `--blocks-engine-php-transformer-path` to test a local Blocks Engine checkout
+without cutting a PHP transformer release first. The bench installs SSI's
+Composer dependencies through a temporary path repository and records the
+override in `cli-run.json` under `dependency_overrides`. The path may point at
+either the Blocks Engine repo root or the `php-transformer/` package directory.
 
 Compare two fixture-matrix finding-packet artifacts without requiring Homeboy run
 state:

--- a/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
+++ b/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
@@ -77,7 +77,8 @@ async function runFixtureMatrix(options) {
     : null;
   const fixtureRoot = path.resolve(intake?.fixture_root || options.fixtureRoot || path.join(packageRoot, 'fixtures'));
   const staticSiteImporterPath = options.staticSiteImporterPath || process.env.HOMEBOY_STATIC_SITE_IMPORTER_PATH || process.cwd();
-  ensureComposerDependencies(staticSiteImporterPath);
+  const dependencyOverrides = prepareDependencyOverrides(options);
+  ensureComposerDependencies(staticSiteImporterPath, { dependencyOverrides });
   const matrix = createFixtureMatrix({
     id: options.id || `static-site-importer-fixture-matrix-${Date.now()}`,
     fixture_root: fixtureRoot,
@@ -178,6 +179,7 @@ async function runFixtureMatrix(options) {
     fixture_root: matrix.fixture_root,
     fixture_count: matrix.count,
     intake,
+    dependency_overrides: dependencyOverrides,
     output_directory: outputDirectory,
     recipe_file: recipeFile,
     artifact_refs: written.artifact_refs,
@@ -189,7 +191,14 @@ async function runFixtureMatrix(options) {
   return { summary, runtimeError, runtime };
 }
 
-function ensureComposerDependencies(pluginPath) {
+function ensureComposerDependencies(pluginPath, options = {}) {
+  const dependencyOverrides = options.dependencyOverrides || {};
+  const blocksEnginePhpTransformerPath = dependencyOverrides.blocks_engine_php_transformer?.path || '';
+  if (blocksEnginePhpTransformerPath) {
+    updateComposerPathRepository(pluginPath, blocksEnginePhpTransformerPath);
+    return;
+  }
+
   if (fs.existsSync(path.join(pluginPath, 'vendor', 'autoload.php')) || !fs.existsSync(path.join(pluginPath, 'composer.json'))) {
     return;
   }
@@ -200,7 +209,84 @@ function ensureComposerDependencies(pluginPath) {
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   if (result.status !== 0) {
-    throw new Error(`Composer install failed for ${pluginPath}: ${result.stderr || result.stdout || `exit ${result.status}`}`);
+    throw new Error(`Composer dependency install failed for ${pluginPath}: ${result.stderr || result.stdout || `exit ${result.status}`}`);
+  }
+}
+
+function prepareDependencyOverrides(options) {
+  const blocksEnginePhpTransformerPath = resolveBlocksEnginePhpTransformerPath(options.blocksEnginePhpTransformerPath);
+  return {
+    ...(blocksEnginePhpTransformerPath
+      ? {
+        blocks_engine_php_transformer: {
+          package: 'automattic/blocks-engine-php-transformer',
+          path: blocksEnginePhpTransformerPath,
+        },
+      }
+      : {}),
+  };
+}
+
+export function resolveBlocksEnginePhpTransformerPath(input) {
+  if (!input) {
+    return '';
+  }
+
+  const candidate = path.resolve(input);
+  const packageComposer = path.join(candidate, 'composer.json');
+  if (composerPackageName(packageComposer) === 'automattic/blocks-engine-php-transformer') {
+    return candidate;
+  }
+
+  const nested = path.join(candidate, 'php-transformer');
+  if (composerPackageName(path.join(nested, 'composer.json')) === 'automattic/blocks-engine-php-transformer') {
+    return nested;
+  }
+
+  throw new Error(`Blocks Engine PHP transformer path must point to the package or Blocks Engine repo root: ${input}`);
+}
+
+function composerPackageName(composerFile) {
+  try {
+    const composer = JSON.parse(fs.readFileSync(composerFile, 'utf8'));
+    return typeof composer.name === 'string' ? composer.name : '';
+  } catch {
+    return '';
+  }
+}
+
+function updateComposerPathRepository(pluginPath, packagePath) {
+  const composerFile = path.join(pluginPath, 'composer.json');
+  const lockFile = path.join(pluginPath, 'composer.lock');
+  const composerJson = fs.readFileSync(composerFile, 'utf8');
+  const composerLock = fs.existsSync(lockFile) ? fs.readFileSync(lockFile, 'utf8') : null;
+  let result = null;
+  try {
+    configureComposerPathRepository(pluginPath, packagePath);
+    result = spawnSync('composer', ['update', 'automattic/blocks-engine-php-transformer', '--with-dependencies', '--no-interaction', '--prefer-source', '--no-progress'], {
+      cwd: pluginPath,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } finally {
+    fs.writeFileSync(composerFile, composerJson);
+    if (composerLock !== null) {
+      fs.writeFileSync(lockFile, composerLock);
+    }
+  }
+  if (result.status !== 0) {
+    throw new Error(`Composer dependency override failed for ${pluginPath}: ${result.stderr || result.stdout || `exit ${result.status}`}`);
+  }
+}
+
+function configureComposerPathRepository(pluginPath, packagePath) {
+  const result = spawnSync('composer', ['config', 'repositories.blocks-engine-php-transformer-dev', 'path', packagePath], {
+    cwd: pluginPath,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (result.status !== 0) {
+    throw new Error(`Composer path repository configuration failed for ${pluginPath}: ${result.stderr || result.stdout || `exit ${result.status}`}`);
   }
 }
 
@@ -253,6 +339,7 @@ function optionsFromEnv(env = process.env) {
     entrypoint: benchEnv.SSI_FIXTURE_MATRIX_ENTRYPOINT || env.SSI_FIXTURE_MATRIX_ENTRYPOINT,
     maxDepth: benchEnv.SSI_FIXTURE_MATRIX_MAX_DEPTH || env.SSI_FIXTURE_MATRIX_MAX_DEPTH,
     artifactRoot: benchEnv.SSI_FIXTURE_MATRIX_ARTIFACT_ROOT || env.SSI_FIXTURE_MATRIX_ARTIFACT_ROOT,
+    blocksEnginePhpTransformerPath: benchEnv.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH || env.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH,
     wordpressVersion: benchEnv.SSI_FIXTURE_MATRIX_WORDPRESS_VERSION || env.SSI_FIXTURE_MATRIX_WORDPRESS_VERSION,
     batchSize: benchEnv.SSI_FIXTURE_MATRIX_BATCH_SIZE || env.SSI_FIXTURE_MATRIX_BATCH_SIZE,
     run: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_RUN) || isTruthy(env.SSI_FIXTURE_MATRIX_RUN),
@@ -301,7 +388,7 @@ function camelCase(value) {
 }
 
 function printHelp() {
-  process.stdout.write(`Usage: static-site-fixture-matrix [fixture-root] [options]\n\nOptions:\n  --fixture-root <path>              Static-site fixture root. Defaults to this package's fixtures directory.\n  --output-directory <path>          Artifact output directory.\n  --static-site-importer-path <path> Static Site Importer checkout/plugin directory.\n  --static-site-importer-slug <slug> Plugin slug. Defaults to static-site-importer.\n  --static-site-importer-plugin <p>  Plugin activation file. Defaults to static-site-importer/static-site-importer.php.\n  --entrypoint <file>                Fixture entrypoint. Defaults to index.html.\n  --max-depth <n>                    Fixture discovery depth. Defaults to 2.\n  --wordpress-version <version>      WP Codebox WordPress version. Defaults to latest.\n  --batch-size <n>                   Fixtures per WP Codebox run when --run is used. Defaults to 10.\n  --run                             Execute WP Codebox recipes. Omit locally to only materialize artifacts.\n`);
+  process.stdout.write(`Usage: static-site-fixture-matrix [fixture-root] [options]\n\nOptions:\n  --fixture-root <path>              Static-site fixture root. Defaults to this package's fixtures directory.\n  --output-directory <path>          Artifact output directory.\n  --static-site-importer-path <path> Static Site Importer checkout/plugin directory.\n  --static-site-importer-slug <slug> Plugin slug. Defaults to static-site-importer.\n  --static-site-importer-plugin <p>  Plugin activation file. Defaults to static-site-importer/static-site-importer.php.\n  --artifact-root <path>             Generated artifact root to normalize into fixtures.\n  --blocks-engine-php-transformer-path <path>\n                                     Blocks Engine repo root or php-transformer package path for Composer.\n  --entrypoint <file>                Fixture entrypoint. Defaults to index.html.\n  --max-depth <n>                    Fixture discovery depth. Defaults to 2.\n  --wordpress-version <version>      WP Codebox WordPress version. Defaults to latest.\n  --batch-size <n>                   Fixtures per WP Codebox run when --run is used. Defaults to 10.\n  --run                             Execute WP Codebox recipes. Omit locally to only materialize artifacts.\n`);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { resolveBlocksEnginePhpTransformerPath } from '../bench/static-site-fixture-matrix.bench.mjs';
 import {
   compareFindingPackets,
   selectorFamily,
@@ -101,6 +102,18 @@ test('materializes generated artifact roots into matrix-compatible fixtures', ()
   assert.deepEqual(matrix.fixtures.map((fixture) => fixture.id), ['alpha', 'beta-site']);
   assert.equal(readFileSync(path.join(fixtureOutput, 'alpha', 'index.html'), 'utf8'), '<h1>Alpha</h1>');
   assert.equal(readFileSync(path.join(fixtureOutput, 'beta-site', 'index.html'), 'utf8'), '<h1>Beta</h1>');
+});
+
+test('resolves Blocks Engine PHP transformer override paths', () => {
+  const repoRoot = mkdtempSync(path.join(tmpdir(), 'blocks-engine-'));
+  const packageRoot = path.join(repoRoot, 'php-transformer');
+  mkdirSync(packageRoot, { recursive: true });
+  writeFileSync(path.join(packageRoot, 'composer.json'), JSON.stringify({
+    name: 'automattic/blocks-engine-php-transformer',
+  }));
+
+  assert.equal(resolveBlocksEnginePhpTransformerPath(repoRoot), packageRoot);
+  assert.equal(resolveBlocksEnginePhpTransformerPath(packageRoot), packageRoot);
 });
 
 test('compares finding packet deltas by repair dimensions', () => {


### PR DESCRIPTION
## Summary
- add a Blocks Engine PHP transformer path override for the SSI fixture matrix
- install SSI Composer dependencies through a temporary Composer path repository for fast candidate runs
- record dependency overrides in matrix run metadata and document the release-free loop

## Testing
- node --test WordPress/static-site-importer/tools/fixture-matrix.test.mjs
- node WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs --help
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** implementation, tests, documentation, and local verification