### PR TITLE
Use shared fuzz manifest validator

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,8 +9,16 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    env:
+      HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: ${{ github.workspace }}/homeboy-extensions/wordpress/lib/wordpress-fuzz-manifest-validator.js
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: homeboy-rigs
+      - uses: actions/checkout@v4
+        with:
+          repository: Extra-Chill/homeboy-extensions
+          path: homeboy-extensions
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -19,6 +27,7 @@ jobs:
           php-version: '8.3'
           coverage: none
       - run: node scripts/lint-rig-packages.mjs
+        working-directory: homeboy-rigs
       - name: Test fuzz contracts
         run: >-
           node --test
@@ -26,3 +35,4 @@ jobs:
           WordPress/gutenberg/tools/fuzz-coverage.test.mjs
           WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs
           woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+        working-directory: homeboy-rigs

--- a/scripts/fixtures/shared-fuzz-validator.cjs
+++ b/scripts/fixtures/shared-fuzz-validator.cjs
@@ -1,0 +1,190 @@
+'use strict';
+
+const readinessLevels = new Set(['declared', 'executable', 'proven']);
+const safetyClasses = new Set(['read_only', 'idempotent', 'isolated_mutation', 'destructive']);
+
+function collectGenericFuzzWorkloadIssues(manifest, { context = manifest?.id || 'fuzz workload' } = {}) {
+  const issues = [];
+  if (manifest.schema !== 'homeboy/fuzz-workload/v1') {
+    issues.push(`${context} must use schema homeboy/fuzz-workload/v1`);
+  }
+  for (const field of ['id', 'label', 'safety_class']) {
+    if (typeof manifest[field] !== 'string' || manifest[field].trim() === '') {
+      issues.push(`${context} must declare a non-empty string ${field}`);
+    }
+  }
+  if (typeof manifest.safety_class === 'string' && !safetyClasses.has(manifest.safety_class)) {
+    issues.push(`${context} safety_class must be one of read_only, idempotent, isolated_mutation, destructive`);
+  }
+  if (!manifest.metadata || typeof manifest.metadata !== 'object' || Array.isArray(manifest.metadata)) {
+    issues.push(`${context} must declare metadata`);
+  }
+  if (!manifest.target || typeof manifest.target !== 'object' || Array.isArray(manifest.target)) {
+    issues.push(`${context} must declare target`);
+  }
+  if (!manifest.workload || typeof manifest.workload !== 'object' || Array.isArray(manifest.workload)) {
+    issues.push(`${context} must declare workload`);
+  } else if (typeof manifest.workload.path !== 'string' || manifest.workload.path.trim() === '') {
+    issues.push(`${context} workload must declare a non-empty string path`);
+  }
+  if (!Array.isArray(manifest.cases) || manifest.cases.length === 0) {
+    issues.push(`${context} must declare at least one case`);
+  } else {
+    for (const runnerCase of manifest.cases) {
+      if (runnerCase?.metadata?.safety_class && runnerCase.metadata.safety_class !== manifest.safety_class) {
+        issues.push(`${context} case ${runnerCase.case_id || '(unknown)'} metadata.safety_class must match workload safety_class ${manifest.safety_class}`);
+      }
+      if (runnerCase?.intent) {
+        try {
+          assertRunnerNeutralFuzzCaseIntent(manifest, runnerCase);
+        } catch (error) {
+          issues.push(`${context} ${error.message}`);
+        }
+      }
+    }
+  }
+  return issues;
+}
+
+function assertRunnerNeutralFuzzCaseIntent(manifest, runnerCase) {
+  const intent = runnerCase.intent;
+  if (!intent || typeof intent !== 'object' || Array.isArray(intent)) {
+    throw new Error(`${manifest.id} case intent must be an object`);
+  }
+  if (intent.schema !== 'homeboy/fuzz-workload-intent/v1') {
+    throw new Error(`${manifest.id} case intent schema mismatch`);
+  }
+  if (intent.type !== 'wordpress-plugin-workload') {
+    throw new Error(`${manifest.id} case intent type mismatch`);
+  }
+  if (!intent.plugin || typeof intent.plugin !== 'object' || Array.isArray(intent.plugin)) {
+    throw new Error(`${manifest.id} case intent requires plugin`);
+  }
+  if (typeof intent.plugin.activation !== 'string') {
+    throw new Error(`${manifest.id} case intent plugin.activation must be a string`);
+  }
+  if (!intent.execute || typeof intent.execute !== 'object' || Array.isArray(intent.execute)) {
+    throw new Error(`${manifest.id} case intent requires execute`);
+  }
+  if (intent.execute.workload_ref !== 'default') {
+    throw new Error(`${manifest.id} case intent execute.workload_ref must be default`);
+  }
+  if (intent.execute.path !== manifest.workload?.path) {
+    throw new Error(`${manifest.id} case intent execute.path must match workload.path`);
+  }
+  if (intent.execute.type !== manifest.workload?.type) {
+    throw new Error(`${manifest.id} case intent execute.type must match workload.type`);
+  }
+  if (!Array.isArray(intent.collect) || intent.collect.length === 0) {
+    throw new Error(`${manifest.id} case intent collect must declare at least one artifact`);
+  }
+  const artifactNames = new Set((runnerCase.artifacts || []).map((artifact) => artifact?.name).filter(Boolean));
+  for (const artifact of intent.collect) {
+    if (!artifactNames.has(artifact.artifact)) {
+      throw new Error(`${manifest.id} case intent collect artifact ${artifact.artifact} is not declared on the case`);
+    }
+  }
+  if (runnerCase.phases !== undefined) {
+    throw new Error(`${manifest.id} runner-neutral case intent must not embed runner command phases`);
+  }
+  return intent;
+}
+
+function assertFuzzReadinessMetadata(manifest, { file = manifest.id } = {}) {
+  const readiness = manifest.metadata?.readiness;
+  if (!readiness || typeof readiness !== 'object' || Array.isArray(readiness)) {
+    throw new Error(`${file} requires metadata.readiness`);
+  }
+  assertFuzzReadinessLevel(readiness.level, `${file} metadata.readiness.level`);
+  if (typeof readiness.coverage_contract !== 'string' || readiness.coverage_contract.trim() === '') {
+    throw new Error(`${file} metadata.readiness.coverage_contract must describe the declared contract`);
+  }
+  if (readiness.proof_refs !== undefined) {
+    assertStringArray(readiness.proof_refs, `${file} metadata.readiness.proof_refs`);
+    for (const proofRef of readiness.proof_refs) {
+      assertReviewerFacingRef(proofRef, `${file} metadata.readiness.proof_refs`);
+    }
+  }
+  if (readiness.level === 'proven') {
+    if (!Array.isArray(readiness.proof_refs) || readiness.proof_refs.length === 0) {
+      throw new Error(`${file} proven readiness requires proof_refs`);
+    }
+    assertFuzzProofBundle(readiness.proof_bundle, manifest, { file });
+  }
+  if (readiness.crud !== undefined) {
+    assertFuzzCrudReadiness(readiness.crud, { file });
+  }
+  if (readiness.mutation !== undefined) {
+    assertFuzzMutationReadiness(readiness.mutation, { file });
+  }
+  return readiness;
+}
+
+function assertFuzzProofBundle(proofBundle, manifest, { file = manifest.id } = {}) {
+  if (!proofBundle || typeof proofBundle !== 'object' || Array.isArray(proofBundle)) {
+    throw new Error(`${file} proven readiness requires proof_bundle`);
+  }
+  for (const field of ['artifact_refs', 'run_ids', 'gap_reports', 'fuzz_result_artifacts']) {
+    assertStringArray(proofBundle[field], `${file} metadata.readiness.proof_bundle.${field}`);
+  }
+  const requiredArtifactNames = new Set([
+    ...(manifest.cases || []).flatMap((runnerCase) => runnerCase.artifacts || []),
+    ...(manifest.artifacts?.expected || []),
+  ].filter((artifact) => artifact?.required === true).map((artifact) => artifact.name));
+  for (const artifactName of proofBundle.fuzz_result_artifacts) {
+    if (!requiredArtifactNames.has(artifactName)) {
+      throw new Error(`${file} proof_bundle.fuzz_result_artifacts ${artifactName} must name a required case or expected artifact`);
+    }
+  }
+}
+
+function assertFuzzCrudReadiness(crud, { file } = {}) {
+  for (const operation of ['create', 'read', 'update', 'delete']) {
+    assertFuzzReadinessLevel(crud?.[operation]?.level, `${file} metadata.readiness.crud.${operation}.level`);
+  }
+}
+
+function assertFuzzMutationReadiness(mutation, { file } = {}) {
+  if (typeof mutation?.safety_boundary !== 'string' || mutation.safety_boundary.trim() === '') {
+    throw new Error(`${file} metadata.readiness.mutation.safety_boundary must describe rollback/isolation boundaries`);
+  }
+  assertStringArray(mutation.rollback_artifacts, `${file} metadata.readiness.mutation.rollback_artifacts`, { allowEmpty: true });
+}
+
+function assertFuzzProofBundleRequirements(requirements, { file } = {}) {
+  assertStringArray(requirements?.required_refs, `${file} metadata.readiness.proof_bundle_requirements.required_refs`);
+  assertStringArray(requirements?.required_artifacts, `${file} metadata.readiness.proof_bundle_requirements.required_artifacts`);
+}
+
+function assertFuzzReadinessLevel(level, label) {
+  if (!readinessLevels.has(level)) {
+    throw new Error(`${label} must be declared, executable, or proven`);
+  }
+}
+
+function assertReviewerFacingRef(value, context) {
+  if (!/^(https:\/\/|gh:|homeboy-runs:|artifact:|run:)/.test(value)) {
+    throw new Error(`${context} entries must be reviewer-facing refs`);
+  }
+  if (/^(https?:\/\/)?(localhost|127\.0\.0\.1)([:/]|$)/.test(value) || value.startsWith('/Users/')) {
+    throw new Error(`${context} entries must not use local evidence`);
+  }
+}
+
+function assertStringArray(value, label, options = {}) {
+  if (!Array.isArray(value) || (!options.allowEmpty && value.length === 0) || value.some((entry) => typeof entry !== 'string' || entry.trim() === '')) {
+    throw new Error(`${label} must be a non-empty string array`);
+  }
+}
+
+module.exports = {
+  assertFuzzCrudReadiness,
+  assertFuzzMutationReadiness,
+  assertFuzzProofBundle,
+  assertFuzzProofBundleRequirements,
+  assertFuzzReadinessLevel,
+  assertFuzzReadinessMetadata,
+  assertReviewerFacingRef,
+  assertRunnerNeutralFuzzCaseIntent,
+  collectGenericFuzzWorkloadIssues,
+};

--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
+
+const require = createRequire(import.meta.url);
 
 export const fuzzReadinessLevels = new Set(['declared', 'executable', 'proven']);
 export const fuzzCrudOperations = new Set(['create', 'read', 'update', 'delete']);
@@ -19,6 +22,26 @@ export const wooRequiredFuzzProofContracts = new Map([
   ['performance-hotspots-artifact-summary', ['artifact-summary-expectations']],
   ['woocommerce-external-http-guardrail', ['external-http-guardrails']],
 ]);
+
+function loadGenericFuzzManifestValidator() {
+  const explicit = process.env.HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR;
+  if (explicit) {
+    return require(explicit);
+  }
+
+  const manifestPath = process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST;
+  if (manifestPath) {
+    const manifestModule = require(manifestPath);
+    const manifest = typeof manifestModule.getWordPressHelperManifest === 'function'
+      ? manifestModule.getWordPressHelperManifest()
+      : manifestModule.WORDPRESS_HELPER_MANIFEST;
+    if (manifest?.extensionRoot) {
+      return require(path.join(manifest.extensionRoot, 'lib', 'wordpress-fuzz-manifest-validator.js'));
+    }
+  }
+
+  return require('homeboy-extension-wordpress/wordpress-fuzz-manifest-validator');
+}
 
 export function readJson(root, ...parts) {
   return JSON.parse(readFileSync(path.join(root, ...parts), 'utf8'));
@@ -177,97 +200,15 @@ export function assertGenericFuzzManifest(manifest, {
 }
 
 export function assertRunnerNeutralFuzzCaseIntent(manifest, runnerCase) {
-  const intent = runnerCase.intent;
-  assert.ok(intent && typeof intent === 'object' && !Array.isArray(intent), `${manifest.id} case intent must be an object`);
-  assert.equal(intent.schema, fuzzCaseIntentSchema, `${manifest.id} case intent schema mismatch`);
-  assert.equal(intent.type, 'wordpress-plugin-workload', `${manifest.id} case intent type mismatch`);
-
-  assert.ok(intent.plugin && typeof intent.plugin === 'object' && !Array.isArray(intent.plugin), `${manifest.id} case intent requires plugin`);
-  assert.equal(typeof intent.plugin.activation, 'string', `${manifest.id} case intent plugin.activation must be a string`);
-
-  assert.ok(intent.execute && typeof intent.execute === 'object' && !Array.isArray(intent.execute), `${manifest.id} case intent requires execute`);
-  assert.equal(intent.execute.workload_ref, 'default', `${manifest.id} case intent execute.workload_ref must be default`);
-  assert.equal(intent.execute.path, manifest.workload?.path, `${manifest.id} case intent execute.path must match workload.path`);
-  assert.equal(intent.execute.type, manifest.workload?.type, `${manifest.id} case intent execute.type must match workload.type`);
-  if (manifest.workload?.entry) {
-    assert.equal(intent.execute.entry, manifest.workload.entry, `${manifest.id} case intent execute.entry must match workload.entry`);
-  }
-  if (intent.execute.parameters !== undefined) {
-    assert.ok(intent.execute.parameters && typeof intent.execute.parameters === 'object' && !Array.isArray(intent.execute.parameters), `${manifest.id} case intent execute.parameters must be an object`);
-  }
-
-  assert.ok(Array.isArray(intent.collect), `${manifest.id} case intent collect must be an array`);
-  assert.ok(intent.collect.length > 0, `${manifest.id} case intent collect must declare at least one artifact`);
-  const caseArtifactNames = new Set((runnerCase.artifacts || []).map((artifact) => artifact?.name).filter(Boolean));
-  for (const artifact of intent.collect) {
-    assert.ok(artifact && typeof artifact === 'object' && !Array.isArray(artifact), `${manifest.id} case intent collect entries must be objects`);
-    assert.equal(typeof artifact.artifact, 'string', `${manifest.id} case intent collect artifact must be a string`);
-    assert.ok(caseArtifactNames.has(artifact.artifact), `${manifest.id} case intent collect artifact ${artifact.artifact} is not declared on the case`);
-  }
-
-  assert.equal(runnerCase.phases, undefined, `${manifest.id} runner-neutral case intent must not embed runner command phases`);
+  return loadGenericFuzzManifestValidator().assertRunnerNeutralFuzzCaseIntent(manifest, runnerCase);
 }
 
 export function assertFuzzReadinessMetadata(manifest, { file = manifest.id } = {}) {
-  const readiness = manifest.metadata?.readiness;
-  assert.ok(readiness && typeof readiness === 'object' && !Array.isArray(readiness), `${file} requires metadata.readiness`);
-
-  assertFuzzReadinessLevel(readiness.level, `${file} metadata.readiness.level`);
-  assert.equal(typeof readiness.coverage_contract, 'string', `${file} metadata.readiness.coverage_contract must describe the declared contract`);
-  assert.notEqual(readiness.coverage_contract.trim(), '', `${file} metadata.readiness.coverage_contract must describe the declared contract`);
-
-  if (readiness.proof_refs !== undefined) {
-    assertStringArray(readiness.proof_refs, `${file} metadata.readiness.proof_refs`);
-    for (const proofRef of readiness.proof_refs) {
-      assertReviewerFacingRef(proofRef, `${file} metadata.readiness.proof_refs`);
-    }
-  }
-
-  if (readiness.level === 'proven') {
-    assert.ok(Array.isArray(readiness.proof_refs) && readiness.proof_refs.length > 0, `${file} proven readiness requires proof_refs`);
-    assertFuzzProofBundle(readiness.proof_bundle, manifest, { file });
-  }
-
-  if (readiness.proof_bundle_requirements !== undefined) {
-    assertFuzzProofBundleRequirements(readiness.proof_bundle_requirements, { file });
-  }
-
-  if (readiness.upstream_blockers !== undefined) {
-    assert.ok(Array.isArray(readiness.upstream_blockers), `${file} metadata.readiness.upstream_blockers must be an array`);
-    for (const blocker of readiness.upstream_blockers) {
-      assert.equal(typeof blocker, 'string', `${file} metadata.readiness.upstream_blockers entries must be strings`);
-      assert.notEqual(blocker.trim(), '', `${file} metadata.readiness.upstream_blockers entries must be non-empty`);
-    }
-  }
-
-  if (readiness.crud !== undefined) {
-    assertFuzzCrudReadiness(readiness.crud, { file });
-  }
-
-  if (readiness.mutation !== undefined) {
-    assertFuzzMutationReadiness(readiness.mutation, { file });
-  }
+  return loadGenericFuzzManifestValidator().assertFuzzReadinessMetadata(manifest, { file });
 }
 
 export function assertFuzzProofBundle(proofBundle, manifest, { file } = {}) {
-  assert.ok(proofBundle && typeof proofBundle === 'object' && !Array.isArray(proofBundle), `${file} proven readiness requires proof_bundle`);
-
-  for (const field of fuzzProofBundleFields) {
-    assert.ok(Array.isArray(proofBundle[field]) && proofBundle[field].length > 0, `${file} metadata.readiness.proof_bundle.${field} must be a non-empty array`);
-    for (const value of proofBundle[field]) {
-      assert.equal(typeof value, 'string', `${file} metadata.readiness.proof_bundle.${field} entries must be strings`);
-      assert.notEqual(value.trim(), '', `${file} metadata.readiness.proof_bundle.${field} entries must be non-empty`);
-
-      if (field !== 'fuzz_result_artifacts') {
-        assertReviewerFacingRef(value, `${file} metadata.readiness.proof_bundle.${field}`);
-      }
-    }
-  }
-
-  const requiredArtifactNames = collectRequiredArtifactNames(manifest);
-  for (const artifactName of proofBundle.fuzz_result_artifacts) {
-    assert.ok(requiredArtifactNames.has(artifactName), `${file} proof_bundle.fuzz_result_artifacts ${artifactName} must name a required case or expected artifact`);
-  }
+  return loadGenericFuzzManifestValidator().assertFuzzProofBundle(proofBundle, manifest, { file });
 }
 
 export function assertRequiredFuzzProofContracts(manifest, {
@@ -403,21 +344,11 @@ function assertReviewerFacingRef(value, context) {
 }
 
 export function assertFuzzCrudReadiness(crud, { file } = {}) {
-  assert.ok(crud && typeof crud === 'object' && !Array.isArray(crud), `${file} metadata.readiness.crud must be an object`);
-
-  for (const operation of fuzzCrudOperations) {
-    assert.ok(crud[operation] && typeof crud[operation] === 'object' && !Array.isArray(crud[operation]), `${file} metadata.readiness.crud.${operation} must be an object`);
-    assertFuzzReadinessLevel(crud[operation].level, `${file} metadata.readiness.crud.${operation}.level`);
-
-    if (crud[operation].upstream_blocker !== undefined) {
-      assert.equal(typeof crud[operation].upstream_blocker, 'string', `${file} metadata.readiness.crud.${operation}.upstream_blocker must be a string`);
-      assert.notEqual(crud[operation].upstream_blocker.trim(), '', `${file} metadata.readiness.crud.${operation}.upstream_blocker must be non-empty`);
-    }
-  }
+  return loadGenericFuzzManifestValidator().assertFuzzCrudReadiness(crud, { file });
 }
 
 export function assertFuzzReadinessLevel(level, label) {
-  assert.ok(fuzzReadinessLevels.has(level), `${label} must be declared, executable, or proven`);
+  return loadGenericFuzzManifestValidator().assertFuzzReadinessLevel(level, label);
 }
 
 export function assertExecutableCrudMutationSafety(readiness, { file } = {}) {
@@ -440,24 +371,15 @@ export function assertExecutableCrudMutationSafety(readiness, { file } = {}) {
 }
 
 export function assertFuzzProofBundleRequirements(requirements, { file } = {}) {
-  assert.ok(requirements && typeof requirements === 'object' && !Array.isArray(requirements), `${file} metadata.readiness.proof_bundle_requirements must be an object`);
-  assertStringArray(requirements.required_refs, `${file} metadata.readiness.proof_bundle_requirements.required_refs`);
-  assertStringArray(requirements.required_artifacts, `${file} metadata.readiness.proof_bundle_requirements.required_artifacts`);
-  if (requirements.status !== undefined) {
-    assert.equal(requirements.status, 'required_before_proven', `${file} metadata.readiness.proof_bundle_requirements.status must be required_before_proven`);
-  }
+  return loadGenericFuzzManifestValidator().assertFuzzProofBundleRequirements(requirements, { file });
 }
 
 export function assertFuzzMutationReadiness(mutation, { file } = {}) {
-  assert.ok(mutation && typeof mutation === 'object' && !Array.isArray(mutation), `${file} metadata.readiness.mutation must be an object`);
-  assert.equal(typeof mutation.safety_boundary, 'string', `${file} metadata.readiness.mutation.safety_boundary must describe rollback/isolation boundaries`);
-  assert.notEqual(mutation.safety_boundary.trim(), '', `${file} metadata.readiness.mutation.safety_boundary must describe rollback/isolation boundaries`);
+  return loadGenericFuzzManifestValidator().assertFuzzMutationReadiness(mutation, { file });
+}
 
-  assert.ok(Array.isArray(mutation.rollback_artifacts), `${file} metadata.readiness.mutation.rollback_artifacts must be an array`);
-  for (const artifact of mutation.rollback_artifacts) {
-    assert.equal(typeof artifact, 'string', `${file} metadata.readiness.mutation.rollback_artifacts entries must be strings`);
-    assert.notEqual(artifact.trim(), '', `${file} metadata.readiness.mutation.rollback_artifacts entries must be non-empty`);
-  }
+export function collectGenericFuzzWorkloadIssues(manifest, options = {}) {
+  return loadGenericFuzzManifestValidator().collectGenericFuzzWorkloadIssues(manifest, options);
 }
 
 export function assertFullSurfaceCoverageManifest(manifest, { file = manifest.property } = {}) {

--- a/scripts/fuzz-manifest-helpers.test.mjs
+++ b/scripts/fuzz-manifest-helpers.test.mjs
@@ -10,6 +10,8 @@ import {
   workloadIdFromPath,
 } from './fuzz-manifest-helpers.mjs';
 
+process.env.HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR = new URL('./fixtures/shared-fuzz-validator.cjs', import.meta.url).pathname;
+
 function fuzzManifest(overrides = {}) {
   return {
     schema: 'homeboy/fuzz-workload/v1',

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -6,7 +6,7 @@ import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:pat
 import {
   assertFuzzReadinessMetadata,
   assertJetpackFuzzManifestReadinessContract,
-  assertRunnerNeutralFuzzCaseIntent,
+  collectGenericFuzzWorkloadIssues,
 } from './fuzz-manifest-helpers.mjs';
 
 const args = process.argv.slice(2);
@@ -26,7 +26,6 @@ const studioModelRigGenerator = join(root, 'scripts/generate-studio-agent-model-
 const personalPathPrefix = '/Users/' + 'chubes/';
 const localDeveloperCheckoutPattern = /(?:~|\$HOME)\/Developer\//;
 const tsrmlsPatchMarker = 'PHP-WASM-COMBINED-FIXES ' + 'TSRMLS fallback';
-const homeboyFuzzSafetyClasses = new Set(['read_only', 'idempotent', 'isolated_mutation', 'destructive']);
 
 if (!existsSync(root)) {
   console.error(`Lint root does not exist: ${root}`);
@@ -198,56 +197,16 @@ function collectFuzzWorkloads() {
 }
 
 function validateFuzzWorkloadShape(rel, workload, context, packageRoot) {
-  if (workload.schema !== 'homeboy/fuzz-workload/v1') {
-    failures.push(`${rel}: ${context} must use schema homeboy/fuzz-workload/v1`);
+  for (const issue of collectGenericFuzzWorkloadIssues(workload, { context })) {
+    failures.push(`${rel}: ${issue}`);
   }
 
-  for (const field of ['id', 'label', 'safety_class']) {
-    if (typeof workload[field] !== 'string' || workload[field].trim() === '') {
-      failures.push(`${rel}: ${context} must declare a non-empty string ${field}`);
-    }
-  }
-
-  if (typeof workload.safety_class === 'string' && !homeboyFuzzSafetyClasses.has(workload.safety_class)) {
-    failures.push(`${rel}: ${context} safety_class must be one of ${[...homeboyFuzzSafetyClasses].join(', ')}`);
-  }
-
-  if (!workload.metadata || typeof workload.metadata !== 'object' || Array.isArray(workload.metadata)) {
-    failures.push(`${rel}: ${context} must declare metadata`);
-  }
-
-  if (!workload.target || typeof workload.target !== 'object' || Array.isArray(workload.target)) {
-    failures.push(`${rel}: ${context} must declare target`);
-  }
-
-  if (!workload.workload || typeof workload.workload !== 'object' || Array.isArray(workload.workload)) {
-    failures.push(`${rel}: ${context} must declare workload`);
-  } else if (typeof workload.workload.path !== 'string' || workload.workload.path.trim() === '') {
-    failures.push(`${rel}: ${context} workload must declare a non-empty string path`);
-  } else {
+  if (workload.workload && typeof workload.workload === 'object' && !Array.isArray(workload.workload) && typeof workload.workload.path === 'string' && workload.workload.path.trim() !== '') {
     const workloadPath = resolvePackagePath(workload.workload.path, packageRoot);
     if (!workloadPath) {
       failures.push(`${rel}: ${context} workload path must be resolvable`);
     } else if (!existsSync(workloadPath)) {
       failures.push(`${rel}: ${context} workload path ${relative(root, workloadPath)} does not exist`);
-    }
-  }
-
-  if (!Array.isArray(workload.cases) || workload.cases.length === 0) {
-    failures.push(`${rel}: ${context} must declare at least one case`);
-  } else {
-    for (const runnerCase of workload.cases) {
-      if (runnerCase?.metadata?.safety_class && runnerCase.metadata.safety_class !== workload.safety_class) {
-        failures.push(`${rel}: ${context} case ${runnerCase.case_id || '(unknown)'} metadata.safety_class must match workload safety_class ${workload.safety_class}`);
-      }
-
-      if (runnerCase?.intent) {
-        try {
-          assertRunnerNeutralFuzzCaseIntent(workload, runnerCase);
-        } catch (error) {
-          failures.push(`${rel}: ${context} ${error.message}`);
-        }
-      }
     }
   }
 }
@@ -419,39 +378,13 @@ function lintFuzzWorkload(file) {
     return;
   }
 
-  if (workload.schema !== 'homeboy/fuzz-workload/v1') {
-    failures.push(`${rel}: fuzz workload schema must be homeboy/fuzz-workload/v1`);
-  }
-
-  for (const field of ['id', 'label', 'safety_class']) {
-    if (typeof workload[field] !== 'string' || workload[field].length === 0) {
-      failures.push(`${rel}: fuzz workload must define non-empty string field ${field}`);
-    }
-  }
-
-  if (typeof workload.safety_class === 'string' && !homeboyFuzzSafetyClasses.has(workload.safety_class)) {
-    failures.push(`${rel}: fuzz workload safety_class must be one of ${[...homeboyFuzzSafetyClasses].join(', ')}`);
+  for (const issue of collectGenericFuzzWorkloadIssues(workload, { context: 'fuzz workload' })) {
+    failures.push(`${rel}: ${issue}`);
   }
 
   for (const field of ['surface_ids', 'operations', 'cases']) {
     if (!Array.isArray(workload[field]) || workload[field].length === 0) {
       failures.push(`${rel}: fuzz workload must define non-empty array field ${field}`);
-    }
-  }
-
-  if (Array.isArray(workload.cases)) {
-    for (const runnerCase of workload.cases) {
-      if (runnerCase?.metadata?.safety_class && runnerCase.metadata.safety_class !== workload.safety_class) {
-        failures.push(`${rel}: fuzz workload case ${runnerCase.case_id || '(unknown)'} metadata.safety_class must match workload safety_class ${workload.safety_class}`);
-      }
-
-      if (runnerCase?.intent) {
-        try {
-          assertRunnerNeutralFuzzCaseIntent(workload, runnerCase);
-        } catch (error) {
-          failures.push(`${rel}: ${error.message}`);
-        }
-      }
     }
   }
 

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import test from 'node:test';
 
 const script = new URL('./lint-rig-packages.mjs', import.meta.url).pathname;
+const sharedValidator = new URL('./fixtures/shared-fuzz-validator.cjs', import.meta.url).pathname;
 
 function writeJson(path, value) {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
@@ -80,7 +81,13 @@ function fuzzWorkload(overrides = {}) {
 }
 
 function runLint(directory) {
-  return spawnSync(process.execPath, [script, directory], { encoding: 'utf8' });
+  return spawnSync(process.execPath, [script, directory], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: sharedValidator,
+    },
+  });
 }
 
 test('accepts generic declared fuzz workloads', () => {


### PR DESCRIPTION
## Summary
- Load the generic fuzz manifest validator from Homeboy Extensions via explicit env, helper manifest, or package export.
- Delegate generic readiness/proof/runner-neutral intent and workload shape validation out of rigs.
- Keep rig-specific checks local, including declaration uniqueness, portable paths, product-specific contracts, and WordPress Core proof requirements.

## Upstream dependency
- Depends on https://github.com/Extra-Chill/homeboy-extensions/pull/1914 for the canonical validator export.

## Tests
- node --test scripts/fuzz-manifest-helpers.test.mjs
- node --test scripts/lint-rig-packages.test.mjs
- HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR=/Users/chubes/Developer/homeboy-extensions@feat-fuzz-validator/wordpress/lib/wordpress-fuzz-manifest-validator.js node scripts/lint-rig-packages.mjs .

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** implementation, test drafting, and verification