### PR TITLE
Delegate Woo Composer prep to Homeboy deps

### DIFF
--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -22,6 +22,7 @@ const restDbQueryProfileWorkload = JSON.parse(readFileSync(path.join(packageRoot
 const coverageGapReport = JSON.parse(readFileSync(path.join(packageRoot, 'fuzz/coverage-gap-report.json'), 'utf8'));
 const coverageGapReportWorkload = JSON.parse(readFileSync(path.join(packageRoot, 'bench/coverage-gap-report.workload.json'), 'utf8'));
 const performanceHotspotsWorkload = JSON.parse(readFileSync(path.join(packageRoot, 'bench/performance-hotspots-artifact-summary.workload.json'), 'utf8'));
+const runtimePrepScript = readFileSync(path.join(packageRoot, 'tools/prepare-runtime-dependency.sh'), 'utf8');
 
 const workloadIdFromPath = (workloadPath) => path.basename(workloadPath, path.extname(workloadPath));
 
@@ -93,6 +94,21 @@ test('fuzz workload metadata does not fall back to benchmark transcripts', () =>
       `${workloadId} must not declare benchmark transcript fallback proof`
     );
   }
+});
+
+test('Woo Composer prep delegates to Homeboy dependency install primitive', () => {
+  const composerRequirements = [
+    ...performanceRig.pipeline.check,
+    ...performanceRig.pipeline.fuzz_prepare,
+  ].filter((step) => step.label === 'WooCommerce Composer package autoloader exists or can be prepared');
+
+  assert.equal(composerRequirements.length, 2);
+  for (const requirement of composerRequirements) {
+    assert.match(requirement.prepare_command, /prepare-runtime-dependency\.sh" composer/);
+  }
+
+  assert.match(runtimePrepScript, /homeboy deps install --path "\$woocommerce_plugin_source"/);
+  assert.doesNotMatch(runtimePrepScript, /composer --working-dir=.* install/);
 });
 
 test('generated REST request cases are driven by route inventory coverage semantics', () => {

--- a/woocommerce/woocommerce/tools/prepare-runtime-dependency.sh
+++ b/woocommerce/woocommerce/tools/prepare-runtime-dependency.sh
@@ -21,7 +21,7 @@ fi
 
 case "$task" in
   composer)
-    XDEBUG_MODE=off composer --working-dir="$woocommerce_plugin_source" install --no-interaction --no-progress
+    XDEBUG_MODE=off homeboy deps install --path "$woocommerce_plugin_source"
     if [ "$woocommerce_plugin_source" != "$woocommerce_component_source" ]; then
       mkdir -p "$woocommerce_component_source/vendor"
       cp "$woocommerce_plugin_source/vendor/autoload_packages.php" "$woocommerce_component_source/vendor/autoload_packages.php"


### PR DESCRIPTION
## Summary
- replace Woo runtime prep's raw Composer install with Homeboy's dependency install primitive
- preserve XDEBUG disabling and copied autoloader behavior for source-root/component-path splits
- add a Woo contract test so Composer prep keeps delegating to {
  "success": false,
  "error": {
    "code": "validation.invalid_argument",
    "message": "Invalid argument 'component_id': No component ID provided and no homeboy.json found in current directory",
    "details": {
      "field": "component_id",
      "problem": "No component ID provided and no homeboy.json found in current directory",
      "tried": [
        "Provide a component ID: homeboy <command> <component-id>",
        "Or run from a directory containing homeboy.json",
        "Initialize the repo: homeboy component create --local-path .",
        "Or attach the repo to a project: homeboy project components attach-path <project> ."
      ]
    }
  }
}

## Upstream
- Depends on https://github.com/Extra-Chill/homeboy/pull/6544 for deterministic Composer install args.

## Tests
- node --test woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** implementation, tests, and PR preparation