### PR TITLE
feat(woocommerce): wire DB API fuzz campaign

### DIFF
--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -193,6 +193,13 @@ the rig: Homeboy/Homeboy Extensions must bind `args.helper`, `args.action`,
 `args.input`, `args.output`, and `args.parameters`, then collect the declared
 `fuzz.report` artifact before those contracts can become executable.
 
+The DB/API campaign contract lives in `manifests/db-api-fuzz-campaign.json` and
+requires reviewer-facing refs for `wp-codebox/fuzz-suite-result/v1`,
+`wp-codebox/wordpress-hotspots/v1`, Homeboy fuzz coverage, Homeboy hotspot
+summary, and the coverage gap report before anyone can mark it proven. Run the
+campaign commands from that manifest only through an approved Homeboy
+Lab/runner/offloaded environment; do not run local benchmarks as campaign proof.
+
 The declared full-surface fuzz proof is API/DB/admin/server coverage plus the
 issue-focused checkout/catalog workloads above. Browser request and performance
 summary fuzz manifests are proof-ready declarations until a `homeboy fuzz run`

--- a/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
+++ b/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
@@ -26,12 +26,14 @@
         "fuzz/rest-schema-query-attribution.json",
         "fuzz/coverage-gap-report.json",
         "fuzz/performance-hotspots-artifact-summary.json",
+        "manifests/db-api-fuzz-campaign.json",
         "manifests/db-api-performance-fuzzer-gap-report.json"
       ],
       "profile": {
         "id": "db-api-performance-fuzzer",
         "rig_profile": "rigs/woocommerce-performance/rig.json#fuzz_profiles.db-api-performance-fuzzer",
         "workload_ids": [
+          "codebox-fuzz-suite-smoke",
           "woocommerce-rest-route-inventory",
           "generated-rest-request-cases",
           "rest-db-query-profile",
@@ -40,7 +42,8 @@
           "coverage-gap-report",
           "performance-hotspots-artifact-summary"
         ],
-        "gap_report_manifest": "manifests/db-api-performance-fuzzer-gap-report.json"
+        "gap_report_manifest": "manifests/db-api-performance-fuzzer-gap-report.json",
+        "campaign_manifest": "manifests/db-api-fuzz-campaign.json"
       },
       "proof_bundle_requirements": {
         "status": "required_before_proven",

--- a/woocommerce/woocommerce/manifests/db-api-fuzz-campaign.json
+++ b/woocommerce/woocommerce/manifests/db-api-fuzz-campaign.json
@@ -1,0 +1,93 @@
+{
+  "schema": "homeboy-rigs/woocommerce-db-api-fuzz-campaign/v1",
+  "id": "woocommerce-db-api-fuzz-campaign",
+  "profile_id": "db-api-performance-fuzzer",
+  "description": "WooCommerce DB/API fuzz campaign declaration tying public Codebox fuzz-suite execution to WordPress hotspot artifacts, Homeboy coverage, Homeboy hotspot summary, and gap-report outputs without claiming proof before reviewer-facing artifacts exist.",
+  "suite_manifest": "manifests/codebox-fuzz-suite-smoke.json",
+  "gap_report_manifest": "manifests/db-api-performance-fuzzer-gap-report.json",
+  "hotspot_artifact_io_manifest": "manifests/db-api-hotspot-artifact-io.json",
+  "workloads": [
+    "codebox-fuzz-suite-smoke",
+    "woocommerce-rest-route-inventory",
+    "generated-rest-request-cases",
+    "rest-db-query-profile",
+    "db-inventory",
+    "rest-schema-query-attribution",
+    "coverage-gap-report",
+    "performance-hotspots-artifact-summary"
+  ],
+  "required_upstream_artifact_refs": [
+    {
+      "id": "codebox_fuzz_suite_result",
+      "schema": "wp-codebox/fuzz-suite-result/v1",
+      "semantic_key": "fuzz.suite_result",
+      "readiness": "required_before_proven"
+    },
+    {
+      "id": "wordpress_hotspots",
+      "schema": "wp-codebox/wordpress-hotspots/v1",
+      "semantic_key": "wordpress.hotspots",
+      "readiness": "required_before_proven"
+    },
+    {
+      "id": "homeboy_fuzz_coverage",
+      "schema": "homeboy/fuzz-coverage/v1",
+      "semantic_key": "fuzz.coverage",
+      "readiness": "required_before_proven"
+    },
+    {
+      "id": "homeboy_hotspot_summary",
+      "schema": "homeboy/woocommerce-performance-hotspots-summary/v1",
+      "semantic_key": "fuzz.report",
+      "readiness": "required_before_proven"
+    },
+    {
+      "id": "coverage_gap_report",
+      "schema": "homeboy-rigs/wordpress-coverage-gap-report/v1",
+      "semantic_key": "fuzz.report",
+      "readiness": "required_before_proven"
+    }
+  ],
+  "operator_commands": {
+    "offload_required": true,
+    "note": "Run these through an approved Homeboy Lab/runner/offloaded environment. Do not use local benchmark execution as proof for this campaign.",
+    "commands": [
+      "homeboy rig up woocommerce-performance",
+      "homeboy fuzz run --rig woocommerce-performance --workload codebox-fuzz-suite-smoke --run-id wc-db-api-codebox-suite --seed 1 --max-duration 10m",
+      "homeboy fuzz run --rig woocommerce-performance --workload woocommerce-rest-route-inventory --run-id wc-db-api-route-inventory --seed 1 --max-duration 10m",
+      "homeboy fuzz run --rig woocommerce-performance --workload generated-rest-request-cases --run-id wc-db-api-generated-cases --seed 1 --max-duration 20m",
+      "homeboy fuzz run --rig woocommerce-performance --workload rest-db-query-profile --run-id wc-db-api-query-profile --seed 1 --max-duration 20m",
+      "homeboy fuzz run --rig woocommerce-performance --workload db-inventory --run-id wc-db-api-db-inventory --seed 1 --max-duration 10m",
+      "homeboy fuzz run --rig woocommerce-performance --workload rest-schema-query-attribution --run-id wc-db-api-schema-query-attribution --seed 1 --max-duration 20m",
+      "homeboy fuzz run --rig woocommerce-performance --workload coverage-gap-report --run-id wc-db-api-coverage-gap-report --seed 1 --max-duration 15m",
+      "homeboy fuzz run --rig woocommerce-performance --workload performance-hotspots-artifact-summary --run-id wc-db-api-hotspots-summary --seed 1 --max-duration 15m"
+    ]
+  },
+  "readiness": {
+    "level": "declared",
+    "execution": "offloaded_fuzz_campaign",
+    "coverage_contract": "The campaign is executable only through the declared Woo fuzz workloads in an approved offloaded WP Codebox/Homeboy runner. It remains declared until reviewer-facing artifact refs exist for Codebox fuzz-suite results, WordPress hotspot artifacts, Homeboy fuzz coverage, Homeboy hotspot summary, and the coverage gap report.",
+    "proof_bundle_requirements": {
+      "status": "required_before_proven",
+      "required_refs": [
+        "reviewer-facing wp-codebox/fuzz-suite-result/v1 artifact ref",
+        "reviewer-facing wp-codebox/wordpress-hotspots/v1 artifact ref",
+        "reviewer-facing Homeboy fuzz coverage artifact ref",
+        "reviewer-facing Homeboy hotspot summary artifact ref",
+        "reviewer-facing coverage gap report artifact ref"
+      ],
+      "required_artifacts": [
+        "codebox_fuzz_suite_result",
+        "wordpress_hotspots",
+        "homeboy_fuzz_coverage",
+        "homeboy_hotspot_summary",
+        "coverage_gap_report"
+      ]
+    },
+    "upstream_blockers": [
+      "Public Codebox fuzz-suite execution must emit reviewer-facing wp-codebox/fuzz-suite-result/v1 artifacts for the Woo DB/API generated contract.",
+      "WordPress hotspot discovery must emit reviewer-facing wp-codebox/wordpress-hotspots/v1 artifacts for the same run set.",
+      "Homeboy fuzz execution must collect coverage, hotspot summary, and gap-report artifacts from the offloaded run before readiness can become proven."
+    ]
+  }
+}

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -198,6 +198,7 @@
     },
     "db-api-performance-fuzzer": {
       "description": "Focused WooCommerce DB/API performance fuzzer profile built only from declared REST inventory, generated REST cases, REST DB query profile, DB inventory, schema/query attribution, and performance hotspot summary workloads.",
+      "campaign_manifest": "manifests/db-api-fuzz-campaign.json",
       "gap_report_manifest": "manifests/db-api-performance-fuzzer-gap-report.json",
       "source_gap_report": "manifests/full-surface-coverage.json#gap_report",
       "required_primitives": [

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -23,6 +23,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
 const rig = readJson(packageRoot, 'rigs/woocommerce-performance/rig.json');
 const coverageManifest = readJson(packageRoot, 'manifests/full-surface-coverage.json');
+const dbApiFuzzCampaign = readJson(packageRoot, 'manifests/db-api-fuzz-campaign.json');
 const dbApiPerformanceFuzzerGapReport = readJson(packageRoot, 'manifests/db-api-performance-fuzzer-gap-report.json');
 const restCrudRouteFamilyCatalog = readJson(packageRoot, 'manifests/rest-crud-route-family-catalog.json');
 const dbApiHotspotArtifactIo = readJson(packageRoot, 'manifests/db-api-hotspot-artifact-io.json');
@@ -118,6 +119,7 @@ const fullSurfaceFuzzIds = new Set(Object.entries(coverageManifest.coverage_prof
   .flatMap(([, workloadIds]) => workloadIds));
 const requiredArtifactWorkloadIds = fullSurfaceRequiredArtifactIds(coverageManifest);
 const dbApiPerformanceFuzzerWorkloadIds = [
+  'codebox-fuzz-suite-smoke',
   'woocommerce-rest-route-inventory',
   'generated-rest-request-cases',
   'rest-db-query-profile',
@@ -126,7 +128,8 @@ const dbApiPerformanceFuzzerWorkloadIds = [
   'coverage-gap-report',
   'performance-hotspots-artifact-summary',
 ];
-const dbApiPerformanceFuzzerGapReportInputIds = dbApiPerformanceFuzzerWorkloadIds.filter((workloadId) => workloadId !== 'coverage-gap-report');
+const dbApiPerformanceFuzzerProfileWorkloadIds = dbApiPerformanceFuzzerWorkloadIds.filter((workloadId) => workloadId !== 'codebox-fuzz-suite-smoke');
+const dbApiPerformanceFuzzerGapReportInputIds = dbApiPerformanceFuzzerProfileWorkloadIds.filter((workloadId) => workloadId !== 'coverage-gap-report');
 const externalDiscoveryWorkloadIds = new Set([
   'woocommerce-browser-coverage',
 ]);
@@ -409,13 +412,16 @@ assert.deepEqual(codeboxSuite.target?.metadata?.source_manifests, [
   'fuzz/rest-schema-query-attribution.json',
   'fuzz/coverage-gap-report.json',
   'fuzz/performance-hotspots-artifact-summary.json',
+  'manifests/db-api-fuzz-campaign.json',
   'manifests/db-api-performance-fuzzer-gap-report.json',
 ]);
-assert.deepEqual(rig.fuzz_profiles?.['db-api-performance-fuzzer'], dbApiPerformanceFuzzerWorkloadIds, 'DB/API performance fuzzer profile workload ids drifted');
+assert.deepEqual(rig.fuzz_profiles?.['db-api-performance-fuzzer'], dbApiPerformanceFuzzerProfileWorkloadIds, 'DB/API performance fuzzer profile workload ids drifted');
 assert.deepEqual(codeboxSuite.target?.metadata?.profile?.workload_ids, dbApiPerformanceFuzzerWorkloadIds, 'Codebox suite DB/API profile workload ids drifted');
 assert.equal(codeboxSuite.target?.metadata?.profile?.gap_report_manifest, 'manifests/db-api-performance-fuzzer-gap-report.json', 'Codebox suite must link the standalone DB/API gap report declaration');
+assert.equal(codeboxSuite.target?.metadata?.profile?.campaign_manifest, 'manifests/db-api-fuzz-campaign.json', 'Codebox suite must link the DB/API fuzz campaign declaration');
 assertFuzzProofBundleRequirements(codeboxSuite.target?.metadata?.proof_bundle_requirements, { file: 'codebox suite metadata proof bundle requirements' });
 assert.equal(codeboxSuite.metadata?.public_result_contract, 'wp-codebox/fuzz-suite-result/v1', 'Codebox suite must declare the public fuzz-suite result contract');
+assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.campaign_manifest, 'manifests/db-api-fuzz-campaign.json', 'DB/API profile must link the campaign declaration');
 assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.gap_report_manifest, 'manifests/db-api-performance-fuzzer-gap-report.json', 'DB/API profile must link the standalone gap report declaration');
 assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.source_gap_report, 'manifests/full-surface-coverage.json#gap_report', 'DB/API profile must identify the source full-surface gap report');
 assertProfileReadiness(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.readiness, 'fuzz_profile_metadata.db-api-performance-fuzzer.readiness');
@@ -435,6 +441,31 @@ assert.deepEqual(dbApiPerformanceFuzzerGapReport.generic_upstream_contracts, [
 assertFuzzProofBundleRequirements(dbApiPerformanceFuzzerGapReport.readiness?.proof_bundle_requirements, { file: 'db-api-performance-fuzzer-gap-report readiness' });
 assert.ok(dbApiPerformanceFuzzerGapReport.readiness?.upstream_blockers?.length > 0, 'DB/API gap report declaration must name upstream blockers');
 assert.ok(dbApiPerformanceFuzzerGapReport.readiness.upstream_blockers.some((blocker) => blocker.includes('args.helper')), 'DB/API gap report declaration must list the missing upstream artifact-postprocess fields');
+assert.equal(dbApiFuzzCampaign.schema, 'homeboy-rigs/woocommerce-db-api-fuzz-campaign/v1', 'DB/API fuzz campaign schema drifted');
+assert.equal(dbApiFuzzCampaign.id, 'woocommerce-db-api-fuzz-campaign', 'DB/API fuzz campaign id drifted');
+assert.equal(dbApiFuzzCampaign.profile_id, 'db-api-performance-fuzzer', 'DB/API fuzz campaign profile id drifted');
+assert.equal(dbApiFuzzCampaign.suite_manifest, 'manifests/codebox-fuzz-suite-smoke.json', 'DB/API fuzz campaign must link the Codebox fuzz suite');
+assert.equal(dbApiFuzzCampaign.gap_report_manifest, 'manifests/db-api-performance-fuzzer-gap-report.json', 'DB/API fuzz campaign must link the gap report manifest');
+assert.equal(dbApiFuzzCampaign.hotspot_artifact_io_manifest, 'manifests/db-api-hotspot-artifact-io.json', 'DB/API fuzz campaign must link hotspot artifact IO');
+assert.deepEqual(dbApiFuzzCampaign.workloads, dbApiPerformanceFuzzerWorkloadIds, 'DB/API fuzz campaign workloads drifted');
+assert.equal(dbApiFuzzCampaign.readiness?.level, 'declared', 'DB/API fuzz campaign must stay declared until reviewer-facing artifacts exist');
+assert.equal(dbApiFuzzCampaign.readiness?.execution, 'offloaded_fuzz_campaign', 'DB/API fuzz campaign execution mode drifted');
+assertFuzzProofBundleRequirements(dbApiFuzzCampaign.readiness?.proof_bundle_requirements, { file: 'db-api-fuzz-campaign readiness' });
+assert.equal(dbApiFuzzCampaign.operator_commands?.offload_required, true, 'DB/API fuzz campaign must require offloaded execution');
+assert.ok(dbApiFuzzCampaign.operator_commands?.commands?.every((command) => command.startsWith('homeboy ')), 'DB/API fuzz campaign commands must use Homeboy rig/fuzz commands');
+assert.ok(dbApiFuzzCampaign.operator_commands.commands.some((command) => command.includes('--workload codebox-fuzz-suite-smoke')), 'DB/API fuzz campaign must include Codebox fuzz-suite workload command');
+const requiredCampaignSchemas = new Set([
+  'wp-codebox/fuzz-suite-result/v1',
+  'wp-codebox/wordpress-hotspots/v1',
+  'homeboy/fuzz-coverage/v1',
+  'homeboy/woocommerce-performance-hotspots-summary/v1',
+  'homeboy-rigs/wordpress-coverage-gap-report/v1',
+]);
+assert.deepEqual(new Set(dbApiFuzzCampaign.required_upstream_artifact_refs.map((artifact) => artifact.schema)), requiredCampaignSchemas, 'DB/API fuzz campaign required artifact schemas drifted');
+for (const artifact of dbApiFuzzCampaign.required_upstream_artifact_refs) {
+  assert.equal(artifact.readiness, 'required_before_proven', `DB/API fuzz campaign artifact ${artifact.id} must be required before proven`);
+  assert.equal(typeof artifact.semantic_key, 'string', `DB/API fuzz campaign artifact ${artifact.id} requires semantic_key`);
+}
 assert.equal(dbApiHotspotArtifactIo.schema, 'homeboy-rigs/woocommerce-db-api-hotspot-artifact-io/v1', 'DB/API hotspot artifact IO schema drifted');
 assert.equal(dbApiHotspotArtifactIo.postprocess_command, 'homeboy.artifact-postprocess', 'DB/API hotspot artifact IO must use upstream artifact-postprocess');
 assert.equal(dbApiHotspotArtifactIo.readiness?.level, 'declared', 'DB/API hotspot artifact IO must stay declared until artifact-postprocess binding lands');


### PR DESCRIPTION
## Summary
- Add a Woo DB/API fuzz campaign manifest that requires public Codebox fuzz-suite and WordPress hotspot artifacts.
- Wire the campaign into the Woo performance rig profile.
- Strengthen validation for required reviewer-facing artifact refs.
- Document the campaign path without claiming proven readiness or running local benchmarks.

## Verification
- node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
- node --test woocommerce/woocommerce/tools/db-api-fuzzer-artifacts.test.mjs scripts/fuzz-manifest-helpers.test.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode task subagents
- **Used for:** Auditing Woo DB/API fuzz campaign gaps, drafting manifest and validator changes, adding focused validation, and preparing the PR.