### PR TITLE
Validate rig shared path self-targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ homeboy trace --rig woocommerce-stripe-ece-product-page \
 
 `rigs/isolated-block-editor/rig.json` runs the checks used while shaving Isolated Block Editor toward modern Gutenberg APIs.
 
-The rig declares `node_modules` as a Homeboy `shared_paths` entry. When the active checkout is a worktree without local dependencies, `shared-path ensure` borrows `~/Developer/isolated-block-editor/node_modules` from the primary checkout and `down` removes only the symlink it created.
+The rig declares `node_modules` as a Homeboy `shared_paths` entry. When the active checkout is a worktree without local dependencies, set `HOMEBOY_RIG_SHARED_PATH_TARGET__ISOLATED_BLOCK_EDITOR__NODE_MODULES` to the primary checkout's `node_modules` directory; `shared-path ensure` borrows that directory and `down` removes only the symlink it created.
 
 ## Conventions
 

--- a/chubes4/isolated-block-editor/rigs/isolated-block-editor/rig.json
+++ b/chubes4/isolated-block-editor/rigs/isolated-block-editor/rig.json
@@ -10,7 +10,7 @@
   "shared_paths": [
     {
       "link": "${components.isolated-block-editor.path}/node_modules",
-      "target": "${components.isolated-block-editor.path}/node_modules"
+      "target": "${env.HOMEBOY_RIG_SHARED_PATH_TARGET__ISOLATED_BLOCK_EDITOR__NODE_MODULES}"
     }
   ],
   "pipeline": {

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -101,9 +101,40 @@ function lintRigPortability(file, fuzzWorkloadsByPackageRoot) {
     failures.push(`${rel}: use shared/wp-codebox/check-cli.sh instead of duplicating WP Codebox CLI discovery in rig commands`);
   }
 
+  lintSharedPaths(rel, rig);
+
   lintFuzzWorkloads(rel, file, rig, fuzzWorkloadsByPackageRoot);
   lintFuzzProfiles(rel, rig);
   lintBenchProfiles(rel, file, rig, fuzzWorkloadsByPackageRoot);
+}
+
+function lintSharedPaths(rel, rig) {
+  if (!rig.shared_paths) {
+    return;
+  }
+
+  if (!Array.isArray(rig.shared_paths)) {
+    failures.push(`${rel}: shared_paths must be an array`);
+    return;
+  }
+
+  rig.shared_paths.forEach((sharedPath, index) => {
+    if (!sharedPath || typeof sharedPath !== 'object' || Array.isArray(sharedPath)) {
+      failures.push(`${rel}: shared_paths[${index}] must be an object`);
+      return;
+    }
+
+    const link = typeof sharedPath.link === 'string' ? sharedPath.link.trim() : '';
+    const target = typeof sharedPath.target === 'string' ? sharedPath.target.trim() : '';
+
+    if (!link || !target) {
+      return;
+    }
+
+    if (link === target && sharedPath.allow_self_target !== true) {
+      failures.push(`${rel}: shared_paths[${index}] link and target must differ unless allow_self_target is true`);
+    }
+  });
 }
 
 function packageRootForRig(file) {

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -153,6 +153,48 @@ test('accepts registry-backed components with portable path settings', () => {
   assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
 });
 
+test('rejects shared paths where link and target are the same path', () => {
+  const directory = createRigPackage({
+    rig: {
+      shared_paths: [
+        {
+          link: '${components.product.path}/node_modules',
+          target: '${components.product.path}/node_modules',
+        },
+      ],
+    },
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+  });
+
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /shared_paths\[0\] link and target must differ unless allow_self_target is true/);
+});
+
+test('accepts explicitly allowed shared path self-targets', () => {
+  const directory = createRigPackage({
+    rig: {
+      shared_paths: [
+        {
+          link: '${components.product.path}/cache',
+          target: '${components.product.path}/cache',
+          allow_self_target: true,
+        },
+      ],
+    },
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+  });
+
+  const result = runLint(directory);
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+});
+
 test('rejects committed local Developer checkout paths in stacks', () => {
   const directory = createRigPackage({
     fuzzWorkloads: {


### PR DESCRIPTION
## Summary
- reject `shared_paths` entries whose `link` and `target` are identical unless `allow_self_target: true` is explicitly set
- update the isolated-block-editor rig to use a portable env-backed source target for borrowed `node_modules`
- document the IBE shared path target env var and add lint coverage for reject/allow cases

## Local verification
- `node --test scripts/lint-rig-packages.test.mjs`
- `HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR="$(pwd)/scripts/fixtures/shared-fuzz-validator.cjs" node scripts/lint-rig-packages.mjs`
- `homeboy rig install ./chubes4/isolated-block-editor --id isolated-block-editor --reinstall --force-hot --allow-local-hot`
- `HOMEBOY_RIG_COMPONENT_PATH__ISOLATED_BLOCK_EDITOR__ISOLATED_BLOCK_EDITOR=/Users/chubes/Developer/isolated-block-editor HOMEBOY_RIG_SHARED_PATH_TARGET__ISOLATED_BLOCK_EDITOR__NODE_MODULES=/Users/chubes/Developer/isolated-block-editor/node_modules homeboy rig check isolated-block-editor --force-hot --allow-local-hot --output ./rig-check-isolated-block-editor.json` reached Homeboy rig-package lint and then failed because this machine does not have the isolated-block-editor checkout or node_modules source target installed.

## GitHub Actions
- GitHub Actions were not invoked manually. Local verification above was used to avoid spending GHA rate-limited capacity.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting the lint hardening, IBE rig update, tests, local verification, commit, push, and PR description.