### PR TITLE
Use registry-backed component declarations

### DIFF
--- a/Automattic/studio/rigs/studio-admin-perf/rig.json
+++ b/Automattic/studio/rigs/studio-admin-perf/rig.json
@@ -3,7 +3,9 @@
   "description": "Focused Studio admin performance rig for WordPress admin page and REST latency evidence without the wordpress-playground component dependency.",
   "components": {
     "studio": {
-      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_ADMIN_PERF__STUDIO}",
+      "component_id": "studio",
+      "default_ref": "origin/trunk",
+      "path_setting": "HOMEBOY_RIG_COMPONENT_PATH__STUDIO_ADMIN_PERF__STUDIO",
       "branch": "dev/combined-fixes",
       "extensions": {
         "nodejs": {

--- a/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
@@ -3,7 +3,9 @@
   "description": "Static Site Importer fixture matrix workload that composes generic WP Codebox recipe orchestration while keeping SSI-specific fixture and diagnostic policy in homeboy-rigs.",
   "components": {
     "static-site-importer": {
-      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STATIC_SITE_IMPORTER_FIXTURE_MATRIX__STATIC_SITE_IMPORTER}",
+      "component_id": "static-site-importer",
+      "default_ref": "origin/trunk",
+      "path_setting": "HOMEBOY_RIG_COMPONENT_PATH__STATIC_SITE_IMPORTER_FIXTURE_MATRIX__STATIC_SITE_IMPORTER",
       "branch": "trunk"
     }
   },

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -131,12 +131,14 @@ test('rejects committed local Developer checkout paths in rigs', () => {
   assert.match(result.stderr, /use portable component path settings instead of committed ~\/Developer or \$HOME\/Developer checkout paths/);
 });
 
-test('accepts component paths resolved through portable settings', () => {
+test('accepts registry-backed components with portable path settings', () => {
   const directory = createRigPackage({
     rig: {
       components: {
         product: {
-          path: '${env.HOMEBOY_RIG_COMPONENT_PATH__GENERIC_RIG__PRODUCT}',
+          component_id: 'product',
+          path_setting: 'HOMEBOY_RIG_COMPONENT_PATH__GENERIC_RIG__PRODUCT',
+          default_ref: 'origin/main',
           branch: 'main',
         },
       },


### PR DESCRIPTION
## Summary
- Convert two representative rigs to registry-backed component declarations with path_setting fallback.
- Keep existing env path setting names available for rollout and older runner environments.
- Update lint test coverage to accept the new declarative shape.

Depends on: https://github.com/Extra-Chill/homeboy/pull/6533

## Tests
- node scripts/lint-rig-packages.test.mjs
- node scripts/lint-rig-packages.mjs . (blocked locally: missing external module homeboy-extension-wordpress/wordpress-fuzz-manifest-validator)

## Rollout plan
- After Homeboy PR #6533 merges/releases to runner/controller environments, migrate remaining rigs package-by-package from path env expansion to component_id/path_setting/default_ref.
- Keep path_setting during rollout so older local env configuration still works while registry coverage is expanded.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementation, representative rig migration, test update, and verification.