### PR TITLE
Scope SSI fixture matrix runtime resources

### DIFF
--- a/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
@@ -15,7 +15,8 @@
       "static-site-importer-fixture-matrix:${env.HOMEBOY_SETTINGS_STATIC_SITE_IMPORTER_FIXTURE_MATRIX_NAMESPACE}"
     ],
     "paths": [
-      "${components.static-site-importer.path}"
+      "${components.static-site-importer.path}",
+      "/tmp/homeboy-rigs-ssi-fixture-matrix-${env.HOMEBOY_SETTINGS_STATIC_SITE_IMPORTER_FIXTURE_MATRIX_NAMESPACE}"
     ]
   },
   "bench": {
@@ -58,6 +59,12 @@
         "command": "node \"${package.root}/tools/fixture-matrix.test.mjs\""
       }
     ],
-    "down": []
+    "down": [
+      {
+        "kind": "command",
+        "label": "Remove run-scoped SSI fixture matrix temp resources",
+        "command": "test -n \"${env.HOMEBOY_SETTINGS_STATIC_SITE_IMPORTER_FIXTURE_MATRIX_NAMESPACE}\" && rm -rf \"/tmp/homeboy-rigs-ssi-fixture-matrix-${env.HOMEBOY_SETTINGS_STATIC_SITE_IMPORTER_FIXTURE_MATRIX_NAMESPACE}\" || true"
+      }
+    ]
   }
 }

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -241,7 +241,11 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   assert.equal(plan.fixture_root, fixtureRoot);
   assert.equal(plan.fixture_count, CANONICAL_FIXTURE_COUNT);
   assert.equal(plan.fixture_count_matches_canonical, true);
-  assert.equal(plan.shared_state, '/tmp/homeboy-rigs-ssi-fixture-matrix-shared-state');
+  assert.equal(plan.namespace, 'ssi-matrix-dev-proof');
+  assert.equal(plan.temp_root, '/tmp/homeboy-rigs-ssi-fixture-matrix-ssi-matrix-dev-proof');
+  assert.equal(plan.shared_state, '/tmp/homeboy-rigs-ssi-fixture-matrix-ssi-matrix-dev-proof/shared-state');
+  assert.equal(plan.artifact_root, '/tmp/homeboy-rigs-ssi-fixture-matrix-ssi-matrix-dev-proof/artifacts');
+  assert.deepEqual(plan.warnings, []);
   assert.equal(plan.dependency_overrides.blocks_engine_php_transformer.path, blocksEngine);
   assert.equal(plan.steps.some((step) => step.args.includes('install')), false);
   assert.ok(plan.steps.some((step) => step.args.includes('sync')));
@@ -254,6 +258,8 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   assert.ok(benchStep.args.includes(`bench_env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH=${staticSiteImporter}`));
   assert.ok(benchStep.args.includes(`bench_env.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH=${blocksEngine}`));
   assert.ok(benchStep.args.includes('bench_env.SSI_FIXTURE_MATRIX_RUN=1'));
+  assert.ok(benchStep.args.includes('static_site_importer_fixture_matrix_namespace=ssi-matrix-dev-proof'));
+  assert.ok(benchStep.args.includes('/tmp/homeboy-rigs-ssi-fixture-matrix-ssi-matrix-dev-proof/artifacts'));
   assert.deepEqual(benchStep.args.slice(-3), ['--', '--batch-size', '5']);
 
   const releasePlan = buildFixtureMatrixRunPlan({
@@ -264,6 +270,32 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   });
   assert.deepEqual(releasePlan.dependency_overrides, {});
   assert.equal(releasePlan.steps.at(-1).args.some((arg) => arg.includes('SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH')), false);
+});
+
+test('fixture matrix dry-run plan surfaces local fallback and dirty workspace warnings', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-warning-plan-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const fixtureRoot = path.join(root, 'fixtures');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(path.join(fixtureRoot, 'fixture-a'), { recursive: true });
+
+  const plan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    fixtureRoot,
+    runId: 'proof/run 1',
+    allowLocalFallback: true,
+    allowDirtyLabWorkspace: true,
+    skipInstall: true,
+    skipSync: true,
+  });
+
+  assert.equal(plan.namespace, 'proof-run-1');
+  assert.equal(plan.temp_root, '/tmp/homeboy-rigs-ssi-fixture-matrix-proof-run-1');
+  assert.deepEqual(plan.warnings.map((warning) => warning.code), [
+    'local_runner_default',
+    'local_fallback_allowed',
+    'dirty_lab_workspace_allowed',
+  ]);
 });
 
 test('operator summary preserves matrix rollups for fanout agents', () => {

--- a/WordPress/static-site-importer/tools/run-fixture-matrix.mjs
+++ b/WordPress/static-site-importer/tools/run-fixture-matrix.mjs
@@ -2,7 +2,6 @@
 
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -46,6 +45,7 @@ export function buildFixtureMatrixRunPlan(input) {
     ...(options.wpCodeboxBin ? { SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN: options.wpCodeboxBin } : {}),
   };
   const fixtureCount = countTopLevelFixtureDirectories(options.fixtureRoot);
+  const warnings = buildWarnings(options);
 
   return {
     schema: 'homeboy-rigs/static-site-importer-fixture-matrix-operator-run/v1',
@@ -60,8 +60,11 @@ export function buildFixtureMatrixRunPlan(input) {
     canonical_fixture_count: CANONICAL_FIXTURE_COUNT,
     fixture_count_matches_canonical: fixtureCount === CANONICAL_FIXTURE_COUNT,
     output_file: options.output,
+    temp_root: options.tempRoot,
     artifact_root: options.artifactRoot,
     shared_state: options.sharedState,
+    namespace: options.namespace,
+    warnings,
     dependency_overrides: options.blocksEnginePhpTransformerPath
       ? { blocks_engine_php_transformer: { path: options.blocksEnginePhpTransformerPath } }
       : {},
@@ -86,28 +89,47 @@ function normalizeOptions(input) {
     : (input.blocksEnginePhpTransformerPath ? path.resolve(input.blocksEnginePhpTransformerPath) : '');
   const mode = input.mode || (blocksEnginePhpTransformerPath ? 'development-override' : 'release-proof');
   const runId = input.runId || `ssi-matrix-${mode}-${timestamp()}`;
+  const namespace = sanitizePathSegment(input.namespace || runId);
+  const tempRoot = input.tempRoot ? path.resolve(input.tempRoot) : defaultTempRoot(namespace, input);
   const output = path.resolve(input.output || path.join(process.cwd(), 'artifacts', `${runId}.homeboy-bench.json`));
 
   return {
     ...input,
     mode,
     runId,
+    namespace,
+    tempRoot,
     output,
     fixtureRoot,
     blocksEngine,
     blocksEnginePhpTransformerPath,
+    passthrough: Array.isArray(input.passthrough) ? input.passthrough : [],
     staticSiteImporter: path.resolve(input.staticSiteImporter),
-    sharedState: input.sharedState ? path.resolve(input.sharedState) : defaultSharedState(input.runner),
-    artifactRoot: input.artifactRoot ? path.resolve(input.artifactRoot) : '',
+    sharedState: input.sharedState ? path.resolve(input.sharedState) : path.join(tempRoot, 'shared-state'),
+    artifactRoot: input.artifactRoot ? path.resolve(input.artifactRoot) : path.join(tempRoot, 'artifacts'),
     runner: input.runner || '',
   };
 }
 
-function defaultSharedState(runner) {
-  if (runner) {
-    return '/tmp/homeboy-rigs-ssi-fixture-matrix-shared-state';
-  }
-  return path.resolve(path.join(os.tmpdir(), 'homeboy-rigs-ssi-fixture-matrix-shared-state'));
+function defaultTempRoot(namespace) {
+  return path.resolve(path.join('/tmp', `homeboy-rigs-ssi-fixture-matrix-${namespace}`));
+}
+
+function buildWarnings(options) {
+  return [
+    ...(!options.runner && !options.labOnly ? [{
+      code: 'local_runner_default',
+      message: 'No --runner/--lab-only routing was provided; the plan will use the local Homeboy runner.',
+    }] : []),
+    ...(options.allowLocalFallback ? [{
+      code: 'local_fallback_allowed',
+      message: '--allow-local-fallback permits Lab routing to fall back to local execution if the runner allows it.',
+    }] : []),
+    ...(options.allowDirtyLabWorkspace ? [{
+      code: 'dirty_lab_workspace_allowed',
+      message: '--allow-dirty-lab-workspace permits reusing or overwriting a dirty Lab workspace.',
+    }] : []),
+  ];
 }
 
 function buildSteps(options, settings) {
@@ -136,6 +158,7 @@ function buildSteps(options, settings) {
     '--run-id', options.runId,
     '--output', options.output,
     '--json',
+    '--setting', `static_site_importer_fixture_matrix_namespace=${options.namespace}`,
     ...Object.entries(settings).flatMap(([key, value]) => ['--setting', `bench_env.${key}=${value}`]),
   ];
   if (options.artifactRoot) {
@@ -321,6 +344,10 @@ function camelCase(value) {
 
 function timestamp() {
   return new Date().toISOString().replace(/[-:]/g, '').replace(/\..+/, 'Z');
+}
+
+function sanitizePathSegment(value) {
+  return String(value).replace(/[^A-Za-z0-9_.-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '') || 'run';
 }
 
 function printHelp() {


### PR DESCRIPTION
## Summary
- scope SSI fixture matrix temp, shared-state, and artifact defaults by run namespace
- pass the namespace into Homeboy settings so rig resources can key cleanup to the same run
- surface dry-run warnings for local runner defaults, local fallback, and dirty Lab workspace allowances
- declare guarded rig resource paths and down cleanup for run-scoped SSI matrix temp resources

## Tests
- node WordPress/static-site-importer/tools/fixture-matrix.test.mjs
- node scripts/lint-rig-packages.mjs WordPress/static-site-importer

## Follow-ups
- Promote a generic Homeboy lifecycle resource contract for run-scoped temp/artifact roots so rigs do not need guarded shell cleanup commands.
- Add first-class dry-run summary fields in Homeboy core for local fallback and dirty workspace routing decisions across all rigs.
- Audit Studio Native fixed /tmp proof output after the core lifecycle contract exists, so cleanup can be declared without relying on ad hoc paths.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing scoped lifecycle/resource declarations, updating tests, and preparing this PR description.