### PR TITLE
Accept canonical fuzz envelope refs

### DIFF
--- a/scripts/fixtures/shared-fuzz-validator.cjs
+++ b/scripts/fixtures/shared-fuzz-validator.cjs
@@ -136,6 +136,9 @@ function assertFuzzProofBundle(proofBundle, manifest, { file = manifest.id } = {
       throw new Error(`${file} proof_bundle.fuzz_result_artifacts ${artifactName} must name a required case or expected artifact`);
     }
   }
+  if (proofBundle.canonical_fuzz_envelope_ref !== undefined) {
+    assertReviewerFacingArtifactRef(proofBundle.canonical_fuzz_envelope_ref, `${file} metadata.readiness.proof_bundle.canonical_fuzz_envelope_ref`);
+  }
 }
 
 function assertFuzzCrudReadiness(crud, { file } = {}) {
@@ -168,6 +171,18 @@ function assertReviewerFacingRef(value, context) {
   }
   if (/^(https?:\/\/)?(localhost|127\.0\.0\.1)([:/]|$)/.test(value) || value.startsWith('/Users/')) {
     throw new Error(`${context} entries must not use local evidence`);
+  }
+}
+
+function assertReviewerFacingArtifactRef(value, context) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${context} must be a reviewer-facing artifact ref string`);
+  }
+  if (!/^(https:\/\/|gh:|homeboy-runs:|homeboy-artifact:\/\/|artifact:|run:)/.test(value)) {
+    throw new Error(`${context} must be a reviewer-facing artifact ref`);
+  }
+  if (/^(https?:\/\/)?(localhost|127\.0\.0\.1)([:/]|$)/.test(value) || value.startsWith('/Users/')) {
+    throw new Error(`${context} must not use local evidence`);
   }
 }
 

--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -8,7 +8,7 @@ const require = createRequire(import.meta.url);
 export const fuzzReadinessLevels = new Set(['declared', 'executable', 'proven']);
 export const fuzzCrudOperations = new Set(['create', 'read', 'update', 'delete']);
 export const fuzzCaseIntentSchema = 'homeboy/fuzz-workload-intent/v1';
-export const fuzzProofBundleFields = new Set(['artifact_refs', 'run_ids', 'gap_reports', 'fuzz_result_artifacts']);
+export const fuzzProofBundleFields = new Set(['artifact_refs', 'run_ids', 'gap_reports', 'fuzz_result_artifacts', 'canonical_fuzz_envelope_ref']);
 export const fullSurfaceCoverageTypes = new Set(['rest', 'admin', 'frontend', 'browser', 'database']);
 export const fullSurfaceGapReportFields = new Set(['surface_type', 'expected', 'covered', 'gaps', 'status', 'evidence_refs']);
 export const wooRequiredFuzzProofContracts = new Map([
@@ -208,7 +208,33 @@ export function assertFuzzReadinessMetadata(manifest, { file = manifest.id } = {
 }
 
 export function assertFuzzProofBundle(proofBundle, manifest, { file } = {}) {
-  return loadGenericFuzzManifestValidator().assertFuzzProofBundle(proofBundle, manifest, { file });
+  const result = loadGenericFuzzManifestValidator().assertFuzzProofBundle(proofBundle, manifest, { file });
+  assertCanonicalFuzzEnvelopeRef(proofBundle, { file: file || manifest.id });
+  return result;
+}
+
+export function assertCanonicalFuzzEnvelopeRef(proofBundle, { file = 'fuzz workload' } = {}) {
+  if (proofBundle?.canonical_fuzz_envelope_ref === undefined) {
+    return;
+  }
+
+  assertReviewerFacingFuzzRef(
+    proofBundle.canonical_fuzz_envelope_ref,
+    `${file} metadata.readiness.proof_bundle.canonical_fuzz_envelope_ref`
+  );
+}
+
+function assertReviewerFacingFuzzRef(value, context) {
+  assert.equal(typeof value, 'string', `${context} must be a reviewer-facing artifact ref string`);
+  assert.ok(value.trim().length > 0, `${context} must be a reviewer-facing artifact ref string`);
+  assert.ok(
+    /^(https:\/\/|gh:|homeboy-runs:|homeboy-artifact:\/\/|artifact:|run:)/.test(value),
+    `${context} must be a reviewer-facing artifact ref`
+  );
+  assert.ok(
+    !/^(https?:\/\/)?(localhost|127\.0\.0\.1)([:/]|$)/.test(value) && !value.startsWith('/Users/'),
+    `${context} must not use local evidence`
+  );
 }
 
 export function assertRequiredFuzzProofContracts(manifest, {

--- a/scripts/fuzz-manifest-helpers.test.mjs
+++ b/scripts/fuzz-manifest-helpers.test.mjs
@@ -1,12 +1,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  assertFuzzProofBundle,
   assertFuzzReadinessMetadata,
   assertGenericFuzzManifest,
   assertJetpackFuzzManifestReadinessContract,
   declaredFuzzIds,
   fullSurfaceRequiredArtifactIds,
   fuzzManifestHasExecutableArtifactContract,
+  fuzzProofBundleFields,
   workloadIdFromPath,
 } from './fuzz-manifest-helpers.mjs';
 
@@ -243,5 +245,29 @@ test('assertGenericFuzzManifest can require readiness metadata', () => {
       requireReadinessMetadata: true,
     }),
     /requires metadata.readiness/
+  );
+});
+
+test('assertFuzzProofBundle accepts a canonical fuzz envelope artifact ref alongside legacy refs', () => {
+  assert.ok(fuzzProofBundleFields.has('canonical_fuzz_envelope_ref'));
+  assert.doesNotThrow(() => assertFuzzProofBundle({
+    artifact_refs: ['https://github.com/chubes4/homeboy-rigs/issues/254'],
+    run_ids: ['run:product-fuzz'],
+    gap_reports: ['https://github.com/chubes4/homeboy-rigs/issues/253'],
+    fuzz_result_artifacts: ['report'],
+    canonical_fuzz_envelope_ref: 'homeboy-runs:product-fuzz/artifacts/fuzz-envelope.json',
+  }, fuzzManifest(), { file: 'product-fuzz.json' }));
+});
+
+test('assertFuzzProofBundle rejects local canonical fuzz envelope artifact refs', () => {
+  assert.throws(
+    () => assertFuzzProofBundle({
+      artifact_refs: ['https://github.com/chubes4/homeboy-rigs/issues/254'],
+      run_ids: ['run:product-fuzz'],
+      gap_reports: ['https://github.com/chubes4/homeboy-rigs/issues/253'],
+      fuzz_result_artifacts: ['report'],
+      canonical_fuzz_envelope_ref: 'https://localhost:8881/fuzz-envelope.json',
+    }, fuzzManifest(), { file: 'product-fuzz.json' }),
+    /canonical_fuzz_envelope_ref must not use local evidence/
   );
 });


### PR DESCRIPTION
## Summary
- Add optional proof_bundle.canonical_fuzz_envelope_ref support to the shared fuzz manifest helper field list.
- Validate canonical envelope refs as reviewer-facing artifact refs while preserving existing artifact_refs, run_ids, gap_reports, and fuzz_result_artifacts arrays.
- Cover acceptance and local-evidence rejection in the helper tests and fixture validator.

## Tests
- node --test scripts/fuzz-manifest-helpers.test.mjs
- HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR="$PWD/scripts/fixtures/shared-fuzz-validator.cjs" node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
- node --test woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
- node --test scripts/lint-rig-packages.test.mjs
- HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR="$PWD/scripts/fixtures/shared-fuzz-validator.cjs" node scripts/lint-rig-packages.mjs
- git diff --check

## Caveats
- This is a forward-compatible downstream acceptance slice; the local worktree does not have the extracted homeboy-extension-wordpress validator package installed, so direct validator/lint commands were run with the repo fixture validator path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the helper/schema acceptance change, adding tests, running validation, and drafting this PR description.