### PR TITLE
Canonicalize fuzz proof bundle refs

### DIFF
--- a/docs/fuzz-coverage-matrix.md
+++ b/docs/fuzz-coverage-matrix.md
@@ -29,11 +29,11 @@ uses `level: declared|executable|proven`, a `coverage_contract` string,
 optional `proof_refs`, optional `upstream_blockers`, optional CRUD operation
 levels for `create`, `read`, `update`, and `delete`, and optional mutation
 rollback fields (`safety_boundary`, `rollback_artifacts`). `level: proven`
-requires a `proof_bundle` with non-local `artifact_refs`, reviewer-facing
-`run_ids`, `gap_reports`, and `fuzz_result_artifacts` that name required case or
-expected artifacts. Product packages can use this shared shape to distinguish
-planned CRUD/mutation coverage from executable workloads and reviewer-facing
-proof artifacts.
+requires a `proof_bundle` with reviewer-facing `canonical_fuzz_envelope_ref` as
+the primary proof pointer, or legacy `artifact_refs`, `run_ids`, `gap_reports`,
+and `fuzz_result_artifacts` for manifests that have not yet migrated. Product
+packages can use this shared shape to distinguish planned CRUD/mutation coverage
+from executable workloads and reviewer-facing proof artifacts.
 
 The repo-wide package linter reports missing `metadata.readiness` on fuzz
 manifests as a warning. Use `node scripts/lint-rig-packages.mjs

--- a/scripts/fixtures/shared-fuzz-validator.cjs
+++ b/scripts/fixtures/shared-fuzz-validator.cjs
@@ -106,10 +106,10 @@ function assertFuzzReadinessMetadata(manifest, { file = manifest.id } = {}) {
     }
   }
   if (readiness.level === 'proven') {
-    if (!Array.isArray(readiness.proof_refs) || readiness.proof_refs.length === 0) {
-      throw new Error(`${file} proven readiness requires proof_refs`);
-    }
     assertFuzzProofBundle(readiness.proof_bundle, manifest, { file });
+    if (!hasCanonicalFuzzEnvelopeRef(readiness.proof_bundle) && (!Array.isArray(readiness.proof_refs) || readiness.proof_refs.length === 0)) {
+      throw new Error(`${file} proven readiness requires proof_refs unless proof_bundle.canonical_fuzz_envelope_ref is present`);
+    }
   }
   if (readiness.crud !== undefined) {
     assertFuzzCrudReadiness(readiness.crud, { file });
@@ -124,21 +124,26 @@ function assertFuzzProofBundle(proofBundle, manifest, { file = manifest.id } = {
   if (!proofBundle || typeof proofBundle !== 'object' || Array.isArray(proofBundle)) {
     throw new Error(`${file} proven readiness requires proof_bundle`);
   }
-  for (const field of ['artifact_refs', 'run_ids', 'gap_reports', 'fuzz_result_artifacts']) {
-    assertStringArray(proofBundle[field], `${file} metadata.readiness.proof_bundle.${field}`);
+  if (hasCanonicalFuzzEnvelopeRef(proofBundle)) {
+    assertReviewerFacingArtifactRef(proofBundle.canonical_fuzz_envelope_ref, `${file} metadata.readiness.proof_bundle.canonical_fuzz_envelope_ref`);
+  } else {
+    for (const field of ['artifact_refs', 'run_ids', 'gap_reports', 'fuzz_result_artifacts']) {
+      assertStringArray(proofBundle[field], `${file} metadata.readiness.proof_bundle.${field}`);
+    }
   }
   const requiredArtifactNames = new Set([
     ...(manifest.cases || []).flatMap((runnerCase) => runnerCase.artifacts || []),
     ...(manifest.artifacts?.expected || []),
   ].filter((artifact) => artifact?.required === true).map((artifact) => artifact.name));
-  for (const artifactName of proofBundle.fuzz_result_artifacts) {
+  for (const artifactName of proofBundle.fuzz_result_artifacts || []) {
     if (!requiredArtifactNames.has(artifactName)) {
       throw new Error(`${file} proof_bundle.fuzz_result_artifacts ${artifactName} must name a required case or expected artifact`);
     }
   }
-  if (proofBundle.canonical_fuzz_envelope_ref !== undefined) {
-    assertReviewerFacingArtifactRef(proofBundle.canonical_fuzz_envelope_ref, `${file} metadata.readiness.proof_bundle.canonical_fuzz_envelope_ref`);
-  }
+}
+
+function hasCanonicalFuzzEnvelopeRef(proofBundle) {
+  return typeof proofBundle?.canonical_fuzz_envelope_ref === 'string' && proofBundle.canonical_fuzz_envelope_ref.trim() !== '';
 }
 
 function assertFuzzCrudReadiness(crud, { file } = {}) {

--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -208,9 +208,13 @@ export function assertFuzzReadinessMetadata(manifest, { file = manifest.id } = {
 }
 
 export function assertFuzzProofBundle(proofBundle, manifest, { file } = {}) {
-  const result = loadGenericFuzzManifestValidator().assertFuzzProofBundle(proofBundle, manifest, { file });
-  assertCanonicalFuzzEnvelopeRef(proofBundle, { file: file || manifest.id });
-  return result;
+  if (proofBundle?.canonical_fuzz_envelope_ref !== undefined) {
+    assertCanonicalFuzzEnvelopeRef(proofBundle, { file: file || manifest.id });
+    assertOptionalFuzzResultArtifacts(proofBundle, manifest, { file: file || manifest.id });
+    return proofBundle;
+  }
+
+  return loadGenericFuzzManifestValidator().assertFuzzProofBundle(proofBundle, manifest, { file });
 }
 
 export function assertCanonicalFuzzEnvelopeRef(proofBundle, { file = 'fuzz workload' } = {}) {
@@ -257,6 +261,21 @@ function localOnlyRefValue(ref) {
     || /^\/private\//.test(ref)
     || /^\/tmp(?:\/|$)/.test(ref)
     || /^\.\.?(?:\/|$)/.test(ref);
+}
+
+function assertOptionalFuzzResultArtifacts(proofBundle, manifest, { file = manifest.id } = {}) {
+  if (proofBundle.fuzz_result_artifacts === undefined) {
+    return;
+  }
+
+  assertStringArray(proofBundle.fuzz_result_artifacts, `${file} metadata.readiness.proof_bundle.fuzz_result_artifacts`);
+  const requiredArtifactNames = new Set([
+    ...(manifest.cases || []).flatMap((runnerCase) => runnerCase.artifacts || []),
+    ...(manifest.artifacts?.expected || []),
+  ].filter((artifact) => artifact?.required === true).map((artifact) => artifact.name));
+  for (const artifactName of proofBundle.fuzz_result_artifacts) {
+    assert.ok(requiredArtifactNames.has(artifactName), `${file} proof_bundle.fuzz_result_artifacts ${artifactName} must name a required case or expected artifact`);
+  }
 }
 
 export function assertRequiredFuzzProofContracts(manifest, {

--- a/scripts/fuzz-manifest-helpers.test.mjs
+++ b/scripts/fuzz-manifest-helpers.test.mjs
@@ -248,13 +248,9 @@ test('assertGenericFuzzManifest can require readiness metadata', () => {
   );
 });
 
-test('assertFuzzProofBundle accepts a canonical fuzz envelope artifact ref alongside legacy refs', () => {
+test('assertFuzzProofBundle accepts a canonical fuzz envelope artifact ref as the primary proof pointer', () => {
   assert.ok(fuzzProofBundleFields.has('canonical_fuzz_envelope_ref'));
   assert.doesNotThrow(() => assertFuzzProofBundle({
-    artifact_refs: ['https://github.com/chubes4/homeboy-rigs/issues/254'],
-    run_ids: ['run:product-fuzz'],
-    gap_reports: ['https://github.com/chubes4/homeboy-rigs/issues/253'],
-    fuzz_result_artifacts: ['report'],
     canonical_fuzz_envelope_ref: 'homeboy-runs:product-fuzz/artifacts/fuzz-envelope.json',
   }, fuzzManifest(), { file: 'product-fuzz.json' }));
 });

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -384,6 +384,28 @@ test('rejects proven fuzz readiness without proof bundle linkage', () => {
   assert.match(result.stderr, /proven readiness requires proof_bundle/);
 });
 
+test('accepts proven fuzz readiness with canonical fuzz envelope proof linkage', () => {
+  const directory = createRigPackage({
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload({
+        metadata: {
+          kind: 'generic-fuzz',
+          readiness: {
+            level: 'proven',
+            coverage_contract: 'Generic fuzz coverage is proven.',
+            proof_bundle: {
+              canonical_fuzz_envelope_ref: 'homeboy://run/product-fuzz/artifact/fuzz-envelope',
+            },
+          },
+        },
+      }),
+    },
+  });
+  const result = runLint(directory);
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+});
+
 test('accepts package-root scoped lint for rigs and fuzz directories', () => {
   const directory = createRigPackage({
     fuzzWorkloads: {

--- a/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
+++ b/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
@@ -48,11 +48,7 @@
       "proof_bundle_requirements": {
         "status": "required_before_proven",
         "required_refs": [
-          "reviewer-facing wp-codebox fuzz-suite run id",
-          "reviewer-facing canonical fuzz envelope artifact ref",
-          "reviewer-facing wp-codebox/fuzz-suite-result artifact ref",
-          "reviewer-facing coverage gap report artifact ref",
-          "reviewer-facing performance hotspot summary artifact ref"
+          "reviewer-facing canonical fuzz envelope artifact ref"
         ],
         "required_artifacts": [
           "canonical_fuzz_envelope",
@@ -62,20 +58,8 @@
         ]
       },
       "proof_bundle": {
-        "artifact_refs": [
-          "artifact:pending/woocommerce-codebox-fuzz-suite-smoke/fuzz-suite-result.json"
-        ],
-        "run_ids": [
-          "run:pending-woocommerce-codebox-fuzz-suite-smoke"
-        ],
-        "gap_reports": [
-          "artifact:pending/woocommerce-codebox-fuzz-suite-smoke/coverage-gap-report.json"
-        ],
-        "fuzz_result_artifacts": [
-          "codebox_fuzz_suite_result"
-        ],
         "canonical_fuzz_envelope_ref": "homeboy://run/wc-db-api-codebox-suite-20260626T0145Z/artifact/cfa06657-0b23-447d-bd04-c75a7597f266",
-        "placeholder_reason": "Canonical fuzz envelope is backed by offloaded Homeboy Lab run wc-db-api-codebox-suite-20260626T0145Z; remaining proof refs stay pending until the coverage gap and performance hotspot artifacts have reviewer-facing refs."
+        "placeholder_reason": "Canonical fuzz envelope is backed by offloaded Homeboy Lab run wc-db-api-codebox-suite-20260626T0145Z; coverage gap and performance hotspot artifacts stay pending until they have reviewer-facing refs."
       }
     }
   },

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -220,5 +220,9 @@ test('DB/API campaign consumes the Codebox fixture canonical fuzz envelope ref',
     proofBundle.canonical_fuzz_envelope_ref,
     'homeboy://run/wc-db-api-codebox-suite-20260626T0145Z/artifact/cfa06657-0b23-447d-bd04-c75a7597f266'
   );
-  assert.match(proofBundle.placeholder_reason, /remaining proof refs stay pending/);
+  assert.equal(proofBundle.artifact_refs, undefined);
+  assert.equal(proofBundle.run_ids, undefined);
+  assert.equal(proofBundle.gap_reports, undefined);
+  assert.equal(proofBundle.fuzz_result_artifacts, undefined);
+  assert.match(proofBundle.placeholder_reason, /coverage gap and performance hotspot artifacts stay pending/);
 });


### PR DESCRIPTION
## Summary
- Make canonical_fuzz_envelope_ref the primary accepted fuzz proof bundle pointer in rigs helpers and shared validator fixture.
- Remove legacy pending proof refs from the already-migrated Woo Codebox fuzz-suite fixture while leaving legacy-only manifests unchanged.
- Update coverage docs and tests for canonical-first proof bundle behavior.

## Local verification
- node --test scripts/fuzz-manifest-helpers.test.mjs
- node --test scripts/lint-rig-packages.test.mjs
- node --test woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
- HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR="/Users/chubes/Developer/homeboy-rigs@cleanup-canonical-fuzz-proof-refs/scripts/fixtures/shared-fuzz-validator.cjs" node scripts/lint-rig-packages.mjs .

## GitHub Actions
- Not invoked manually. Local verification was used as the GHA rate-limit bypass for this PR.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inventorying fuzz proof refs, updating validators/manifests/tests/docs, and running local verification.