### PR TITLE
Align Woo REST delete fuzz readiness

### DIFF
--- a/woocommerce/woocommerce/manifests/rest-crud-route-family-catalog.json
+++ b/woocommerce/woocommerce/manifests/rest-crud-route-family-catalog.json
@@ -21,8 +21,7 @@
         "delete_workload": "generated-rest-request-cases",
         "rollback_contract_schema": "homeboy/wordpress-rest-mutation-rollback-contract/v1",
         "mutation_isolation_artifact_schema": "wp-codebox/mutation-isolation-artifact/v1",
-        "delete_boundary_rollback_artifacts": ["wp-codebox/delete-boundary-artifact/v1"],
-        "executable_operations": ["create", "update", "delete"]
+        "executable_operations": ["create", "update"]
       },
       "payload_fixtures": {
         "namespace": "wc/v3",
@@ -30,11 +29,8 @@
         "create": ["simple product", "grouped product", "variable product parent"],
         "update": ["price/status/catalog visibility", "attribute and category assignment", "slug/title/SKU collision guardrails"],
         "delete": {
-          "level": "executable",
-          "contract_refs": [
-            "homeboy/wordpress-rest-mutation-rollback-contract/v1",
-            "wp-codebox/delete-boundary-artifact/v1"
-          ]
+          "level": "declared",
+          "upstream_blocker": "delete-boundary rollback artifact contract is unavailable"
         }
       },
       "readiness": {
@@ -42,11 +38,8 @@
         "read": { "level": "executable", "via": "generated-rest-request-cases" },
         "update": { "level": "executable", "via": "rest-product-batch-import" },
         "delete": {
-          "level": "executable",
-          "via": "generated-rest-request-cases",
-          "primitive": "wordpress.rollback-safe-rest-mutation",
-          "safety_class": "isolated_mutation",
-          "delete_boundary_artifact_schema": "wp-codebox/delete-boundary-artifact/v1"
+          "level": "declared",
+          "upstream_blocker": "generated REST request cases do not emit delete-boundary rollback artifacts"
         }
       },
       "skipped_coverage": [

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -258,7 +258,7 @@
       }
     },
     "product-rest-crud-fuzzer": {
-      "description": "Focused WooCommerce product REST CRUD fuzzing profile for batch create/update/readback readiness plus generic rollback-safe product delete-boundary coverage.",
+      "description": "Focused WooCommerce product REST CRUD fuzzing profile for batch create/update/readback readiness. Product delete remains declared until rollback-safe delete emits delete-boundary artifacts.",
       "route_family_catalog_manifest": "manifests/rest-crud-route-family-catalog.json",
       "hotspot_artifact_contract_manifest": "manifests/db-api-hotspot-artifact-io.json",
       "generic_upstream_contracts": [
@@ -270,7 +270,7 @@
       ],
       "readiness": {
         "level": "executable",
-        "coverage_contract": "Product REST CRUD fuzzing can execute isolated create/update plus readback through rest-product-batch-import, and product collection delete-boundary coverage through the generic rollback-safe REST mutation contract. Proven status requires reviewer-facing run artifacts and gap reports.",
+        "coverage_contract": "Product REST CRUD fuzzing can execute isolated create/update plus readback through rest-product-batch-import. Product delete remains declared until the generic rollback-safe REST delete primitive emits reviewer-facing delete-boundary rollback artifacts. Proven status requires reviewer-facing run artifacts and gap reports.",
         "proof_bundle_requirements": {
           "status": "required_before_proven",
           "required_refs": [
@@ -301,18 +301,14 @@
             "safety_class": "isolated_mutation"
           },
           "delete": {
-            "level": "executable",
-            "workload": "generated-rest-request-cases",
-            "primitive": "wordpress.rollback-safe-rest-mutation",
-            "safety_class": "isolated_mutation",
-            "rollback_contract_schema": "homeboy/wordpress-rest-mutation-rollback-contract/v1",
-            "delete_boundary_artifact_schema": "wp-codebox/delete-boundary-artifact/v1"
+            "level": "declared",
+            "upstream_blocker": "Product delete coverage waits for the generic rollback-safe REST delete primitive to emit a reviewer-facing delete-boundary rollback artifact contract."
           }
         },
         "mutation": {
           "primitive": "wordpress.rollback-safe-rest-mutation",
-          "safety_boundary": "Executable product create/update/delete cases run only inside disposable WP Codebox fixtures and must emit rollback/readback or delete-boundary details before any proof claim.",
-          "rollback_artifacts": ["raw_result", "delete_boundary"],
+          "safety_boundary": "Executable product create/update cases run only inside disposable WP Codebox fixtures and must emit rollback/readback details before any proof claim. Delete remains declared until rollback-safe delete emits delete-boundary details.",
+          "rollback_artifacts": ["raw_result"],
           "rollback_artifact_schemas": [
             "wp-codebox/mutation-isolation-artifact/v1",
             "wp-codebox/delete-boundary-artifact/v1"

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -530,13 +530,9 @@ assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.update?.level, 'executable', 'product REST CRUD update readiness must be executable');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.update?.primitive, 'wordpress.rollback-safe-rest-mutation', 'product REST CRUD update must use the generic rollback-safe REST mutation primitive');
 const productRestCrudProfile = rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer'];
-assert.equal(hasDeleteBoundaryContractRefs({
-  generic_upstream_contracts: productRestCrudProfile?.generic_upstream_contracts,
-  mutation: productRestCrudProfile?.readiness?.mutation,
-}), true, 'product REST CRUD profile must reference generic delete-boundary contracts before delete is executable');
-assert.equal(productRestCrudProfile?.readiness?.crud?.delete?.level, 'executable', 'product REST CRUD delete readiness must be executable when delete-boundary contract refs are present');
-assert.equal(productRestCrudProfile?.readiness?.crud?.delete?.primitive, 'wordpress.rollback-safe-rest-mutation', 'product REST CRUD delete must use the generic rollback-safe REST mutation primitive');
-assert.equal(productRestCrudProfile?.readiness?.crud?.delete?.delete_boundary_artifact_schema, 'wp-codebox/delete-boundary-artifact/v1', 'product REST CRUD delete must name the generic delete-boundary artifact schema');
+assert.equal(productRestCrudProfile?.readiness?.crud?.delete?.level, 'declared', 'product REST CRUD delete readiness must remain declared until delete-boundary artifacts exist');
+assert.match(productRestCrudProfile?.readiness?.crud?.delete?.upstream_blocker || '', /delete-boundary rollback artifact contract/, 'product REST CRUD delete blocker must name missing delete-boundary rollback artifact contract');
+assert.equal(productRestCrudProfile?.readiness?.mutation?.rollback_artifacts?.includes('delete_boundary'), false, 'product REST CRUD mutation readiness must not require delete_boundary until delete is executable');
 
 const productBatchManifest = fuzzManifests.find(({ manifest }) => manifest.id === 'rest-product-batch-import')?.manifest;
 assert.equal(productBatchManifest.metadata?.readiness?.profile, 'product-rest-crud-fuzzer', 'product batch import readiness profile drifted');


### PR DESCRIPTION
## Summary
- Mark Woo product REST delete fuzz readiness as declared instead of executable until delete-boundary rollback artifacts exist.
- Align the Woo performance rig metadata with the current create/update executable coverage.
- Update validator assertions to prevent delete readiness drifting back to executable without artifacts.

## Tests
- `node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs`
- `node scripts/lint-rig-packages.mjs`
- `node --test scripts/fuzz-manifest-helpers.test.mjs WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs WordPress/gutenberg/tools/fuzz-coverage.test.mjs Automattic/jetpack/tools/fuzz-workload-validator.test.mjs woocommerce/woocommerce/tools/db-api-fuzzer-artifacts.test.mjs woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Aligned WooCommerce fuzz readiness metadata and validator coverage.