### PR TITLE
Extract WordPress Core fuzz validator

### DIFF
--- a/WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs
+++ b/WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs
@@ -4,6 +4,7 @@ import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { assertFullSurfaceCoverageManifest } from '../../../scripts/fuzz-manifest-helpers.mjs';
+import { validateWordPressCoreFuzzContract } from '../tools/core-fuzz-contract-validator.mjs';
 
 const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
 const packageRoot = path.join( __dirname, '..' );
@@ -79,4 +80,21 @@ test( 'Core browser request coverage includes frontend, posts, pages, media, and
 		.join( '\n' );
 	assert.doesNotMatch( scenarioSteps, /"kind"\s*:\s*"(?:click|fill|select|submit)"|bulk-action|delete/i );
 	assert.match( trace, /Coverage stays read-only in the browser/ );
+} );
+
+test( 'Core validator reports REST proof contract drift', () => {
+	const failures = validateWordPressCoreFuzzContract( {
+		rel: 'WordPress/wordpress-develop/fuzz/rest-api.json',
+		root: path.join( packageRoot, '..', '..' ),
+		workload: {
+			id: 'rest-api',
+			target: { type: 'wordpress-core', component: 'wordpress-develop' },
+			surface_ids: [ 'wordpress-core-rest-routes' ],
+			operations: [ 'rest-route-inventory' ],
+			artifacts: { expected: [] },
+		},
+	} );
+
+	assert.ok( failures.some( ( failure ) => failure.includes( 'role-boundary-execution' ) ) );
+	assert.ok( failures.some( ( failure ) => failure.includes( 'fuzz.rest.permission_boundaries' ) ) );
 } );

--- a/WordPress/wordpress-develop/tools/core-fuzz-contract-validator.mjs
+++ b/WordPress/wordpress-develop/tools/core-fuzz-contract-validator.mjs
@@ -1,0 +1,92 @@
+export function validateWordPressCoreFuzzContract({ rel, root, workload }) {
+  const failures = [];
+  const isWordPressDevelopFuzz = rel.startsWith('WordPress/wordpress-develop/fuzz/')
+    || (rel.startsWith('fuzz/') && root.endsWith('/WordPress/wordpress-develop'));
+
+  if (isWordPressCoreFuzzWorkload(workload) && !isWordPressDevelopFuzz) {
+    failures.push(`${rel}: WordPress Core fuzz workloads must live under WordPress/wordpress-develop/fuzz; WordPress/wordpress is legacy bench/trace compatibility scaffolding`);
+  }
+
+  if (!isWordPressDevelopFuzz) {
+    return failures;
+  }
+
+  const semanticKeys = collectExpectedSemanticKeys(workload);
+
+  if (workload.id === 'rest-api') {
+    assertIncludesAll(failures, rel, workload, 'operations', [
+      'rest-route-inventory',
+      'generated-rest-case-plan',
+      'request-case-execution',
+      'permission-boundary-classification',
+      'role-boundary-execution',
+    ]);
+
+    for (const semanticKey of ['fuzz.rest.route_inventory', 'fuzz.rest.generated_cases', 'fuzz.rest.permission_boundaries']) {
+      if (!semanticKeys.has(semanticKey)) {
+        failures.push(`${rel}: rest-api must declare expected artifact semantic key ${semanticKey}`);
+      }
+    }
+  }
+
+  if (workload.id === 'db-inventory-query-profile') {
+    assertIncludesAll(failures, rel, workload, 'surface_ids', [
+      'wordpress-core-database',
+      'wordpress-core-rest-routes',
+      'wordpress-core-options',
+      'wordpress-core-postmeta',
+      'wordpress-core-rewrites',
+    ]);
+    assertIncludesAll(failures, rel, workload, 'operations', [
+      'schema-inventory',
+      'rest-query-profile',
+      'options-query-attribution',
+      'postmeta-query-attribution',
+      'rewrite-query-attribution',
+    ]);
+
+    for (const semanticKey of ['fuzz.db.schema_inventory', 'fuzz.db.rest_query_attribution', 'fuzz.db.options_postmeta_rewrite_attribution']) {
+      if (!semanticKeys.has(semanticKey)) {
+        failures.push(`${rel}: db-inventory-query-profile must declare expected artifact semantic key ${semanticKey}`);
+      }
+    }
+  }
+
+  if (workload.id === 'hooks-cron-options') {
+    assertIncludesAll(failures, rel, workload, 'surface_ids', ['wordpress-core-options', 'wordpress-core-postmeta', 'wordpress-core-rewrites']);
+    assertIncludesAll(failures, rel, workload, 'operations', ['option-inventory', 'transient-inventory', 'postmeta-inventory', 'rewrite-rule-inventory', 'rewrite-query-attribution']);
+
+    if (!semanticKeys.has('fuzz.runtime.rewrite_postmeta_options_inventory')) {
+      failures.push(`${rel}: hooks-cron-options must declare expected artifact semantic key fuzz.runtime.rewrite_postmeta_options_inventory`);
+    }
+  }
+
+  return failures;
+}
+
+export function isWordPressCoreFuzzWorkload(workload) {
+  const surfaceIds = Array.isArray(workload.surface_ids) ? workload.surface_ids : [];
+
+  return workload.target?.type === 'wordpress-core'
+    || workload.target?.component === 'wordpress-develop'
+    || workload.metadata?.kind === 'wordpress-core-fuzz'
+    || surfaceIds.some((surfaceId) => typeof surfaceId === 'string' && surfaceId.startsWith('wordpress-core-'));
+}
+
+function assertIncludesAll(failures, rel, workload, field, expectedValues) {
+  const values = Array.isArray(workload[field]) ? workload[field] : [];
+  for (const expectedValue of expectedValues) {
+    if (!values.includes(expectedValue)) {
+      failures.push(`${rel}: ${workload.id} must include ${expectedValue} in ${field}`);
+    }
+  }
+}
+
+function collectExpectedSemanticKeys(workload) {
+  const expectedArtifacts = workload.artifacts?.expected;
+  if (!Array.isArray(expectedArtifacts)) {
+    return new Set();
+  }
+
+  return new Set(expectedArtifacts.map((artifact) => artifact?.semantic_key).filter(Boolean));
+}

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -8,6 +8,7 @@ import {
   assertJetpackFuzzManifestReadinessContract,
   assertRunnerNeutralFuzzCaseIntent,
 } from './fuzz-manifest-helpers.mjs';
+import { validateWordPressCoreFuzzContract } from '../WordPress/wordpress-develop/tools/core-fuzz-contract-validator.mjs';
 
 const args = process.argv.slice(2);
 const strictFuzzReadiness = args.includes('--strict-fuzz-readiness');
@@ -476,7 +477,7 @@ function lintFuzzWorkload(file) {
     }
   }
 
-  lintWordPressCoreFuzzContract(rel, workload);
+  failures.push(...validateWordPressCoreFuzzContract({ rel, root, workload }));
 }
 
 function lintFuzzReadinessMetadata(rel, workload) {
@@ -528,95 +529,6 @@ function lintJetpackFuzzContract(rel, workload) {
   } catch (error) {
     failures.push(error.message);
   }
-}
-
-function assertIncludesAll(rel, workload, field, expectedValues) {
-  const values = Array.isArray(workload[field]) ? workload[field] : [];
-  for (const expectedValue of expectedValues) {
-    if (!values.includes(expectedValue)) {
-      failures.push(`${rel}: ${workload.id} must include ${expectedValue} in ${field}`);
-    }
-  }
-}
-
-function collectExpectedSemanticKeys(workload) {
-  const expectedArtifacts = workload.artifacts?.expected;
-  if (!Array.isArray(expectedArtifacts)) {
-    return new Set();
-  }
-
-  return new Set(expectedArtifacts.map((artifact) => artifact?.semantic_key).filter(Boolean));
-}
-
-function lintWordPressCoreFuzzContract(rel, workload) {
-  const isWordPressDevelopFuzz = rel.startsWith('WordPress/wordpress-develop/fuzz/') || (rel.startsWith('fuzz/') && root.endsWith('/WordPress/wordpress-develop'));
-
-  if (isWordPressCoreFuzzWorkload(workload) && !isWordPressDevelopFuzz) {
-    failures.push(`${rel}: WordPress Core fuzz workloads must live under WordPress/wordpress-develop/fuzz; WordPress/wordpress is legacy bench/trace compatibility scaffolding`);
-  }
-
-  if (!isWordPressDevelopFuzz) {
-    return;
-  }
-
-  const semanticKeys = collectExpectedSemanticKeys(workload);
-
-  if (workload.id === 'rest-api') {
-    assertIncludesAll(rel, workload, 'operations', [
-      'rest-route-inventory',
-      'generated-rest-case-plan',
-      'request-case-execution',
-      'permission-boundary-classification',
-      'role-boundary-execution',
-    ]);
-
-    for (const semanticKey of ['fuzz.rest.route_inventory', 'fuzz.rest.generated_cases', 'fuzz.rest.permission_boundaries']) {
-      if (!semanticKeys.has(semanticKey)) {
-        failures.push(`${rel}: rest-api must declare expected artifact semantic key ${semanticKey}`);
-      }
-    }
-  }
-
-  if (workload.id === 'db-inventory-query-profile') {
-    assertIncludesAll(rel, workload, 'surface_ids', [
-      'wordpress-core-database',
-      'wordpress-core-rest-routes',
-      'wordpress-core-options',
-      'wordpress-core-postmeta',
-      'wordpress-core-rewrites',
-    ]);
-    assertIncludesAll(rel, workload, 'operations', [
-      'schema-inventory',
-      'rest-query-profile',
-      'options-query-attribution',
-      'postmeta-query-attribution',
-      'rewrite-query-attribution',
-    ]);
-
-    for (const semanticKey of ['fuzz.db.schema_inventory', 'fuzz.db.rest_query_attribution', 'fuzz.db.options_postmeta_rewrite_attribution']) {
-      if (!semanticKeys.has(semanticKey)) {
-        failures.push(`${rel}: db-inventory-query-profile must declare expected artifact semantic key ${semanticKey}`);
-      }
-    }
-  }
-
-  if (workload.id === 'hooks-cron-options') {
-    assertIncludesAll(rel, workload, 'surface_ids', ['wordpress-core-options', 'wordpress-core-postmeta', 'wordpress-core-rewrites']);
-    assertIncludesAll(rel, workload, 'operations', ['option-inventory', 'transient-inventory', 'postmeta-inventory', 'rewrite-rule-inventory', 'rewrite-query-attribution']);
-
-    if (!semanticKeys.has('fuzz.runtime.rewrite_postmeta_options_inventory')) {
-      failures.push(`${rel}: hooks-cron-options must declare expected artifact semantic key fuzz.runtime.rewrite_postmeta_options_inventory`);
-    }
-  }
-}
-
-function isWordPressCoreFuzzWorkload(workload) {
-  const surfaceIds = Array.isArray(workload.surface_ids) ? workload.surface_ids : [];
-
-  return workload.target?.type === 'wordpress-core'
-    || workload.target?.component === 'wordpress-develop'
-    || workload.metadata?.kind === 'wordpress-core-fuzz'
-    || surfaceIds.some((surfaceId) => typeof surfaceId === 'string' && surfaceId.startsWith('wordpress-core-'));
 }
 
 function lintPhp(file) {


### PR DESCRIPTION
## Summary
- Extract WordPress Core-specific fuzz contract checks from the global rig linter into a package-local validator module.
- Keep global lint behavior by calling the package validator from scripts/lint-rig-packages.mjs.
- Add focused Core validator coverage for REST proof-contract drift.

## Tests
- node --test scripts/lint-rig-packages.test.mjs
- node --test WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs
- node --test scripts/fuzz-manifest-helpers.test.mjs
- node scripts/lint-rig-packages.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Extracting the Core fuzz validator helper, updating tests, and running verification.