### PR TITLE
fix(rigs): remove committed local checkout paths

### DIFF
--- a/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
+++ b/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
@@ -3,13 +3,13 @@
   "description": "Jetpack REST route inventory scaffold for adapting generic Homeboy Extensions and WP Codebox API performance primitives.",
   "components": {
     "jetpack": {
-      "path": "~/Developer/jetpack/projects/plugins/jetpack",
-      "checkout_root": "~/Developer/jetpack",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__JETPACK_API_ROUTE_INVENTORY__JETPACK}",
+      "checkout_root": "${env.HOMEBOY_RIG_COMPONENT_CHECKOUT_ROOT__JETPACK_API_ROUTE_INVENTORY__JETPACK}",
       "branch": "trunk",
       "extensions": {
         "wordpress": {
           "wp_codebox_wordpress_version": "7.0",
-          "wp_codebox_source_root": "~/Developer/jetpack",
+          "wp_codebox_source_root": "${env.HOMEBOY_RIG_COMPONENT_CHECKOUT_ROOT__JETPACK_API_ROUTE_INVENTORY__JETPACK}",
           "wp_codebox_source_subpath": "projects/plugins/jetpack"
         }
       }

--- a/Automattic/jetpack/rigs/jetpack-browser-coverage/rig.json
+++ b/Automattic/jetpack/rigs/jetpack-browser-coverage/rig.json
@@ -3,7 +3,7 @@
   "description": "WP Codebox browser-actions request coverage for Jetpack dashboard, connection, modules, settings admin, and public module frontend surfaces.",
   "components": {
     "jetpack": {
-      "path": "~/Developer/jetpack/projects/plugins/jetpack",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__JETPACK_BROWSER_COVERAGE__JETPACK}",
       "branch": "trunk"
     }
   },

--- a/Automattic/studio/rigs/studio-admin-perf/rig.json
+++ b/Automattic/studio/rigs/studio-admin-perf/rig.json
@@ -3,7 +3,7 @@
   "description": "Focused Studio admin performance rig for WordPress admin page and REST latency evidence without the wordpress-playground component dependency.",
   "components": {
     "studio": {
-      "path": "~/Developer/studio",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_ADMIN_PERF__STUDIO}",
       "branch": "dev/combined-fixes",
       "extensions": {
         "nodejs": {

--- a/Automattic/studio/rigs/studio-agent-claude-ssi/rig.json
+++ b/Automattic/studio/rigs/studio-agent-claude-ssi/rig.json
@@ -3,7 +3,7 @@
   "description": "Studio Claude Sonnet 4.6 on the active Static Site Importer draft branch. Pairs with studio-agent-gpt55-ssi so the same SSI substrate can be compared across models.",
   "components": {
     "studio": {
-      "path": "~/Developer/studio@bfb-mu-plugin-agent-output",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_AGENT_CLAUDE_SSI__STUDIO}",
       "branch": "bfb-mu-plugin-agent-output-draft",
       "extensions": {
         "nodejs": {

--- a/Automattic/studio/rigs/studio-agent-claude-trunk/rig.json
+++ b/Automattic/studio/rigs/studio-agent-claude-trunk/rig.json
@@ -3,7 +3,7 @@
   "description": "Studio Claude Sonnet 4.6 on current Automattic/studio trunk. Used as the reference rig for trunk-vs-SSI comparisons.",
   "components": {
     "studio": {
-      "path": "~/Developer/studio@agent-sdk-baseline",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_AGENT_CLAUDE_EVALTIMING__STUDIO}",
       "branch": "agent-sdk-baseline",
       "extensions": {
         "nodejs": {

--- a/Automattic/studio/rigs/studio-agent-gpt55-ssi/rig.json
+++ b/Automattic/studio/rigs/studio-agent-gpt55-ssi/rig.json
@@ -3,7 +3,7 @@
   "description": "Studio GPT 5.5 / pi-agent-core runtime on the active Static Site Importer draft branch. Pairs with studio-agent-claude-ssi so the same SSI substrate can be compared across models.",
   "components": {
     "studio": {
-      "path": "~/Developer/studio@bfb-mu-plugin-agent-output",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_AGENT_GPT55_SSI__STUDIO}",
       "branch": "bfb-mu-plugin-agent-output-draft",
       "extensions": {
         "nodejs": {

--- a/Automattic/studio/rigs/studio-agent-model-comparison.variants.json
+++ b/Automattic/studio/rigs/studio-agent-model-comparison.variants.json
@@ -64,7 +64,7 @@
     {
       "id": "studio-agent-claude-trunk",
       "description": "Studio Claude Sonnet 4.6 on current Automattic/studio trunk. Used as the reference rig for trunk-vs-SSI comparisons.",
-      "studio_path": "~/Developer/studio@agent-sdk-baseline",
+      "studio_path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_AGENT_CLAUDE_EVALTIMING__STUDIO}",
       "studio_branch": "agent-sdk-baseline",
       "studio_bench_variant": "claude-sonnet-4-6-trunk",
       "studio_agent_model": "claude-sonnet-4-6"
@@ -72,7 +72,7 @@
     {
       "id": "studio-agent-claude-ssi",
       "description": "Studio Claude Sonnet 4.6 on the active Static Site Importer draft branch. Pairs with studio-agent-gpt55-ssi so the same SSI substrate can be compared across models.",
-      "studio_path": "~/Developer/studio@bfb-mu-plugin-agent-output",
+      "studio_path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_AGENT_CLAUDE_SSI__STUDIO}",
       "studio_branch": "bfb-mu-plugin-agent-output-draft",
       "studio_bench_variant": "claude-sonnet-4-6-ssi",
       "studio_agent_model": "claude-sonnet-4-6"
@@ -80,7 +80,7 @@
     {
       "id": "studio-agent-gpt55-ssi",
       "description": "Studio GPT 5.5 / pi-agent-core runtime on the active Static Site Importer draft branch. Pairs with studio-agent-claude-ssi so the same SSI substrate can be compared across models.",
-      "studio_path": "~/Developer/studio@bfb-mu-plugin-agent-output",
+      "studio_path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_AGENT_GPT55_SSI__STUDIO}",
       "studio_branch": "bfb-mu-plugin-agent-output-draft",
       "studio_bench_variant": "gpt-5.5-ssi",
       "studio_agent_model": "gpt-5.5"

--- a/Automattic/studio/rigs/studio-canonical-loop-proof/rig.json
+++ b/Automattic/studio/rigs/studio-canonical-loop-proof/rig.json
@@ -3,15 +3,15 @@
   "description": "Safe skeleton proof for the canonical Studio website artifact loop: host request, Codebox/fanout generation, Studio Native canonical artifact storage, SSI materialization, user mutation, reimport, and diagnostics. Current implementation is filesystem-only and stubbed until executable component seams exist.",
   "components": {
     "studio-native": {
-      "path": "~/Developer/studio-native",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_CANONICAL_LOOP_PROOF__STUDIO_NATIVE}",
       "branch": "main"
     },
     "static-site-importer": {
-      "path": "~/Developer/static-site-importer",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_CANONICAL_LOOP_PROOF__STATIC_SITE_IMPORTER}",
       "branch": "HEAD"
     },
     "wp-codebox": {
-      "path": "~/Developer/wp-codebox",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_CANONICAL_LOOP_PROOF__WP_CODEBOX}",
       "branch": "HEAD"
     }
   },

--- a/Automattic/studio/rigs/studio-cli-password-node/rig.json
+++ b/Automattic/studio/rigs/studio-cli-password-node/rig.json
@@ -4,7 +4,7 @@
 
   "components": {
     "studio": {
-      "path": "~/Developer/studio",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_CLI_PASSWORD_NODE__STUDIO}",
       "branch": "dev/combined-fixes",
       "extensions": {
         "nodejs": {

--- a/Automattic/studio/rigs/studio-combined/rig.json
+++ b/Automattic/studio/rigs/studio-combined/rig.json
@@ -4,7 +4,7 @@
 
   "components": {
     "studio": {
-      "path": "~/Developer/studio",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_COMBINED__STUDIO}",
       "branch": "dev/combined-fixes",
       "extensions": {
         "nodejs": {
@@ -13,7 +13,7 @@
       }
     },
     "wordpress-playground": {
-      "path": "~/Developer/wordpress-playground",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_COMBINED__WORDPRESS_PLAYGROUND}",
       "branch": "dev/combined-fixes"
     }
   },

--- a/Automattic/studio/rigs/studio-datamachine-pipelines-scale/rig.json
+++ b/Automattic/studio/rigs/studio-datamachine-pipelines-scale/rig.json
@@ -3,7 +3,7 @@
   "description": "Studio WordPress admin profile for the Data Machine Pipelines page with a configurable scale fixture.",
   "components": {
     "studio": {
-      "path": "~/Developer/studio",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_DATAMACHINE_PIPELINES_SCALE__STUDIO}",
       "branch": "dev/combined-fixes",
       "extensions": {
         "nodejs": {

--- a/Automattic/studio/rigs/studio-figma-to-wordpress-import/rig.json
+++ b/Automattic/studio/rigs/studio-figma-to-wordpress-import/rig.json
@@ -3,7 +3,7 @@
   "description": "Adapter rig for the Blocks Engine Figma transformer fixture matrix. The Figma transformer repo owns the .fig fixture discovery, frame selection, transform command, and artifacts; this rig only exposes that repo-local entrypoint through Homeboy.",
   "components": {
     "blocks-engine": {
-      "path": "~/Developer/blocks-engine",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_FIGMA_TO_WORDPRESS_IMPORT__BLOCKS_ENGINE}",
       "branch": "trunk",
       "extensions": {}
     }

--- a/Automattic/studio/rigs/studio-many-sites-memory-scroll/rig.json
+++ b/Automattic/studio/rigs/studio-many-sites-memory-scroll/rig.json
@@ -3,7 +3,7 @@
   "description": "Durable Studio many-sites memory and sidebar scroll benchmark. Runs Studio's in-repo Playwright metrics harness against a configurable large local site list and records RSS, scroll timing, and screenshots.",
   "components": {
     "studio": {
-      "path": "~/Developer/studio",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_MANY_SITES_MEMORY_SCROLL__STUDIO}",
       "branch": "dev/combined-fixes",
       "extensions": {
         "nodejs": {

--- a/Automattic/studio/stacks/studio-combined.json
+++ b/Automattic/studio/stacks/studio-combined.json
@@ -2,7 +2,7 @@
   "id": "studio-combined",
   "description": "Studio dev/combined-fixes stack: Automattic/studio trunk plus Chris's active local-dev PRs.",
   "component": "studio",
-  "component_path": "~/Developer/studio",
+  "component_path": "${env.HOMEBOY_STACK_COMPONENT_PATH__STUDIO_COMBINED__STUDIO}",
   "base": {
     "remote": "origin",
     "branch": "trunk"

--- a/WordPress/gutenberg/rigs/gutenberg-api-route-inventory/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-api-route-inventory/rig.json
@@ -3,12 +3,12 @@
   "description": "Gutenberg REST route inventory scaffold for adapting generic Homeboy Extensions and WP Codebox API performance primitives.",
   "components": {
     "gutenberg": {
-      "path": "~/Developer/gutenberg",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__GUTENBERG_API_ROUTE_INVENTORY__GUTENBERG}",
       "branch": "trunk",
       "extensions": {
         "wordpress": {
           "wp_codebox_wordpress_version": "7.0",
-          "wp_codebox_source_root": "~/Developer/gutenberg",
+          "wp_codebox_source_root": "${env.HOMEBOY_RIG_COMPONENT_PATH__GUTENBERG_API_ROUTE_INVENTORY__GUTENBERG}",
           "wp_codebox_source_subpath": "."
         }
       }

--- a/WordPress/gutenberg/rigs/gutenberg-browser-coverage/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-browser-coverage/rig.json
@@ -3,7 +3,7 @@
   "description": "WP Codebox browser-actions request coverage for Gutenberg post editor, site editor, template editor, and patterns surfaces.",
   "components": {
     "gutenberg": {
-      "path": "~/Developer/gutenberg",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__GUTENBERG_BROWSER_COVERAGE__GUTENBERG}",
       "branch": "trunk"
     }
   },

--- a/WordPress/gutenberg/rigs/gutenberg-notes-unsaved-attachment/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-notes-unsaved-attachment/rig.json
@@ -3,7 +3,7 @@
   "description": "Gutenberg Block Notes unsaved attachment repro rig for WordPress/gutenberg#72717.",
   "components": {
     "gutenberg": {
-      "path": "~/Developer/gutenberg",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__GUTENBERG_NOTES_UNSAVED_ATTACHMENT__GUTENBERG}",
       "branch": "trunk"
     }
   },

--- a/WordPress/gutenberg/rigs/gutenberg-pattern-preview-assets/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-pattern-preview-assets/rig.json
@@ -3,7 +3,7 @@
   "description": "Gutenberg pattern preview asset fan-out rig for reproducing WordPress/gutenberg#68979 and the request-spike symptoms discussed in WordPress/gutenberg#71547.",
   "components": {
     "gutenberg": {
-      "path": "~/Developer/gutenberg",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__GUTENBERG_PATTERN_PREVIEW_ASSETS__GUTENBERG}",
       "branch": "trunk"
     }
   },

--- a/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
@@ -3,7 +3,7 @@
   "description": "Static Site Importer fixture matrix workload that composes generic WP Codebox recipe orchestration while keeping SSI-specific fixture and diagnostic policy in homeboy-rigs.",
   "components": {
     "static-site-importer": {
-      "path": "~/Developer/static-site-importer",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STATIC_SITE_IMPORTER_FIXTURE_MATRIX__STATIC_SITE_IMPORTER}",
       "branch": "trunk"
     }
   },

--- a/WordPress/wordpress-develop/rigs/wordpress-core-fuzz-coverage/rig.json
+++ b/WordPress/wordpress-develop/rigs/wordpress-core-fuzz-coverage/rig.json
@@ -3,12 +3,12 @@
   "description": "WordPress Core coverage/fuzz rig suite using generic Homeboy fuzz workload manifests and no bench fallback.",
   "components": {
     "wordpress-develop": {
-      "path": "~/Developer/wordpress-develop",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__WORDPRESS_CORE_FUZZ_COVERAGE__WORDPRESS_DEVELOP}",
       "branch": "trunk",
       "extensions": {
         "wordpress": {
           "wp_codebox_wordpress_version": "latest",
-          "wp_codebox_source_root": "~/Developer/wordpress-develop",
+          "wp_codebox_source_root": "${env.HOMEBOY_RIG_COMPONENT_PATH__WORDPRESS_CORE_FUZZ_COVERAGE__WORDPRESS_DEVELOP}",
           "wp_codebox_source_subpath": "src"
         }
       }

--- a/WordPress/wordpress-playground/rigs/playground-cli-diagnostics/rig.json
+++ b/WordPress/wordpress-playground/rigs/playground-cli-diagnostics/rig.json
@@ -3,7 +3,7 @@
   "description": "WordPress Playground CLI diagnostic rig. Reproduces Blueprint runPHP fatal reporting through the local unbuilt CLI and captures evidence for upstream fixes.",
   "components": {
     "wordpress-playground": {
-      "path": "~/Developer/wordpress-playground",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__PLAYGROUND_CLI_DIAGNOSTICS__WORDPRESS_PLAYGROUND}",
       "branch": "trunk",
       "extensions": {
         "nodejs": {}

--- a/WordPress/wordpress-playground/stacks/playground-combined.json
+++ b/WordPress/wordpress-playground/stacks/playground-combined.json
@@ -2,7 +2,7 @@
   "id": "playground-combined",
   "description": "WordPress Playground dev/combined-fixes stack: upstream trunk plus Chris's active PHP-WASM and worker-pool PRs.",
   "component": "wordpress-playground",
-  "component_path": "~/Developer/wordpress-playground",
+  "component_path": "${env.HOMEBOY_STACK_COMPONENT_PATH__PLAYGROUND_COMBINED__WORDPRESS_PLAYGROUND}",
   "base": {
     "remote": "upstream",
     "branch": "trunk"

--- a/WordPress/wordpress/rigs/wordpress-core-api-route-inventory/rig.json
+++ b/WordPress/wordpress/rigs/wordpress-core-api-route-inventory/rig.json
@@ -3,7 +3,7 @@
   "description": "WordPress core REST route inventory scaffold for adapting generic Homeboy Extensions and WP Codebox API performance primitives.",
   "components": {
     "wordpress": {
-      "path": "~/Developer/wordpress-develop",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__WORDPRESS_CORE_API_ROUTE_INVENTORY__WORDPRESS}",
       "branch": "trunk"
     }
   },

--- a/WordPress/wordpress/rigs/wordpress-core-browser-coverage/rig.json
+++ b/WordPress/wordpress/rigs/wordpress-core-browser-coverage/rig.json
@@ -3,7 +3,7 @@
   "description": "WP Codebox browser-actions request coverage for WordPress core front page, post editor, site editor, and media library surfaces.",
   "components": {
     "wordpress": {
-      "path": "~/Developer/wordpress-develop",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__WORDPRESS_CORE_BROWSER_COVERAGE__WORDPRESS}",
       "branch": "trunk"
     }
   },

--- a/chubes4/isolated-block-editor/rigs/isolated-block-editor/rig.json
+++ b/chubes4/isolated-block-editor/rigs/isolated-block-editor/rig.json
@@ -3,14 +3,14 @@
   "description": "Isolated Block Editor maintenance rig. Runs the build and unit test checks used when shaving IBE toward modern Gutenberg APIs. Worktree-friendly: if node_modules is missing, borrows the primary checkout's node_modules through Homeboy shared-path primitives.",
   "components": {
     "isolated-block-editor": {
-      "path": "~/Developer/isolated-block-editor",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__ISOLATED_BLOCK_EDITOR__ISOLATED_BLOCK_EDITOR}",
       "branch": "trunk"
     }
   },
   "shared_paths": [
     {
       "link": "${components.isolated-block-editor.path}/node_modules",
-      "target": "~/Developer/isolated-block-editor/node_modules"
+      "target": "${components.isolated-block-editor.path}/node_modules"
     }
   ],
   "pipeline": {

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -24,6 +24,7 @@ const failures = [];
 const warnings = [];
 const studioModelRigGenerator = join(root, 'scripts/generate-studio-agent-model-rigs.mjs');
 const personalPathPrefix = '/Users/' + 'chubes/';
+const localDeveloperCheckoutPattern = /(?:~|\$HOME)\/Developer\//;
 const tsrmlsPatchMarker = 'PHP-WASM-COMBINED-FIXES ' + 'TSRMLS fallback';
 const homeboyFuzzSafetyClasses = new Set(['read_only', 'idempotent', 'isolated_mutation', 'destructive']);
 
@@ -90,6 +91,10 @@ function lintRigPortability(file, fuzzWorkloadsByPackageRoot) {
 
   if (rel === 'chubes4/isolated-block-editor/rigs/isolated-block-editor/rig.json' && contents.includes('/var/lib/datamachine')) {
     failures.push(`${rel}: isolated-block-editor must use the component path or shared node_modules setting instead of /var/lib/datamachine`);
+  }
+
+  if (localDeveloperCheckoutPattern.test(contents)) {
+    failures.push(`${rel}: use portable component path settings instead of committed ~/Developer or $HOME/Developer checkout paths`);
   }
 
   if (/WP Codebox CLI/.test(pipelineCommands) && /command -v wp-codebox|Developer\/wp-codebox|HOMEBOY_WP_CODEBOX_BIN/.test(pipelineCommands)) {
@@ -392,6 +397,10 @@ function lintPortableSource(file) {
 
   if (contents.includes(personalPathPrefix)) {
     failures.push(`${rel}: use $HOME, homedir(), component paths, or settings instead of hard-coded /Users/chubes paths`);
+  }
+
+  if (rel.includes('/stacks/') && localDeveloperCheckoutPattern.test(contents)) {
+    failures.push(`${rel}: use portable component path settings instead of committed ~/Developer or $HOME/Developer checkout paths`);
   }
 
   if (contents.includes(tsrmlsPatchMarker)) {

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -128,6 +128,67 @@ test('rejects missing declared fuzz workload files', () => {
   assert.match(result.stderr, /declares missing file/);
 });
 
+test('rejects committed local Developer checkout paths in rigs', () => {
+  const directory = createRigPackage({
+    rig: {
+      components: {
+        product: {
+          path: '~/Developer/product',
+          branch: 'main',
+        },
+      },
+    },
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+  });
+
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /use portable component path settings instead of committed ~\/Developer or \$HOME\/Developer checkout paths/);
+});
+
+test('accepts component paths resolved through portable settings', () => {
+  const directory = createRigPackage({
+    rig: {
+      components: {
+        product: {
+          path: '${env.HOMEBOY_RIG_COMPONENT_PATH__GENERIC_RIG__PRODUCT}',
+          branch: 'main',
+        },
+      },
+    },
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+  });
+
+  const result = runLint(directory);
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+});
+
+test('rejects committed local Developer checkout paths in stacks', () => {
+  const directory = createRigPackage({
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+  });
+  const stackRoot = join(directory, 'Vendor', 'product', 'stacks');
+  mkdirSync(stackRoot, { recursive: true });
+  writeJson(join(stackRoot, 'combined.json'), {
+    id: 'combined',
+    component: 'product',
+    component_path: '$HOME/Developer/product',
+  });
+
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /stacks\/combined\.json: use portable component path settings/);
+});
+
 test('rejects invalid declared fuzz workload shapes', () => {
   const directory = createRigPackage({
     fuzzWorkloads: {

--- a/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
+++ b/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
@@ -3,11 +3,11 @@
   "description": "WooCommerce Stripe product-page Express Checkout Element waterfall rig for reproducing and measuring issue #1439 third-party page-load fan-out.",
   "components": {
     "woocommerce-gateway-stripe": {
-      "path": "~/Developer/woocommerce-gateway-stripe",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__WOOCOMMERCE_STRIPE_ECE_PRODUCT_PAGE__WOOCOMMERCE_GATEWAY_STRIPE}",
       "branch": "develop"
     },
     "woocommerce": {
-      "path": "$HOME/Developer/woocommerce/plugins/woocommerce",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__WOOCOMMERCE_STRIPE_ECE_PRODUCT_PAGE__WOOCOMMERCE}",
       "branch": "trunk"
     }
   },

--- a/woocommerce/woocommerce/rigs/woocommerce-browser-coverage/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-browser-coverage/rig.json
@@ -3,7 +3,7 @@
   "description": "WP Codebox browser-actions request coverage for WooCommerce shop, product, cart, checkout, orders admin, products admin, and analytics admin surfaces.",
   "components": {
     "woocommerce": {
-      "path": "$HOME/Developer/woocommerce/plugins/woocommerce",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__WOOCOMMERCE_BROWSER_COVERAGE__WOOCOMMERCE}",
       "branch": "trunk"
     }
   },

--- a/woocommerce/woocommerce/rigs/woocommerce-cart-session-race-browser/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-cart-session-race-browser/rig.json
@@ -3,7 +3,7 @@
   "description": "WP Codebox browser-level two-tab/product-page/cart-page repro rig for WooCommerce cart session overwrite race issue #46483.",
   "components": {
     "woocommerce": {
-      "path": "~/Developer/woocommerce",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__WOOCOMMERCE_CART_SESSION_RACE_BROWSER__WOOCOMMERCE}",
       "branch": "trunk",
       "extensions": {
         "nodejs": {}

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -3,12 +3,12 @@
   "description": "WooCommerce large-merchant performance and fuzz rig. Uses WordPress/WP Codebox runtimes for performance benchmarks plus declared fuzz workloads tied to concrete WooCommerce issues and coverage surfaces.",
   "components": {
     "woocommerce": {
-      "path": "~/Developer/woocommerce/plugins/woocommerce",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__WOOCOMMERCE_PERFORMANCE__WOOCOMMERCE}",
       "branch": "trunk",
       "extensions": {
         "wordpress": {
           "wp_codebox_wordpress_version": "7.0",
-          "wp_codebox_source_root": "~/Developer/woocommerce",
+          "wp_codebox_source_root": "${env.HOMEBOY_RIG_COMPONENT_CHECKOUT_ROOT__WOOCOMMERCE_PERFORMANCE__WOOCOMMERCE}",
           "wp_codebox_source_subpath": "plugins/woocommerce",
           "bench_env": {
             "WC_CHECKOUT_GATEWAY_MATRIX_PROFILE_SET": "core_only",


### PR DESCRIPTION
## Summary
- Replace committed `~/Developer` / `/Users/chubes/Developer` rig and stack checkout paths with explicit Homeboy env-expanded component path settings.
- Add lint coverage rejecting new committed local Developer checkout paths in rig and stack JSON.
- Keep generated Studio agent model rigs in sync through the variants source.

## Tests
- `node --test scripts/lint-rig-packages.test.mjs`
- `node scripts/generate-studio-agent-model-rigs.mjs --check`
- `node scripts/lint-rig-packages.mjs`
- `node --test` *(fails: `Automattic/studio/bench/studio-agent-site-build.test.mjs` requires unset `HOMEBOY_NODEJS_WORKLOAD_UTILS`; 178/179 tests passed)*

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code changes, lint/test updates, verification, and PR preparation.
