### PR TITLE
Improve WordPress helper portability

### DIFF
--- a/WordPress/gutenberg/bench/pattern-preview-assets.trace.mjs
+++ b/WordPress/gutenberg/bench/pattern-preview-assets.trace.mjs
@@ -2,10 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { createRequire } from 'node:module';
-
-const require = createRequire( import.meta.url );
-const { runWpCodeboxRecipe } = require( 'homeboy-extension-wordpress/wp-codebox-recipe-helper' );
+import { runWpCodeboxRecipe } from '../../../shared/wp-codebox/recipe.mjs';
 
 const componentPath = process.env.HOMEBOY_COMPONENT_PATH;
 const componentId = process.env.HOMEBOY_COMPONENT_ID || 'gutenberg';

--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -1,9 +1,7 @@
 import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
-import { createRequire } from 'node:module';
 import path from 'node:path';
-
-const require = createRequire(import.meta.url);
+import { loadWordPressHelperModule } from '../shared/wordpress-helper-loader.mjs';
 
 export const fuzzReadinessLevels = new Set(['declared', 'executable', 'proven']);
 export const fuzzCrudOperations = new Set(['create', 'read', 'update', 'delete']);
@@ -24,23 +22,12 @@ export const wooRequiredFuzzProofContracts = new Map([
 ]);
 
 function loadGenericFuzzManifestValidator() {
-  const explicit = process.env.HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR;
-  if (explicit) {
-    return require(explicit);
-  }
-
-  const manifestPath = process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST;
-  if (manifestPath) {
-    const manifestModule = require(manifestPath);
-    const manifest = typeof manifestModule.getWordPressHelperManifest === 'function'
-      ? manifestModule.getWordPressHelperManifest()
-      : manifestModule.WORDPRESS_HELPER_MANIFEST;
-    if (manifest?.extensionRoot) {
-      return require(path.join(manifest.extensionRoot, 'lib', 'wordpress-fuzz-manifest-validator.js'));
-    }
-  }
-
-  return require('homeboy-extension-wordpress/wordpress-fuzz-manifest-validator');
+  return loadWordPressHelperModule({
+    helperName: 'wordpress-fuzz-manifest-validator',
+    envVar: 'HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR',
+    manifestFileName: 'wordpress-fuzz-manifest-validator.js',
+    packageImport: 'homeboy-extension-wordpress/wordpress-fuzz-manifest-validator',
+  });
 }
 
 export function readJson(root, ...parts) {

--- a/shared/wordpress-helper-loader.mjs
+++ b/shared/wordpress-helper-loader.mjs
@@ -1,0 +1,88 @@
+import { createRequire } from 'node:module';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+const bootstrapCommand = 'homeboy extension setup wordpress';
+
+function helperDiagnostic({ helperName, envVar, packageImport }) {
+  const envLines = [
+    `HOMEBOY_WORDPRESS_HELPER_MANIFEST=/path/to/homeboy-extension-wordpress/lib/helper-manifest.js`,
+    `HOMEBOY_WORDPRESS_EXTENSION_ROOT=/path/to/homeboy-extension-wordpress`,
+  ];
+
+  if (envVar) {
+    envLines.push(`${envVar}=/path/to/${helperName}.js`);
+  }
+
+  return [
+    `Homeboy WordPress helper "${helperName}" is unavailable.`,
+    packageImport ? `Missing fallback package import: ${packageImport}` : '',
+    `Run ${bootstrapCommand}, then export one of:`,
+    ...envLines.map((line) => `  ${line}`),
+  ].filter(Boolean).join('\n');
+}
+
+function requireHelper(filePath, context) {
+  try {
+    return require(filePath);
+  } catch (error) {
+    error.message = `${context}: ${error.message}`;
+    throw error;
+  }
+}
+
+function loadHelperManifest(manifestPath) {
+  const manifestModule = requireHelper(manifestPath, `Failed to load HOMEBOY_WORDPRESS_HELPER_MANIFEST at ${manifestPath}`);
+  return typeof manifestModule.getWordPressHelperManifest === 'function'
+    ? manifestModule.getWordPressHelperManifest()
+    : manifestModule.WORDPRESS_HELPER_MANIFEST;
+}
+
+function defaultHelperManifestPath() {
+  const extensionRoot = process.env.HOMEBOY_WORDPRESS_EXTENSION_ROOT;
+  if (extensionRoot) {
+    return path.join(extensionRoot, 'lib', 'helper-manifest.js');
+  }
+
+  const home = process.env.HOME;
+  if (!home) {
+    return '';
+  }
+
+  const installedManifest = path.join(home, '.config', 'homeboy', 'extensions', 'wordpress', 'lib', 'helper-manifest.js');
+  return existsSync(installedManifest) ? installedManifest : '';
+}
+
+export function loadWordPressHelperModule({ helperName, envVar, manifestFileName, packageImport }) {
+  const explicit = envVar ? process.env[envVar] : '';
+  if (explicit) {
+    return requireHelper(explicit, `Failed to load ${envVar} at ${explicit}`);
+  }
+
+  const manifestPath = process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST || defaultHelperManifestPath();
+  if (manifestPath) {
+    const manifest = loadHelperManifest(manifestPath);
+    if (manifest?.extensionRoot) {
+      return requireHelper(
+        path.join(manifest.extensionRoot, 'lib', manifestFileName),
+        `Failed to load ${helperName} from HOMEBOY_WORDPRESS_HELPER_MANIFEST`
+      );
+    }
+  }
+
+  if (packageImport) {
+    try {
+      return require(packageImport);
+    } catch (error) {
+      if (error?.code !== 'MODULE_NOT_FOUND' || !String(error.message).includes(packageImport)) {
+        throw error;
+      }
+    }
+  }
+
+  throw new Error(helperDiagnostic({ helperName, envVar, packageImport }));
+}
+
+export { bootstrapCommand as wordpressHelperBootstrapCommand };

--- a/shared/wordpress-helper-loader.test.mjs
+++ b/shared/wordpress-helper-loader.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { loadWordPressHelperModule } from './wordpress-helper-loader.mjs';
+
+function withEnv(env, callback) {
+  const previous = Object.fromEntries(Object.keys(env).map((key) => [key, process.env[key]]));
+  try {
+    for (const [key, value] of Object.entries(env)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    return callback();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+test('WordPress helper loader reports actionable setup when fallback package is unavailable', () => {
+  const isolatedHome = path.join(tmpdir(), 'wordpress-helper-loader-missing-home');
+
+  assert.throws(
+    () => withEnv({
+      HOME: isolatedHome,
+      HOMEBOY_WORDPRESS_HELPER_MANIFEST: undefined,
+      HOMEBOY_WORDPRESS_EXTENSION_ROOT: undefined,
+      HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: undefined,
+    }, () => loadWordPressHelperModule({
+      helperName: 'wordpress-fuzz-manifest-validator',
+      envVar: 'HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR',
+      manifestFileName: 'wordpress-fuzz-manifest-validator.js',
+      packageImport: 'homeboy-extension-wordpress/wordpress-fuzz-manifest-validator',
+    })),
+    /homeboy extension setup wordpress[\s\S]*HOMEBOY_WORDPRESS_HELPER_MANIFEST[\s\S]*HOMEBOY_WORDPRESS_EXTENSION_ROOT[\s\S]*HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR/
+  );
+});
+
+test('WordPress helper loader resolves helpers through the manifest contract', async () => {
+  const extensionRoot = await mkdtemp(path.join(tmpdir(), 'wordpress-helper-extension-'));
+  const libRoot = path.join(extensionRoot, 'lib');
+  const manifestPath = path.join(libRoot, 'helper-manifest.js');
+  const helperPath = path.join(libRoot, 'example-helper.js');
+
+  await mkdir(libRoot, { recursive: true });
+  await writeFile(helperPath, `module.exports = { loaded: true };\n`, 'utf8');
+  await writeFile(manifestPath, `
+const path = require('node:path');
+function getWordPressHelperManifest() {
+  return { extensionRoot: path.resolve(__dirname, '..') };
+}
+module.exports = { getWordPressHelperManifest };
+`, 'utf8');
+
+  const helper = withEnv({
+    HOMEBOY_WORDPRESS_HELPER_MANIFEST: manifestPath,
+    HOMEBOY_WORDPRESS_EXTENSION_ROOT: undefined,
+    HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: undefined,
+  }, () => loadWordPressHelperModule({
+    helperName: 'example-helper',
+    envVar: 'HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR',
+    manifestFileName: 'example-helper.js',
+    packageImport: 'homeboy-extension-wordpress/example-helper',
+  }));
+
+  assert.equal(helper.loaded, true);
+});

--- a/shared/wp-codebox/artifacts.mjs
+++ b/shared/wp-codebox/artifacts.mjs
@@ -1,26 +1,12 @@
-import { createRequire } from 'node:module';
-import path from 'node:path';
-
-const require = createRequire(import.meta.url);
+import { loadWordPressHelperModule } from '../wordpress-helper-loader.mjs';
 
 function loadArtifactHelper() {
-  const explicit = process.env.HOMEBOY_WP_CODEBOX_ARTIFACT_HELPER;
-  if (explicit) {
-    return require(explicit);
-  }
-
-  const manifestPath = process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST;
-  if (manifestPath) {
-    const manifestModule = require(manifestPath);
-    const manifest = typeof manifestModule.getWordPressHelperManifest === 'function'
-      ? manifestModule.getWordPressHelperManifest()
-      : manifestModule.WORDPRESS_HELPER_MANIFEST;
-    if (manifest?.extensionRoot) {
-      return require(path.join(manifest.extensionRoot, 'lib', 'wp-codebox-artifacts.js'));
-    }
-  }
-
-  return require('homeboy-extension-wordpress/wp-codebox-artifacts');
+  return loadWordPressHelperModule({
+    helperName: 'wp-codebox-artifacts',
+    envVar: 'HOMEBOY_WP_CODEBOX_ARTIFACT_HELPER',
+    manifestFileName: 'wp-codebox-artifacts.js',
+    packageImport: 'homeboy-extension-wordpress/wp-codebox-artifacts',
+  });
 }
 
 export function wpCodeboxArtifactPath(output, relativePath) {

--- a/shared/wp-codebox/browser-coverage-trace.mjs
+++ b/shared/wp-codebox/browser-coverage-trace.mjs
@@ -1,26 +1,12 @@
-import { createRequire } from 'node:module';
-import path from 'node:path';
-
-const require = createRequire( import.meta.url );
+import { loadWordPressHelperModule } from '../wordpress-helper-loader.mjs';
 
 function loadBrowserCoverageHelper() {
-	const explicit = process.env.HOMEBOY_WP_CODEBOX_BROWSER_COVERAGE_HELPER;
-	if ( explicit ) {
-		return require( explicit );
-	}
-
-	const manifestPath = process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST;
-	if ( manifestPath ) {
-		const manifestModule = require( manifestPath );
-		const manifest = typeof manifestModule.getWordPressHelperManifest === 'function'
-			? manifestModule.getWordPressHelperManifest()
-			: manifestModule.WORDPRESS_HELPER_MANIFEST;
-		if ( manifest?.extensionRoot ) {
-			return require( path.join( manifest.extensionRoot, 'lib', 'wp-codebox-browser-coverage.js' ) );
-		}
-	}
-
-	return require( 'homeboy-extension-wordpress/wp-codebox-browser-coverage' );
+	return loadWordPressHelperModule( {
+		helperName: 'wp-codebox-browser-coverage',
+		envVar: 'HOMEBOY_WP_CODEBOX_BROWSER_COVERAGE_HELPER',
+		manifestFileName: 'wp-codebox-browser-coverage.js',
+		packageImport: 'homeboy-extension-wordpress/wp-codebox-browser-coverage',
+	} );
 }
 
 export async function runBrowserCoverageTrace( config ) {

--- a/shared/wp-codebox/recipe.mjs
+++ b/shared/wp-codebox/recipe.mjs
@@ -1,26 +1,12 @@
-import { createRequire } from 'node:module';
-import path from 'node:path';
-
-const require = createRequire(import.meta.url);
+import { loadWordPressHelperModule } from '../wordpress-helper-loader.mjs';
 
 function loadRecipeHelper() {
-  const explicit = process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
-  if (explicit) {
-    return require(explicit);
-  }
-
-  const manifestPath = process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST;
-  if (manifestPath) {
-    const manifestModule = require(manifestPath);
-    const manifest = typeof manifestModule.getWordPressHelperManifest === 'function'
-      ? manifestModule.getWordPressHelperManifest()
-      : manifestModule.WORDPRESS_HELPER_MANIFEST;
-    if (manifest?.extensionRoot) {
-      return require(path.join(manifest.extensionRoot, 'lib', 'wp-codebox-recipe-helper.js'));
-    }
-  }
-
-  return require('homeboy-extension-wordpress/wp-codebox-recipe-helper');
+  return loadWordPressHelperModule({
+    helperName: 'wp-codebox-recipe-helper',
+    envVar: 'HOMEBOY_WP_CODEBOX_RECIPE_HELPER',
+    manifestFileName: 'wp-codebox-recipe-helper.js',
+    packageImport: 'homeboy-extension-wordpress/wp-codebox-recipe-helper',
+  });
 }
 
 export function wpCodeboxBin(env = process.env) {


### PR DESCRIPTION
## Summary
- Centralize WordPress extension helper loading behind a shared helper loader.
- Prefer explicit helper env vars, the declared helper manifest/env contract, or the standard installed WordPress extension helper manifest before falling back to package-layout imports.
- Route the Gutenberg pattern preview trace through the existing shared WP Codebox recipe helper.
- Add coverage for the actionable missing-helper diagnostic and manifest resolution contract.

## Tests
- `node --test shared/wordpress-helper-loader.test.mjs shared/wp-codebox/artifacts.test.mjs scripts/fuzz-manifest-helpers.test.mjs scripts/lint-rig-packages.test.mjs`
- `node scripts/lint-rig-packages.mjs`

## Follow-up
- Extra-Chill/homeboy-extensions#1937 should expose explicit helper manifest entries for these modules so consumers no longer derive paths from `extensionRoot/lib/<file>.js`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the helper portability changes, added focused tests, and ran local verification.