### PR TITLE
Use helper manifest fixture in rig tests

### DIFF
--- a/scripts/fixtures/homeboy-extension-wordpress/lib/helper-manifest.js
+++ b/scripts/fixtures/homeboy-extension-wordpress/lib/helper-manifest.js
@@ -1,0 +1,7 @@
+const path = require('node:path');
+
+function getWordPressHelperManifest() {
+  return { extensionRoot: path.resolve(__dirname, '..') };
+}
+
+module.exports = { getWordPressHelperManifest };

--- a/scripts/fixtures/homeboy-extension-wordpress/lib/wordpress-fuzz-manifest-validator.js
+++ b/scripts/fixtures/homeboy-extension-wordpress/lib/wordpress-fuzz-manifest-validator.js
@@ -1,0 +1,1 @@
+module.exports = require('../../shared-fuzz-validator.cjs');

--- a/scripts/fuzz-manifest-helpers.test.mjs
+++ b/scripts/fuzz-manifest-helpers.test.mjs
@@ -11,7 +11,8 @@ import {
   workloadIdFromPath,
 } from './fuzz-manifest-helpers.mjs';
 
-process.env.HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR = new URL('./fixtures/shared-fuzz-validator.cjs', import.meta.url).pathname;
+process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST = new URL('./fixtures/homeboy-extension-wordpress/lib/helper-manifest.js', import.meta.url).pathname;
+delete process.env.HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR;
 
 function fuzzManifest(overrides = {}) {
   return {

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import test from 'node:test';
 
 const script = new URL('./lint-rig-packages.mjs', import.meta.url).pathname;
-const sharedValidator = new URL('./fixtures/shared-fuzz-validator.cjs', import.meta.url).pathname;
+const wordpressHelperManifest = new URL('./fixtures/homeboy-extension-wordpress/lib/helper-manifest.js', import.meta.url).pathname;
 const wordpressCoreFuzzValidatorSource = `
 export function validateFuzzWorkload({ rel, root, workload }) {
   const failures = [];
@@ -142,7 +142,8 @@ function runLint(directory) {
     encoding: 'utf8',
     env: {
       ...process.env,
-      HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: sharedValidator,
+      HOMEBOY_WORDPRESS_HELPER_MANIFEST: wordpressHelperManifest,
+      HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: '',
     },
   });
 }

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -17,7 +17,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
 const repoRoot = path.join(packageRoot, '..', '..');
 
-process.env.HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR = path.join(repoRoot, 'scripts/fixtures/shared-fuzz-validator.cjs');
+process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST = path.join(repoRoot, 'scripts/fixtures/homeboy-extension-wordpress/lib/helper-manifest.js');
+delete process.env.HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR;
 
 const manifest = JSON.parse(readFileSync(path.join(__dirname, 'full-surface-coverage.json'), 'utf8'));
 const performanceRig = JSON.parse(readFileSync(path.join(packageRoot, 'rigs/woocommerce-performance/rig.json'), 'utf8'));


### PR DESCRIPTION
## Summary
- add upstream-style WordPress helper manifest fixtures for rig tests
- switch focused fuzz/lint tests from direct validator file injection to helper manifest discovery
- preserve product-specific rig semantics while exercising the cleaner helper contract

## Testing
- node --test scripts/fuzz-manifest-helpers.test.mjs
- node --test scripts/lint-rig-packages.test.mjs
- node --test shared/wordpress-helper-loader.test.mjs
- node --test woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
- node scripts/lint-rig-packages.mjs .

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, cleanup edits, test updates, and verification.