### PR TITLE
Declare Woo rollback-safe REST mutation fixtures

### DIFF
--- a/woocommerce/woocommerce/fuzz/rest-product-batch-import.json
+++ b/woocommerce/woocommerce/fuzz/rest-product-batch-import.json
@@ -25,7 +25,7 @@
       "level": "executable",
       "profile": "product-rest-crud-fuzzer",
       "execution": "wp-codebox-isolated-mutation",
-      "coverage_contract": "WP Codebox can execute isolated WooCommerce product and variation batch create/update cases with synthetic fixture readback. Delete remains declared until rollback-safe delete primitives emit rollback artifacts, and proven status still requires reviewer-facing run evidence.",
+      "coverage_contract": "WP Codebox can execute isolated WooCommerce product and variation batch create/update cases through the generic rollback-safe REST mutation primitive with synthetic fixture readback. Delete remains declared until rollback-safe delete primitives emit delete-boundary rollback artifacts, and proven status still requires reviewer-facing run evidence.",
       "upstream_blockers": [
         "Reviewer-facing fuzz run artifacts and rollback/gap reports are required before proven status.",
         "Rollback-safe REST delete primitives and delete-boundary artifacts are required before delete coverage can execute."
@@ -45,8 +45,10 @@
       "crud": {
         "create": {
           "level": "executable",
+          "primitive": "wordpress.rollback-safe-rest-mutation",
           "safety_class": "isolated_mutation",
-          "fixture_scope": "synthetic_products_attributes_terms_and_variations"
+          "fixture_scope": "synthetic_products_attributes_terms_and_variations",
+          "rollback_artifacts": ["raw_result"]
         },
         "read": {
           "level": "executable",
@@ -55,19 +57,54 @@
         },
         "update": {
           "level": "executable",
+          "primitive": "wordpress.rollback-safe-rest-mutation",
           "safety_class": "isolated_mutation",
-          "fixture_scope": "synthetic_products_attributes_terms_and_variations"
+          "fixture_scope": "synthetic_products_attributes_terms_and_variations",
+          "rollback_artifacts": ["raw_result"]
         },
         "delete": {
           "level": "declared",
-          "upstream_blocker": "The current workload exercises batch create/update and readback guardrails only; delete coverage waits for an upstream rollback-safe REST delete primitive and delete-boundary artifact contract."
+          "upstream_blocker": "The current workload exercises batch create/update and readback guardrails only; delete coverage waits for the generic rollback-safe REST delete primitive to emit a reviewer-facing delete-boundary rollback artifact contract."
         }
       },
       "mutation": {
-        "safety_boundary": "Product, attribute, term, and variation mutations are bounded to disposable WP Codebox WordPress fixtures and must be represented in the required raw_result artifact before any proof claim.",
+        "primitive": "wordpress.rollback-safe-rest-mutation",
+        "safety_boundary": "Product, attribute, term, and variation create/update mutations are bounded to disposable WP Codebox WordPress fixtures and must be represented in the required raw_result artifact before any proof claim.",
         "rollback_artifacts": [
           "raw_result"
         ]
+      }
+    },
+    "payload_fixtures": {
+      "namespace": "wc/v3",
+      "roles": ["administrator", "shop_manager"],
+      "routes": [
+        "/wc/v3/products/batch",
+        "/wc/v3/products/<product_id>/variations/batch"
+      ],
+      "product_create": {
+        "methods": ["POST"],
+        "payload_shape": "synthetic simple, grouped, and variable products with unique SKU/title/slug inputs",
+        "rollback_artifact": "raw_result"
+      },
+      "product_update": {
+        "methods": ["PUT", "PATCH"],
+        "payload_shape": "synthetic product price, catalog visibility, attributes, category, image, slug, title, and duplicate-meta readback updates",
+        "rollback_artifact": "raw_result"
+      },
+      "variation_create": {
+        "methods": ["POST"],
+        "payload_shape": "synthetic variations under fixture-owned variable products with attribute option matrix values",
+        "rollback_artifact": "raw_result"
+      },
+      "variation_update": {
+        "methods": ["PUT", "PATCH"],
+        "payload_shape": "synthetic variation price, stock, status, attribute, image, and duplicate-meta readback updates",
+        "rollback_artifact": "raw_result"
+      },
+      "delete": {
+        "level": "declared",
+        "upstream_blocker": "Delete payload execution requires a generic delete-boundary rollback artifact contract before Woo marks delete executable."
       }
     },
     "fixture": {

--- a/woocommerce/woocommerce/manifests/rest-crud-route-family-catalog.json
+++ b/woocommerce/woocommerce/manifests/rest-crud-route-family-catalog.json
@@ -18,20 +18,36 @@
         "primitive": "wordpress.rollback-safe-rest-mutation",
         "workload": "rest-product-batch-import",
         "rollback_artifacts": ["raw_result"],
-        "executable_operations": ["create", "update"]
+        "delete_workload": "generated-rest-request-cases",
+        "rollback_contract_schema": "homeboy/wordpress-rest-mutation-rollback-contract/v1",
+        "mutation_isolation_artifact_schema": "wp-codebox/mutation-isolation-artifact/v1",
+        "delete_boundary_rollback_artifacts": ["wp-codebox/delete-boundary-artifact/v1"],
+        "executable_operations": ["create", "update", "delete"]
       },
       "payload_fixtures": {
         "namespace": "wc/v3",
         "roles": ["administrator", "shop_manager"],
         "create": ["simple product", "grouped product", "variable product parent"],
         "update": ["price/status/catalog visibility", "attribute and category assignment", "slug/title/SKU collision guardrails"],
-        "delete": { "level": "declared", "upstream_blocker": "delete-boundary rollback artifact contract is unavailable" }
+        "delete": {
+          "level": "executable",
+          "contract_refs": [
+            "homeboy/wordpress-rest-mutation-rollback-contract/v1",
+            "wp-codebox/delete-boundary-artifact/v1"
+          ]
+        }
       },
       "readiness": {
         "create": { "level": "executable", "via": "rest-product-batch-import" },
         "read": { "level": "executable", "via": "generated-rest-request-cases" },
         "update": { "level": "executable", "via": "rest-product-batch-import" },
-        "delete": { "level": "declared", "upstream_blocker": "generic rollback-safe REST delete primitive must emit reviewer-facing delete-boundary rollback artifacts before this route family is executable" }
+        "delete": {
+          "level": "executable",
+          "via": "generated-rest-request-cases",
+          "primitive": "wordpress.rollback-safe-rest-mutation",
+          "safety_class": "isolated_mutation",
+          "delete_boundary_artifact_schema": "wp-codebox/delete-boundary-artifact/v1"
+        }
       },
       "skipped_coverage": [
         {
@@ -39,8 +55,8 @@
           "reason_code": "owned_by_batch_import_workload"
         },
         {
-          "scope": "delete",
-          "reason_code": "missing_rollback_safe_delete_primitive"
+          "scope": "non_batch_delete_payloads",
+          "reason_code": "owned_by_generated_rest_request_cases"
         }
       ]
     },
@@ -153,6 +169,7 @@
     "fixture_owned_dynamic_path_parameter",
     "missing_rollback_safe_delete_primitive",
     "current_workload_does_not_execute_delete",
-    "owned_by_batch_import_workload"
+    "owned_by_batch_import_workload",
+    "owned_by_generated_rest_request_cases"
   ]
 }

--- a/woocommerce/woocommerce/manifests/rest-crud-route-family-catalog.json
+++ b/woocommerce/woocommerce/manifests/rest-crud-route-family-catalog.json
@@ -14,11 +14,24 @@
         "workloads": ["generated-rest-request-cases", "rest-schema-query-attribution", "rest-product-batch-import"],
         "profiles": ["product-rest-crud-fuzzer", "full-surface"]
       },
+      "mutation_contract": {
+        "primitive": "wordpress.rollback-safe-rest-mutation",
+        "workload": "rest-product-batch-import",
+        "rollback_artifacts": ["raw_result"],
+        "executable_operations": ["create", "update"]
+      },
+      "payload_fixtures": {
+        "namespace": "wc/v3",
+        "roles": ["administrator", "shop_manager"],
+        "create": ["simple product", "grouped product", "variable product parent"],
+        "update": ["price/status/catalog visibility", "attribute and category assignment", "slug/title/SKU collision guardrails"],
+        "delete": { "level": "declared", "upstream_blocker": "delete-boundary rollback artifact contract is unavailable" }
+      },
       "readiness": {
         "create": { "level": "executable", "via": "rest-product-batch-import" },
         "read": { "level": "executable", "via": "generated-rest-request-cases" },
         "update": { "level": "executable", "via": "rest-product-batch-import" },
-        "delete": { "level": "declared", "upstream_blocker": "rollback-safe REST delete primitive and delete-boundary rollback artifacts are unavailable" }
+        "delete": { "level": "declared", "upstream_blocker": "generic rollback-safe REST delete primitive must emit reviewer-facing delete-boundary rollback artifacts before this route family is executable" }
       },
       "skipped_coverage": [
         {
@@ -40,6 +53,19 @@
       "owned_by": {
         "workloads": ["rest-product-batch-import"],
         "profiles": ["product-rest-crud-fuzzer", "full-surface"]
+      },
+      "mutation_contract": {
+        "primitive": "wordpress.rollback-safe-rest-mutation",
+        "workload": "rest-product-batch-import",
+        "rollback_artifacts": ["raw_result"],
+        "executable_operations": ["create", "update"]
+      },
+      "payload_fixtures": {
+        "namespace": "wc/v3",
+        "roles": ["administrator", "shop_manager"],
+        "create": ["simple product", "grouped product", "variable product parent"],
+        "update": ["price/status/catalog visibility", "attribute and category assignment", "slug/title/SKU collision guardrails"],
+        "delete": { "level": "declared", "upstream_blocker": "delete-boundary rollback artifact contract is unavailable" }
       },
       "readiness": {
         "create": { "level": "executable", "via": "isolated_mutation" },
@@ -63,6 +89,19 @@
       "owned_by": {
         "workloads": ["rest-product-batch-import"],
         "profiles": ["product-rest-crud-fuzzer", "full-surface"]
+      },
+      "mutation_contract": {
+        "primitive": "wordpress.rollback-safe-rest-mutation",
+        "workload": "rest-product-batch-import",
+        "rollback_artifacts": ["raw_result"],
+        "executable_operations": ["create", "update"]
+      },
+      "payload_fixtures": {
+        "namespace": "wc/v3",
+        "roles": ["administrator", "shop_manager"],
+        "create": ["variation under fixture-owned variable product"],
+        "update": ["regular/sale price", "stock and status", "attribute option and image assignment"],
+        "delete": { "level": "declared", "upstream_blocker": "delete-boundary rollback artifact contract is unavailable" }
       },
       "readiness": {
         "create": { "level": "executable", "via": "isolated_mutation" },

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -261,6 +261,10 @@
       "description": "Focused WooCommerce product REST CRUD fuzzing profile for batch create/update/readback readiness, with delete explicitly blocked until upstream rollback-safe delete primitives land.",
       "route_family_catalog_manifest": "manifests/rest-crud-route-family-catalog.json",
       "hotspot_artifact_contract_manifest": "manifests/db-api-hotspot-artifact-io.json",
+      "generic_upstream_contracts": [
+        "wordpress.rollback-safe-rest-mutation",
+        "wp-codebox/wordpress-workload-run/v1"
+      ],
       "readiness": {
         "level": "executable",
         "coverage_contract": "Product REST CRUD fuzzing can execute isolated create/update plus readback through rest-product-batch-import. Delete remains declared until rollback-safe delete primitives and delete-boundary rollback artifacts exist; proven status requires reviewer-facing run artifacts and gap reports.",
@@ -279,6 +283,7 @@
           "create": {
             "level": "executable",
             "workload": "rest-product-batch-import",
+            "primitive": "wordpress.rollback-safe-rest-mutation",
             "safety_class": "isolated_mutation"
           },
           "read": {
@@ -289,14 +294,16 @@
           "update": {
             "level": "executable",
             "workload": "rest-product-batch-import",
+            "primitive": "wordpress.rollback-safe-rest-mutation",
             "safety_class": "isolated_mutation"
           },
           "delete": {
             "level": "declared",
-            "upstream_blocker": "Generic rollback-safe REST delete primitive and delete-boundary rollback artifact contract are not available to this profile."
+            "upstream_blocker": "Generic rollback-safe REST delete primitive must emit reviewer-facing delete-boundary rollback artifacts before this profile marks delete executable."
           }
         },
         "mutation": {
+          "primitive": "wordpress.rollback-safe-rest-mutation",
           "safety_boundary": "Executable product create/update cases run only inside disposable WP Codebox fixtures and must emit rollback/readback details in raw_result before any proof claim.",
           "rollback_artifacts": ["raw_result"]
         }

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -258,16 +258,19 @@
       }
     },
     "product-rest-crud-fuzzer": {
-      "description": "Focused WooCommerce product REST CRUD fuzzing profile for batch create/update/readback readiness, with delete explicitly blocked until upstream rollback-safe delete primitives land.",
+      "description": "Focused WooCommerce product REST CRUD fuzzing profile for batch create/update/readback readiness plus generic rollback-safe product delete-boundary coverage.",
       "route_family_catalog_manifest": "manifests/rest-crud-route-family-catalog.json",
       "hotspot_artifact_contract_manifest": "manifests/db-api-hotspot-artifact-io.json",
       "generic_upstream_contracts": [
         "wordpress.rollback-safe-rest-mutation",
-        "wp-codebox/wordpress-workload-run/v1"
+        "homeboy/wordpress-rest-mutation-rollback-contract/v1",
+        "wp-codebox/wordpress-workload-run/v1",
+        "wp-codebox/mutation-isolation-artifact/v1",
+        "wp-codebox/delete-boundary-artifact/v1"
       ],
       "readiness": {
         "level": "executable",
-        "coverage_contract": "Product REST CRUD fuzzing can execute isolated create/update plus readback through rest-product-batch-import. Delete remains declared until rollback-safe delete primitives and delete-boundary rollback artifacts exist; proven status requires reviewer-facing run artifacts and gap reports.",
+        "coverage_contract": "Product REST CRUD fuzzing can execute isolated create/update plus readback through rest-product-batch-import, and product collection delete-boundary coverage through the generic rollback-safe REST mutation contract. Proven status requires reviewer-facing run artifacts and gap reports.",
         "proof_bundle_requirements": {
           "status": "required_before_proven",
           "required_refs": [
@@ -298,14 +301,22 @@
             "safety_class": "isolated_mutation"
           },
           "delete": {
-            "level": "declared",
-            "upstream_blocker": "Generic rollback-safe REST delete primitive must emit reviewer-facing delete-boundary rollback artifacts before this profile marks delete executable."
+            "level": "executable",
+            "workload": "generated-rest-request-cases",
+            "primitive": "wordpress.rollback-safe-rest-mutation",
+            "safety_class": "isolated_mutation",
+            "rollback_contract_schema": "homeboy/wordpress-rest-mutation-rollback-contract/v1",
+            "delete_boundary_artifact_schema": "wp-codebox/delete-boundary-artifact/v1"
           }
         },
         "mutation": {
           "primitive": "wordpress.rollback-safe-rest-mutation",
-          "safety_boundary": "Executable product create/update cases run only inside disposable WP Codebox fixtures and must emit rollback/readback details in raw_result before any proof claim.",
-          "rollback_artifacts": ["raw_result"]
+          "safety_boundary": "Executable product create/update/delete cases run only inside disposable WP Codebox fixtures and must emit rollback/readback or delete-boundary details before any proof claim.",
+          "rollback_artifacts": ["raw_result", "delete_boundary"],
+          "rollback_artifact_schemas": [
+            "wp-codebox/mutation-isolation-artifact/v1",
+            "wp-codebox/delete-boundary-artifact/v1"
+          ]
         }
       }
     }

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -177,6 +177,18 @@ function assertNoLocalOnlyRefs(value, context = 'value') {
   }
 }
 
+function hasDeleteBoundaryContractRefs(container) {
+  const refs = [
+    ...(container?.generic_upstream_contracts || []),
+    ...(container?.mutation?.rollback_artifact_schemas || []),
+    ...(container?.rollback_artifact_schemas || []),
+    ...(container?.delete_boundary_rollback_artifacts || []),
+    container?.delete_boundary_artifact_schema,
+    container?.rollback_contract_schema,
+  ].filter(Boolean);
+  return refs.includes('homeboy/wordpress-rest-mutation-rollback-contract/v1') && refs.includes('wp-codebox/delete-boundary-artifact/v1');
+}
+
 assertArtifactPostprocessWorkloadContract(coverageGapReportWorkload, {
   id: 'coverage-gap-report',
   action: 'coverage-gap-report',
@@ -507,16 +519,24 @@ assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.route_fami
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.hotspot_artifact_contract_manifest, 'manifests/db-api-hotspot-artifact-io.json', 'product REST CRUD profile must link the hotspot artifact IO contract');
 assert.deepEqual(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.generic_upstream_contracts, [
   'wordpress.rollback-safe-rest-mutation',
+  'homeboy/wordpress-rest-mutation-rollback-contract/v1',
   'wp-codebox/wordpress-workload-run/v1',
+  'wp-codebox/mutation-isolation-artifact/v1',
+  'wp-codebox/delete-boundary-artifact/v1',
 ], 'product REST CRUD profile must consume the generic rollback-safe REST mutation primitive');
 assertProfileReadiness(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness, 'fuzz_profile_metadata.product-rest-crud-fuzzer.readiness');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.create?.level, 'executable', 'product REST CRUD create readiness must be executable');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.create?.primitive, 'wordpress.rollback-safe-rest-mutation', 'product REST CRUD create must use the generic rollback-safe REST mutation primitive');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.update?.level, 'executable', 'product REST CRUD update readiness must be executable');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.update?.primitive, 'wordpress.rollback-safe-rest-mutation', 'product REST CRUD update must use the generic rollback-safe REST mutation primitive');
-assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.delete?.level, 'declared', 'product REST CRUD delete readiness must be declared/blocked by upstream');
-assert.equal(typeof rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.delete?.upstream_blocker, 'string', 'product REST CRUD delete readiness must name upstream blocker');
-assert.match(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.delete?.upstream_blocker, /delete-boundary rollback artifacts/, 'product REST CRUD delete blocker must name missing delete-boundary rollback artifacts');
+const productRestCrudProfile = rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer'];
+assert.equal(hasDeleteBoundaryContractRefs({
+  generic_upstream_contracts: productRestCrudProfile?.generic_upstream_contracts,
+  mutation: productRestCrudProfile?.readiness?.mutation,
+}), true, 'product REST CRUD profile must reference generic delete-boundary contracts before delete is executable');
+assert.equal(productRestCrudProfile?.readiness?.crud?.delete?.level, 'executable', 'product REST CRUD delete readiness must be executable when delete-boundary contract refs are present');
+assert.equal(productRestCrudProfile?.readiness?.crud?.delete?.primitive, 'wordpress.rollback-safe-rest-mutation', 'product REST CRUD delete must use the generic rollback-safe REST mutation primitive');
+assert.equal(productRestCrudProfile?.readiness?.crud?.delete?.delete_boundary_artifact_schema, 'wp-codebox/delete-boundary-artifact/v1', 'product REST CRUD delete must name the generic delete-boundary artifact schema');
 
 const productBatchManifest = fuzzManifests.find(({ manifest }) => manifest.id === 'rest-product-batch-import')?.manifest;
 assert.equal(productBatchManifest.metadata?.readiness?.profile, 'product-rest-crud-fuzzer', 'product batch import readiness profile drifted');
@@ -551,11 +571,21 @@ for (const family of restCrudRouteFamilyCatalog.route_families) {
   if (['products-collection', 'products-batch', 'product-variations-batch'].includes(family.id)) {
     assert.equal(family.mutation_contract?.primitive, 'wordpress.rollback-safe-rest-mutation', `${family.id} must consume the generic rollback-safe REST mutation primitive`);
     assert.deepEqual(family.mutation_contract?.rollback_artifacts, ['raw_result'], `${family.id} must declare raw_result as the rollback artifact`);
-    assert.deepEqual(family.mutation_contract?.executable_operations, ['create', 'update'], `${family.id} must keep only create/update executable`);
+    const familyHasDeleteBoundaryContracts = hasDeleteBoundaryContractRefs(family.mutation_contract);
+    assert.deepEqual(
+      family.mutation_contract?.executable_operations,
+      familyHasDeleteBoundaryContracts ? ['create', 'update', 'delete'] : ['create', 'update'],
+      `${family.id} executable operations must match declared rollback/delete-boundary contract refs`
+    );
     assert.equal(family.payload_fixtures?.namespace, 'wc/v3', `${family.id} payload fixtures must declare wc/v3 namespace`);
     assert.deepEqual(family.payload_fixtures?.roles, ['administrator', 'shop_manager'], `${family.id} payload fixtures must declare Woo REST roles`);
-    assert.equal(family.payload_fixtures?.delete?.level, 'declared', `${family.id} delete payload fixture must remain declared`);
-    assert.match(family.payload_fixtures?.delete?.upstream_blocker || '', /delete-boundary rollback artifact/, `${family.id} delete payload fixture must name missing delete-boundary artifact`);
+    if (familyHasDeleteBoundaryContracts) {
+      assert.equal(family.payload_fixtures?.delete?.level, 'executable', `${family.id} delete payload fixture must be executable when delete-boundary contract refs are present`);
+      assert.deepEqual(family.mutation_contract?.delete_boundary_rollback_artifacts, ['wp-codebox/delete-boundary-artifact/v1'], `${family.id} executable delete requires delete-boundary rollback artifacts`);
+    } else {
+      assert.equal(family.payload_fixtures?.delete?.level, 'declared', `${family.id} delete payload fixture must remain declared without delete-boundary contract refs`);
+      assert.match(family.payload_fixtures?.delete?.upstream_blocker || '', /delete-boundary rollback artifact|current workload does not execute delete/, `${family.id} delete payload fixture must name the precise delete blocker`);
+    }
   }
   if (family.readiness.delete.level === 'executable') {
     assert.ok(family.mutation_contract?.delete_boundary_rollback_artifacts?.length > 0, `${family.id} executable delete requires delete-boundary rollback artifacts`);

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -505,18 +505,32 @@ const productCrudProfileIds = ['rest-product-batch-import', 'woocommerce-rest-ro
 assert.deepEqual(rig.fuzz_profiles?.['product-rest-crud-fuzzer'], productCrudProfileIds, 'product REST CRUD fuzzer profile workload ids drifted');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.route_family_catalog_manifest, 'manifests/rest-crud-route-family-catalog.json', 'product REST CRUD profile must link the route-family catalog');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.hotspot_artifact_contract_manifest, 'manifests/db-api-hotspot-artifact-io.json', 'product REST CRUD profile must link the hotspot artifact IO contract');
+assert.deepEqual(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.generic_upstream_contracts, [
+  'wordpress.rollback-safe-rest-mutation',
+  'wp-codebox/wordpress-workload-run/v1',
+], 'product REST CRUD profile must consume the generic rollback-safe REST mutation primitive');
 assertProfileReadiness(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness, 'fuzz_profile_metadata.product-rest-crud-fuzzer.readiness');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.create?.level, 'executable', 'product REST CRUD create readiness must be executable');
+assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.create?.primitive, 'wordpress.rollback-safe-rest-mutation', 'product REST CRUD create must use the generic rollback-safe REST mutation primitive');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.update?.level, 'executable', 'product REST CRUD update readiness must be executable');
+assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.update?.primitive, 'wordpress.rollback-safe-rest-mutation', 'product REST CRUD update must use the generic rollback-safe REST mutation primitive');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.delete?.level, 'declared', 'product REST CRUD delete readiness must be declared/blocked by upstream');
 assert.equal(typeof rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.delete?.upstream_blocker, 'string', 'product REST CRUD delete readiness must name upstream blocker');
+assert.match(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.delete?.upstream_blocker, /delete-boundary rollback artifacts/, 'product REST CRUD delete blocker must name missing delete-boundary rollback artifacts');
 
 const productBatchManifest = fuzzManifests.find(({ manifest }) => manifest.id === 'rest-product-batch-import')?.manifest;
 assert.equal(productBatchManifest.metadata?.readiness?.profile, 'product-rest-crud-fuzzer', 'product batch import readiness profile drifted');
 assert.equal(productBatchManifest.metadata?.readiness?.level, 'executable', 'product batch import create/update readiness must be executable');
 assert.equal(productBatchManifest.metadata?.readiness?.crud?.create?.level, 'executable', 'product batch import create readiness must be executable');
+assert.equal(productBatchManifest.metadata?.readiness?.crud?.create?.primitive, 'wordpress.rollback-safe-rest-mutation', 'product batch import create must consume rollback-safe REST mutation');
 assert.equal(productBatchManifest.metadata?.readiness?.crud?.update?.level, 'executable', 'product batch import update readiness must be executable');
+assert.equal(productBatchManifest.metadata?.readiness?.crud?.update?.primitive, 'wordpress.rollback-safe-rest-mutation', 'product batch import update must consume rollback-safe REST mutation');
 assert.equal(productBatchManifest.metadata?.readiness?.crud?.delete?.level, 'declared', 'product batch import delete readiness must remain declared/blocked');
+assert.match(productBatchManifest.metadata?.readiness?.crud?.delete?.upstream_blocker, /delete-boundary rollback artifact contract/, 'product batch import delete blocker must name missing delete-boundary rollback artifact contract');
+assert.equal(productBatchManifest.metadata?.readiness?.mutation?.primitive, 'wordpress.rollback-safe-rest-mutation', 'product batch import mutation readiness must name the generic mutation primitive');
+assert.deepEqual(productBatchManifest.metadata?.payload_fixtures?.roles, ['administrator', 'shop_manager'], 'product batch import payload fixtures must declare Woo REST roles');
+assert.equal(productBatchManifest.metadata?.payload_fixtures?.namespace, 'wc/v3', 'product batch import payload fixtures must declare Woo REST namespace');
+assert.equal(productBatchManifest.metadata?.payload_fixtures?.delete?.level, 'declared', 'product batch import delete payload fixture must remain declared');
 assert.ok(productBatchManifest.route_families.includes('wc/v3/products/batch'), 'product batch import must list products batch route family');
 assert.ok(productBatchManifest.route_families.includes('wc/v3/products/<product_id>/variations/batch'), 'product batch import must list variations batch route family');
 
@@ -533,6 +547,20 @@ for (const family of restCrudRouteFamilyCatalog.route_families) {
   assert.ok(family.readiness?.delete, `${family.id} must declare delete readiness`);
   for (const operation of ['create', 'read', 'update', 'delete']) {
     assertFuzzReadinessLevel(family.readiness?.[operation]?.level, `${family.id} ${operation} readiness level`);
+  }
+  if (['products-collection', 'products-batch', 'product-variations-batch'].includes(family.id)) {
+    assert.equal(family.mutation_contract?.primitive, 'wordpress.rollback-safe-rest-mutation', `${family.id} must consume the generic rollback-safe REST mutation primitive`);
+    assert.deepEqual(family.mutation_contract?.rollback_artifacts, ['raw_result'], `${family.id} must declare raw_result as the rollback artifact`);
+    assert.deepEqual(family.mutation_contract?.executable_operations, ['create', 'update'], `${family.id} must keep only create/update executable`);
+    assert.equal(family.payload_fixtures?.namespace, 'wc/v3', `${family.id} payload fixtures must declare wc/v3 namespace`);
+    assert.deepEqual(family.payload_fixtures?.roles, ['administrator', 'shop_manager'], `${family.id} payload fixtures must declare Woo REST roles`);
+    assert.equal(family.payload_fixtures?.delete?.level, 'declared', `${family.id} delete payload fixture must remain declared`);
+    assert.match(family.payload_fixtures?.delete?.upstream_blocker || '', /delete-boundary rollback artifact/, `${family.id} delete payload fixture must name missing delete-boundary artifact`);
+  }
+  if (family.readiness.delete.level === 'executable') {
+    assert.ok(family.mutation_contract?.delete_boundary_rollback_artifacts?.length > 0, `${family.id} executable delete requires delete-boundary rollback artifacts`);
+  } else {
+    assert.match(family.readiness.delete.upstream_blocker || '', /delete-boundary rollback artifacts|current workload does not execute delete/, `${family.id} blocked delete must name the precise delete-boundary blocker`);
   }
 }
 


### PR DESCRIPTION
## Summary
- Declare Woo product REST create/update coverage as consuming the generic rollback-safe REST mutation primitive.
- Mark product collection delete-boundary coverage executable where the merged generic rollback/delete-boundary contracts are referenced.
- Keep batch workload and route-family delete gaps blocked where the Woo workload still does not execute delete.
- Validate executable delete readiness only when `homeboy/wordpress-rest-mutation-rollback-contract/v1` and `wp-codebox/delete-boundary-artifact/v1` contract refs are present.

## Verification
- `node scripts/lint-rig-packages.mjs`
- `node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs`
- `node WordPress/wordpress-develop/tools/validate-fuzz-manifests.mjs`
- `node WordPress/gutenberg/tools/validate-fuzz-manifests.mjs`
- `node Automattic/jetpack/tools/validate-fuzz-manifests.mjs`

## Blockers
- None for the declared product collection REST mutation/delete-boundary contract coverage.
- Remaining Woo-owned delete gaps stay declared with exact blocker text where the current batch workload does not execute delete.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Manifest/validator updates, validation, and PR preparation.
