### PR TITLE
Use trace profile metadata for Stripe ECE compare

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/README.md
+++ b/woocommerce/woocommerce-gateway-stripe/README.md
@@ -188,8 +188,9 @@ homeboy trace --rig woocommerce-stripe-ece-product-page \
   woocommerce-gateway-stripe ece-product-page-waterfall
 ```
 
-The profile fails before WP Codebox starts when either `STRIPE_PUBLISHABLE_KEY`
-or `STRIPE_SECRET_KEY` is absent. It also requires
+The profile declares `STRIPE_PUBLISHABLE_KEY` and `STRIPE_SECRET_KEY` in
+Homeboy `required_env`, so Homeboy fails before WP Codebox starts when either
+is absent. The runtime also requires
 `HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL` to be an HTTPS public origin; local
 HTTP origins and `localhost` are rejected because wallet eligibility requires a
 secure, public browser context.
@@ -225,38 +226,38 @@ so reviewers can inspect the broken fixture directly.
 
 ## Canonical Real-Wallet Compare
 
-Use the package wrapper when collecting PR evidence for real-wallet product-page
-ECE behavior. It fails before traces run unless the candidate ref/path, Stripe
-keys, preview port, and HTTPS public preview URL are present, then runs both the
-load-only waterfall and scroll-to-ECE target compares with canonical defaults.
+Use the Homeboy trace profile directly when collecting PR evidence for
+real-wallet product-page ECE behavior. The `real-wallet-compare` profile
+declares the two compare scenarios, required Stripe env vars, repeat count,
+interleaved schedule, and canonical evidence mode.
 
 ```bash
 export STRIPE_PUBLISHABLE_KEY=pk_test_...
 export STRIPE_SECRET_KEY=sk_test_...
+export HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL=https://your-public-preview.example
 
-woocommerce/woocommerce-gateway-stripe/tools/real-wallet-ece-compare.sh \
-  --candidate your-branch-or-worktree \
-  --preview-port 49800 \
-  --public-url https://your-public-preview.example
+homeboy trace compare-bundle \
+  --rig woocommerce-stripe-ece-product-page \
+  --profile real-wallet-compare \
+  --baseline-target origin/develop \
+  --candidate your-branch-or-worktree
 ```
+
+`tools/real-wallet-ece-compare.sh` remains as a compatibility shim for older
+operator notes. It delegates to the same Homeboy profile and only maps legacy
+flags such as `--public-url` and `--preview-port` into environment variables.
 
 Defaults:
 
 - Baseline: `origin/develop`
-- Profile: `real-wallet`
+- Profile: `real-wallet-compare`
 - Repeat: `5`
 - Schedule: `interleaved`
 - Evidence mode: `--canonical`
 - Output directory: `woocommerce/woocommerce-gateway-stripe/.homeboy/evidence/woo-stripe-ece-real-wallet-<timestamp>/`
 
-The wrapper writes:
-
-- `README.md` with baseline/candidate/profile/preview settings.
-- `ece-product-page-waterfall.compare.json` and `.compare.log`.
-- `ece-product-page-scroll-to-ece.compare.json` and `.compare.log`.
-- `ece-product-page-waterfall.compare.md` and
-  `ece-product-page-scroll-to-ece.compare.md` markdown summaries copied from
-  Homeboy's trace compare `summary.md` artifacts.
+Homeboy writes a compare-bundle directory with `manifest.json`, `bundle.json`,
+`README.md`, `summary.md`, and one scenario subdirectory per compare target.
 
 Reviewer evidence fields to inspect in each compare artifact:
 

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -358,7 +359,50 @@ test('rig manifest exposes the ECE webperf profile matrix', () => {
     woocommerce_stripe_ece_browser_profile: 'webperf-stripe-deferred-preconnect',
     woocommerce_stripe_ece_hint_strategy: 'stripe-deferred-preconnect',
   });
-  assert.equal(manifest.trace_profiles['real-wallet'].public_preview, undefined);
+  assert.deepEqual(manifest.trace_profiles['real-wallet'], {
+    scenario: 'ece-product-page-waterfall',
+    required_env: ['STRIPE_PUBLISHABLE_KEY', 'STRIPE_SECRET_KEY'],
+    settings: {
+      woocommerce_stripe_ece_browser_profile: 'real-wallet',
+    },
+  });
+  assert.deepEqual(manifest.trace_profiles['real-wallet-compare'], {
+    required_env: ['STRIPE_PUBLISHABLE_KEY', 'STRIPE_SECRET_KEY'],
+    settings: {
+      woocommerce_stripe_ece_browser_profile: 'real-wallet',
+    },
+    compare_bundle: {
+      component: 'woocommerce-gateway-stripe',
+      scenarios: ['ece-product-page-waterfall', 'ece-product-page-scroll-to-ece'],
+      repeat: 5,
+      schedule: 'interleaved',
+      canonical: true,
+    },
+  });
+});
+
+test('real-wallet compare wrapper delegates to Homeboy trace profile', () => {
+  const wrapper = path.resolve(__dirname, '../tools/real-wallet-ece-compare.sh');
+  const output = execFileSync(wrapper, [
+    '--candidate',
+    'candidate-ref',
+    '--baseline',
+    'baseline-ref',
+    '--output-dir',
+    '/tmp/wc-stripe-ece-compare-fixture',
+    '--public-url',
+    'https://preview.example.test',
+    '--preview-port',
+    '49800',
+    '--dry-run',
+  ], { encoding: 'utf8' });
+
+  assert.match(output, /homeboy trace compare-bundle/);
+  assert.match(output, /--rig woocommerce-stripe-ece-product-page/);
+  assert.match(output, /--profile real-wallet-compare/);
+  assert.match(output, /--baseline-target baseline-ref/);
+  assert.match(output, /--candidate candidate-ref/);
+  assert.doesNotMatch(output, /ece-product-page-waterfall,ece-product-page-scroll-to-ece/);
 });
 
 test('real-wallet profile fails fast when Stripe keys are missing', () => {

--- a/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
+++ b/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
@@ -160,8 +160,31 @@
     },
     "real-wallet": {
       "scenario": "ece-product-page-waterfall",
+      "required_env": [
+        "STRIPE_PUBLISHABLE_KEY",
+        "STRIPE_SECRET_KEY"
+      ],
       "settings": {
         "woocommerce_stripe_ece_browser_profile": "real-wallet"
+      }
+    },
+    "real-wallet-compare": {
+      "required_env": [
+        "STRIPE_PUBLISHABLE_KEY",
+        "STRIPE_SECRET_KEY"
+      ],
+      "settings": {
+        "woocommerce_stripe_ece_browser_profile": "real-wallet"
+      },
+      "compare_bundle": {
+        "component": "woocommerce-gateway-stripe",
+        "scenarios": [
+          "ece-product-page-waterfall",
+          "ece-product-page-scroll-to-ece"
+        ],
+        "repeat": 5,
+        "schedule": "interleaved",
+        "canonical": true
       }
     },
     "hot": {

--- a/woocommerce/woocommerce-gateway-stripe/tools/real-wallet-ece-compare.sh
+++ b/woocommerce/woocommerce-gateway-stripe/tools/real-wallet-ece-compare.sh
@@ -3,41 +3,36 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RIG_ID="woocommerce-stripe-ece-product-page"
-COMPONENT="woocommerce-gateway-stripe"
+PROFILE="real-wallet-compare"
 BASELINE_REF="${BASELINE_REF:-origin/develop}"
 CANDIDATE_REF="${CANDIDATE_REF:-}"
-REPEAT="${REPEAT:-5}"
 OUTPUT_DIR="${OUTPUT_DIR:-}"
-PREVIEW_PORT="${HOMEBOY_WC_STRIPE_ECE_PREVIEW_PORT:-}"
-PREVIEW_PUBLIC_URL="${HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL:-}"
 DRY_RUN=0
 
 usage() {
   cat <<'USAGE'
 Usage: real-wallet-ece-compare.sh --candidate <ref-or-path> [options]
 
-Canonical Woo Stripe product-page real-wallet ECE compare workflow.
+Compatibility wrapper for the Woo Stripe product-page real-wallet ECE compare profile.
 
-Required preflight:
+Required preflight is declared by the Homeboy trace profile:
   --candidate, CANDIDATE_REF             Candidate ref/path to compare
-  --preview-port, HOMEBOY_WC_STRIPE_ECE_PREVIEW_PORT
-  --public-url, HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL
   STRIPE_PUBLISHABLE_KEY
   STRIPE_SECRET_KEY
+
+Runtime wallet eligibility still requires an HTTPS public preview origin via
+HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL or HOMEBOY_PREVIEW_PUBLIC_URL.
 
 Options:
   --baseline <ref-or-path>               Default: origin/develop
   --candidate <ref-or-path>              Candidate ref/path
-  --repeat <n>                           Default: 5
   --output-dir <dir>                     Default: .homeboy/evidence/woo-stripe-ece-real-wallet-<timestamp>
   --preview-port <port>                  Export HOMEBOY_WC_STRIPE_ECE_PREVIEW_PORT for this run
   --public-url <https-url>               Export HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL for this run
-  --dry-run                              Print commands without running Homeboy
+  --dry-run                              Print command without running Homeboy
   -h, --help                             Show this help
 
-Runs these compare scenarios with --profile real-wallet, --schedule interleaved, and --canonical:
-  ece-product-page-waterfall
-  ece-product-page-scroll-to-ece
+Profile defaults: real-wallet-compare, repeat 5, schedule interleaved, canonical.
 USAGE
 }
 
@@ -62,11 +57,6 @@ while [[ $# -gt 0 ]]; do
       CANDIDATE_REF="${2:-}"
       shift 2
       ;;
-    --repeat)
-      require_arg "$1" "${2:-}"
-      REPEAT="${2:-}"
-      shift 2
-      ;;
     --output-dir)
       require_arg "$1" "${2:-}"
       OUTPUT_DIR="${2:-}"
@@ -74,14 +64,12 @@ while [[ $# -gt 0 ]]; do
       ;;
     --preview-port)
       require_arg "$1" "${2:-}"
-      PREVIEW_PORT="${2:-}"
-      export HOMEBOY_WC_STRIPE_ECE_PREVIEW_PORT="$PREVIEW_PORT"
+      export HOMEBOY_WC_STRIPE_ECE_PREVIEW_PORT="${2:-}"
       shift 2
       ;;
     --public-url)
       require_arg "$1" "${2:-}"
-      PREVIEW_PUBLIC_URL="${2:-}"
-      export HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL="$PREVIEW_PUBLIC_URL"
+      export HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL="${2:-}"
       shift 2
       ;;
     --dry-run)
@@ -100,47 +88,30 @@ done
 
 [[ -n "$BASELINE_REF" ]] || fail 'baseline ref/path is required.'
 [[ -n "$CANDIDATE_REF" ]] || fail 'candidate ref/path is required. Set CANDIDATE_REF or pass --candidate.'
-[[ "$REPEAT" =~ ^[1-9][0-9]*$ ]] || fail 'repeat must be a positive integer.'
-[[ -n "$PREVIEW_PORT" ]] || fail 'preview port is required. Set HOMEBOY_WC_STRIPE_ECE_PREVIEW_PORT or pass --preview-port.'
-[[ "$PREVIEW_PORT" =~ ^[0-9]+$ ]] || fail 'preview port must be numeric.'
-[[ -n "$PREVIEW_PUBLIC_URL" ]] || fail 'public preview URL is required. Set HOMEBOY_WC_STRIPE_ECE_PREVIEW_PUBLIC_URL or pass --public-url.'
-[[ "$PREVIEW_PUBLIC_URL" =~ ^https:// ]] || fail 'public preview URL must start with https://.'
-[[ "$PREVIEW_PUBLIC_URL" != https://localhost* && "$PREVIEW_PUBLIC_URL" != https://127.0.0.1* ]] || fail 'public preview URL must not be localhost.'
-[[ -n "${STRIPE_PUBLISHABLE_KEY:-}" ]] || fail 'STRIPE_PUBLISHABLE_KEY is required.'
-[[ -n "${STRIPE_SECRET_KEY:-}" ]] || fail 'STRIPE_SECRET_KEY is required.'
 
 if [[ -z "$OUTPUT_DIR" ]]; then
   OUTPUT_DIR="$ROOT_DIR/.homeboy/evidence/woo-stripe-ece-real-wallet-$(date -u +%Y%m%dT%H%M%SZ)"
 fi
 
-mkdir -p "$OUTPUT_DIR"
-
-SCENARIOS="ece-product-page-waterfall,ece-product-page-scroll-to-ece"
-LOG_FILE="$OUTPUT_DIR/compare-bundle.log"
 COMMAND=(
-  homeboy trace compare-bundle "$COMPONENT" "$SCENARIOS"
+  homeboy trace compare-bundle
   --rig "$RIG_ID"
+  --profile "$PROFILE"
   --baseline-target "$BASELINE_REF"
   --candidate "$CANDIDATE_REF"
-  --profile real-wallet
-  --repeat "$REPEAT"
-  --schedule interleaved
-  --canonical
   --output-dir "$OUTPUT_DIR"
 )
 
 printf 'Evidence directory: %s\n' "$OUTPUT_DIR"
 printf 'Baseline: %s\n' "$BASELINE_REF"
 printf 'Candidate: %s\n' "$CANDIDATE_REF"
-printf 'Repeat/schedule: %s/interleaved\n' "$REPEAT"
-printf 'Preview: localhost:%s -> %s\n' "$PREVIEW_PORT" "$PREVIEW_PUBLIC_URL"
-printf 'Scenarios: %s\n' "$SCENARIOS"
+printf 'Profile: %s\n' "$PROFILE"
 printf 'Command:'
 printf ' %q' "${COMMAND[@]}"
 printf '\n'
 
 if [[ "$DRY_RUN" -eq 0 ]]; then
-  "${COMMAND[@]}" 2>&1 | tee "$LOG_FILE"
+  "${COMMAND[@]}"
 fi
 
 printf '\nEvidence directory: %s\n' "$OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- declare Woo Stripe real-wallet compare defaults in the `real-wallet-compare` trace profile
- add required Stripe env metadata to real-wallet profiles
- reduce `real-wallet-ece-compare.sh` to a compatibility delegator over `homeboy trace compare-bundle --profile real-wallet-compare`
- update docs and targeted tests for the declarative compare profile

## Upstream dependency
- Depends on Homeboy profile metadata support merged in https://github.com/Extra-Chill/homeboy/pull/6545

## Tests
- `node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`
- `node scripts/lint-rig-packages.mjs woocommerce/woocommerce-gateway-stripe`

Full `node scripts/lint-rig-packages.mjs` was not runnable locally because this checkout lacks the CI-provided `HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR` module path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the rig profile metadata change, wrapper simplification, tests, documentation, and PR preparation.
