### PR TITLE
Prefer directory taxonomy for SSI fixture matrix

### DIFF
--- a/WordPress/static-site-importer/lib/fixture-matrix.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix.mjs
@@ -67,6 +67,16 @@ const FIXTURE_CLASS_RULES = [
   },
 ];
 
+const FIXTURE_DIRECTORY_CLASSES = {
+  'marketing-static': 'marketing/static',
+  'docs-blog': 'docs/blog',
+  'ecommerce-catalog': 'ecommerce/catalog',
+  'app-dashboard': 'app/dashboard',
+  'runtime-heavy': 'canvas/webgl/audio/runtime-heavy',
+  'canvas-webgl-audio': 'canvas/webgl/audio/runtime-heavy',
+  'edge-cases': 'unknown',
+};
+
 export function discoverFixtures(root, options = {}) {
   const fixtureRoot = requiredDirectory(root || options.fixtureRoot || options.fixture_root, 'fixtureRoot');
   const entrypoint = options.entrypoint || 'index.html';
@@ -341,6 +351,11 @@ export function classifyFixture(input = {}) {
     return { fixture_class: explicit, product_class: explicit, signals: ['explicit_metadata'] };
   }
 
+  const pathClass = classifyFixturePath(input);
+  if (pathClass) {
+    return { fixture_class: pathClass, product_class: pathClass, signals: ['directory_taxonomy'] };
+  }
+
   const files = normalizeArray(input.files || input.fixture_files || input.fixtureFiles);
   const diagnostics = normalizeArray(input.diagnostics || input.findings || input.messages || input.runtime_target_gaps || input.runtimeTargetGaps);
   const text = [
@@ -389,6 +404,28 @@ export function classifyFixture(input = {}) {
   const [fixtureClass, score] = ranked[0] || ['unknown', 0];
   const normalized = score > 0 ? fixtureClass : 'unknown';
   return { fixture_class: normalized, product_class: normalized, signals: signals.slice(0, 8) };
+}
+
+function classifyFixturePath(input = {}) {
+  const directory = input.directory || input.path || input.fixture_path || input.fixturePath;
+  const root = input.root || input.fixture_root || input.fixtureRoot;
+  const segments = [];
+
+  if (directory && root) {
+    const relative = path.relative(path.resolve(root), path.resolve(directory));
+    if (relative && !relative.startsWith('..') && !path.isAbsolute(relative)) {
+      segments.push(...relative.split(path.sep));
+    }
+  }
+
+  for (const segment of segments) {
+    const key = String(segment || '').trim().toLowerCase();
+    if (Object.hasOwn(FIXTURE_DIRECTORY_CLASSES, key)) {
+      return FIXTURE_DIRECTORY_CLASSES[key];
+    }
+  }
+
+  return '';
 }
 
 function findingsForFixtureResult(result, context = {}) {
@@ -447,7 +484,7 @@ function normalizeFixture(input) {
   const relative = path.relative(path.resolve(root), path.resolve(directory));
   const id = slug(input.id || input.slug || (relative && !relative.startsWith('..') ? relative : path.basename(directory)));
   const files = input.files || input.fixture_files || input.fixtureFiles || collectFixtureFiles(directory, { maxFiles: input.maxFiles || input.max_files || 1000 });
-  const taxonomy = classifyFixture({ ...input, id, directory, files });
+  const taxonomy = normalizeFixtureTaxonomy(input.taxonomy) || classifyFixture({ ...input, id, directory, root, files });
   return {
     id,
     label: input.label || input.name || id,
@@ -458,6 +495,24 @@ function normalizeFixture(input) {
     fixture_class: taxonomy.fixture_class,
     product_class: taxonomy.product_class,
     taxonomy,
+  };
+}
+
+function normalizeFixtureTaxonomy(taxonomy) {
+  if (!taxonomy || typeof taxonomy !== 'object') {
+    return null;
+  }
+  const fixtureClassValue = taxonomy.fixture_class || taxonomy.fixtureClass || taxonomy.product_class || taxonomy.productClass;
+  const productClassValue = taxonomy.product_class || taxonomy.productClass || taxonomy.fixture_class || taxonomy.fixtureClass;
+  if (!fixtureClassValue && !productClassValue) {
+    return null;
+  }
+  const fixtureClass = normalizeFixtureClass(fixtureClassValue);
+  const productClass = normalizeFixtureClass(productClassValue);
+  return {
+    fixture_class: fixtureClass || 'unknown',
+    product_class: productClass || fixtureClass || 'unknown',
+    signals: normalizeArray(taxonomy.signals),
   };
 }
 

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -107,6 +107,35 @@ test('classifies fixtures into generic product taxonomy from metadata and files'
   assert.equal(matrix.fixtures.find((fixture) => fixture.id === 'interactive-demo').fixture_class, 'canvas/webgl/audio/runtime-heavy');
 });
 
+test('classifies fixtures from directory taxonomy before heuristic fallback', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-fixture-directory-taxonomy-'));
+  const cases = [
+    ['marketing-static', 'spring-shop', '<h1>Product Catalog Checkout</h1>', 'marketing/static'],
+    ['docs-blog', 'admin-portal', '<h1>Dashboard Settings</h1>', 'docs/blog'],
+    ['ecommerce-catalog', 'launch-page', '<h1>Marketing Landing Hero</h1>', 'ecommerce/catalog'],
+    ['app-dashboard', 'news-guide', '<article>Blog documentation tutorial</article>', 'app/dashboard'],
+    ['runtime-heavy', 'plain-copy', '<h1>Simple static brochure</h1>', 'canvas/webgl/audio/runtime-heavy'],
+    ['canvas-webgl-audio', 'plain-copy', '<h1>Simple static brochure</h1>', 'canvas/webgl/audio/runtime-heavy'],
+    ['edge-cases', 'shop-catalog', '<h1>Product Catalog Checkout</h1>', 'unknown'],
+  ];
+
+  for (const [directoryClass, fixtureName, html] of cases) {
+    const fixtureDirectory = path.join(root, directoryClass, fixtureName);
+    mkdirSync(fixtureDirectory, { recursive: true });
+    writeFileSync(path.join(fixtureDirectory, 'index.html'), html);
+  }
+
+  const matrix = createFixtureMatrix({ fixture_root: root });
+  const byId = new Map(matrix.fixtures.map((fixture) => [fixture.id, fixture]));
+
+  for (const [directoryClass, fixtureName, , fixtureClass] of cases) {
+    assert.equal(byId.get(`${directoryClass}-${fixtureName}`).fixture_class, fixtureClass);
+    assert.deepEqual(byId.get(`${directoryClass}-${fixtureName}`).taxonomy.signals, ['directory_taxonomy']);
+  }
+
+  assert.equal(classifyFixture({ fixture_class: 'docs/blog', root, directory: path.join(root, 'marketing-static', 'manual') }).fixture_class, 'docs/blog');
+});
+
 test('rolls fixture matrix summaries up by fixture class and repair bucket', () => {
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-fixture-class-rollups-'));
   const shop = path.join(root, 'shop-catalog');


### PR DESCRIPTION
## Summary
- classify SSI matrix fixtures by explicit metadata, then recognized directory segment, then heuristic fallback
- support product-class directory names for future fixture organization
- preserve existing flat fixture behavior until fixtures are moved

## Testing
- node --test tools/fixture-matrix.test.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode general subagents
- **Used for:** matrix taxonomy implementation and tests