### PR TITLE
Wire Woo canonical fuzz envelope fixture consumption

### DIFF
--- a/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
+++ b/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
@@ -49,15 +49,33 @@
         "status": "required_before_proven",
         "required_refs": [
           "reviewer-facing wp-codebox fuzz-suite run id",
+          "reviewer-facing canonical fuzz envelope artifact ref",
           "reviewer-facing wp-codebox/fuzz-suite-result artifact ref",
           "reviewer-facing coverage gap report artifact ref",
           "reviewer-facing performance hotspot summary artifact ref"
         ],
         "required_artifacts": [
+          "canonical_fuzz_envelope",
           "codebox_fuzz_suite_result",
           "coverage_gap_report",
           "performance_hotspots_summary"
         ]
+      },
+      "proof_bundle": {
+        "artifact_refs": [
+          "artifact:pending/woocommerce-codebox-fuzz-suite-smoke/fuzz-suite-result.json"
+        ],
+        "run_ids": [
+          "run:pending-woocommerce-codebox-fuzz-suite-smoke"
+        ],
+        "gap_reports": [
+          "artifact:pending/woocommerce-codebox-fuzz-suite-smoke/coverage-gap-report.json"
+        ],
+        "fuzz_result_artifacts": [
+          "codebox_fuzz_suite_result"
+        ],
+        "canonical_fuzz_envelope_ref": "artifact:pending/woocommerce-codebox-fuzz-suite-smoke/canonical-fuzz-envelope.json",
+        "placeholder_reason": "No reviewer-facing offloaded Woo Codebox fuzz-suite run artifact exists yet; replace this placeholder with the published artifact ref before marking the campaign proven."
       }
     }
   },

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -5,6 +5,7 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import {
   assertArtifactPostprocessWorkloadContract,
+  assertCanonicalFuzzEnvelopeRef,
   assertFullSurfaceCoverageManifest,
   assertRequiredFuzzProofContracts,
   wooRequiredFuzzProofContracts,
@@ -12,11 +13,17 @@ import {
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
+const repoRoot = path.join(packageRoot, '..', '..');
+
+process.env.HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR = path.join(repoRoot, 'scripts/fixtures/shared-fuzz-validator.cjs');
 
 const manifest = JSON.parse(readFileSync(path.join(__dirname, 'full-surface-coverage.json'), 'utf8'));
 const performanceRig = JSON.parse(readFileSync(path.join(packageRoot, 'rigs/woocommerce-performance/rig.json'), 'utf8'));
 const browserRig = JSON.parse(readFileSync(path.join(packageRoot, 'rigs/woocommerce-browser-coverage/rig.json'), 'utf8'));
 const generatedRestCases = JSON.parse(readFileSync(path.join(packageRoot, 'fuzz/generated-rest-request-cases.json'), 'utf8'));
+const codeboxFuzzSuiteWorkload = JSON.parse(readFileSync(path.join(packageRoot, 'fuzz/codebox-fuzz-suite-smoke.json'), 'utf8'));
+const codeboxFuzzSuiteManifest = JSON.parse(readFileSync(path.join(packageRoot, 'manifests/codebox-fuzz-suite-smoke.json'), 'utf8'));
+const dbApiFuzzCampaign = JSON.parse(readFileSync(path.join(packageRoot, 'manifests/db-api-fuzz-campaign.json'), 'utf8'));
 const performanceHotspots = JSON.parse(readFileSync(path.join(packageRoot, 'fuzz/performance-hotspots-artifact-summary.json'), 'utf8'));
 const restDbQueryProfileWorkload = JSON.parse(readFileSync(path.join(packageRoot, 'bench/rest-db-query-profile.workload.json'), 'utf8'));
 const coverageGapReport = JSON.parse(readFileSync(path.join(packageRoot, 'fuzz/coverage-gap-report.json'), 'utf8'));
@@ -201,4 +208,17 @@ test('coverage gap and hotspot reports declare the generic artifact postprocess 
     outputPath: 'performance-hotspots-artifact-summary/performance_hotspots_summary.json',
     schema: 'homeboy/woocommerce-performance-hotspots-summary/v1',
   });
+});
+
+test('DB/API campaign consumes the Codebox fixture canonical fuzz envelope ref', () => {
+  const proofBundle = codeboxFuzzSuiteManifest.target.metadata.proof_bundle;
+
+  assert.equal(dbApiFuzzCampaign.suite_manifest, 'manifests/codebox-fuzz-suite-smoke.json');
+  assert.equal(codeboxFuzzSuiteWorkload.metadata.fixture.suite_manifest, '${package.root}/manifests/codebox-fuzz-suite-smoke.json');
+  assertCanonicalFuzzEnvelopeRef(proofBundle, { file: 'codebox-fuzz-suite-smoke.json' });
+  assert.equal(
+    proofBundle.canonical_fuzz_envelope_ref,
+    'artifact:pending/woocommerce-codebox-fuzz-suite-smoke/canonical-fuzz-envelope.json'
+  );
+  assert.match(proofBundle.placeholder_reason, /No reviewer-facing offloaded Woo Codebox fuzz-suite run artifact exists yet/);
 });


### PR DESCRIPTION
## Summary
- Add a documented placeholder `proof_bundle.canonical_fuzz_envelope_ref` to the Woo Codebox fuzz-suite fixture.
- Update the Woo full-surface manifest test to prove the DB/API campaign consumes that suite fixture link and validates the canonical envelope ref.

## Tests
- `node --test "woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs"`
- `node --test "scripts/fuzz-manifest-helpers.test.mjs"`
- `HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR="$(pwd)/scripts/fixtures/shared-fuzz-validator.cjs" node scripts/lint-rig-packages.mjs`
- `HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR="$(pwd)/scripts/fixtures/shared-fuzz-validator.cjs" node --test Automattic/jetpack/manifests/full-surface-coverage.test.mjs WordPress/gutenberg/tools/fuzz-coverage.test.mjs WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs`

## Caveat
- No real reviewer-facing offloaded Woo Codebox fuzz-suite artifact ref exists in this repo yet, so this intentionally uses a non-local `artifact:pending/...` placeholder in the fixture and documents replacement before proven readiness.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the fixture/test update, running verification, and drafting this PR description.
