### PR TITLE
Declare SSI matrix WordPress env provider

### DIFF
--- a/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
@@ -25,7 +25,8 @@
   "bench_workloads": {
     "nodejs": [
       {
-        "path": "${package.root}/bench/static-site-fixture-matrix.bench.mjs"
+        "path": "${package.root}/bench/static-site-fixture-matrix.bench.mjs",
+        "env_provider_extensions": ["wordpress"]
       }
     ]
   },


### PR DESCRIPTION
## Summary
- Declare the WordPress extension env provider for the SSI fixture matrix Node workload.
- Keeps the rig-specific WordPress helper requirement in Homeboy Rigs metadata instead of Homeboy core.

## Tests
- `jq empty WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json`

Depends on Extra-Chill/homeboy#6588.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Updating rig metadata and PR description.