### PR TITLE
Fix SSI fixture matrix validation command

### DIFF
--- a/WordPress/static-site-importer/README.md
+++ b/WordPress/static-site-importer/README.md
@@ -109,7 +109,7 @@ The workload composes these generic surfaces:
   commands.
 
 SSI-specific behavior remains here: plugin slug/defaults, fixture artifact
-packing, `static-site-importer validate-in-codebox` command construction,
+packing, `static-site-importer validate-artifact` command construction,
 artifact expectations, and diagnostic-to-repair grouping.
 
 ## Generated Artifact Intake Contract

--- a/WordPress/static-site-importer/lib/fixture-matrix.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix.mjs
@@ -143,7 +143,7 @@ export function buildFixtureMatrixRecipe(input = {}) {
         ...matrix.fixtures.map((fixture) => ({
           command: 'wordpress.wp-cli',
           args: [
-            `command=static-site-importer validate-in-codebox --artifact=${shellToken(path.join(commandArtifactsDirectory, fixture.id, 'artifact.json'))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --allow-missing-woocommerce --allow-failure`,
+            `command=static-site-importer validate-artifact --artifact=${shellToken(path.join(commandArtifactsDirectory, fixture.id, 'artifact.json'))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --allow-missing-woocommerce --allow-failure`,
           ],
         })),
       ],

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -60,7 +60,7 @@ test('builds a generic WP Codebox recipe with SSI-owned plugin defaults', () => 
   });
   assert.equal(recipe.workflow.steps[0].command, 'wordpress.wp-cli');
   assert.equal(recipe.workflow.steps[0].args[0], 'command=plugin activate static-site-importer/static-site-importer.php');
-  assert.match(recipe.workflow.steps[1].args[0], /static-site-importer validate-in-codebox/);
+  assert.match(recipe.workflow.steps[1].args[0], /static-site-importer validate-artifact/);
   assert.match(recipe.workflow.steps[1].args[0], /--allow-failure/);
 });
 


### PR DESCRIPTION
## Summary
- Update the SSI fixture matrix recipe to call `static-site-importer validate-artifact`.
- Update the fixture matrix test and README to match the current SSI CLI contract.

Closes #490.

## Testing
- `node --test WordPress/static-site-importer/tools/fixture-matrix.test.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Reproducing the Lab blocker, updating the matrix command/test/docs, and drafting the PR description.