### PR TITLE
Declare SSI matrix package dependency

### DIFF
--- a/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
@@ -1,6 +1,7 @@
 {
   "id": "static-site-importer-fixture-matrix",
   "description": "Static Site Importer fixture matrix workload that composes generic WP Codebox recipe orchestration while keeping SSI-specific fixture and diagnostic policy in homeboy-rigs.",
+  "package_dependencies": ["../../shared/wp-codebox"],
   "components": {
     "static-site-importer": {
       "component_id": "static-site-importer",


### PR DESCRIPTION
## Summary
- Declare `../../shared/wp-codebox` as an install-time package dependency for the Static Site Importer fixture matrix rig
- Keeps existing relative WP Codebox imports available when Homeboy Lab materializes `WordPress/static-site-importer`

Depends on Extra-Chill/homeboy#6578.
Related: Extra-Chill/homeboy#6574.

## Tests
- Isolated install verification using Homeboy branch `fix/issue-6574-rig-package-dependencies`: `HOME="$tmp" XDG_DATA_HOME="$tmp/.local/share" ./target/debug/homeboy rig install /Users/chubes/Developer/homeboy-rigs@fix-ssi-matrix-package-dependencies/WordPress/static-site-importer --id static-site-importer-fixture-matrix && HOME="$tmp" XDG_DATA_HOME="$tmp/.local/share" ./target/debug/homeboy rig sources list`
- `git diff --check`

Actions credits are exhausted; local targeted verification passed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Applying the package dependency declaration and verifying install metadata with the Homeboy implementation branch.