### PR TITLE
Move Woo fuzz proof contracts into Woo helper

### DIFF
--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -9,17 +9,6 @@ export const fuzzCaseIntentSchema = 'homeboy/fuzz-workload-intent/v1';
 export const fuzzProofBundleFields = new Set(['artifact_refs', 'run_ids', 'gap_reports', 'fuzz_result_artifacts', 'canonical_fuzz_envelope_ref']);
 export const fullSurfaceCoverageTypes = new Set(['rest', 'admin', 'frontend', 'browser', 'database']);
 export const fullSurfaceGapReportFields = new Set(['surface_type', 'expected', 'covered', 'gaps', 'status', 'evidence_refs']);
-export const wooRequiredFuzzProofContracts = new Map([
-  ['cart-session-overwrite-race', ['cart-session-race']],
-  ['checkout-gateway-compatibility-matrix', ['gateway-compatibility']],
-  ['checkout-shipping-cache', ['shipping-cache-invalidation']],
-  ['frontend-rendering-request-coverage', ['shop-product-cart-checkout-rendering-requests']],
-  ['layered-nav-catalog-crawl', ['catalog-layered-nav-transient-growth']],
-  ['layered-nav-count-cache', ['layered-nav-transient-growth']],
-  ['options-transients-coverage', ['cache-invalidation-and-transient-growth']],
-  ['performance-hotspots-artifact-summary', ['artifact-summary-expectations']],
-  ['woocommerce-external-http-guardrail', ['external-http-guardrails']],
-]);
 
 function loadGenericFuzzManifestValidator() {
   return loadWordPressHelperModule({
@@ -266,7 +255,7 @@ function assertOptionalFuzzResultArtifacts(proofBundle, manifest, { file = manif
 }
 
 export function assertRequiredFuzzProofContracts(manifest, {
-  requiredContracts = wooRequiredFuzzProofContracts.get(manifest.id) || [],
+  requiredContracts = [],
   runnerCase = manifest.cases?.[0],
   file = manifest.id,
 } = {}) {

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -7,9 +7,11 @@ import {
   assertArtifactPostprocessWorkloadContract,
   assertCanonicalFuzzEnvelopeRef,
   assertFullSurfaceCoverageManifest,
-  assertRequiredFuzzProofContracts,
-  wooRequiredFuzzProofContracts,
 } from '../../../scripts/fuzz-manifest-helpers.mjs';
+import {
+  assertWooRequiredFuzzProofContracts,
+  wooRequiredFuzzProofContracts,
+} from '../tools/fuzz-proof-contracts.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
@@ -81,11 +83,11 @@ test('manifest workload metadata stays scoped to full-surface workload ids', () 
 });
 
 test('high-risk Woo fuzz manifests declare required proof contracts', () => {
-  for (const [workloadId, contractIds] of wooRequiredFuzzProofContracts) {
+  for (const workloadId of wooRequiredFuzzProofContracts.keys()) {
     const workloadPath = path.join(packageRoot, 'fuzz', `${workloadId}.json`);
     const workload = JSON.parse(readFileSync(workloadPath, 'utf8'));
 
-    assertRequiredFuzzProofContracts(workload, { requiredContracts: contractIds });
+    assertWooRequiredFuzzProofContracts(workload);
   }
 });
 

--- a/woocommerce/woocommerce/tools/fuzz-proof-contracts.mjs
+++ b/woocommerce/woocommerce/tools/fuzz-proof-contracts.mjs
@@ -1,0 +1,20 @@
+import { assertRequiredFuzzProofContracts } from '../../../scripts/fuzz-manifest-helpers.mjs';
+
+export const wooRequiredFuzzProofContracts = new Map([
+  ['cart-session-overwrite-race', ['cart-session-race']],
+  ['checkout-gateway-compatibility-matrix', ['gateway-compatibility']],
+  ['checkout-shipping-cache', ['shipping-cache-invalidation']],
+  ['frontend-rendering-request-coverage', ['shop-product-cart-checkout-rendering-requests']],
+  ['layered-nav-catalog-crawl', ['catalog-layered-nav-transient-growth']],
+  ['layered-nav-count-cache', ['layered-nav-transient-growth']],
+  ['options-transients-coverage', ['cache-invalidation-and-transient-growth']],
+  ['performance-hotspots-artifact-summary', ['artifact-summary-expectations']],
+  ['woocommerce-external-http-guardrail', ['external-http-guardrails']],
+]);
+
+export function assertWooRequiredFuzzProofContracts(manifest, options = {}) {
+  return assertRequiredFuzzProofContracts(manifest, {
+    requiredContracts: wooRequiredFuzzProofContracts.get(manifest.id) || [],
+    ...options,
+  });
+}

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -11,7 +11,6 @@ import {
   assertFuzzProofBundleRequirements,
   assertFuzzReadinessLevel,
   assertGenericFuzzManifest,
-  assertRequiredFuzzProofContracts,
   collectFuzzManifests,
   declaredBenchProfileIds,
   declaredBenchWorkloadIds,
@@ -19,8 +18,8 @@ import {
   fullSurfaceRequiredArtifactIds,
   fuzzManifestHasExecutableArtifactContract,
   readJson,
-  wooRequiredFuzzProofContracts,
 } from '../../../scripts/fuzz-manifest-helpers.mjs';
+import { assertWooRequiredFuzzProofContracts } from './fuzz-proof-contracts.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
@@ -299,7 +298,6 @@ for (const { file, manifest } of fuzzManifests) {
     assert.ok(proofBundle.run_ids.length > 0, `${manifest.id} proven readiness must link at least one run id`);
   }
 
-  const requiredContractIds = wooRequiredFuzzProofContracts.get(manifest.id) || [];
   if (requiredArtifactWorkloadIds.has(manifest.id) && fuzzManifestHasExecutableArtifactContract(manifest)) {
     for (const artifact of runnerCase.artifacts) {
       assert.equal(artifact.required, true, `${manifest.id} full-surface executable case artifact ${artifact.name} must be required`);
@@ -309,7 +307,7 @@ for (const { file, manifest } of fuzzManifests) {
     }
   }
 
-  assertRequiredFuzzProofContracts(manifest, { requiredContracts: requiredContractIds, runnerCase });
+  assertWooRequiredFuzzProofContracts(manifest, { runnerCase });
 
   if (manifest.id === 'admin-page-coverage') {
     assert.ok(manifest.operations.includes('safe-menu-enumeration-contract'), 'admin-page-coverage requires safe menu enumeration contract operation');


### PR DESCRIPTION
## Summary
- move Woo-specific required fuzz proof contract ownership out of the shared fuzz manifest helper
- add a Woo-owned proof contract helper for Woo validators/tests
- keep the shared assertion helper generic by requiring callers to pass product-specific contract ids

## Verification
- \Rig package lint passed.
- PHP syntax: 22 file(s)
- rig portability: 27 rig(s)
- fuzz workloads: 57 workload(s)
- portable source paths: 273 file(s)
- \validated 23 WooCommerce fuzz manifests; no migrated fuzz IDs are present in bench_workloads or bench_profiles
- \validated WordPress Core fuzz coverage manifests
- \validated 12 Gutenberg fuzz manifests; no fuzz IDs are present in bench_workloads or bench_profiles
- \validated 14 Jetpack fuzz manifests; no fuzz IDs are present in bench_workloads or bench_profiles
- \✔ workloadIdFromPath strips supported workload suffixes (0.463292ms)
✔ declaredFuzzIds accepts object and string workload declarations (0.290834ms)
✔ assertGenericFuzzManifest accepts a linked generic fuzz workload contract (0.544875ms)
✔ assertGenericFuzzManifest rejects runner commands when intent is required (0.47325ms)
✔ assertGenericFuzzManifest rejects fuzz workloads that leak into bench paths (0.090875ms)
✔ assertGenericFuzzManifest can preserve product-specific optional artifact semantics (0.104ms)
✔ fullSurfaceRequiredArtifactIds follows reviewer-facing coverage artifact expectations (0.080625ms)
✔ fuzzManifestHasExecutableArtifactContract excludes declared or blocked contracts (0.063ms)
✔ assertJetpackFuzzManifestReadinessContract rejects executable readiness with optional artifacts (0.13825ms)
✔ assertFuzzReadinessMetadata accepts declared CRUD and isolated mutation contracts (0.17025ms)
✔ assertGenericFuzzManifest can require readiness metadata (0.074ms)
✔ assertFuzzProofBundle accepts a canonical fuzz envelope artifact ref as the primary proof pointer (0.281666ms)
✔ assertFuzzProofBundle accepts Homeboy run artifact refs for canonical fuzz envelopes (0.186542ms)
✔ assertFuzzProofBundle rejects local canonical fuzz envelope artifact refs (0.260667ms)
ℹ tests 14
ℹ suites 0
ℹ pass 14
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 39.991125
- \✔ full-surface manifest uses shared coverage-map and gap-report schema (0.553667ms)
✔ full-surface executable workloads have coverage contract metadata (0.247042ms)
✔ manifest workload metadata stays scoped to full-surface workload ids (0.474583ms)
✔ high-risk Woo fuzz manifests declare required proof contracts (0.5725ms)
✔ fuzz workload metadata does not fall back to benchmark transcripts (0.1035ms)
✔ Woo Composer prep delegates to Homeboy dependency install primitive (0.1435ms)
✔ generated REST request cases are driven by route inventory coverage semantics (0.072542ms)
✔ performance hotspot summary contract uses relative ranking instead of hard thresholds (0.043125ms)
✔ REST DB query profile consumes generated request case artifacts with caps (0.057625ms)
✔ coverage gap and hotspot reports declare the generic artifact postprocess contract (0.164958ms)
✔ DB/API campaign consumes the Codebox fixture canonical fuzz envelope ref (0.233792ms)
ℹ tests 11
ℹ suites 0
ℹ pass 11
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 39.9695

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the helper ownership split, running local verification, and drafting this PR.