### PR TITLE
chore(woo): dedupe fuzz contract assertions

### DIFF
--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -8,6 +8,17 @@ export const fuzzCaseIntentSchema = 'homeboy/fuzz-workload-intent/v1';
 export const fuzzProofBundleFields = new Set(['artifact_refs', 'run_ids', 'gap_reports', 'fuzz_result_artifacts']);
 export const fullSurfaceCoverageTypes = new Set(['rest', 'admin', 'frontend', 'browser', 'database']);
 export const fullSurfaceGapReportFields = new Set(['surface_type', 'expected', 'covered', 'gaps', 'status', 'evidence_refs']);
+export const wooRequiredFuzzProofContracts = new Map([
+  ['cart-session-overwrite-race', ['cart-session-race']],
+  ['checkout-gateway-compatibility-matrix', ['gateway-compatibility']],
+  ['checkout-shipping-cache', ['shipping-cache-invalidation']],
+  ['frontend-rendering-request-coverage', ['shop-product-cart-checkout-rendering-requests']],
+  ['layered-nav-catalog-crawl', ['catalog-layered-nav-transient-growth']],
+  ['layered-nav-count-cache', ['layered-nav-transient-growth']],
+  ['options-transients-coverage', ['cache-invalidation-and-transient-growth']],
+  ['performance-hotspots-artifact-summary', ['artifact-summary-expectations']],
+  ['woocommerce-external-http-guardrail', ['external-http-guardrails']],
+]);
 
 export function readJson(root, ...parts) {
   return JSON.parse(readFileSync(path.join(root, ...parts), 'utf8'));
@@ -257,6 +268,78 @@ export function assertFuzzProofBundle(proofBundle, manifest, { file } = {}) {
   for (const artifactName of proofBundle.fuzz_result_artifacts) {
     assert.ok(requiredArtifactNames.has(artifactName), `${file} proof_bundle.fuzz_result_artifacts ${artifactName} must name a required case or expected artifact`);
   }
+}
+
+export function assertRequiredFuzzProofContracts(manifest, {
+  requiredContracts = wooRequiredFuzzProofContracts.get(manifest.id) || [],
+  runnerCase = manifest.cases?.[0],
+  file = manifest.id,
+} = {}) {
+  if (requiredContracts.length === 0) {
+    return;
+  }
+
+  const proofContracts = manifest.proof_contracts || [];
+  assert.ok(Array.isArray(proofContracts), `${file} proof_contracts must be an array`);
+
+  const proofContractIds = new Set(proofContracts.map((contract) => contract.id));
+  for (const contractId of requiredContracts) {
+    assert.ok(proofContractIds.has(contractId), `${file} missing proof contract ${contractId}`);
+  }
+
+  for (const contract of proofContracts) {
+    assert.equal(typeof contract.description, 'string', `${file} proof contract ${contract.id} requires description`);
+    assert.ok(contract.description.length > 0, `${file} proof contract ${contract.id} description must not be empty`);
+    assert.equal(typeof contract.required_artifact, 'string', `${file} proof contract ${contract.id} requires required_artifact`);
+  }
+
+  const requiredArtifactNames = new Set(proofContracts.map((contract) => contract.required_artifact));
+  for (const artifactName of requiredArtifactNames) {
+    const caseArtifact = runnerCase?.artifacts?.find((artifact) => artifact.name === artifactName);
+    const expectedArtifact = manifest.artifacts?.expected?.find((artifact) => artifact.name === artifactName);
+    assert.equal(caseArtifact?.required, true, `${file} proof artifact ${artifactName} must be required on the case`);
+    assert.equal(expectedArtifact?.required, true, `${file} proof artifact ${artifactName} must be required in expected artifacts`);
+  }
+}
+
+export function assertArtifactPostprocessWorkloadContract(workload, { id, action, artifact, outputPath, schema }) {
+  assert.equal(workload.schema, 'wp-codebox/wordpress-workload-run/v1', `${id} workload must use the generic workload-run contract`);
+  assert.equal(workload.id, id, `${id} workload id drifted`);
+  assert.equal(workload.steps?.length, 1, `${id} must declare one artifact postprocess step`);
+  assert.equal(workload.steps[0].command, 'homeboy.artifact-postprocess', `${id} must use the generic artifact postprocess command`);
+  assert.equal(workload.steps[0].type, undefined, `${id} must not invent an unsupported step type`);
+  assert.equal(workload.steps[0].runner_support_status, undefined, `${id} runner support status belongs in metadata, not the executable step`);
+
+  const args = workload.steps[0].args;
+  assert.equal(args.helper, '${package.root}/tools/db-api-fuzzer-artifacts.mjs', `${id} helper drifted`);
+  assert.equal(args.action, action, `${id} action drifted`);
+  assert.deepEqual(args.input, {
+    type: 'artifact-root',
+    path: '${artifacts.root}',
+    artifact_globs: ['**/*.json'],
+    max_bytes: 1048576,
+  }, `${id} input artifact binding drifted`);
+  assert.equal(args.output.artifact, artifact, `${id} output artifact drifted`);
+  assert.equal(args.output.path, outputPath, `${id} output path drifted`);
+  assert.equal(args.output.kind, 'json', `${id} output kind drifted`);
+  assert.equal(args.output.contentType, 'application/json', `${id} output contentType drifted`);
+  assert.equal(args.output.schema, schema, `${id} output schema drifted`);
+  assert.equal(args.output.semantic_key, 'fuzz.report', `${id} semantic key drifted`);
+
+  assert.deepEqual(workload.artifacts?.[0], {
+    name: artifact,
+    path: outputPath,
+    kind: 'json',
+    contentType: 'application/json',
+    required: true,
+    metadata: {
+      schema,
+      semantic_key: 'fuzz.report',
+    },
+  }, `${id} collected artifact declaration drifted`);
+
+  assert.equal(workload.metadata?.runner_support_status, 'requires-upstream-binding', `${id} must stay declared until upstream binds this command`);
+  assert.match(workload.metadata?.missing_upstream_contract || '', /args\.helper, args\.action, args\.input, args\.output, and args\.parameters/, `${id} must document missing upstream fields`);
 }
 
 function collectRequiredArtifactNames(manifest) {

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -3,7 +3,12 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { assertFullSurfaceCoverageManifest } from '../../../scripts/fuzz-manifest-helpers.mjs';
+import {
+  assertArtifactPostprocessWorkloadContract,
+  assertFullSurfaceCoverageManifest,
+  assertRequiredFuzzProofContracts,
+  wooRequiredFuzzProofContracts,
+} from '../../../scripts/fuzz-manifest-helpers.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
@@ -38,18 +43,6 @@ const expectedSafetyClassifications = new Set([
   'synthetic_checkout_mutation',
 ]);
 
-const requiredFuzzProofContracts = new Map([
-  ['cart-session-overwrite-race', ['cart-session-race']],
-  ['checkout-gateway-compatibility-matrix', ['gateway-compatibility']],
-  ['checkout-shipping-cache', ['shipping-cache-invalidation']],
-  ['frontend-rendering-request-coverage', ['shop-product-cart-checkout-rendering-requests']],
-  ['layered-nav-catalog-crawl', ['catalog-layered-nav-transient-growth']],
-  ['layered-nav-count-cache', ['layered-nav-transient-growth']],
-  ['options-transients-coverage', ['cache-invalidation-and-transient-growth']],
-  ['performance-hotspots-artifact-summary', ['artifact-summary-expectations']],
-  ['woocommerce-external-http-guardrail', ['external-http-guardrails']],
-]);
-
 test('full-surface manifest uses shared coverage-map and gap-report schema', () => {
   assertFullSurfaceCoverageManifest(manifest, { file: 'woocommerce full-surface coverage' });
 });
@@ -80,28 +73,11 @@ test('manifest workload metadata stays scoped to full-surface workload ids', () 
 });
 
 test('high-risk Woo fuzz manifests declare required proof contracts', () => {
-  for (const [workloadId, contractIds] of requiredFuzzProofContracts) {
+  for (const [workloadId, contractIds] of wooRequiredFuzzProofContracts) {
     const workloadPath = path.join(packageRoot, 'fuzz', `${workloadId}.json`);
     const workload = JSON.parse(readFileSync(workloadPath, 'utf8'));
-    const actualContractIds = new Set((workload.proof_contracts || []).map((contract) => contract.id));
 
-    for (const contractId of contractIds) {
-      assert.ok(actualContractIds.has(contractId), `${workloadId} missing ${contractId}`);
-    }
-
-    const requiredArtifactNames = new Set(workload.proof_contracts.map((contract) => contract.required_artifact));
-    for (const artifactName of requiredArtifactNames) {
-      assert.equal(
-        workload.cases[0].artifacts.find((artifact) => artifact.name === artifactName)?.required,
-        true,
-        `${workloadId} case artifact ${artifactName} must be required`
-      );
-      assert.equal(
-        workload.artifacts.expected.find((artifact) => artifact.name === artifactName)?.required,
-        true,
-        `${workloadId} expected artifact ${artifactName} must be required`
-      );
-    }
+    assertRequiredFuzzProofContracts(workload, { requiredContracts: contractIds });
   }
 });
 
@@ -182,45 +158,6 @@ test('REST DB query profile consumes generated request case artifacts with caps'
     assert.equal(step.fallback_policy, 'require_generated_rest_request_cases_artifact');
   }
 });
-
-function assertArtifactPostprocessWorkloadContract(workload, { id, action, artifact, outputPath, schema }) {
-  assert.equal(workload.schema, 'wp-codebox/wordpress-workload-run/v1', `${id} workload must use the generic workload-run contract`);
-  assert.equal(workload.id, id, `${id} workload id drifted`);
-  assert.equal(workload.steps?.length, 1, `${id} must declare one artifact postprocess step`);
-  assert.equal(workload.steps[0].command, 'homeboy.artifact-postprocess', `${id} must use the generic artifact postprocess command`);
-  assert.equal(workload.steps[0].type, undefined, `${id} must not invent an unsupported step type`);
-  assert.equal(workload.steps[0].runner_support_status, undefined, `${id} runner support status belongs in metadata, not the executable step`);
-
-  const args = workload.steps[0].args;
-  assert.equal(args.helper, '${package.root}/tools/db-api-fuzzer-artifacts.mjs', `${id} helper drifted`);
-  assert.equal(args.action, action, `${id} action drifted`);
-  assert.deepEqual(args.input, {
-    type: 'artifact-root',
-    path: '${artifacts.root}',
-    artifact_globs: ['**/*.json'],
-    max_bytes: 1048576,
-  }, `${id} input artifact binding drifted`);
-  assert.equal(args.output.artifact, artifact, `${id} output artifact drifted`);
-  assert.equal(args.output.path, outputPath, `${id} output path drifted`);
-  assert.equal(args.output.kind, 'json', `${id} output kind drifted`);
-  assert.equal(args.output.contentType, 'application/json', `${id} output contentType drifted`);
-  assert.equal(args.output.schema, schema, `${id} output schema drifted`);
-  assert.equal(args.output.semantic_key, 'fuzz.report', `${id} semantic key drifted`);
-
-  assert.deepEqual(workload.artifacts?.[0], {
-    name: artifact,
-    path: outputPath,
-    kind: 'json',
-    contentType: 'application/json',
-    required: true,
-    metadata: {
-      schema,
-      semantic_key: 'fuzz.report',
-    },
-  }, `${id} collected artifact declaration drifted`);
-  assert.equal(workload.metadata?.runner_support_status, 'requires-upstream-binding', `${id} must stay declared until upstream binds this command`);
-  assert.match(workload.metadata?.missing_upstream_contract || '', /args\.helper, args\.action, args\.input, args\.output, and args\.parameters/, `${id} must document missing upstream fields`);
-}
 
 test('coverage gap and hotspot reports declare the generic artifact postprocess contract', () => {
   assert.equal(coverageGapReport.metadata.readiness.level, 'declared');

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -5,11 +5,13 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
+  assertArtifactPostprocessWorkloadContract,
   assertExecutableCrudMutationSafety,
   assertFullSurfaceCoverageManifest,
   assertFuzzProofBundleRequirements,
   assertFuzzReadinessLevel,
   assertGenericFuzzManifest,
+  assertRequiredFuzzProofContracts,
   collectFuzzManifests,
   declaredBenchProfileIds,
   declaredBenchWorkloadIds,
@@ -17,6 +19,7 @@ import {
   fullSurfaceRequiredArtifactIds,
   fuzzManifestHasExecutableArtifactContract,
   readJson,
+  wooRequiredFuzzProofContracts,
 } from '../../../scripts/fuzz-manifest-helpers.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -60,18 +63,6 @@ const expectedFuzzIds = new Set([
   'rest-db-query-profile',
   'woocommerce-external-http-guardrail',
   'woocommerce-rest-route-inventory',
-]);
-
-const requiredProofContracts = new Map([
-  ['cart-session-overwrite-race', ['cart-session-race']],
-  ['checkout-gateway-compatibility-matrix', ['gateway-compatibility']],
-  ['checkout-shipping-cache', ['shipping-cache-invalidation']],
-  ['frontend-rendering-request-coverage', ['shop-product-cart-checkout-rendering-requests']],
-  ['layered-nav-catalog-crawl', ['catalog-layered-nav-transient-growth']],
-  ['layered-nav-count-cache', ['layered-nav-transient-growth']],
-  ['options-transients-coverage', ['cache-invalidation-and-transient-growth']],
-  ['performance-hotspots-artifact-summary', ['artifact-summary-expectations']],
-  ['woocommerce-external-http-guardrail', ['external-http-guardrails']],
 ]);
 
 const fuzzManifests = collectFuzzManifests(packageRoot);
@@ -154,33 +145,6 @@ function assertDeclaredOrExternalDiscoveryWorkload(workloadId, context) {
   );
 }
 
-function assertArtifactPostprocessWorkload(workload, { id, action, artifactName, schema }) {
-  assert.equal(workload.schema, 'wp-codebox/wordpress-workload-run/v1', `${id} must use the upstream workload-run envelope`);
-  assert.equal(workload.id, id, `${id} workload id drifted`);
-  assert.equal(workload.steps?.length, 1, `${id} must declare one generic artifact-postprocess step`);
-  assert.equal(workload.steps[0].command, 'homeboy.artifact-postprocess', `${id} must use the generic artifact-postprocess command`);
-  assert.equal(workload.steps[0].type, undefined, `${id} must not invent unsupported step types`);
-
-  const args = workload.steps[0].args;
-  assert.equal(args.helper, '${package.root}/tools/db-api-fuzzer-artifacts.mjs', `${id} helper drifted`);
-  assert.equal(args.action, action, `${id} action drifted`);
-  assert.deepEqual(args.input, {
-    type: 'artifact-root',
-    path: '${artifacts.root}',
-    artifact_globs: ['**/*.json'],
-    max_bytes: 1048576,
-  }, `${id} input artifact root contract drifted`);
-  assert.equal(args.output.artifact, artifactName, `${id} output artifact name drifted`);
-  assert.equal(args.output.kind, 'json', `${id} output kind drifted`);
-  assert.equal(args.output.contentType, 'application/json', `${id} output contentType drifted`);
-  assert.equal(args.output.schema, schema, `${id} output schema drifted`);
-  assert.equal(args.output.semantic_key, 'fuzz.report', `${id} output semantic key drifted`);
-  assert.equal(workload.artifacts?.[0]?.name, artifactName, `${id} collected artifact name drifted`);
-  assert.equal(workload.artifacts?.[0]?.required, true, `${id} collected artifact must be required`);
-  assert.equal(workload.metadata?.runner_support_status, 'requires-upstream-binding', `${id} must stay blocked until upstream binds homeboy.artifact-postprocess`);
-  assert.match(workload.metadata?.missing_upstream_contract || '', /args\.helper, args\.action, args\.input, args\.output, and args\.parameters/, `${id} must document exact missing upstream fields`);
-}
-
 function assertCampaignPostprocessOutput(workload, output, context) {
   assert.ok(output && typeof output === 'object' && !Array.isArray(output), `${context} requires postprocess output metadata`);
   assert.equal(output.workload, workload.id, `${context} workload id drifted`);
@@ -214,17 +178,19 @@ function assertNoLocalOnlyRefs(value, context = 'value') {
   }
 }
 
-assertArtifactPostprocessWorkload(coverageGapReportWorkload, {
+assertArtifactPostprocessWorkloadContract(coverageGapReportWorkload, {
   id: 'coverage-gap-report',
   action: 'coverage-gap-report',
-  artifactName: 'coverage_gap_report',
+  artifact: 'coverage_gap_report',
+  outputPath: 'coverage-gap-report/coverage_gap_report.json',
   schema: 'homeboy-rigs/wordpress-coverage-gap-report/v1',
 });
 
-assertArtifactPostprocessWorkload(performanceHotspotsWorkload, {
+assertArtifactPostprocessWorkloadContract(performanceHotspotsWorkload, {
   id: 'performance-hotspots-artifact-summary',
   action: 'performance-hotspots-summary',
-  artifactName: 'performance_hotspots_summary',
+  artifact: 'performance_hotspots_summary',
+  outputPath: 'performance-hotspots-artifact-summary/performance_hotspots_summary.json',
   schema: 'homeboy/woocommerce-performance-hotspots-summary/v1',
 });
 
@@ -333,7 +299,7 @@ for (const { file, manifest } of fuzzManifests) {
     assert.ok(proofBundle.run_ids.length > 0, `${manifest.id} proven readiness must link at least one run id`);
   }
 
-  const requiredContractIds = requiredProofContracts.get(manifest.id) || [];
+  const requiredContractIds = wooRequiredFuzzProofContracts.get(manifest.id) || [];
   if (requiredArtifactWorkloadIds.has(manifest.id) && fuzzManifestHasExecutableArtifactContract(manifest)) {
     for (const artifact of runnerCase.artifacts) {
       assert.equal(artifact.required, true, `${manifest.id} full-surface executable case artifact ${artifact.name} must be required`);
@@ -343,29 +309,7 @@ for (const { file, manifest } of fuzzManifests) {
     }
   }
 
-  if (requiredContractIds.length > 0) {
-    const proofContracts = manifest.proof_contracts || [];
-    assert.ok(Array.isArray(proofContracts), `${manifest.id} proof_contracts must be an array`);
-
-    const proofContractIds = new Set(proofContracts.map((contract) => contract.id));
-    for (const contractId of requiredContractIds) {
-      assert.ok(proofContractIds.has(contractId), `${manifest.id} missing proof contract ${contractId}`);
-    }
-
-    for (const contract of proofContracts) {
-      assert.equal(typeof contract.description, 'string', `${manifest.id} proof contract ${contract.id} requires description`);
-      assert.ok(contract.description.length > 0, `${manifest.id} proof contract ${contract.id} description must not be empty`);
-      assert.equal(typeof contract.required_artifact, 'string', `${manifest.id} proof contract ${contract.id} requires required_artifact`);
-    }
-
-    const requiredArtifactNames = new Set(proofContracts.map((contract) => contract.required_artifact));
-    for (const artifactName of requiredArtifactNames) {
-      const caseArtifact = runnerCase.artifacts.find((artifact) => artifact.name === artifactName);
-      const expectedArtifact = manifest.artifacts.expected.find((artifact) => artifact.name === artifactName);
-      assert.equal(caseArtifact?.required, true, `${manifest.id} proof artifact ${artifactName} must be required on the case`);
-      assert.equal(expectedArtifact?.required, true, `${manifest.id} proof artifact ${artifactName} must be required in expected artifacts`);
-    }
-  }
+  assertRequiredFuzzProofContracts(manifest, { requiredContracts: requiredContractIds, runnerCase });
 
   if (manifest.id === 'admin-page-coverage') {
     assert.ok(manifest.operations.includes('safe-menu-enumeration-contract'), 'admin-page-coverage requires safe menu enumeration contract operation');


### PR DESCRIPTION
## Summary
- Move Woo required proof-contract expectations into the shared fuzz manifest helpers.
- Move the artifact-postprocess workload contract assertion into the shared helper.
- Keep the full-surface manifest test and Woo validation script asserting the same semantic coverage through the shared source of truth.

## Tests
- `node --test woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs`
- `node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs`
- `node --test woocommerce/woocommerce/tools/db-api-fuzzer-artifacts.test.mjs woocommerce/woocommerce/bench/admin-page-coverage.test.mjs woocommerce/woocommerce/bench/checkout-shipping-cache.test.mjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Deducing duplicate assertions, refactoring shared Node test helpers, running focused validation, and drafting this PR description.
