### PR TITLE
Use registry-backed Jetpack rig components

### DIFF
--- a/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
+++ b/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
@@ -3,7 +3,9 @@
   "description": "Jetpack REST route inventory scaffold for adapting generic Homeboy Extensions and WP Codebox API performance primitives.",
   "components": {
     "jetpack": {
-      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__JETPACK_API_ROUTE_INVENTORY__JETPACK}",
+      "component_id": "jetpack",
+      "default_ref": "origin/trunk",
+      "path_setting": "HOMEBOY_RIG_COMPONENT_PATH__JETPACK_API_ROUTE_INVENTORY__JETPACK",
       "checkout_root": "${env.HOMEBOY_RIG_COMPONENT_CHECKOUT_ROOT__JETPACK_API_ROUTE_INVENTORY__JETPACK}",
       "branch": "trunk",
       "extensions": {

--- a/Automattic/jetpack/rigs/jetpack-browser-coverage/rig.json
+++ b/Automattic/jetpack/rigs/jetpack-browser-coverage/rig.json
@@ -3,7 +3,9 @@
   "description": "WP Codebox browser-actions request coverage for Jetpack dashboard, connection, modules, settings admin, and public module frontend surfaces.",
   "components": {
     "jetpack": {
-      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__JETPACK_BROWSER_COVERAGE__JETPACK}",
+      "component_id": "jetpack",
+      "default_ref": "origin/trunk",
+      "path_setting": "HOMEBOY_RIG_COMPONENT_PATH__JETPACK_BROWSER_COVERAGE__JETPACK",
       "branch": "trunk"
     }
   },


### PR DESCRIPTION
## Summary
- Convert the Jetpack API route inventory rig component declaration to use component_id/default_ref/path_setting.
- Convert the Jetpack browser coverage rig component declaration to use component_id/default_ref/path_setting.
- Preserve the existing Jetpack checkout_root env fallback for the Codebox source-root monorepo subpath case.

## Tests
- PASS: node scripts/lint-rig-packages.test.mjs
- PASS: HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR="/Users/chubes/Developer/homeboy-rigs@homeboy-rigs-component-path-rollout/scripts/fixtures/shared-fuzz-validator.cjs" node scripts/lint-rig-packages.mjs .
- BLOCKED: homeboy lint homeboy-rigs did not reach lint execution on homeboy-lab because the runner-side registry has no homeboy-rigs component id (component.not_found). Registering the synced checkout per the hint created a derived worktree id, but retrying against that id then failed with extension.unsupported because the derived component has no extension provider configured.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Migrating the Jetpack rig component declarations, running local validation, and drafting this PR description.
