### PR TITLE
Add Studio canonical loop proof rig

### DIFF
--- a/Automattic/studio/docs/studio-canonical-loop-proof.md
+++ b/Automattic/studio/docs/studio-canonical-loop-proof.md
@@ -1,0 +1,71 @@
+# Studio Canonical Loop Proof
+
+This is a minimal, safe proof skeleton for the canonical website artifact loop:
+
+1. Host request arrives with prompt, fanout targets, artifact contract, and user-change intent.
+2. Codebox/fanout generation produces a website artifact.
+3. Studio Native stores that artifact as the canonical site source.
+4. Static Site Importer materializes the artifact into a block theme in an ephemeral Codebox/site.
+5. A user change mutates the original canonical artifact.
+6. Reimport materializes the updated artifact.
+7. Progress and diagnostics artifacts explain what happened.
+
+Current status: the proof is filesystem-only and stubbed. It verifies the artifact contract, mutation path, reimport path, and diagnostic bundle shape without launching Codebox, WordPress, Studio Native, or SSI.
+
+## Safe Validation
+
+```bash
+node Automattic/studio/proofs/studio-canonical-loop-proof.mjs --check
+node scripts/lint-rig-packages.mjs Automattic/studio
+```
+
+## Run The Stub Proof
+
+```bash
+node Automattic/studio/proofs/studio-canonical-loop-proof.mjs \
+  --out /tmp/studio-canonical-loop-proof
+```
+
+The script writes:
+
+- `progress.json` for phase-by-phase evidence.
+- `diagnostics.json` for assertions, real/stubbed boundaries, and blockers.
+- `codebox-fanout-artifact.json` for the generated website artifact stub.
+- `studio-native-canonical-artifact.v1.json` and `.v2.json` for the stored artifact before and after user mutation.
+- `ssi-materialized-theme.initial.json` and `.reimport.json` for block-theme materialization stubs.
+- `result.json` with the artifact index and success flag.
+
+## Rig Entry Point
+
+```bash
+homeboy rig check studio-canonical-loop-proof
+```
+
+The rig check validates only local files and the fixture. It intentionally declares no benchmark workload.
+
+## Real vs Stubbed
+
+Real now:
+
+- Host request fixture schema validation.
+- Website artifact creation in the expected site-artifact shape.
+- Canonical artifact versioning on disk.
+- User mutation against the original artifact.
+- Reimport proof that the updated artifact reaches the materialized theme output.
+- Progress and diagnostics artifact writing.
+
+Stubbed now:
+
+- Codebox/fanout execution.
+- Studio Native canonical artifact persistence APIs.
+- Static Site Importer execution in an ephemeral Codebox/site.
+- WordPress block theme installation and active-theme verification.
+- Reviewer-facing artifact bundle publication.
+
+## Blockers To Make This Executable
+
+- Host request API contract needs an executable endpoint and auth shape.
+- Codebox fanout generation needs a durable artifact bundle contract for website artifacts.
+- Studio Native needs a canonical website artifact store/read/update surface.
+- SSI reimport needs an idempotent CLI or ability path that accepts the stored canonical artifact.
+- Progress diagnostics need stable reviewer-facing artifact bundle links.

--- a/Automattic/studio/fixtures/studio-canonical-loop/host-request.json
+++ b/Automattic/studio/fixtures/studio-canonical-loop/host-request.json
@@ -1,0 +1,25 @@
+{
+  "schema": "studio/canonical-loop/host-request/v1",
+  "request_id": "canonical-loop-fixture-001",
+  "site_slug": "canonical-loop-proof",
+  "prompt": "Create a concise landing page for a physical therapy studio with a hero, services section, and contact call to action.",
+  "fanout": {
+    "targets": [
+      "homepage",
+      "theme-tokens",
+      "navigation"
+    ],
+    "strategy": "stubbed-codebox-generation"
+  },
+  "artifact_contract": {
+    "schema": "blocks-engine/php-transformer/site-artifact/v1",
+    "entrypoint": "website/index.html",
+    "canonical_store": "studio-native"
+  },
+  "user_change": {
+    "operation": "replace_text",
+    "file": "website/index.html",
+    "from": "Move Better. Feel Stronger.",
+    "to": "Recover Faster. Move Better."
+  }
+}

--- a/Automattic/studio/proofs/studio-canonical-loop-proof.mjs
+++ b/Automattic/studio/proofs/studio-canonical-loop-proof.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const defaultHostRequestPath = path.join(packageRoot, 'fixtures', 'studio-canonical-loop', 'host-request.json');
+
+function argValue(name) {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? null : process.argv[index + 1] || null;
+}
+
+function hasArg(name) {
+  return process.argv.includes(name);
+}
+
+function now() {
+  return new Date().toISOString();
+}
+
+function artifactFile(artifact, filePath) {
+  return artifact.files.find((file) => file.path === filePath);
+}
+
+function writeArtifactFile(artifact, filePath, content) {
+  const file = artifactFile(artifact, filePath);
+  if (!file) {
+    throw new Error(`Artifact file not found: ${filePath}`);
+  }
+  file.content = content;
+}
+
+function createGeneratedArtifact(hostRequest) {
+  return {
+    schema: hostRequest.artifact_contract.schema,
+    root: 'website',
+    entrypoint: hostRequest.artifact_contract.entrypoint,
+    files: [
+      {
+        path: 'website/index.html',
+        mime_type: 'text/html',
+        content: '<!doctype html>\n<html lang="en">\n<head>\n  <meta charset="utf-8">\n  <meta name="viewport" content="width=device-width, initial-scale=1">\n  <title>Canonical Loop Proof</title>\n  <link rel="stylesheet" href="assets/styles.css">\n</head>\n<body>\n  <main class="hero">\n    <p class="eyebrow">Fisiostetic rehab studio</p>\n    <h1>Move Better. Feel Stronger.</h1>\n    <p>Hands-on treatment, guided strength work, and a clear plan from first visit to full return.</p>\n    <a href="/contact/">Book an assessment</a>\n  </main>\n</body>\n</html>\n'
+      },
+      {
+        path: 'website/assets/styles.css',
+        mime_type: 'text/css',
+        content: ':root { --bg: #f6f1e8; --ink: #17312b; --accent: #ce5f36; }\nbody { margin: 0; font-family: Inter, ui-sans-serif, system-ui, sans-serif; color: var(--ink); background: var(--bg); }\n.hero { min-height: 100vh; display: grid; align-content: center; gap: 1.25rem; width: min(960px, calc(100% - 40px)); margin: 0 auto; }\n.eyebrow { color: var(--accent); font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }\nh1 { max-width: 760px; margin: 0; font-size: clamp(3rem, 8vw, 6.5rem); line-height: .9; }\np { max-width: 620px; font-size: 1.2rem; line-height: 1.55; }\na { color: var(--bg); background: var(--ink); width: max-content; padding: .9rem 1.2rem; border-radius: 999px; text-decoration: none; font-weight: 800; }\n'
+      }
+    ],
+    provenance: {
+      generated_by: 'stubbed-codebox-fanout',
+      host_request_id: hostRequest.request_id,
+      generated_at: now()
+    }
+  };
+}
+
+function materializeBlockTheme(artifact, generation) {
+  const html = artifactFile(artifact, artifact.entrypoint)?.content || '';
+  const css = artifactFile(artifact, 'website/assets/styles.css')?.content || '';
+  const titleMatch = html.match(/<h1>(.*?)<\/h1>/i);
+
+  return {
+    slug: `canonical-loop-proof-${generation}`,
+    files: [
+      {
+        path: 'style.css',
+        content: `/*\nTheme Name: Canonical Loop Proof ${generation}\n*/\n${css}`
+      },
+      {
+        path: 'templates/index.html',
+        content: `<!-- wp:group {"tagName":"main","className":"canonical-loop-proof"} -->\n<main class="wp-block-group canonical-loop-proof">\n<!-- wp:heading {"level":1} -->\n<h1>${titleMatch?.[1] || 'Canonical Loop Proof'}</h1>\n<!-- /wp:heading -->\n<!-- wp:paragraph -->\n<p>Materialized from the canonical website artifact.</p>\n<!-- /wp:paragraph -->\n</main>\n<!-- /wp:group -->\n`
+      },
+      {
+        path: 'theme.json',
+        content: `${JSON.stringify({ version: 3, settings: { layout: { contentSize: '960px', wideSize: '1180px' } } }, null, 2)}\n`
+      }
+    ],
+    diagnostics: {
+      importer: 'static-site-importer-stub',
+      fallback_blocks: 0,
+      source_file_count: artifact.files.length,
+      theme_file_count: 3,
+      materialized_at: now()
+    }
+  };
+}
+
+async function writeJson(filePath, value) {
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function main() {
+  const checkOnly = hasArg('--check');
+  const mode = argValue('--mode') || 'stub';
+  const hostRequestPath = argValue('--host-request') || defaultHostRequestPath;
+  const outDir = path.resolve(argValue('--out') || path.join(os.tmpdir(), `studio-canonical-loop-proof-${process.pid}`));
+
+  if (mode !== 'stub') {
+    throw new Error('Only --mode stub is implemented. Real Codebox, Studio Native, SSI, and WordPress seams are documented blockers.');
+  }
+
+  const hostRequest = JSON.parse(await readFile(hostRequestPath, 'utf8'));
+  const requiredFields = ['schema', 'request_id', 'prompt', 'fanout', 'artifact_contract', 'user_change'];
+  for (const field of requiredFields) {
+    if (!hostRequest[field]) {
+      throw new Error(`Host request fixture is missing ${field}`);
+    }
+  }
+
+  if (checkOnly) {
+    console.log('Studio canonical loop proof fixture passed validation.');
+    return;
+  }
+
+  await mkdir(outDir, { recursive: true });
+
+  const progress = {
+    schema: 'studio/canonical-loop/progress/v1',
+    run_id: `canonical-loop-${process.pid}-${Date.now()}`,
+    mode,
+    host_request: hostRequestPath,
+    steps: []
+  };
+
+  function step(name, evidence = {}) {
+    progress.steps.push({ name, status: 'ok', recorded_at: now(), ...evidence });
+  }
+
+  step('host_request_received', { request_id: hostRequest.request_id, fanout_targets: hostRequest.fanout.targets });
+
+  const generatedArtifact = createGeneratedArtifact(hostRequest);
+  const fanoutPath = path.join(outDir, 'codebox-fanout-artifact.json');
+  await writeJson(fanoutPath, generatedArtifact);
+  step('codebox_fanout_generation_stubbed', { artifact: fanoutPath, generated_files: generatedArtifact.files.map((file) => file.path) });
+
+  const canonicalArtifact = structuredClone(generatedArtifact);
+  canonicalArtifact.provenance.canonical_store = hostRequest.artifact_contract.canonical_store;
+  canonicalArtifact.provenance.stored_at = now();
+  const canonicalPath = path.join(outDir, 'studio-native-canonical-artifact.v1.json');
+  await writeJson(canonicalPath, canonicalArtifact);
+  step('studio_native_canonical_artifact_stored_stubbed', { artifact: canonicalPath });
+
+  const firstTheme = materializeBlockTheme(canonicalArtifact, 'initial');
+  const firstThemePath = path.join(outDir, 'ssi-materialized-theme.initial.json');
+  await writeJson(firstThemePath, firstTheme);
+  step('ssi_materialized_block_theme_stubbed', { theme: firstThemePath, diagnostics: firstTheme.diagnostics });
+
+  const mutatedArtifact = structuredClone(canonicalArtifact);
+  const change = hostRequest.user_change;
+  const changedFile = artifactFile(mutatedArtifact, change.file);
+  if (!changedFile || !changedFile.content.includes(change.from)) {
+    throw new Error(`User change target text not found in ${change.file}`);
+  }
+  writeArtifactFile(mutatedArtifact, change.file, changedFile.content.replace(change.from, change.to));
+  mutatedArtifact.provenance.user_mutation = { operation: change.operation, file: change.file, mutated_at: now() };
+  const mutatedPath = path.join(outDir, 'studio-native-canonical-artifact.v2.json');
+  await writeJson(mutatedPath, mutatedArtifact);
+  step('user_change_mutated_original_artifact_stubbed', { artifact: mutatedPath, change });
+
+  const secondTheme = materializeBlockTheme(mutatedArtifact, 'reimport');
+  const secondThemePath = path.join(outDir, 'ssi-materialized-theme.reimport.json');
+  await writeJson(secondThemePath, secondTheme);
+  step('reimport_materialized_updated_theme_stubbed', { theme: secondThemePath, diagnostics: secondTheme.diagnostics });
+
+  const diagnostics = {
+    schema: 'studio/canonical-loop/diagnostics/v1',
+    real: [],
+    stubbed: [
+      'Codebox/fanout generation',
+      'Studio Native canonical artifact store',
+      'Static Site Importer materialization in ephemeral Codebox/site',
+      'User edit propagation back into the original artifact',
+      'Reimport execution'
+    ],
+    blockers: [
+      'Host request API contract needs an executable endpoint and auth shape.',
+      'Codebox fanout generation needs a durable artifact bundle contract for website artifacts.',
+      'Studio Native needs a canonical website artifact store/read/update surface.',
+      'SSI reimport needs an idempotent CLI or ability path that accepts the stored canonical artifact.',
+      'Progress diagnostics need stable reviewer-facing artifact bundle links.'
+    ],
+    assertions: {
+      canonical_artifact_schema_preserved: mutatedArtifact.schema === generatedArtifact.schema,
+      user_change_reaches_reimport_theme: secondTheme.files.some((file) => file.content.includes(change.to)),
+      fallback_blocks: secondTheme.diagnostics.fallback_blocks
+    }
+  };
+  const diagnosticsPath = path.join(outDir, 'diagnostics.json');
+  await writeJson(diagnosticsPath, diagnostics);
+
+  const progressPath = path.join(outDir, 'progress.json');
+  await writeJson(progressPath, progress);
+
+  const result = {
+    schema: 'studio/canonical-loop/proof-result/v1',
+    success: diagnostics.assertions.canonical_artifact_schema_preserved && diagnostics.assertions.user_change_reaches_reimport_theme,
+    mode,
+    artifacts: {
+      progress: progressPath,
+      diagnostics: diagnosticsPath,
+      fanout_artifact: fanoutPath,
+      canonical_artifact_v1: canonicalPath,
+      canonical_artifact_v2: mutatedPath,
+      initial_theme: firstThemePath,
+      reimport_theme: secondThemePath
+    },
+    real_vs_stubbed: {
+      real: diagnostics.real,
+      stubbed: diagnostics.stubbed
+    }
+  };
+  const resultPath = path.join(outDir, 'result.json');
+  await writeJson(resultPath, result);
+
+  console.log(JSON.stringify({ result: resultPath, progress: progressPath, diagnostics: diagnosticsPath, success: result.success }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/Automattic/studio/rigs/studio-canonical-loop-proof/rig.json
+++ b/Automattic/studio/rigs/studio-canonical-loop-proof/rig.json
@@ -1,0 +1,51 @@
+{
+  "id": "studio-canonical-loop-proof",
+  "description": "Safe skeleton proof for the canonical Studio website artifact loop: host request, Codebox/fanout generation, Studio Native canonical artifact storage, SSI materialization, user mutation, reimport, and diagnostics. Current implementation is filesystem-only and stubbed until executable component seams exist.",
+  "components": {
+    "studio-native": {
+      "path": "~/Developer/studio-native",
+      "branch": "main"
+    },
+    "static-site-importer": {
+      "path": "~/Developer/static-site-importer",
+      "branch": "HEAD"
+    },
+    "wp-codebox": {
+      "path": "~/Developer/wp-codebox",
+      "branch": "HEAD"
+    }
+  },
+  "resources": {
+    "paths": [
+      "${components.studio-native.path}",
+      "${components.static-site-importer.path}",
+      "${components.wp-codebox.path}"
+    ]
+  },
+  "pipeline": {
+    "check": [
+      {
+        "kind": "check",
+        "label": "node available",
+        "command": "command -v node >/dev/null 2>&1",
+        "expect_exit": 0
+      },
+      {
+        "kind": "check",
+        "label": "canonical loop proof script exists",
+        "file": "${package.root}/proofs/studio-canonical-loop-proof.mjs"
+      },
+      {
+        "kind": "check",
+        "label": "canonical loop host request fixture exists",
+        "file": "${package.root}/fixtures/studio-canonical-loop/host-request.json"
+      },
+      {
+        "kind": "check",
+        "label": "canonical loop fixture validates",
+        "command": "node ${package.root}/proofs/studio-canonical-loop-proof.mjs --check",
+        "expect_exit": 0
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add a safe filesystem-only proof skeleton for the canonical Studio website artifact loop.
- Cover host request, Codebox/fanout generation, Studio Native canonical artifact storage, SSI materialization, user mutation, reimport, progress, and diagnostics.
- Document what is real versus stubbed and the blockers for live endpoint wiring.

## Verification
- node Automattic/studio/proofs/studio-canonical-loop-proof.mjs --check
- node Automattic/studio/proofs/studio-canonical-loop-proof.mjs --out /var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/studio-canonical-loop-proof
- node scripts/lint-rig-packages.mjs Automattic/studio
- node --test scripts/lint-rig-packages.test.mjs scripts/fuzz-manifest-helpers.test.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Drafting the proof skeleton, rig metadata, fixture, and documentation.