### PR TITLE
Clarify Studio loop proof and add live runtime open check

### DIFF
--- a/Automattic/studio/docs/studio-canonical-loop-proof.md
+++ b/Automattic/studio/docs/studio-canonical-loop-proof.md
@@ -1,6 +1,6 @@
-# Studio Canonical Loop Proof
+# Studio Canonical Loop Contract Harness
 
-This is a deterministic contract proof for the canonical website artifact loop:
+This is a deterministic contract harness for the intended website artifact loop:
 
 1. Host request arrives with prompt, fanout targets, artifact contract, and user-change intent.
 2. Codebox/fanout generation produces a website artifact.
@@ -10,7 +10,9 @@ This is a deterministic contract proof for the canonical website artifact loop:
 6. Reimport materializes the updated artifact.
 7. Progress and diagnostics artifacts explain what happened.
 
-Current status: the default proof verifies the end-to-end contract and writes a portable evidence bundle. Runtime execution for Codebox browser fanout, Studio Native persistence APIs, and ephemeral Codebox/WordPress remains explicitly marked as blocked rather than faked. A stronger `local-wp` mode exercises Static Site Importer through a local WordPress install with WP-CLI when that runtime is available.
+Current status: the default harness verifies contract shape and writes a portable evidence bundle. It is not evidence that the production Studio Native loop works or produces valuable iteration PRs. Runtime execution for Codebox browser fanout, Studio Native persistence APIs, and ephemeral Codebox/WordPress remains explicitly marked as blocked rather than faked. A stronger `local-wp` mode exercises Static Site Importer through a local WordPress install with WP-CLI when that runtime is available.
+
+The first real runtime proof is `studio-native-live-runtime-open.mjs`: it opens a Studio Native runtime site and verifies that the real Studio Native, agentic UI, and WP Codebox REST surfaces are present. That is still only a runtime-open proof, not a generation-quality proof.
 
 ## Safe Validation
 
@@ -21,14 +23,14 @@ node Automattic/studio/proofs/studio-canonical-loop-proof.mjs \
 node scripts/lint-rig-packages.mjs Automattic/studio
 ```
 
-## Run The Stub Proof
+## Run The Contract Harness
 
 ```bash
 node Automattic/studio/proofs/studio-canonical-loop-proof.mjs \
   --out /tmp/studio-canonical-loop-proof
 ```
 
-## Run The Local WordPress Proof
+## Run The Local WordPress Harness
 
 Run this from a Studio site directory that has Static Site Importer active:
 
@@ -38,7 +40,19 @@ node /path/to/homeboy-rigs/Automattic/studio/proofs/studio-canonical-loop-proof.
   --out /tmp/studio-canonical-loop-local-wp-proof
 ```
 
-`local-wp` mode writes the same proof artifacts as stub mode, but the initial materialization and reimport materialization are performed through `static_site_importer_ability_import_website_artifact()` via `studio wp eval-file`.
+`local-wp` mode writes the same artifacts as stub mode, but the initial materialization and reimport materialization are performed through `static_site_importer_ability_import_website_artifact()` via `studio wp eval-file`.
+
+## Run The Live Runtime Open Proof
+
+Run this against the purpose-built local Studio Native runtime:
+
+```bash
+node Automattic/studio/proofs/studio-native-live-runtime-open.mjs \
+  --url http://studio-native-local-runtime.local/ \
+  --out /tmp/studio-native-live-runtime-open
+```
+
+This proof opens the site, opens the WordPress REST index, reaches `/wp-json/studio-native/v1/status` even when auth-protected, and fails unless the real routes for chat, run events, Codebox artifact handoff, Codebox artifact session, contained-site open/create, and WP Codebox browser endpoints are present.
 
 The script writes:
 
@@ -50,7 +64,7 @@ The script writes:
 - `evidence-bundle.json` with portable `homeboy-artifact://` refs for reviewer-facing artifacts.
 - `result.json` with the artifact index and success flag.
 
-## Acceptance Criteria
+## Contract Harness Acceptance Criteria
 
 The proof fails unless these user-facing outcomes are present:
 
@@ -68,7 +82,22 @@ The proof fails unless these user-facing outcomes are present:
 homeboy rig check studio-canonical-loop-proof
 ```
 
-The rig check validates the fixture and runs the deterministic contract proof. It intentionally does not claim live Codebox or Studio Native runtime execution until those interfaces are available.
+The rig check validates the fixture and runs the deterministic contract harness. It intentionally does not claim live Codebox or Studio Native runtime execution.
+
+## Production Loop Acceptance Criteria
+
+The production proof still needs to drive the real runtime:
+
+- Open the Studio Native runtime in a browser or through its real REST surfaces.
+- Submit a real host chat/generation request through `/studio-native-agentic-ui/v1/chat` or the UI.
+- Observe real progress through `/studio-native-agentic-ui/v1/runs/{run_id}/events`.
+- Verify real Codebox delegation and artifact refs.
+- Verify Studio Native stores the accepted artifact as project source-of-truth state.
+- Verify SSI materializes the artifact into the runtime site.
+- Submit a real edit request against the existing project.
+- Verify the original stored artifact is mutated and reimported.
+- Verify the visible site output changes.
+- Produce reviewer-facing artifacts/screenshots/events that demonstrate the iteration has value.
 
 ## Real vs Stubbed
 
@@ -85,7 +114,7 @@ Contract-verified now:
 - In `local-wp` mode, Static Site Importer website artifact materialization through local WordPress/WP-CLI.
 - In `local-wp` mode, reimport materialization through local WordPress/WP-CLI.
 
-Stubbed now:
+Stubbed by the contract harness:
 
 - Codebox browser execution.
 - Studio Native canonical artifact persistence APIs.
@@ -94,7 +123,7 @@ Stubbed now:
 - WordPress active-theme verification.
 - Reviewer-facing artifact bundle publication.
 
-## Blockers To Make This Executable
+## Blockers To Make The Full Production Proof Executable
 
 - Host request API contract needs an executable endpoint and auth shape.
 - Codebox fanout generation needs a durable artifact bundle contract for website artifacts.

--- a/Automattic/studio/proofs/studio-native-live-runtime-open.mjs
+++ b/Automattic/studio/proofs/studio-native-live-runtime-open.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+function argValue(name) {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? null : process.argv[index + 1] || null;
+}
+
+function now() {
+  return new Date().toISOString();
+}
+
+function normalizeBaseUrl(value) {
+  const url = new URL(value || 'http://studio-native-local-runtime.local/');
+  url.pathname = url.pathname.replace(/\/+$/, '/');
+  url.search = '';
+  url.hash = '';
+  return url;
+}
+
+async function fetchText(url) {
+  const response = await fetch(url, { redirect: 'follow' });
+  const body = await response.text();
+  return { response, body };
+}
+
+async function fetchJson(url) {
+  const { response, body } = await fetchText(url);
+  let json = null;
+  try {
+    json = JSON.parse(body);
+  } catch (error) {
+    throw new Error(`Expected JSON from ${url}, got HTTP ${response.status}: ${body.slice(0, 200)}`);
+  }
+  return { response, json };
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function main() {
+  const baseUrl = normalizeBaseUrl(argValue('--url') || process.env.STUDIO_NATIVE_RUNTIME_URL);
+  const outDir = path.resolve(argValue('--out') || path.join(os.tmpdir(), `studio-native-live-runtime-open-${process.pid}`));
+  await mkdir(outDir, { recursive: true });
+
+  const homepage = await fetchText(baseUrl);
+  assert(homepage.response.ok, `Studio Native runtime homepage did not open: HTTP ${homepage.response.status}`);
+
+  const restUrl = new URL('/wp-json/', baseUrl);
+  const rest = await fetchJson(restUrl);
+  assert(rest.response.ok, `WordPress REST index did not open: HTTP ${rest.response.status}`);
+  const routes = rest.json.routes && typeof rest.json.routes === 'object' ? Object.keys(rest.json.routes) : [];
+  const requiredRoutes = [
+    '/studio-native/v1/status',
+    '/studio-native-agentic-ui/v1/chat',
+    '/studio-native-agentic-ui/v1/runs/(?P<run_id>[^/]+)/events',
+    '/studio-native/v1/browser-codebox/artifacts',
+    '/studio-native/v1/projects/(?P<project_id>\\d+)/codebox/artifact-session',
+    '/studio-native/v1/codebox/browser-contained-site/open-or-create',
+    '/wp-codebox/v1/browser-provider-request',
+    '/wp-codebox/v1/browser-blueprint-ref'
+  ];
+
+  const missingRoutes = requiredRoutes.filter((route) => !routes.includes(route));
+  assert(missingRoutes.length === 0, `Studio Native runtime is missing required route(s): ${missingRoutes.join(', ')}`);
+
+  const statusUrl = new URL('/wp-json/studio-native/v1/status', baseUrl);
+  const status = await fetchJson(statusUrl);
+  assert(
+    status.response.ok || status.response.status === 401,
+    `Studio Native status route was not reachable: HTTP ${status.response.status}`
+  );
+
+  const result = {
+    schema: 'studio-native/live-runtime-open-proof/v1',
+    success: true,
+    checked_at: now(),
+    runtime_url: baseUrl.toString(),
+    assertions: {
+      homepage_opened: true,
+      rest_index_opened: true,
+      studio_native_status_reachable: true,
+      studio_native_status_auth_required: status.response.status === 401,
+      required_routes_present: true
+    },
+    required_routes: requiredRoutes,
+    route_count: routes.length,
+    status: status.json
+  };
+
+  const resultPath = path.join(outDir, 'studio-native-live-runtime-open.json');
+  await writeFile(resultPath, `${JSON.stringify(result, null, 2)}\n`);
+  console.log(JSON.stringify({ success: true, result: resultPath, runtime_url: baseUrl.toString() }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/Automattic/studio/rigs/studio-canonical-loop-proof/rig.json
+++ b/Automattic/studio/rigs/studio-canonical-loop-proof/rig.json
@@ -1,6 +1,6 @@
 {
   "id": "studio-canonical-loop-proof",
-  "description": "Contract proof for the canonical Studio website artifact loop: host prompt/delegation, Codebox browser/fanout artifact, Studio Native source-of-truth artifact storage, SSI materialization, user mutation of the original artifact, reimport, and portable evidence refs. Runtime-only seams remain explicit blockers until executable interfaces exist.",
+  "description": "Contract harness for the intended Studio website artifact loop. It validates shape and portable evidence refs, but does not prove the production Studio Native runtime loop or iteration quality.",
   "components": {
     "studio-native": {
       "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_CANONICAL_LOOP_PROOF__STUDIO_NATIVE}",
@@ -32,7 +32,7 @@
       },
       {
         "kind": "check",
-        "label": "canonical loop proof script exists",
+        "label": "canonical loop contract harness exists",
         "file": "${package.root}/proofs/studio-canonical-loop-proof.mjs"
       },
       {
@@ -48,7 +48,7 @@
       },
       {
         "kind": "check",
-        "label": "canonical loop contract proof passes",
+        "label": "canonical loop contract harness passes",
         "command": "node ${package.root}/proofs/studio-canonical-loop-proof.mjs --out /tmp/studio-canonical-loop-proof-rig-check",
         "expect_exit": 0
       }

--- a/Automattic/studio/rigs/studio-native-live-runtime-open/rig.json
+++ b/Automattic/studio/rigs/studio-native-live-runtime-open/rig.json
@@ -1,0 +1,25 @@
+{
+  "id": "studio-native-live-runtime-open",
+  "description": "Opens a real Studio Native runtime and verifies the REST surfaces needed for the host chat, Codebox handoff, artifact session, contained-site runtime, and WP Codebox browser endpoints.",
+  "pipeline": {
+    "check": [
+      {
+        "kind": "check",
+        "label": "node available",
+        "command": "command -v node >/dev/null 2>&1",
+        "expect_exit": 0
+      },
+      {
+        "kind": "check",
+        "label": "live runtime open proof script exists",
+        "file": "${package.root}/proofs/studio-native-live-runtime-open.mjs"
+      },
+      {
+        "kind": "check",
+        "label": "studio native live runtime opens",
+        "command": "node ${package.root}/proofs/studio-native-live-runtime-open.mjs --url ${env.STUDIO_NATIVE_RUNTIME_URL} --out /tmp/studio-native-live-runtime-open-rig-check",
+        "expect_exit": 0
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Renames the existing Studio canonical loop “proof” language to a contract harness so it no longer implies production-loop coverage.
- Adds a separate `studio-native-live-runtime-open` rig and script that opens a real Studio Native runtime and verifies the real Studio Native, agentic UI, and WP Codebox REST surfaces are present.
- Documents the remaining production-loop acceptance criteria: real chat/generation request, real Codebox delegation, real artifact persistence, SSI materialization, edit/reimport, visible site change, and reviewer-facing evidence.

## Verification
- `node Automattic/studio/proofs/studio-native-live-runtime-open.mjs --url http://studio-native-local-runtime.local/ --out /tmp/studio-native-live-runtime-open`
- `node Automattic/studio/proofs/studio-canonical-loop-proof.mjs --check`
- `node scripts/lint-rig-packages.mjs Automattic/studio`
- `homeboy rig install --all /Users/chubes/Developer/homeboy-rigs@fix-studio-native-live-runtime-proof/Automattic/studio --reinstall`
- `STUDIO_NATIVE_RUNTIME_URL=http://studio-native-local-runtime.local/ homeboy rig check studio-native-live-runtime-open --force-hot --allow-local-hot`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Correcting misleading proof language, adding the live-runtime open check, and verifying against the local Studio Native runtime.
