### PR TITLE
Gate SSI fixture matrix on fixture failures

### DIFF
--- a/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
@@ -20,7 +20,10 @@
   },
   "bench": {
     "default_component": "static-site-importer",
-    "warmup_iterations": 0
+    "warmup_iterations": 0,
+    "result_gates": {
+      "failed_fixture_count": { "lte": 0 }
+    }
   },
   "bench_workloads": {
     "nodejs": [


### PR DESCRIPTION
## Summary
- declares the Static Site Importer fixture matrix result gate against Homeboy's generic bench result gate contract
- fails matrix fanout when `failed_fixture_count > 0` while keeping SSI fixture semantics in homeboy-rigs

Pairs with Extra-Chill/homeboy#6613 and closes Extra-Chill/homeboy#6606.

## Tests
- `node "WordPress/static-site-importer/tools/fixture-matrix.test.mjs"`
- `node "scripts/lint-rig-packages.test.mjs"`
- `node "scripts/fuzz-manifest-helpers.test.mjs"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** metadata update, targeted test selection, PR drafting
