### PR TITLE
Harden fuzz proof evidence refs

### DIFF
--- a/scripts/fixtures/shared-fuzz-validator.cjs
+++ b/scripts/fixtures/shared-fuzz-validator.cjs
@@ -169,7 +169,7 @@ function assertReviewerFacingRef(value, context) {
   if (!/^(https:\/\/|gh:|homeboy-runs:|homeboy:\/\/run\/|artifact:|run:)/.test(value)) {
     throw new Error(`${context} entries must be reviewer-facing refs`);
   }
-  if (/^(https?:\/\/)?(localhost|127\.0\.0\.1)([:/]|$)/.test(value) || value.startsWith('/Users/')) {
+  if (localOnlyReviewerFacingRef(value)) {
     throw new Error(`${context} entries must not use local evidence`);
   }
 }
@@ -181,9 +181,31 @@ function assertReviewerFacingArtifactRef(value, context) {
   if (!/^(https:\/\/|gh:|homeboy-runs:|homeboy:\/\/run\/|homeboy-artifact:\/\/|artifact:|run:)/.test(value)) {
     throw new Error(`${context} must be a reviewer-facing artifact ref`);
   }
-  if (/^(https?:\/\/)?(localhost|127\.0\.0\.1)([:/]|$)/.test(value) || value.startsWith('/Users/')) {
+  if (localOnlyReviewerFacingRef(value)) {
     throw new Error(`${context} must not use local evidence`);
   }
+}
+
+function localOnlyReviewerFacingRef(value) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return false;
+  }
+  const ref = value.trim();
+  return localOnlyRefValue(ref) || localOnlySchemePayload(ref);
+}
+
+function localOnlySchemePayload(ref) {
+  const match = /^(?:artifact:|run:|homeboy-runs:|homeboy-artifact:\/\/)(.*)$/i.exec(ref);
+  return Boolean(match && localOnlyRefValue(match[1]));
+}
+
+function localOnlyRefValue(ref) {
+  return /^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::|\/|$)/i.test(ref)
+    || /^file:\/\//i.test(ref)
+    || /^\/Users\//.test(ref)
+    || /^\/private\//.test(ref)
+    || /^\/tmp(?:\/|$)/.test(ref)
+    || /^\.\.?(?:\/|$)/.test(ref);
 }
 
 function assertStringArray(value, label, options = {}) {

--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -232,9 +232,31 @@ function assertReviewerFacingFuzzRef(value, context) {
     `${context} must be a reviewer-facing artifact ref`
   );
   assert.ok(
-    !/^(https?:\/\/)?(localhost|127\.0\.0\.1)([:/]|$)/.test(value) && !value.startsWith('/Users/'),
+    !localOnlyReviewerFacingRef(value),
     `${context} must not use local evidence`
   );
+}
+
+function localOnlyReviewerFacingRef(value) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return false;
+  }
+  const ref = value.trim();
+  return localOnlyRefValue(ref) || localOnlySchemePayload(ref);
+}
+
+function localOnlySchemePayload(ref) {
+  const match = /^(?:artifact:|run:|homeboy-runs:|homeboy-artifact:\/\/)(.*)$/i.exec(ref);
+  return Boolean(match && localOnlyRefValue(match[1]));
+}
+
+function localOnlyRefValue(ref) {
+  return /^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::|\/|$)/i.test(ref)
+    || /^file:\/\//i.test(ref)
+    || /^\/Users\//.test(ref)
+    || /^\/private\//.test(ref)
+    || /^\/tmp(?:\/|$)/.test(ref)
+    || /^\.\.?(?:\/|$)/.test(ref);
 }
 
 export function assertRequiredFuzzProofContracts(manifest, {
@@ -365,8 +387,7 @@ function assertReviewerFacingRef(value, context) {
     /^(https:\/\/|gh:|homeboy-runs:|artifact:|run:)/.test(value),
     `${context} entries must be reviewer-facing refs`
   );
-  assert.ok(!/^(https?:\/\/)?(localhost|127\.0\.0\.1)([:/]|$)/.test(value), `${context} entries must not use local URLs`);
-  assert.ok(!value.startsWith('/Users/'), `${context} entries must not use local filesystem paths`);
+  assert.ok(!localOnlyReviewerFacingRef(value), `${context} entries must not use local evidence`);
 }
 
 export function assertFuzzCrudReadiness(crud, { file } = {}) {

--- a/scripts/fuzz-manifest-helpers.test.mjs
+++ b/scripts/fuzz-manifest-helpers.test.mjs
@@ -270,14 +270,28 @@ test('assertFuzzProofBundle accepts Homeboy run artifact refs for canonical fuzz
 });
 
 test('assertFuzzProofBundle rejects local canonical fuzz envelope artifact refs', () => {
-  assert.throws(
-    () => assertFuzzProofBundle({
-      artifact_refs: ['https://github.com/chubes4/homeboy-rigs/issues/254'],
-      run_ids: ['run:product-fuzz'],
-      gap_reports: ['https://github.com/chubes4/homeboy-rigs/issues/253'],
-      fuzz_result_artifacts: ['report'],
-      canonical_fuzz_envelope_ref: 'https://localhost:8881/fuzz-envelope.json',
-    }, fuzzManifest(), { file: 'product-fuzz.json' }),
-    /canonical_fuzz_envelope_ref must not use local evidence/
-  );
+  for (const localRef of [
+    'https://localhost:8881/fuzz-envelope.json',
+    'https://127.0.0.1:8881/fuzz-envelope.json',
+    'https://0.0.0.0:8881/fuzz-envelope.json',
+    'file:///tmp/fuzz-envelope.json',
+    '/tmp/fuzz-envelope.json',
+    '/Users/chris/fuzz-envelope.json',
+    './fuzz-envelope.json',
+    '../fuzz-envelope.json',
+    'homeboy-artifact:///tmp/fuzz-envelope.json',
+    'artifact:./fuzz-envelope.json',
+  ]) {
+    assert.throws(
+      () => assertFuzzProofBundle({
+        artifact_refs: ['https://github.com/chubes4/homeboy-rigs/issues/254'],
+        run_ids: ['run:product-fuzz'],
+        gap_reports: ['https://github.com/chubes4/homeboy-rigs/issues/253'],
+        fuzz_result_artifacts: ['report'],
+        canonical_fuzz_envelope_ref: localRef,
+      }, fuzzManifest(), { file: 'product-fuzz.json' }),
+      /canonical_fuzz_envelope_ref (must not use local evidence|must be a reviewer-facing artifact ref)/,
+      `${localRef} should be rejected`
+    );
+  }
 });


### PR DESCRIPTION
## Summary
- Harden homeboy-rigs fuzz proof metadata validation for reviewer-facing refs.
- Keep product/fuzz readiness proof policy in homeboy-rigs while rejecting local-only paths and local hosts.
- Cover canonical fuzz envelope refs for localhost/127.0.0.1/0.0.0.0, file://, /tmp, /Users, relative paths, and local payloads inside artifact schemes.

## Local verification
- `node --test scripts/fuzz-manifest-helpers.test.mjs`
- `node --test scripts/lint-rig-packages.test.mjs`
- `node --test scripts/fuzz-manifest-helpers.test.mjs scripts/lint-rig-packages.test.mjs`

## GitHub Actions
- Not invoked per task instruction. Local verification is documented here as the GHA rate-limit bypass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing fuzz proof ref hardening, focused tests, local verification, and PR preparation.
