### PR TITLE
Fix SSI matrix shared state on runners

### DIFF
--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -166,6 +166,7 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   assert.equal(plan.fixture_root, fixtureRoot);
   assert.equal(plan.fixture_count, CANONICAL_FIXTURE_COUNT);
   assert.equal(plan.fixture_count_matches_canonical, true);
+  assert.equal(plan.shared_state, '/tmp/homeboy-rigs-ssi-fixture-matrix-shared-state');
   assert.equal(plan.dependency_overrides.blocks_engine_php_transformer.path, blocksEngine);
   assert.equal(plan.steps.some((step) => step.args.includes('install')), false);
   assert.ok(plan.steps.some((step) => step.args.includes('sync')));

--- a/WordPress/static-site-importer/tools/run-fixture-matrix.mjs
+++ b/WordPress/static-site-importer/tools/run-fixture-matrix.mjs
@@ -97,10 +97,17 @@ function normalizeOptions(input) {
     blocksEngine,
     blocksEnginePhpTransformerPath,
     staticSiteImporter: path.resolve(input.staticSiteImporter),
-    sharedState: path.resolve(input.sharedState || path.join(os.tmpdir(), 'homeboy-rigs-ssi-fixture-matrix-shared-state')),
+    sharedState: input.sharedState ? path.resolve(input.sharedState) : defaultSharedState(input.runner),
     artifactRoot: input.artifactRoot ? path.resolve(input.artifactRoot) : '',
     runner: input.runner || '',
   };
+}
+
+function defaultSharedState(runner) {
+  if (runner) {
+    return '/tmp/homeboy-rigs-ssi-fixture-matrix-shared-state';
+  }
+  return path.resolve(path.join(os.tmpdir(), 'homeboy-rigs-ssi-fixture-matrix-shared-state'));
 }
 
 function buildSteps(options, settings) {


### PR DESCRIPTION
## Summary
- Use a runner-safe shared-state default for SSI fixture matrix wrapper runs with --runner.
- Keep local/default non-runner shared state on the controller temp directory.
- Cover runner shared-state default in the canonical plan test.

Fixes #472.

## Verification
- node WordPress/static-site-importer/tools/fixture-matrix.test.mjs
- node --check WordPress/static-site-importer/tools/run-fixture-matrix.mjs
- node WordPress/static-site-importer/tools/run-fixture-matrix.mjs --runner homeboy-lab --static-site-importer /Users/chubes/Developer/static-site-importer@run-ssi-matrix-20260626 --blocks-engine /Users/chubes/Developer/blocks-engine@run-ssi-matrix-20260626 --lab-only --run-id ssi-matrix-post-fixes-20260626 --dry-run

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Diagnosing the runner shared-state path failure, implementing the wrapper fix, and drafting test coverage.