### PR TITLE
fix(ssi): satisfy transformer path override constraint

### DIFF
--- a/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
+++ b/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
@@ -280,14 +280,38 @@ function updateComposerPathRepository(pluginPath, packagePath) {
 }
 
 function configureComposerPathRepository(pluginPath, packagePath) {
-  const result = spawnSync('composer', ['config', 'repositories.blocks-engine-php-transformer-dev', 'path', packagePath], {
-    cwd: pluginPath,
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-  if (result.status !== 0) {
-    throw new Error(`Composer path repository configuration failed for ${pluginPath}: ${result.stderr || result.stdout || `exit ${result.status}`}`);
+  const composerFile = path.join(pluginPath, 'composer.json');
+  const composer = JSON.parse(fs.readFileSync(composerFile, 'utf8'));
+  composer.repositories = composer.repositories && typeof composer.repositories === 'object' && !Array.isArray(composer.repositories)
+    ? composer.repositories
+    : {};
+  composer.repositories['blocks-engine-php-transformer-dev'] = composerPathRepositoryConfig(composer, packagePath);
+  fs.writeFileSync(composerFile, `${JSON.stringify(composer, null, 2)}\n`);
+}
+
+export function composerPathRepositoryConfig(rootComposer, packagePath) {
+  return {
+    type: 'path',
+    url: packagePath,
+    canonical: false,
+    options: {
+      symlink: false,
+      versions: {
+        'automattic/blocks-engine-php-transformer': composerPathRepositoryVersion(rootComposer),
+      },
+    },
+  };
+}
+
+function composerPathRepositoryVersion(rootComposer) {
+  const constraint = rootComposer?.require?.['automattic/blocks-engine-php-transformer'];
+  if (typeof constraint !== 'string') {
+    return '0.1.15';
   }
+
+  const trimmed = constraint.trim();
+  const match = trimmed.match(/^\^?(\d+\.\d+\.\d+)$/);
+  return match ? match[1] : '0.1.15';
 }
 
 function runtimeSummary(runtime, runtimeError) {

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -4,7 +4,10 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { resolveBlocksEnginePhpTransformerPath } from '../bench/static-site-fixture-matrix.bench.mjs';
+import {
+  composerPathRepositoryConfig,
+  resolveBlocksEnginePhpTransformerPath,
+} from '../bench/static-site-fixture-matrix.bench.mjs';
 import {
   compareFindingPackets,
   selectorFamily,
@@ -114,6 +117,26 @@ test('resolves Blocks Engine PHP transformer override paths', () => {
 
   assert.equal(resolveBlocksEnginePhpTransformerPath(repoRoot), packageRoot);
   assert.equal(resolveBlocksEnginePhpTransformerPath(packageRoot), packageRoot);
+});
+
+test('builds Composer path repository override matching SSI constraints', () => {
+  const config = composerPathRepositoryConfig({
+    require: {
+      'automattic/blocks-engine-php-transformer': '^0.1.15',
+    },
+  }, '/tmp/blocks-engine/php-transformer');
+
+  assert.deepEqual(config, {
+    type: 'path',
+    url: '/tmp/blocks-engine/php-transformer',
+    canonical: false,
+    options: {
+      symlink: false,
+      versions: {
+        'automattic/blocks-engine-php-transformer': '0.1.15',
+      },
+    },
+  });
 });
 
 test('compares finding packet deltas by repair dimensions', () => {


### PR DESCRIPTION
## Summary
- Write the Blocks Engine PHP transformer override as an explicit Composer path repository config.
- Mark the path repository non-canonical and provide a version alias matching SSI's required transformer constraint.
- Add focused coverage for the generated Composer path repository config.

## Context
The full SSI matrix now reaches the intended rig workload, but Composer rejects the local Blocks Engine transformer path because path repositories default to a dev branch version that does not satisfy SSI's ^0.1.15 constraint. This fixes the generic rig override path instead of bypassing Composer.

## Verification
- node WordPress/static-site-importer/tools/fixture-matrix.test.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Debugging the Composer override failure, implementing the fix, adding focused coverage, and drafting this PR description.