### PR TITLE
Discover product-scoped fuzz validators

### DIFF
--- a/Automattic/jetpack/tools/fuzz-workload-validator.mjs
+++ b/Automattic/jetpack/tools/fuzz-workload-validator.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { fuzzManifestHasExecutableArtifactContract } from '../../../scripts/fuzz-manifest-helpers.mjs';
+
+export function validateFuzzWorkload({ rel, root, workload }) {
+  const isJetpackFuzz = rel.startsWith('Automattic/jetpack/fuzz/')
+    || (rel.startsWith('fuzz/') && root.endsWith('/Automattic/jetpack'))
+    || workload.target?.slug === 'jetpack'
+    || workload.target?.component === 'jetpack';
+
+  if (!isJetpackFuzz) {
+    return [];
+  }
+
+  try {
+    assertJetpackFuzzManifestReadinessContract(workload, { file: rel });
+    return [];
+  } catch (error) {
+    return [error.message];
+  }
+}
+
+export function assertJetpackFuzzManifestReadinessContract(manifest, { file = manifest.id } = {}) {
+  assert.equal(manifest.target?.slug, 'jetpack', `${file} Jetpack manifest target.slug must be jetpack`);
+
+  const readiness = manifest.metadata?.readiness;
+  if (manifest.metadata?.generic_primitive?.status === 'blocked') {
+    assert.ok(Array.isArray(readiness?.upstream_blockers) && readiness.upstream_blockers.length > 0, `${file} blocked generic primitive requires readiness upstream_blockers`);
+  }
+
+  if (readiness?.level === 'declared') {
+    assert.ok(Array.isArray(readiness.upstream_blockers) && readiness.upstream_blockers.length > 0, `${file} declared Jetpack readiness requires upstream_blockers`);
+  }
+
+  if (fuzzManifestHasExecutableArtifactContract(manifest)) {
+    assertAllArtifactsRequired(manifest, { file });
+  }
+
+  assertJetpackConnectedStateContract(manifest, { file });
+}
+
+function assertAllArtifactsRequired(manifest, { file } = {}) {
+  for (const runnerCase of manifest.cases || []) {
+    for (const artifact of runnerCase.artifacts || []) {
+      assert.equal(artifact.required, true, `${file} executable Jetpack readiness requires case artifact ${artifact.name} to be required`);
+    }
+  }
+
+  for (const artifact of manifest.artifacts?.expected || []) {
+    assert.equal(artifact.required, true, `${file} executable Jetpack readiness requires expected artifact ${artifact.name} to be required`);
+  }
+}
+
+function assertJetpackConnectedStateContract(manifest, { file } = {}) {
+  const cases = manifest.cases || [];
+  const coversConnectedState = manifest.operations?.some((operation) => typeof operation === 'string' && operation.includes('connected'))
+    || cases.some((runnerCase) => runnerCase.inputs?.states?.includes('connected') || runnerCase.inputs?.fixture_states?.includes('connected'));
+
+  if (!coversConnectedState) {
+    return;
+  }
+
+  for (const runnerCase of cases) {
+    const inputs = runnerCase.inputs || {};
+    const skipReasonCodes = inputs.skip_reason_codes || [];
+
+    assert.ok(skipReasonCodes.includes('connection_required'), `${file} connected-state cases must classify connection_required skips`);
+    assert.ok(
+      skipReasonCodes.includes('credential_unavailable') || skipReasonCodes.includes('external_service_required'),
+      `${file} connected-state cases must classify credential or external-service blockers`
+    );
+
+    if (inputs.real_wpcom_credentials_allowed !== undefined) {
+      assert.equal(inputs.real_wpcom_credentials_allowed, false, `${file} connected-state cases must not allow real WP.com credentials`);
+    }
+
+    if (manifest.operations?.includes('token-placeholder-serialization')) {
+      assert.equal(inputs.secret_placeholders_only, true, `${file} token placeholder serialization requires secret_placeholders_only`);
+    }
+  }
+}

--- a/Automattic/jetpack/tools/fuzz-workload-validator.test.mjs
+++ b/Automattic/jetpack/tools/fuzz-workload-validator.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { assertJetpackFuzzManifestReadinessContract } from './fuzz-workload-validator.mjs';
+
+test('rejects executable readiness with optional artifacts', () => {
+  assert.throws(
+    () => assertJetpackFuzzManifestReadinessContract({
+      schema: 'homeboy/fuzz-workload/v1',
+      id: 'jetpack-fuzz',
+      target: { type: 'wordpress-plugin', slug: 'jetpack', component: 'jetpack' },
+      operations: ['route-inventory'],
+      metadata: {
+        readiness: { level: 'executable', coverage_contract: 'Jetpack executable fuzz contract.' },
+      },
+      cases: [
+        {
+          case_id: 'jetpack-fuzz:default',
+          artifacts: [{ name: 'report', path: 'report.json', required: false }],
+        },
+      ],
+      artifacts: { expected: [{ name: 'report', path: 'report.json', required: true }] },
+    }, { file: 'jetpack-fuzz.json' }),
+    /executable Jetpack readiness requires case artifact report to be required/
+  );
+});

--- a/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
+++ b/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
@@ -6,7 +6,6 @@ import { fileURLToPath } from 'node:url';
 import {
   assertFullSurfaceCoverageManifest,
   assertGenericFuzzManifest,
-  assertJetpackFuzzManifestReadinessContract,
   collectFuzzManifests,
   declaredBenchProfileIds,
   declaredBenchWorkloadIds,
@@ -14,6 +13,7 @@ import {
   fuzzManifestHasExecutableArtifactContract,
   readJson,
 } from '../../../scripts/fuzz-manifest-helpers.mjs';
+import { assertJetpackFuzzManifestReadinessContract } from './fuzz-workload-validator.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');

--- a/WordPress/wordpress-develop/tools/fuzz-workload-validator.mjs
+++ b/WordPress/wordpress-develop/tools/fuzz-workload-validator.mjs
@@ -1,0 +1,1 @@
+export { validateWordPressCoreFuzzContract as validateFuzzWorkload } from './core-fuzz-contract-validator.mjs';

--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -78,25 +78,6 @@ export function fuzzManifestHasExecutableArtifactContract(manifest) {
     && manifest.metadata?.generic_primitive?.status !== 'blocked';
 }
 
-export function assertJetpackFuzzManifestReadinessContract(manifest, { file = manifest.id } = {}) {
-  assert.equal(manifest.target?.slug, 'jetpack', `${file} Jetpack manifest target.slug must be jetpack`);
-
-  const readiness = manifest.metadata?.readiness;
-  if (manifest.metadata?.generic_primitive?.status === 'blocked') {
-    assert.ok(Array.isArray(readiness?.upstream_blockers) && readiness.upstream_blockers.length > 0, `${file} blocked generic primitive requires readiness upstream_blockers`);
-  }
-
-  if (readiness?.level === 'declared') {
-    assert.ok(Array.isArray(readiness.upstream_blockers) && readiness.upstream_blockers.length > 0, `${file} declared Jetpack readiness requires upstream_blockers`);
-  }
-
-  if (fuzzManifestHasExecutableArtifactContract(manifest)) {
-    assertAllArtifactsRequired(manifest, { file });
-  }
-
-  assertJetpackConnectedStateContract(manifest, { file });
-}
-
 export function assertGenericFuzzManifest(manifest, {
   file,
   declaredIds,
@@ -334,55 +315,6 @@ function collectRequiredArtifactNames(manifest) {
     .filter((artifact) => artifact?.required === true)
     .map((artifact) => artifact?.name)
     .filter(Boolean));
-}
-
-function assertAllArtifactsRequired(manifest, { file } = {}) {
-  for (const runnerCase of manifest.cases || []) {
-    for (const artifact of runnerCase.artifacts || []) {
-      assert.equal(artifact.required, true, `${file} executable Jetpack readiness requires case artifact ${artifact.name} to be required`);
-    }
-  }
-
-  for (const artifact of manifest.artifacts?.expected || []) {
-    assert.equal(artifact.required, true, `${file} executable Jetpack readiness requires expected artifact ${artifact.name} to be required`);
-  }
-}
-
-function assertJetpackConnectedStateContract(manifest, { file } = {}) {
-  const cases = manifest.cases || [];
-  const coversConnectedState = manifest.operations?.some((operation) => typeof operation === 'string' && operation.includes('connected'))
-    || cases.some((runnerCase) => runnerCase.inputs?.states?.includes('connected') || runnerCase.inputs?.fixture_states?.includes('connected'));
-
-  if (!coversConnectedState) {
-    return;
-  }
-
-  for (const runnerCase of cases) {
-    const inputs = runnerCase.inputs || {};
-    const skipReasonCodes = inputs.skip_reason_codes || [];
-
-    assert.ok(skipReasonCodes.includes('connection_required'), `${file} connected-state cases must classify connection_required skips`);
-    assert.ok(
-      skipReasonCodes.includes('credential_unavailable') || skipReasonCodes.includes('external_service_required'),
-      `${file} connected-state cases must classify credential or external-service blockers`
-    );
-
-    if (inputs.real_wpcom_credentials_allowed !== undefined) {
-      assert.equal(inputs.real_wpcom_credentials_allowed, false, `${file} connected-state cases must not allow real WP.com credentials`);
-    }
-
-    if (manifest.operations?.includes('token-placeholder-serialization')) {
-      assert.equal(inputs.secret_placeholders_only, true, `${file} token placeholder serialization requires secret_placeholders_only`);
-    }
-  }
-}
-
-function assertReviewerFacingRef(value, context) {
-  assert.ok(
-    /^(https:\/\/|gh:|homeboy-runs:|artifact:|run:)/.test(value),
-    `${context} entries must be reviewer-facing refs`
-  );
-  assert.ok(!localOnlyReviewerFacingRef(value), `${context} entries must not use local evidence`);
 }
 
 export function assertFuzzCrudReadiness(crud, { file } = {}) {

--- a/scripts/fuzz-manifest-helpers.test.mjs
+++ b/scripts/fuzz-manifest-helpers.test.mjs
@@ -4,7 +4,6 @@ import {
   assertFuzzProofBundle,
   assertFuzzReadinessMetadata,
   assertGenericFuzzManifest,
-  assertJetpackFuzzManifestReadinessContract,
   declaredFuzzIds,
   fullSurfaceRequiredArtifactIds,
   fuzzManifestHasExecutableArtifactContract,
@@ -190,27 +189,6 @@ test('fuzzManifestHasExecutableArtifactContract excludes declared or blocked con
       generic_primitive: { status: 'blocked' },
     },
   })), false);
-});
-
-test('assertJetpackFuzzManifestReadinessContract rejects executable readiness with optional artifacts', () => {
-  assert.throws(
-    () => assertJetpackFuzzManifestReadinessContract(fuzzManifest({
-      target: { type: 'wordpress-plugin', slug: 'jetpack', component: 'jetpack' },
-      metadata: {
-        workload_path: '${package.root}/bench/product.workload.json',
-        readiness: { level: 'executable', coverage_contract: 'Jetpack executable fuzz contract.' },
-      },
-      cases: [
-        {
-          case_id: 'product-fuzz:default',
-          surface_ids: ['product-api'],
-          operations: ['route-inventory'],
-          artifacts: [{ name: 'report', path: 'report.json', required: false }],
-        },
-      ],
-    }), { file: 'jetpack-fuzz.json' }),
-    /executable Jetpack readiness requires case artifact report to be required/
-  );
 });
 
 test('assertFuzzReadinessMetadata accepts declared CRUD and isolated mutation contracts', () => {

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -3,12 +3,11 @@
 import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import {
   assertFuzzReadinessMetadata,
-  assertJetpackFuzzManifestReadinessContract,
   collectGenericFuzzWorkloadIssues,
 } from './fuzz-manifest-helpers.mjs';
-import { validateWordPressCoreFuzzContract } from '../WordPress/wordpress-develop/tools/core-fuzz-contract-validator.mjs';
 
 const args = process.argv.slice(2);
 const strictFuzzReadiness = args.includes('--strict-fuzz-readiness');
@@ -21,6 +20,7 @@ const jsonFiles = [];
 const fuzzWorkloadFiles = [];
 const portableSourceFiles = [];
 const fuzzManifestValidators = [];
+const fuzzWorkloadValidatorFiles = [];
 const failures = [];
 const warnings = [];
 const studioModelRigGenerator = join(root, 'scripts/generate-studio-agent-model-rigs.mjs');
@@ -65,7 +65,31 @@ function walk(directory) {
     if (entry.isFile() && entry.name === 'validate-fuzz-manifests.mjs') {
       fuzzManifestValidators.push(join(directory, entry.name));
     }
+
+    if (entry.isFile() && entry.name === 'fuzz-workload-validator.mjs') {
+      fuzzWorkloadValidatorFiles.push(join(directory, entry.name));
+    }
   }
+}
+
+async function loadFuzzWorkloadValidators() {
+  const validators = [];
+
+  for (const file of fuzzWorkloadValidatorFiles.sort()) {
+    try {
+      const module = await import(pathToFileURL(file));
+      const validate = module.validateFuzzWorkload || module.default;
+      if (typeof validate !== 'function') {
+        failures.push(`${relative(root, file)}: fuzz workload validator must export validateFuzzWorkload(workloadContext) or a default function`);
+        continue;
+      }
+      validators.push({ file, validate });
+    } catch (error) {
+      failures.push(`${relative(root, file)}: failed to load fuzz workload validator: ${error.message}`);
+    }
+  }
+
+  return validators;
 }
 
 function lintRigPortability(file, fuzzWorkloadsByPackageRoot) {
@@ -399,7 +423,7 @@ function lintPortableSource(file) {
   }
 }
 
-function lintFuzzWorkload(file) {
+function lintFuzzWorkload(file, fuzzWorkloadValidators) {
   const rel = relative(root, file);
   let workload;
 
@@ -429,7 +453,7 @@ function lintFuzzWorkload(file) {
   }
 
   lintFuzzReadinessMetadata(rel, workload);
-  lintJetpackFuzzContract(rel, workload);
+  lintProductFuzzWorkloadValidators(rel, file, workload, fuzzWorkloadValidators);
 
   if (workload.limits) {
     if (!Number.isInteger(workload.limits.max_cases) || workload.limits.max_cases < 1) {
@@ -440,8 +464,6 @@ function lintFuzzWorkload(file) {
       failures.push(`${rel}: limits.max_duration_seconds must be a positive integer`);
     }
   }
-
-  failures.push(...validateWordPressCoreFuzzContract({ rel, root, workload }));
 }
 
 function lintFuzzReadinessMetadata(rel, workload) {
@@ -478,20 +500,21 @@ function lintFuzzReadinessMetadata(rel, workload) {
   }
 }
 
-function lintJetpackFuzzContract(rel, workload) {
-  const isJetpackFuzz = rel.startsWith('Automattic/jetpack/fuzz/')
-    || (rel.startsWith('fuzz/') && root.endsWith('/Automattic/jetpack'))
-    || workload.target?.slug === 'jetpack'
-    || workload.target?.component === 'jetpack';
-
-  if (!isJetpackFuzz) {
-    return;
-  }
-
-  try {
-    assertJetpackFuzzManifestReadinessContract(workload, { file: rel });
-  } catch (error) {
-    failures.push(error.message);
+function lintProductFuzzWorkloadValidators(rel, file, workload, fuzzWorkloadValidators) {
+  for (const validator of fuzzWorkloadValidators) {
+    try {
+      const issues = validator.validate({ rel, root, file, workload });
+      if (issues === undefined) {
+        continue;
+      }
+      if (!Array.isArray(issues)) {
+        failures.push(`${relative(root, validator.file)}: validateFuzzWorkload must return an array of failure strings or undefined`);
+        continue;
+      }
+      failures.push(...issues);
+    } catch (error) {
+      failures.push(error.message);
+    }
   }
 }
 
@@ -559,10 +582,11 @@ function lintFuzzManifestValidators() {
 
 walk(root);
 
+const fuzzWorkloadValidators = await loadFuzzWorkloadValidators();
 const fuzzWorkloadsByPackageRoot = collectFuzzWorkloads();
 
 rigFiles.forEach((file) => lintRigPortability(file, fuzzWorkloadsByPackageRoot));
-fuzzWorkloadFiles.forEach(lintFuzzWorkload);
+fuzzWorkloadFiles.forEach((file) => lintFuzzWorkload(file, fuzzWorkloadValidators));
 portableSourceFiles.forEach(lintPortableSource);
 lintGeneratedStudioModelRigs();
 lintFuzzManifestValidators();

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -7,6 +7,60 @@ import test from 'node:test';
 
 const script = new URL('./lint-rig-packages.mjs', import.meta.url).pathname;
 const sharedValidator = new URL('./fixtures/shared-fuzz-validator.cjs', import.meta.url).pathname;
+const wordpressCoreFuzzValidatorSource = `
+export function validateFuzzWorkload({ rel, root, workload }) {
+  const failures = [];
+  const isWordPressDevelopFuzz = rel.startsWith('WordPress/wordpress-develop/fuzz/')
+    || (rel.startsWith('fuzz/') && root.endsWith('/WordPress/wordpress-develop'));
+  const surfaceIds = Array.isArray(workload.surface_ids) ? workload.surface_ids : [];
+  const isWordPressCoreFuzz = workload.target?.type === 'wordpress-core'
+    || workload.target?.component === 'wordpress-develop'
+    || workload.metadata?.kind === 'wordpress-core-fuzz'
+    || surfaceIds.some((surfaceId) => typeof surfaceId === 'string' && surfaceId.startsWith('wordpress-core-'));
+
+  if (isWordPressCoreFuzz && !isWordPressDevelopFuzz) {
+    failures.push(\`${'${rel}'}: WordPress Core fuzz workloads must live under WordPress/wordpress-develop/fuzz; WordPress/wordpress is legacy bench/trace compatibility scaffolding\`);
+  }
+
+  if (!isWordPressDevelopFuzz) {
+    return failures;
+  }
+
+  const semanticKeys = new Set((workload.artifacts?.expected || []).map((artifact) => artifact?.semantic_key).filter(Boolean));
+  if (workload.id === 'rest-api') {
+    for (const operation of ['rest-route-inventory', 'generated-rest-case-plan', 'request-case-execution', 'permission-boundary-classification', 'role-boundary-execution']) {
+      if (!workload.operations?.includes(operation)) {
+        failures.push(\`${'${rel}'}: rest-api must include ${'${operation}'} in operations\`);
+      }
+    }
+    for (const semanticKey of ['fuzz.rest.route_inventory', 'fuzz.rest.generated_cases', 'fuzz.rest.permission_boundaries']) {
+      if (!semanticKeys.has(semanticKey)) {
+        failures.push(\`${'${rel}'}: rest-api must declare expected artifact semantic key ${'${semanticKey}'}\`);
+      }
+    }
+  }
+
+  if (workload.id === 'db-inventory-query-profile') {
+    for (const surfaceId of ['wordpress-core-database', 'wordpress-core-rest-routes', 'wordpress-core-options', 'wordpress-core-postmeta', 'wordpress-core-rewrites']) {
+      if (!workload.surface_ids?.includes(surfaceId)) {
+        failures.push(\`${'${rel}'}: db-inventory-query-profile must include ${'${surfaceId}'} in surface_ids\`);
+      }
+    }
+    for (const operation of ['schema-inventory', 'rest-query-profile', 'options-query-attribution', 'postmeta-query-attribution', 'rewrite-query-attribution']) {
+      if (!workload.operations?.includes(operation)) {
+        failures.push(\`${'${rel}'}: db-inventory-query-profile must include ${'${operation}'} in operations\`);
+      }
+    }
+    for (const semanticKey of ['fuzz.db.schema_inventory', 'fuzz.db.rest_query_attribution', 'fuzz.db.options_postmeta_rewrite_attribution']) {
+      if (!semanticKeys.has(semanticKey)) {
+        failures.push(\`${'${rel}'}: db-inventory-query-profile must declare expected artifact semantic key ${'${semanticKey}'}\`);
+      }
+    }
+  }
+
+  return failures;
+}
+`;
 
 function writeJson(path, value) {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
@@ -49,11 +103,14 @@ function createWordPressDevelopFuzzPackage(workload) {
   const directory = mkdtempSync(join(tmpdir(), 'homeboy-rigs-wp-lint-'));
   const fuzzRoot = join(directory, 'WordPress', 'wordpress-develop', 'fuzz');
   const manifestsRoot = join(directory, 'WordPress', 'wordpress-develop', 'manifests');
+  const toolsRoot = join(directory, 'WordPress', 'wordpress-develop', 'tools');
 
   mkdirSync(fuzzRoot, { recursive: true });
   mkdirSync(manifestsRoot, { recursive: true });
+  mkdirSync(toolsRoot, { recursive: true });
   writeJson(join(manifestsRoot, 'rest-route-coverage.json'), { schema: 'test' });
   writeJson(join(fuzzRoot, `${workload.id}.json`), workload);
+  writeFileSync(join(toolsRoot, 'fuzz-workload-validator.mjs'), wordpressCoreFuzzValidatorSource);
 
   return directory;
 }
@@ -417,6 +474,26 @@ test('accepts package-root scoped lint for rigs and fuzz directories', () => {
   assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
 });
 
+test('discovers product fuzz workload validators without central product branches', () => {
+  const directory = createRigPackage({
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+  });
+  const toolsRoot = join(directory, 'Vendor', 'product', 'tools');
+  mkdirSync(toolsRoot, { recursive: true });
+  writeFileSync(join(toolsRoot, 'fuzz-workload-validator.mjs'), `
+export function validateFuzzWorkload({ rel, workload }) {
+  return workload.id === 'generic-fuzz' ? [\`${'${rel}'}: product-local validator ran\`] : [];
+}
+`);
+
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /product-local validator ran/);
+});
+
 test('requires WordPress Core REST fuzz permission proof artifacts', () => {
   const directory = createWordPressDevelopFuzzPackage(fuzzWorkload({
     id: 'rest-api',
@@ -465,8 +542,11 @@ test('requires WordPress Core proof artifacts when linting package root directly
 test('rejects WordPress Core fuzz workloads outside wordpress-develop', () => {
   const directory = mkdtempSync(join(tmpdir(), 'homeboy-rigs-wp-legacy-lint-'));
   const fuzzRoot = join(directory, 'WordPress', 'wordpress', 'fuzz');
+  const toolsRoot = join(directory, 'WordPress', 'wordpress-develop', 'tools');
 
   mkdirSync(fuzzRoot, { recursive: true });
+  mkdirSync(toolsRoot, { recursive: true });
+  writeFileSync(join(toolsRoot, 'fuzz-workload-validator.mjs'), wordpressCoreFuzzValidatorSource);
   writeJson(join(fuzzRoot, 'rest-api.json'), fuzzWorkload({
     id: 'rest-api',
     surface_ids: ['wordpress-core-rest-routes'],


### PR DESCRIPTION
## Summary
- add a generic `tools/fuzz-workload-validator.mjs` discovery convention for fuzz workload validators
- move Jetpack readiness validation into the Jetpack package and register WordPress Core validation through the same convention
- update lint tests to prove product-local validator discovery without central product branches

Fixes #505

## Tests
- `node --test scripts/fuzz-manifest-helpers.test.mjs scripts/lint-rig-packages.test.mjs Automattic/jetpack/tools/fuzz-workload-validator.test.mjs WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs`
- `node scripts/lint-rig-packages.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementing the validator discovery refactor, moving product-specific validation, updating tests, and running verification.