### PR TITLE
Use Woo canonical fuzz envelope artifact ref

### DIFF
--- a/scripts/fixtures/shared-fuzz-validator.cjs
+++ b/scripts/fixtures/shared-fuzz-validator.cjs
@@ -166,7 +166,7 @@ function assertFuzzReadinessLevel(level, label) {
 }
 
 function assertReviewerFacingRef(value, context) {
-  if (!/^(https:\/\/|gh:|homeboy-runs:|artifact:|run:)/.test(value)) {
+  if (!/^(https:\/\/|gh:|homeboy-runs:|homeboy:\/\/run\/|artifact:|run:)/.test(value)) {
     throw new Error(`${context} entries must be reviewer-facing refs`);
   }
   if (/^(https?:\/\/)?(localhost|127\.0\.0\.1)([:/]|$)/.test(value) || value.startsWith('/Users/')) {
@@ -178,7 +178,7 @@ function assertReviewerFacingArtifactRef(value, context) {
   if (typeof value !== 'string' || value.trim() === '') {
     throw new Error(`${context} must be a reviewer-facing artifact ref string`);
   }
-  if (!/^(https:\/\/|gh:|homeboy-runs:|homeboy-artifact:\/\/|artifact:|run:)/.test(value)) {
+  if (!/^(https:\/\/|gh:|homeboy-runs:|homeboy:\/\/run\/|homeboy-artifact:\/\/|artifact:|run:)/.test(value)) {
     throw new Error(`${context} must be a reviewer-facing artifact ref`);
   }
   if (/^(https?:\/\/)?(localhost|127\.0\.0\.1)([:/]|$)/.test(value) || value.startsWith('/Users/')) {

--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -228,7 +228,7 @@ function assertReviewerFacingFuzzRef(value, context) {
   assert.equal(typeof value, 'string', `${context} must be a reviewer-facing artifact ref string`);
   assert.ok(value.trim().length > 0, `${context} must be a reviewer-facing artifact ref string`);
   assert.ok(
-    /^(https:\/\/|gh:|homeboy-runs:|homeboy-artifact:\/\/|artifact:|run:)/.test(value),
+    /^(https:\/\/|gh:|homeboy-runs:|homeboy:\/\/run\/|homeboy-artifact:\/\/|artifact:|run:)/.test(value),
     `${context} must be a reviewer-facing artifact ref`
   );
   assert.ok(

--- a/scripts/fuzz-manifest-helpers.test.mjs
+++ b/scripts/fuzz-manifest-helpers.test.mjs
@@ -259,6 +259,16 @@ test('assertFuzzProofBundle accepts a canonical fuzz envelope artifact ref along
   }, fuzzManifest(), { file: 'product-fuzz.json' }));
 });
 
+test('assertFuzzProofBundle accepts Homeboy run artifact refs for canonical fuzz envelopes', () => {
+  assert.doesNotThrow(() => assertFuzzProofBundle({
+    artifact_refs: ['https://github.com/chubes4/homeboy-rigs/issues/254'],
+    run_ids: ['run:product-fuzz'],
+    gap_reports: ['https://github.com/chubes4/homeboy-rigs/issues/253'],
+    fuzz_result_artifacts: ['report'],
+    canonical_fuzz_envelope_ref: 'homeboy://run/product-fuzz/artifact/fuzz-envelope',
+  }, fuzzManifest(), { file: 'product-fuzz.json' }));
+});
+
 test('assertFuzzProofBundle rejects local canonical fuzz envelope artifact refs', () => {
   assert.throws(
     () => assertFuzzProofBundle({

--- a/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
+++ b/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
@@ -74,8 +74,8 @@
         "fuzz_result_artifacts": [
           "codebox_fuzz_suite_result"
         ],
-        "canonical_fuzz_envelope_ref": "artifact:pending/woocommerce-codebox-fuzz-suite-smoke/canonical-fuzz-envelope.json",
-        "placeholder_reason": "No reviewer-facing offloaded Woo Codebox fuzz-suite run artifact exists yet; replace this placeholder with the published artifact ref before marking the campaign proven."
+        "canonical_fuzz_envelope_ref": "homeboy://run/wc-db-api-codebox-suite-20260626T0145Z/artifact/cfa06657-0b23-447d-bd04-c75a7597f266",
+        "placeholder_reason": "Canonical fuzz envelope is backed by offloaded Homeboy Lab run wc-db-api-codebox-suite-20260626T0145Z; remaining proof refs stay pending until the coverage gap and performance hotspot artifacts have reviewer-facing refs."
       }
     }
   },

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -218,7 +218,7 @@ test('DB/API campaign consumes the Codebox fixture canonical fuzz envelope ref',
   assertCanonicalFuzzEnvelopeRef(proofBundle, { file: 'codebox-fuzz-suite-smoke.json' });
   assert.equal(
     proofBundle.canonical_fuzz_envelope_ref,
-    'artifact:pending/woocommerce-codebox-fuzz-suite-smoke/canonical-fuzz-envelope.json'
+    'homeboy://run/wc-db-api-codebox-suite-20260626T0145Z/artifact/cfa06657-0b23-447d-bd04-c75a7597f266'
   );
-  assert.match(proofBundle.placeholder_reason, /No reviewer-facing offloaded Woo Codebox fuzz-suite run artifact exists yet/);
+  assert.match(proofBundle.placeholder_reason, /remaining proof refs stay pending/);
 });


### PR DESCRIPTION
## Summary
- Replace the Woo canonical fuzz envelope placeholder with the stable Homeboy run artifact ref emitted for the offloaded Homeboy Lab run.
- Accept `homeboy://run/.../artifact/...` refs in the shared fuzz validators so the manifest can use the actual emitted ref shape.
- Keep the remaining proof refs pending until coverage gap and performance hotspot artifacts have reviewer-facing refs.

## Evidence
- Offloaded run: `wc-db-api-codebox-suite-20260626T0145Z`
- Command recorded on the run: `homeboy fuzz run woocommerce --rig woocommerce-performance --workload codebox-fuzz-suite-smoke --run-id wc-db-api-codebox-suite-20260626T0145Z --seed 1 --max-duration 10m`
- Stable artifact ref: `homeboy://run/wc-db-api-codebox-suite-20260626T0145Z/artifact/cfa06657-0b23-447d-bd04-c75a7597f266`
- Artifact kind: `fuzz_results`, status: `pass`, remote runner artifact address recorded by `homeboy runs evidence wc-db-api-codebox-suite-20260626T0145Z`.

## Remaining blocker
- The DB/API campaign is not fully proven yet. Coverage gap and performance hotspot artifacts still need reviewer-facing refs from the declared offloaded campaign commands in `woocommerce/woocommerce/manifests/db-api-fuzz-campaign.json`.

## Tests
- `node --test scripts/fuzz-manifest-helpers.test.mjs`
- `node --test woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs`
- `node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs` could not run because `homeboy-extension-wordpress/wordpress-fuzz-manifest-validator` is not installed in this worktree.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, code edits, tests, and PR drafting.