### PR TITLE
Improve SSI fixture matrix diagnostic rollups

### DIFF
--- a/WordPress/static-site-importer/lib/fixture-matrix.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix.mjs
@@ -190,10 +190,20 @@ export function normalizeFixtureMatrixResult(input = {}) {
       not_run: fixtureResults.filter((result) => result.status === 'not_run').length,
       finding_count: findings.length,
       groups: Object.fromEntries(Object.entries(grouped).map(([key, items]) => [key, items.length])),
+      top_pattern_families: topPatternFamilies(findings),
+      fixture_exemplars: fixtureExemplars(findings),
+      diagnostic_blind_spots: diagnosticBlindSpots(findings),
     },
     fixtures: fixtureResults,
     findings,
-    fanout_groups: Object.entries(grouped).map(([group_key, items], index) => ({ group_key, index, findings: items })),
+    fanout_groups: Object.entries(grouped).map(([group_key, items], index) => ({
+      group_key,
+      index,
+      count: items.length,
+      top_pattern_families: topPatternFamilies(items, 5),
+      fixture_exemplars: fixtureExemplars(items, 5),
+      findings: items,
+    })),
   };
 }
 
@@ -253,7 +263,7 @@ export function writeFixtureMatrixResultArtifacts(input = {}) {
 }
 
 export function classifyStaticSiteFinding(input = {}) {
-  const haystack = [input.kind, input.code, input.category, input.message, input.reason, input.detail]
+  const haystack = [input.kind, input.type, input.code, input.category, input.repair_bucket, input.group_key, input.message, input.reason, input.detail]
     .filter(Boolean)
     .join(' ');
   for (const [group_key, group] of Object.entries(DEFAULT_FINDING_GROUPS)) {
@@ -282,19 +292,33 @@ function findingsForFixtureResult(result, context = {}) {
 
 function normalizeDiagnosticFinding(diagnostic, result, index) {
   const raw = diagnostic && typeof diagnostic === 'object' ? diagnostic : { message: String(diagnostic || '') };
-  const message = raw.message || raw.reason || raw.detail || raw.code || result.error || '';
+  const rawSource = objectValue(raw.source);
+  const rawObserved = objectValue(raw.observed);
+  const rawExpected = objectValue(raw.expected);
+  const rawReproduction = objectValue(raw.reproduction_context || raw.reproductionContext);
+  const message = raw.message || raw.reason || raw.detail || rawObserved.reason_code || rawExpected.outcome || raw.code || result.error || '';
   const group = classifyStaticSiteFinding({ ...raw, message });
+  const kind = raw.kind || raw.code || raw.type || rawObserved.reason_code || 'static_site_fixture_diagnostic';
+  const selector = raw.selector || rawSource.selector || rawReproduction.selector || '';
+  const sourcePath = raw.source_path || raw.path || rawSource.path || rawReproduction.source_path || result.fixture_path || '';
+  const repairBucket = raw.repair_bucket || group.group_key;
   return {
     id: raw.id || `${result.fixture_id || 'fixture'}:${group.group_key}:${index + 1}`,
-    kind: raw.kind || raw.code || 'static_site_fixture_diagnostic',
+    kind,
     category: raw.category || group.group_key,
     group_key: group.group_key,
+    repair_bucket: repairBucket,
     severity: raw.severity || (result.status === 'failed' ? 'error' : 'warning'),
     fixture_id: result.fixture_id || '',
-    path: raw.path || raw.source_path || result.fixture_path || '',
-    source_path: raw.source_path || raw.path || result.fixture_path || '',
-    selector: raw.selector || '',
+    path: sourcePath,
+    source_path: sourcePath,
+    selector,
+    selector_family: selectorFamily(selector),
+    pattern_family: patternFamily({ ...raw, kind, group_key: group.group_key, repair_bucket: repairBucket, selector }),
     reason: message,
+    source_snippet: raw.source_html_preview || raw.html_excerpt || rawSource.snippet || '',
+    observed_output: raw.emitted_block_preview || rawObserved.output || '',
+    observed_block_name: raw.block_name || rawObserved.block_name || '',
     repair_mode: raw.repair_mode || group.repair_mode,
     candidate_repo: raw.candidate_repo || group.candidate_repo,
     artifact_refs: normalizeArray(raw.artifact_refs),
@@ -378,6 +402,7 @@ function collectFixtureDiagnostics(payload) {
     ...normalizeArray(payload.diagnostics),
     ...normalizeArray(payload.fixture_diagnostics?.diagnostics || payload.fixtureDiagnostics?.diagnostics),
     ...normalizeArray(payload.findings),
+    ...collectFindingPacketDiagnostics(payload),
     ...normalizeArray(payload.messages),
     ...normalizeArray(payload.errors),
     ...normalizeArray(payload.warnings),
@@ -391,6 +416,139 @@ function collectFixtureDiagnostics(payload) {
     diagnostics.push({ kind: 'invalid_block_content', message: `${invalidBlockCount} invalid block${invalidBlockCount === 1 ? '' : 's'} reported by SSI validation.` });
   }
   return dedupeDiagnostics(diagnostics);
+}
+
+function collectFindingPacketDiagnostics(payload) {
+  return [
+    ...normalizeArray(payload.finding_packets?.packets || payload.findingPackets?.packets),
+    ...normalizeArray(payload.import_report?.finding_packets?.packets || payload.importReport?.finding_packets?.packets),
+    ...normalizeArray(payload.report?.finding_packets?.packets),
+  ];
+}
+
+function topPatternFamilies(findings, limit = 10) {
+  const families = new Map();
+  for (const finding of findings) {
+    const key = finding.pattern_family || patternFamily(finding);
+    const row = families.get(key) || {
+      key,
+      count: 0,
+      repair_bucket: finding.repair_bucket || finding.group_key || '',
+      kind: finding.kind || '',
+      candidate_repo: finding.candidate_repo || '',
+      fixture_ids: [],
+      selectors: [],
+      exemplars: [],
+    };
+    row.count += 1;
+    pushUnique(row.fixture_ids, finding.fixture_id, 5);
+    pushUnique(row.selectors, finding.selector, 5);
+    if (row.exemplars.length < 3) {
+      row.exemplars.push(fixtureExemplar(finding));
+    }
+    families.set(key, row);
+  }
+  return [...families.values()]
+    .sort((left, right) => right.count - left.count || left.key.localeCompare(right.key))
+    .slice(0, limit);
+}
+
+function fixtureExemplars(findings, limit = 10) {
+  const exemplars = [];
+  const seen = new Set();
+  for (const finding of findings) {
+    const exemplar = fixtureExemplar(finding);
+    const key = [exemplar.pattern_family, exemplar.fixture_id, exemplar.selector, exemplar.source_path].join('\u0000');
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    exemplars.push(exemplar);
+    if (exemplars.length >= limit) {
+      break;
+    }
+  }
+  return exemplars;
+}
+
+function fixtureExemplar(finding) {
+  return compactObject({
+    fixture_id: finding.fixture_id,
+    pattern_family: finding.pattern_family || patternFamily(finding),
+    repair_bucket: finding.repair_bucket || finding.group_key,
+    kind: finding.kind,
+    candidate_repo: finding.candidate_repo,
+    source_path: finding.source_path || finding.path,
+    selector: finding.selector,
+    selector_family: finding.selector_family || selectorFamily(finding.selector),
+    reason: finding.reason,
+    source_snippet: finding.source_snippet,
+    observed_block_name: finding.observed_block_name,
+    observed_output: finding.observed_output,
+  });
+}
+
+function diagnosticBlindSpots(findings) {
+  const spots = [];
+  const genericFindings = findings.filter((finding) => isGenericFinding(finding));
+  const missingSourceContext = findings.filter((finding) => !finding.selector && !finding.source_snippet && !finding.observed_output);
+  if (genericFindings.length > 0) {
+    spots.push(blindSpot('generic_finding_family', genericFindings, 'Findings need a specific type, repair bucket, or reason code before fanout.'));
+  }
+  if (missingSourceContext.length > 0) {
+    spots.push(blindSpot('missing_source_context', missingSourceContext, 'Findings need selector, source snippet, or observed block output for direct transformer repair.'));
+  }
+  return spots;
+}
+
+function blindSpot(kind, findings, recommendation) {
+  return {
+    kind,
+    count: findings.length,
+    recommendation,
+    exemplars: fixtureExemplars(findings, 5),
+  };
+}
+
+function isGenericFinding(finding) {
+  return ['static_site_fixture_diagnostic', 'import_diagnostic', 'diagnostic'].includes(finding.kind)
+    || ['static_site_import_quality'].includes(finding.group_key)
+    || !finding.reason;
+}
+
+function patternFamily(finding) {
+  return [
+    finding.repair_bucket || finding.group_key || 'static_site_import_quality',
+    finding.kind || 'diagnostic',
+    selectorFamily(finding.selector),
+  ].join(':');
+}
+
+function selectorFamily(selector) {
+  const value = String(selector || '').trim();
+  if (!value) {
+    return '(none)';
+  }
+
+  const firstToken = value.split(/\s+|\s*[>+~]\s*/).find(Boolean) || value;
+  if (firstToken.startsWith('#')) {
+    return `id:${firstToken.slice(1).split(/[:.#[\]]/)[0] || '(unknown)'}`;
+  }
+  if (firstToken.startsWith('.')) {
+    return `class:${firstToken.slice(1).split(/[:.#[\]]/)[0] || '(unknown)'}`;
+  }
+  if (firstToken.startsWith('[')) {
+    return `attr:${firstToken.slice(1).split(/[=\]]/)[0] || '(unknown)'}`;
+  }
+
+  return firstToken.split(/[:.#[\]]/)[0] || firstToken;
+}
+
+function pushUnique(values, value, limit) {
+  if (!value || values.includes(value) || values.length >= limit) {
+    return;
+  }
+  values.push(value);
 }
 
 function dedupeDiagnostics(diagnostics) {

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -11,6 +11,7 @@ import {
 import {
   buildFixtureMatrixRunPlan,
   CANONICAL_FIXTURE_COUNT,
+  summarizeRun,
 } from './run-fixture-matrix.mjs';
 import {
   compareFindingPackets,
@@ -19,6 +20,7 @@ import {
 import {
   buildFixtureMatrixRecipe,
   classifyStaticSiteFinding,
+  collectFixtureMatrixRunResults,
   createFixtureMatrix,
   normalizeFixtureMatrixResult,
   writeFixtureMatrixArtifacts,
@@ -84,6 +86,79 @@ test('normalizes SSI diagnostics into product repair groups', () => {
   assert.equal(result.summary.groups.dropped_images, 1);
   assert.equal(result.summary.groups.invalid_block_content, 1);
   assert.equal(classifyStaticSiteFinding({ message: 'canvas target missing' }).repair_mode, 'runtime-dom-target-parity');
+});
+
+test('aggregates pattern families, fixture exemplars, and diagnostic blind spots', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'diagnostic-rollup-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'runtime_dependency_missing_dom_target',
+            repair_bucket: 'runtime_target_gap',
+            candidate_repo: 'blocks-engine',
+            source_path: 'website/index.html',
+            selector: '#hero canvas',
+            source_html_preview: '<canvas id="hero"></canvas>',
+            emitted_block_preview: '<!-- wp:group -->',
+            message: 'Runtime target #hero canvas is missing after import.',
+          },
+          { message: 'Unclassified import quality issue.' },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(result.summary.top_pattern_families[0].key, 'runtime_target_gap:runtime_dependency_missing_dom_target:id:hero');
+  assert.equal(result.summary.fixture_exemplars[0].fixture_id, 'simple-site');
+  assert.equal(result.summary.fixture_exemplars[0].source_snippet, '<canvas id="hero"></canvas>');
+  assert.equal(result.fanout_groups[0].count, 1);
+  assert.ok(result.summary.diagnostic_blind_spots.some((spot) => spot.kind === 'generic_finding_family'));
+});
+
+test('collects SSI finding packet source and observed context from fixture artifacts', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-finding-packet-context-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'packet-context-test' });
+  const fixtureDirectory = path.join(outputDirectory, 'simple-site');
+  mkdirSync(fixtureDirectory, { recursive: true });
+  writeFileSync(path.join(fixtureDirectory, 'import-report.json'), JSON.stringify({
+    success: false,
+    fixture_id: 'simple-site',
+    finding_packets: {
+      packets: [
+        {
+          type: 'runtime_dependency_missing_dom_target',
+          severity: 'error',
+          source: {
+            path: 'website/index.html',
+            selector: '.shader canvas',
+            snippet: '<canvas class="shader"></canvas>',
+          },
+          observed: {
+            reason_code: 'runtime_dependency_missing_dom_target',
+            output: '<!-- wp:html /-->',
+          },
+          expected: {
+            outcome: 'Runtime target should exist after import.',
+          },
+        },
+      ],
+    },
+  }));
+
+  const result = collectFixtureMatrixRunResults({ matrix, outputDirectory });
+  const finding = result.findings[0];
+
+  assert.equal(result.summary.finding_count, 1);
+  assert.equal(finding.source_path, 'website/index.html');
+  assert.equal(finding.selector, '.shader canvas');
+  assert.equal(finding.selector_family, 'class:shader');
+  assert.equal(finding.source_snippet, '<canvas class="shader"></canvas>');
+  assert.equal(finding.observed_output, '<!-- wp:html /-->');
 });
 
 test('materializes generated artifact roots into matrix-compatible fixtures', () => {
@@ -189,6 +264,40 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   });
   assert.deepEqual(releasePlan.dependency_overrides, {});
   assert.equal(releasePlan.steps.at(-1).args.some((arg) => arg.includes('SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH')), false);
+});
+
+test('operator summary preserves matrix rollups for fanout agents', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-operator-summary-'));
+  const outputFile = path.join(root, 'homeboy-bench.json');
+  writeFileSync(outputFile, JSON.stringify({
+    run_id: 'ssi-matrix-rollup-proof',
+    result_summary: {
+      failed: 71,
+      finding_count: 1126,
+      groups: { runtime_target_gap: 806 },
+      top_pattern_families: [
+        { key: 'runtime_target_gap:runtime_dependency_missing_dom_target:canvas', count: 312, fixture_ids: ['shader-site'] },
+      ],
+      fixture_exemplars: [
+        { fixture_id: 'shader-site', selector: 'canvas', reason: 'Runtime target missing.' },
+      ],
+      diagnostic_blind_spots: [
+        { kind: 'missing_source_context', count: 12 },
+      ],
+    },
+  }));
+
+  const summary = summarizeRun({
+    mode: 'development-override',
+    run_id: 'planned-run',
+    fixture_count: 71,
+    output_file: outputFile,
+  });
+
+  assert.equal(summary.run_id, 'ssi-matrix-rollup-proof');
+  assert.equal(summary.top_pattern_families[0].count, 312);
+  assert.equal(summary.fixture_exemplars[0].fixture_id, 'shader-site');
+  assert.equal(summary.diagnostic_blind_spots[0].kind, 'missing_source_context');
 });
 
 test('compares finding packet deltas by repair dimensions', () => {

--- a/WordPress/static-site-importer/tools/run-fixture-matrix.mjs
+++ b/WordPress/static-site-importer/tools/run-fixture-matrix.mjs
@@ -182,7 +182,7 @@ function runCommand(step) {
   }
 }
 
-function summarizeRun(plan) {
+export function summarizeRun(plan) {
   const output = readJson(plan.output_file);
   const resultSummary = findFirstKey(output, 'result_summary') || {};
   const artifacts = findFirstKey(output, 'artifacts') || findFirstKey(output, 'artifact_refs') || {};
@@ -196,6 +196,9 @@ function summarizeRun(plan) {
     finding_count: Number(resultSummary.finding_count || 0),
     top_buckets: topObjectCounts(resultSummary.buckets || resultSummary.groups || {}),
     top_kinds: topObjectCounts(resultSummary.kinds || {}),
+    top_pattern_families: normalizeSummaryRows(resultSummary.top_pattern_families),
+    fixture_exemplars: normalizeSummaryRows(resultSummary.fixture_exemplars),
+    diagnostic_blind_spots: normalizeSummaryRows(resultSummary.diagnostic_blind_spots),
     artifact_urls: collectArtifactUrls(artifacts),
     output_file: plan.output_file,
   };
@@ -279,6 +282,10 @@ function topObjectCounts(value, limit = 10) {
     .filter((row) => Number.isFinite(row.count))
     .sort((a, b) => b.count - a.count || a.key.localeCompare(b.key))
     .slice(0, limit);
+}
+
+function normalizeSummaryRows(value, limit = 10) {
+  return Array.isArray(value) ? value.slice(0, limit) : [];
 }
 
 function collectArtifactUrls(value) {


### PR DESCRIPTION
## Summary
- Ingest SSI finding packet artifacts into the fixture matrix diagnostics path so source/observed context reaches fanout artifacts.
- Add top pattern families, fixture exemplars, and diagnostic blind spot rollups to matrix result, fanout groups, and operator summary output.
- Cover rollup shape, SSI packet context preservation, and operator summary propagation with targeted Node tests.

## Tests
- ✔ discovers SSI fixtures and writes Blocks Engine site artifacts (6.786875ms)
✔ builds a generic WP Codebox recipe with SSI-owned plugin defaults (0.865667ms)
✔ normalizes SSI diagnostics into product repair groups (0.377167ms)
✔ aggregates pattern families, fixture exemplars, and diagnostic blind spots (0.27225ms)
✔ collects SSI finding packet source and observed context from fixture artifacts (1.241709ms)
✔ materializes generated artifact roots into matrix-compatible fixtures (1.916667ms)
✔ resolves Blocks Engine PHP transformer override paths (0.620583ms)
✔ builds Composer path repository override matching SSI constraints (0.108875ms)
✔ builds one-command canonical Blocks Engine fixture matrix plan (5.000791ms)
✔ operator summary preserves matrix rollups for fanout agents (0.584084ms)
✔ compares finding packet deltas by repair dimensions (0.26125ms)
ℹ tests 11
ℹ suites 0
ℹ pass 11
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 50.898291
- 

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Code investigation, implementation, tests, and PR description drafting.
