### PR TITLE
Fix Studio site-build env resolution

### DIFF
--- a/Automattic/studio/bench/lib/site-build-runtime.mjs
+++ b/Automattic/studio/bench/lib/site-build-runtime.mjs
@@ -5,12 +5,12 @@ import path from 'node:path';
 import {
   SHARED_STATE,
   STUDIO_PATH,
-  createStudioSite,
+  createStudioSite as sharedCreateStudioSite,
   expandHome,
   runCli as sharedRunCli,
   runEval as sharedRunEval,
   setting,
-  studioSiteStatusJson,
+  studioSiteStatusJson as sharedStudioSiteStatusJson,
   variant,
 } from './studio-bench.mjs';
 
@@ -292,10 +292,16 @@ export async function systemPromptFingerprint() {
   };
 }
 
-export async function createFreshSite(sitePath) {
-  await createStudioSite(sitePath, { name: `Studio Bench ${variant()} ${process.pid}`, env: cliEnv() });
+export async function createFreshSite(sitePath, options = {}) {
+  const { createStudioSite = sharedCreateStudioSite, env: extraEnv, ...createOptions } = options;
+  await createStudioSite(sitePath, {
+    ...createOptions,
+    name: `Studio Bench ${variant()} ${process.pid}`,
+    env: await cliEnv(extraEnv),
+  });
 }
 
-export async function siteStatus(sitePath) {
-  return studioSiteStatusJson(sitePath, { env: cliEnv() });
+export async function siteStatus(sitePath, options = {}) {
+  const { studioSiteStatusJson = sharedStudioSiteStatusJson, env: extraEnv, ...statusOptions } = options;
+  return studioSiteStatusJson(sitePath, { ...statusOptions, env: await cliEnv(extraEnv) });
 }

--- a/Automattic/studio/bench/site-build-runtime.test.mjs
+++ b/Automattic/studio/bench/site-build-runtime.test.mjs
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+process.env.HOMEBOY_COMPONENT_PATH ||= '/tmp/homeboy-rigs-test-component';
+
+const workloadUtilsDir = await mkdtemp(path.join(os.tmpdir(), 'homeboy-node-workload-utils-'));
+const workloadUtilsPath = path.join(workloadUtilsDir, 'workload-utils.mjs');
+await writeFile(workloadUtilsPath, `
+import os from 'node:os';
+import path from 'node:path';
+
+export function artifactDir(name, options = {}) {
+  return path.join(options.sharedState || process.env.HOMEBOY_BENCH_SHARED_STATE || os.tmpdir(), name);
+}
+
+export function expandHome(value) {
+  if (!value) return value;
+  if (value === '~') return os.homedir();
+  if (value.startsWith('~/')) return path.join(os.homedir(), value.slice(2));
+  return value;
+}
+
+export function metric(value, fallback = 0) {
+  const number = Number(value ?? fallback);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+export function redactText(value) {
+  return String(value || '');
+}
+
+export async function sanitizeArtifactFile(file) {
+  return { path: file };
+}
+
+export function safeResult(result) {
+  return result;
+}
+
+export function setting(key, fallback = '') {
+  try {
+    const settings = JSON.parse(process.env.HOMEBOY_SETTINGS_JSON || '{}');
+    if (settings && settings[key] !== undefined && settings[key] !== null) return String(settings[key]);
+  } catch {}
+  return process.env['HOMEBOY_SETTINGS_' + String(key).toUpperCase()] || fallback;
+}
+
+export function runNode() {
+  throw new Error('runNode is not used by these unit tests.');
+}
+`);
+process.env.HOMEBOY_NODEJS_WORKLOAD_UTILS ||= workloadUtilsPath;
+
+const invocationRuntimeHelper = `data:text/javascript,${encodeURIComponent(`
+export function resolveHomeboyInvocationRuntime({ namespace }) {
+  const state = process.env.HOMEBOY_INVOCATION_STATE_DIR ? process.env.HOMEBOY_INVOCATION_STATE_DIR + '/' + namespace : null;
+  const artifact = process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR ? process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR + '/' + namespace : null;
+  const tmp = process.env.HOMEBOY_INVOCATION_TMP_DIR ? process.env.HOMEBOY_INVOCATION_TMP_DIR + '/' + namespace : null;
+  return {
+    isolated: true,
+    namespace,
+    invocationId: process.env.HOMEBOY_INVOCATION_ID || null,
+    baseDirs: {
+      state: process.env.HOMEBOY_INVOCATION_STATE_DIR || null,
+      artifact: process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR || null,
+      tmp: process.env.HOMEBOY_INVOCATION_TMP_DIR || null,
+    },
+    dirs: { state, artifact, tmp },
+    portRange: {
+      base: Number(process.env.HOMEBOY_INVOCATION_PORT_BASE),
+      max: Number(process.env.HOMEBOY_INVOCATION_PORT_MAX),
+    },
+    childEnv(extra = {}) {
+      return {
+        HOMEBOY_INVOCATION_NAMESPACE: namespace,
+        HOMEBOY_INVOCATION_STATE_DIR: state,
+        HOMEBOY_INVOCATION_ARTIFACT_DIR: artifact,
+        HOMEBOY_INVOCATION_TMP_DIR: tmp,
+        TMPDIR: tmp,
+        ...extra,
+      };
+    },
+    async prepareDirs() {},
+    assertPort(port) { return Number(port); },
+  };
+}
+`)}`;
+
+async function withEnv(values, callback) {
+  const previous = {};
+  for (const key of Object.keys(values)) {
+    previous[key] = process.env[key];
+    if (values[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = values[key];
+    }
+  }
+
+  try {
+    return await callback();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+const { createFreshSite, siteStatus } = await import('./lib/site-build-runtime.mjs');
+
+test('site-build CLI wrappers pass resolved invocation env objects', async () => {
+  await withEnv(
+    {
+      HOMEBOY_NODEJS_INVOCATION_RUNTIME_HELPER: invocationRuntimeHelper,
+      HOMEBOY_INVOCATION_ID: 'inv-env-test',
+      HOMEBOY_INVOCATION_STATE_DIR: '/tmp/inv-env/state',
+      HOMEBOY_INVOCATION_ARTIFACT_DIR: '/tmp/inv-env/artifacts',
+      HOMEBOY_INVOCATION_TMP_DIR: '/tmp/inv-env/tmp',
+      HOMEBOY_INVOCATION_PORT_BASE: '21000',
+      HOMEBOY_INVOCATION_PORT_MAX: '21009',
+      STUDIO_CALLER_ENV: 'caller-value',
+    },
+    async () => {
+      const calls = [];
+      await createFreshSite('/tmp/example-site', {
+        env: { EXTRA_CREATE_ENV: 'create-value' },
+        async createStudioSite(sitePath, options) {
+          calls.push({ name: 'createFreshSite', sitePath, options });
+        },
+      });
+
+      const status = await siteStatus('/tmp/example-site', {
+        env: { EXTRA_STATUS_ENV: 'status-value' },
+        async studioSiteStatusJson(sitePath, options) {
+          calls.push({ name: 'siteStatus', sitePath, options });
+          return { ok: true };
+        },
+      });
+
+      assert.deepEqual(status, { ok: true });
+      assert.equal(calls.length, 2);
+
+      for (const call of calls) {
+        assert.equal(call.sitePath, '/tmp/example-site');
+        assert.equal(typeof call.options.env, 'object');
+        assert.equal(typeof call.options.env.then, 'undefined');
+        assert.equal(call.options.env.STUDIO_CALLER_ENV, 'caller-value');
+        assert.equal(call.options.env.HOMEBOY_INVOCATION_NAMESPACE, 'studio-agent-site-build');
+        assert.equal(call.options.env.HOMEBOY_INVOCATION_STATE_DIR, '/tmp/inv-env/state/studio-agent-site-build');
+        assert.equal(call.options.env.HOMEBOY_INVOCATION_ARTIFACT_DIR, '/tmp/inv-env/artifacts/studio-agent-site-build');
+        assert.equal(call.options.env.HOMEBOY_INVOCATION_TMP_DIR, '/tmp/inv-env/tmp/studio-agent-site-build');
+        assert.equal(call.options.env.E2E, '1');
+        assert.equal(call.options.env.E2E_CLI_CONFIG_PATH, '/tmp/inv-env/state/studio-agent-site-build/cli-config');
+        assert.equal(call.options.env.E2E_APP_DATA_PATH, '/tmp/inv-env/state/studio-agent-site-build/appdata');
+        assert.equal(call.options.env.STUDIO_PROCESS_MANAGER_HOME, '/tmp/inv-env/state/studio-agent-site-build/daemon');
+      }
+
+      assert.equal(calls[0].options.env.EXTRA_CREATE_ENV, 'create-value');
+      assert.equal(calls[1].options.env.EXTRA_STATUS_ENV, 'status-value');
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- Await Studio site-build CLI env resolution before create/status CLI calls.
- Add a focused regression test proving createFreshSite and siteStatus pass plain resolved env objects with invocation/runtime env, not Promises.

## Tests
- `node --test Automattic/studio/bench/site-build-runtime.test.mjs`
- `node --check Automattic/studio/bench/lib/site-build-runtime.mjs`
- `node --check Automattic/studio/bench/site-build-runtime.test.mjs`

## Caveats
- `node --test Automattic/studio/bench/studio-agent-site-build.test.mjs` is not runnable in this bare shell without `HOMEBOY_NODEJS_WORKLOAD_UTILS`; it fails during module load before tests run.
- Benchmarks were not run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the env await fix, adding targeted regression coverage, running verification, and drafting this PR.