### PR TITLE
Guard Studio trunk rig variants

### DIFF
--- a/Automattic/studio/rigs/studio-agent-claude-trunk/rig.json
+++ b/Automattic/studio/rigs/studio-agent-claude-trunk/rig.json
@@ -4,7 +4,7 @@
   "components": {
     "studio": {
       "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_AGENT_CLAUDE_EVALTIMING__STUDIO}",
-      "branch": "agent-sdk-baseline",
+      "branch": "trunk",
       "extensions": {
         "nodejs": {
           "studio_bench_variant": "claude-sonnet-4-6-trunk",

--- a/Automattic/studio/rigs/studio-agent-model-comparison.variants.json
+++ b/Automattic/studio/rigs/studio-agent-model-comparison.variants.json
@@ -69,7 +69,7 @@
       "id": "studio-agent-claude-trunk",
       "description": "Studio Claude Sonnet 4.6 on current Automattic/studio trunk. Used as the reference rig for trunk-vs-SSI comparisons.",
       "studio_path": "${env.HOMEBOY_RIG_COMPONENT_PATH__STUDIO_AGENT_CLAUDE_EVALTIMING__STUDIO}",
-      "studio_branch": "agent-sdk-baseline",
+      "studio_branch": "trunk",
       "studio_bench_variant": "claude-sonnet-4-6-trunk",
       "studio_agent_model": "claude-sonnet-4-6"
     },

--- a/scripts/generate-studio-agent-model-rigs.mjs
+++ b/scripts/generate-studio-agent-model-rigs.mjs
@@ -50,6 +50,8 @@ const variants = Array.isArray(data.variants) ? data.variants : [];
 const shared = data.shared || {};
 const ids = new Set();
 const failures = [];
+const rigs = [];
+const trunkEquivalentBranches = new Set(['trunk', 'main', 'origin/trunk', 'origin/main']);
 
 if (variants.length === 0) {
   throw new Error(`${variantsPath}: variants must contain at least one variant`);
@@ -57,11 +59,37 @@ if (variants.length === 0) {
 
 for (const variant of variants) {
   const rig = rigFromVariant(variant, shared);
+  const expectedDescriptionRef = rig.components.studio.branch.endsWith('/main') || rig.components.studio.branch === 'main'
+    ? 'main'
+    : 'trunk';
+
   if (ids.has(rig.id)) {
     throw new Error(`${variantsPath}: duplicate variant id ${rig.id}`);
   }
   ids.add(rig.id);
 
+  if (rig.id.endsWith('-trunk')) {
+    const description = rig.description.toLowerCase();
+    if (!trunkEquivalentBranches.has(rig.components.studio.branch)) {
+      failures.push(`${rig.id}: reserved *-trunk variants must use a trunk/main-equivalent studio_branch, got ${rig.components.studio.branch}`);
+    }
+    if (!description.includes(expectedDescriptionRef)) {
+      failures.push(`${rig.id}: description must mention ${expectedDescriptionRef} to match studio_branch ${rig.components.studio.branch}`);
+    }
+  }
+
+  rigs.push(rig);
+}
+
+if (failures.length > 0) {
+  console.error('Generated Studio agent model rig metadata is invalid:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+for (const rig of rigs) {
   const rigPath = path.join(repoRoot, 'Automattic/studio/rigs', rig.id, 'rig.json');
   const next = stableJson(rig);
 


### PR DESCRIPTION
## Summary
- Fix studio-agent-claude-trunk to point at Automattic/studio trunk instead of agent-sdk-baseline.
- Regenerate the generated Studio trunk rig from studio-agent-model-comparison.variants.json.
- Extend the Studio model rig generator/check so reserved *-trunk variants must use trunk/main-equivalent refs and matching descriptions before generated rigs are written.

## Issues filed / linked
- Dynamic service ports: https://github.com/Extra-Chill/homeboy/issues/6679
- Run-scoped temp cleanup: https://github.com/Extra-Chill/homeboy/issues/6678
- Evidence/fuzz proof validators: https://github.com/Extra-Chill/homeboy/issues/6680
- Secret profiles: https://github.com/Extra-Chill/homeboy/issues/6682
- Rig variants/inheritance: https://github.com/Extra-Chill/homeboy/issues/6681
- Product-local linter validator migration: https://github.com/chubes4/homeboy-rigs/issues/519

## Verification
- node scripts/generate-studio-agent-model-rigs.mjs
- node scripts/generate-studio-agent-model-rigs.mjs --check
- node --test scripts/lint-rig-packages.test.mjs
- node scripts/lint-rig-packages.mjs .
- node --test scripts/fuzz-manifest-helpers.test.mjs scripts/lint-rig-packages.test.mjs shared/webperf/deferred-init-webperf.test.mjs shared/wp-codebox/artifacts.test.mjs shared/wordpress-helper-loader.test.mjs Automattic/jetpack/tools/fuzz-workload-validator.test.mjs Automattic/jetpack/manifests/full-surface-coverage.test.mjs WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs WordPress/gutenberg/tools/fuzz-coverage.test.mjs Automattic/studio/bench/site-build-runtime.test.mjs Automattic/studio/bench/studio-agent-site-build.test.mjs Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs WordPress/static-site-importer/tools/fixture-matrix.test.mjs woocommerce/woocommerce/bench/admin-page-coverage.test.mjs woocommerce/woocommerce/bench/checkout-shipping-cache.test.mjs woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs woocommerce/woocommerce/tools/db-api-fuzzer-artifacts.test.mjs woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs failed locally because Automattic/studio/bench/studio-agent-site-build.test.mjs requires HOMEBOY_NODEJS_WORKLOAD_UTILS in this shell; 177/178 tests passed before that environment failure.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the variant fix/guard, running verification, filing upstream tracking issues, and drafting this PR body.
