### PR TITLE
Fix Gutenberg fuzz profile docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,10 +386,11 @@ homeboy rig check gutenberg-api-route-inventory
 homeboy bench --rig gutenberg-api-route-inventory --scenario gutenberg-rest-route-inventory --iterations 1 --shared-state /tmp/gutenberg-api-inventory
 ```
 
-`WordPress/gutenberg/manifests/fuzzer-profile.json` adds a rig-owned fuzzer profile shape for REST route coverage, wp-admin/editor page coverage, block editor load/action probes, DB query/profile hooks, external HTTP guardrails, and coverage-gap reporting. Run its bench and browser sides separately:
+`WordPress/gutenberg/manifests/fuzzer-profile.json` adds a rig-owned fuzzer profile shape for REST route coverage, wp-admin/editor page coverage, block editor load/action probes, DB query/profile hooks, external HTTP guardrails, and coverage-gap reporting. Inspect its fuzz declarations through Homeboy's generic fuzz command and run browser coverage separately:
 
 ```bash
-homeboy bench --rig gutenberg-api-route-inventory --profile fuzzer --iterations 1 --shared-state /tmp/gutenberg-fuzzer-bench
+homeboy fuzz list --rig gutenberg-api-route-inventory
+homeboy fuzz run --rig gutenberg-api-route-inventory --workload gutenberg-rest-route-fuzz --run-id gutenberg-rest-route-fuzz --seed 1 --max-duration 10m
 homeboy trace --rig gutenberg-browser-coverage --profile fuzzer
 ```
 

--- a/WordPress/gutenberg/README.md
+++ b/WordPress/gutenberg/README.md
@@ -18,10 +18,12 @@ Run the route inventory workload:
 homeboy bench --rig gutenberg-api-route-inventory --scenario gutenberg-rest-route-inventory --iterations 1 --shared-state /tmp/gutenberg-api-inventory
 ```
 
-Run the currently executable full-surface profile:
+Inspect the declared fuzz workloads and run an individual workload through
+Homeboy's generic fuzz command:
 
 ```sh
-homeboy bench --rig gutenberg-api-route-inventory --profile full-surface --iterations 1 --shared-state /tmp/gutenberg-full-surface
+homeboy fuzz list --rig gutenberg-api-route-inventory
+homeboy fuzz run --rig gutenberg-api-route-inventory --workload gutenberg-rest-route-fuzz --run-id gutenberg-rest-route-fuzz --seed 1 --max-duration 10m
 ```
 
 The coverage manifest lives at `manifests/rest-route-coverage.json`. It keeps
@@ -41,7 +43,8 @@ homeboy fuzz run --rig gutenberg-api-route-inventory --workload gutenberg-rest-r
 
 The rig exposes `smoke`, `fuzzer`, and `full-surface` `fuzz_profiles` for fleet
 orchestration. These profiles only group existing fuzz workload declarations;
-they do not change readiness levels or convert declarations into proof.
+they are not `homeboy bench` profiles and do not change readiness levels or
+convert declarations into proof.
 
 Use an offloaded Lab runner for heavy proof campaigns. A `homeboy fuzz list` result is only a declaration check; P status requires persisted `homeboy fuzz run` evidence and artifacts.
 

--- a/WordPress/wordpress/README.md
+++ b/WordPress/wordpress/README.md
@@ -1,9 +1,9 @@
 # Legacy WordPress Core Bench/Trace Rigs
 
 This package is deprecated and remains only as a compatibility path for existing
-bench-oriented WordPress Core scaffolding. New Core fuzz workload contracts belong in
-`../wordpress-develop`, the canonical `WordPress/wordpress-develop` rig package
-for `homeboy/fuzz-workload/v1` manifests.
+bench-oriented WordPress Core scaffolding. Keep new Core fuzz workload contracts
+in `../wordpress-develop`, the canonical `WordPress/wordpress-develop` rig
+package for `homeboy/fuzz-workload/v1` manifests.
 
 ## `wordpress-core-api-route-inventory`
 


### PR DESCRIPTION
## Summary
- Replace stale Gutenberg bench profile docs with generic fuzz list/run commands.
- Clarify that Gutenberg fuzz profiles are not Homeboy bench profiles.
- Tighten legacy WordPress Core package wording to point new fuzz contracts at WordPress/wordpress-develop.

## Verification
- node scripts/lint-rig-packages.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Documentation cleanup, local verification, and PR preparation.