### PR TITLE
Require durable Woo DB API fuzz proof refs

### DIFF
--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -185,7 +185,7 @@ export function assertCanonicalFuzzEnvelopeRef(proofBundle, { file = 'fuzz workl
   );
 }
 
-function assertReviewerFacingFuzzRef(value, context) {
+export function assertReviewerFacingFuzzRef(value, context) {
   assert.equal(typeof value, 'string', `${context} must be a reviewer-facing artifact ref string`);
   assert.ok(value.trim().length > 0, `${context} must be a reviewer-facing artifact ref string`);
   assert.ok(
@@ -198,7 +198,7 @@ function assertReviewerFacingFuzzRef(value, context) {
   );
 }
 
-function localOnlyReviewerFacingRef(value) {
+export function localOnlyReviewerFacingRef(value) {
   if (typeof value !== 'string' || value.trim() === '') {
     return false;
   }

--- a/scripts/fuzz-manifest-helpers.test.mjs
+++ b/scripts/fuzz-manifest-helpers.test.mjs
@@ -4,10 +4,12 @@ import {
   assertFuzzProofBundle,
   assertFuzzReadinessMetadata,
   assertGenericFuzzManifest,
+  assertReviewerFacingFuzzRef,
   declaredFuzzIds,
   fullSurfaceRequiredArtifactIds,
   fuzzManifestHasExecutableArtifactContract,
   fuzzProofBundleFields,
+  localOnlyReviewerFacingRef,
   workloadIdFromPath,
 } from './fuzz-manifest-helpers.mjs';
 
@@ -269,4 +271,18 @@ test('assertFuzzProofBundle rejects local canonical fuzz envelope artifact refs'
       `${localRef} should be rejected`
     );
   }
+});
+
+test('reviewer-facing fuzz refs accept durable refs and reject placeholders/local refs', () => {
+  assert.doesNotThrow(() => assertReviewerFacingFuzzRef('homeboy://run/product-fuzz/artifact/report', 'proof ref'));
+  assert.equal(localOnlyReviewerFacingRef('artifact:./report.json'), true);
+  assert.equal(localOnlyReviewerFacingRef('homeboy-artifact:///tmp/report.json'), true);
+  assert.throws(
+    () => assertReviewerFacingFuzzRef('<artifact-ref>', 'proof ref'),
+    /must be a reviewer-facing artifact ref/
+  );
+  assert.throws(
+    () => assertReviewerFacingFuzzRef('artifact:./report.json', 'proof ref'),
+    /must not use local evidence/
+  );
 });

--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -187,11 +187,12 @@ The Woo DB/API fuzz progression is split into two focused profiles:
   on the same upstream rollback-safe delete primitive and delete-boundary artifact
   contract.
 
-The hotspot and coverage aggregation workloads intentionally keep
-`homeboy.artifact-postprocess` as a runner blocker. Do not shim aggregation in
-the rig: Homeboy/Homeboy Extensions must bind `args.helper`, `args.action`,
-`args.input`, `args.output`, and `args.parameters`, then collect the declared
-`fuzz.report` artifact before those contracts can become executable.
+The hotspot and coverage aggregation workloads execute through
+`homeboy.artifact-postprocess` when the approved offloaded runner provides the
+campaign artifact root. Do not shim aggregation in the rig: Homeboy/Homeboy
+Extensions must bind `args.helper`, `args.action`, `args.input`, `args.output`,
+and `args.parameters`, then collect the declared `fuzz.report` artifact before
+those contracts can become proven.
 
 The DB/API campaign manifest wires those two aggregation workloads to generic
 postprocess metadata instead of abstract proof placeholders:

--- a/woocommerce/woocommerce/bench/codebox-fuzz-suite-smoke.workload.json
+++ b/woocommerce/woocommerce/bench/codebox-fuzz-suite-smoke.workload.json
@@ -39,6 +39,6 @@
     "workload": "codebox-fuzz-suite-smoke",
     "contract": "wp-codebox/wordpress-workload-run/v1",
     "fuzz_suite": "${package.root}/manifests/codebox-fuzz-suite-smoke.json",
-    "proof_status": "contract_only_placeholder"
+    "proof_status": "declared_contract"
   }
 }

--- a/woocommerce/woocommerce/bench/coverage-gap-report.workload.json
+++ b/woocommerce/woocommerce/bench/coverage-gap-report.workload.json
@@ -47,6 +47,17 @@
     "runner_support_status": "supported",
     "readiness": {
       "level": "executable",
+      "coverage_contract": "Artifact-postprocess can execute the coverage gap report over an approved offloaded Woo DB/API campaign artifact root, but proven status requires reviewer-facing run and coverage_gap_report artifact refs.",
+      "proof_bundle_requirements": {
+        "status": "required_before_proven",
+        "required_refs": [
+          "reviewer-facing artifact-postprocess run id",
+          "reviewer-facing coverage gap report artifact ref"
+        ],
+        "required_artifacts": [
+          "coverage_gap_report"
+        ]
+      },
       "proven_when": [
         "An approved offloaded campaign run provides a reviewer-facing artifact root for prior workload outputs.",
         "The runner collects the declared coverage_gap_report fuzz.report JSON artifact as reviewer-facing evidence."

--- a/woocommerce/woocommerce/bench/performance-hotspots-artifact-summary.workload.json
+++ b/woocommerce/woocommerce/bench/performance-hotspots-artifact-summary.workload.json
@@ -51,6 +51,17 @@
     "runner_support_status": "supported",
     "readiness": {
       "level": "executable",
+      "coverage_contract": "Artifact-postprocess can execute the Woo performance hotspot summary over an approved offloaded DB/API campaign artifact root, but proven status requires reviewer-facing run and performance_hotspots_summary artifact refs.",
+      "proof_bundle_requirements": {
+        "status": "required_before_proven",
+        "required_refs": [
+          "reviewer-facing artifact-postprocess run id",
+          "reviewer-facing performance hotspot summary artifact ref"
+        ],
+        "required_artifacts": [
+          "performance_hotspots_summary"
+        ]
+      },
       "proven_when": [
         "An approved offloaded campaign run provides a reviewer-facing artifact root for prior workload outputs.",
         "The runner collects the declared performance_hotspots_summary fuzz.report JSON artifact as reviewer-facing evidence."

--- a/woocommerce/woocommerce/docs/db-api-performance-fuzzer.md
+++ b/woocommerce/woocommerce/docs/db-api-performance-fuzzer.md
@@ -42,6 +42,11 @@ log. The reviewer-facing proof bundle must contain artifacts with these schemas:
 - `homeboy/woocommerce-performance-hotspots-summary/v1` for hotspot ranking output.
 - `homeboy-rigs/wordpress-coverage-gap-report/v1` for the coverage gap report.
 
+Every proof ref must be durable and reviewer-facing, using one of the accepted
+Homeboy/GitHub ref forms (`https://`, `gh:`, `homeboy-runs:`,
+`homeboy://run/`, `homeboy-artifact://`, `artifact:`, or `run:`). Local paths,
+`file://` URLs, localhost URLs, and placeholder refs are not proof.
+
 The declared source contracts live in:
 
 - `manifests/db-api-fuzz-campaign.json`.
@@ -229,11 +234,11 @@ Runs:
 - `wc-db-api-hotspots-summary-candidate`: <stable-run-ref>
 
 Required artifacts:
-- `wp-codebox/fuzz-suite-result/v1`: <artifact-ref>
-- `wp-codebox/wordpress-hotspots/v1`: <artifact-ref>
-- `homeboy/fuzz-coverage/v1`: <artifact-ref>
-- `homeboy-rigs/wordpress-coverage-gap-report/v1`: <artifact-ref>
-- `homeboy/woocommerce-performance-hotspots-summary/v1`: <artifact-ref>
+- `wp-codebox/fuzz-suite-result/v1`: durable artifact ref from `homeboy runs refs`
+- `wp-codebox/wordpress-hotspots/v1`: durable artifact ref from `homeboy runs refs`
+- `homeboy/fuzz-coverage/v1`: durable artifact ref from `homeboy runs refs`
+- `homeboy-rigs/wordpress-coverage-gap-report/v1`: durable artifact ref from `homeboy runs refs`
+- `homeboy/woocommerce-performance-hotspots-summary/v1`: durable artifact ref from `homeboy runs refs`
 
 Compare: <compare-artifact-ref>
 Result: <pass/fail/partial with the concrete gap or hotspot delta>

--- a/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
+++ b/woocommerce/woocommerce/manifests/codebox-fuzz-suite-smoke.json
@@ -78,7 +78,7 @@
       },
       "metadata": {
         "safety_class": "read_only",
-        "proof_status": "contract_only_placeholder",
+        "proof_status": "declared_contract",
         "readiness_level": "declared"
       }
     }
@@ -86,7 +86,7 @@
   "metadata": {
     "component": "woocommerce",
     "contract": "wp-codebox/fuzz-suite/v1",
-    "proof_status": "contract_only_placeholder",
+    "proof_status": "declared_contract",
     "readiness_level": "declared",
     "public_result_contract": "wp-codebox/fuzz-suite-result/v1"
   }

--- a/woocommerce/woocommerce/manifests/db-api-fuzz-campaign.json
+++ b/woocommerce/woocommerce/manifests/db-api-fuzz-campaign.json
@@ -151,6 +151,8 @@
     "coverage_contract": "The campaign is executable only through the declared Woo fuzz workloads in an approved offloaded WP Codebox/Homeboy runner. It remains declared until reviewer-facing artifact refs exist for Codebox fuzz-suite results, WordPress hotspot artifacts, Homeboy fuzz coverage, Homeboy hotspot summary, and the coverage gap report.",
     "proof_bundle_requirements": {
       "status": "required_before_proven",
+      "local_only_refs_allowed": false,
+      "placeholder_refs_allowed": false,
       "required_refs": [
         "reviewer-facing wp-codebox/fuzz-suite-result/v1 artifact ref",
         "reviewer-facing wp-codebox/wordpress-hotspots/v1 artifact ref",
@@ -164,6 +166,39 @@
         "homeboy_fuzz_coverage",
         "homeboy_hotspot_summary",
         "coverage_gap_report"
+      ]
+    },
+    "promotion_to_proven": {
+      "local_only_refs_allowed": false,
+      "placeholder_refs_allowed": false,
+      "ref_field": "readiness.proof_bundle.required_artifact_refs",
+      "accepted_ref_schemes": ["https://", "gh:", "homeboy-runs:", "homeboy://run/", "homeboy-artifact://", "artifact:", "run:"],
+      "required_artifact_refs": [
+        {
+          "id": "codebox_fuzz_suite_result",
+          "schema": "wp-codebox/fuzz-suite-result/v1",
+          "semantic_key": "fuzz.suite_result"
+        },
+        {
+          "id": "wordpress_hotspots",
+          "schema": "wp-codebox/wordpress-hotspots/v1",
+          "semantic_key": "wordpress.hotspots"
+        },
+        {
+          "id": "homeboy_fuzz_coverage",
+          "schema": "homeboy/fuzz-coverage/v1",
+          "semantic_key": "fuzz.coverage"
+        },
+        {
+          "id": "homeboy_hotspot_summary",
+          "schema": "homeboy/woocommerce-performance-hotspots-summary/v1",
+          "semantic_key": "fuzz.report"
+        },
+        {
+          "id": "coverage_gap_report",
+          "schema": "homeboy-rigs/wordpress-coverage-gap-report/v1",
+          "semantic_key": "fuzz.report"
+        }
       ]
     },
     "upstream_blockers": [

--- a/woocommerce/woocommerce/tools/db-api-fuzzer-artifacts.mjs
+++ b/woocommerce/woocommerce/tools/db-api-fuzzer-artifacts.mjs
@@ -216,6 +216,23 @@ export function normalizeArtifactPostprocessStep(step) {
   if (output.contentType !== 'application/json') {
     throw new Error(`Unsupported artifact postprocess output contentType: ${output.contentType}`);
   }
+  if (output.schema === coverageGapSchema) {
+    const requiredFields = output.required_fields || [];
+    const expectedFields = ['surface_type', 'expected', 'covered', 'gaps', 'status', 'evidence_refs'];
+    if (JSON.stringify(requiredFields) !== JSON.stringify(expectedFields)) {
+      throw new Error(`Coverage gap output required_fields must be ${expectedFields.join(', ')}`);
+    }
+  }
+  if (output.schema === hotspotSummarySchema) {
+    const requiredFields = output.ranking?.required_fields || [];
+    const expectedFields = ['rank', 'surface', 'relative_score', 'request_attribution', 'query_attribution', 'fixture_scale', 'run_refs'];
+    if (output.ranking?.mode !== 'relative') {
+      throw new Error('Performance hotspot output ranking.mode must be relative');
+    }
+    if (JSON.stringify(requiredFields) !== JSON.stringify(expectedFields)) {
+      throw new Error(`Performance hotspot output ranking.required_fields must be ${expectedFields.join(', ')}`);
+    }
+  }
 
   return {
     command: args.action,

--- a/woocommerce/woocommerce/tools/db-api-fuzzer-artifacts.test.mjs
+++ b/woocommerce/woocommerce/tools/db-api-fuzzer-artifacts.test.mjs
@@ -173,6 +173,52 @@ test('generic artifact postprocess contract rejects invented commands and incomp
   );
 });
 
+test('generic artifact postprocess contract rejects drifted coverage output schema', () => {
+  assert.throws(
+    () => normalizeArtifactPostprocessStep({
+      command: artifactPostprocessCommand,
+      args: {
+        helper: '${package.root}/tools/db-api-fuzzer-artifacts.mjs',
+        action: 'coverage-gap-report',
+        input: { type: 'artifact-root', path: '/tmp/artifacts', artifact_globs: ['**/*.json'] },
+        output: {
+          artifact: 'coverage_gap_report',
+          path: 'coverage-gap-report/coverage_gap_report.json',
+          kind: 'json',
+          contentType: 'application/json',
+          schema: 'homeboy-rigs/wordpress-coverage-gap-report/v1',
+          semantic_key: 'fuzz.report',
+          required_fields: ['surface_type'],
+        },
+      },
+    }),
+    /Coverage gap output required_fields/
+  );
+});
+
+test('generic artifact postprocess contract rejects drifted hotspot ranking schema', () => {
+  assert.throws(
+    () => normalizeArtifactPostprocessStep({
+      command: artifactPostprocessCommand,
+      args: {
+        helper: '${package.root}/tools/db-api-fuzzer-artifacts.mjs',
+        action: 'performance-hotspots-summary',
+        input: { type: 'artifact-root', path: '/tmp/artifacts', artifact_globs: ['**/*.json'] },
+        output: {
+          artifact: 'performance_hotspots_summary',
+          path: 'performance-hotspots-artifact-summary/performance_hotspots_summary.json',
+          kind: 'json',
+          contentType: 'application/json',
+          schema: 'homeboy/woocommerce-performance-hotspots-summary/v1',
+          semantic_key: 'fuzz.report',
+          ranking: { mode: 'absolute', required_fields: ['rank'] },
+        },
+      },
+    }),
+    /ranking\.mode must be relative/
+  );
+});
+
 test('CLI rejects unsupported artifact commands', () => {
   const root = mkdtempSync(path.join(tmpdir(), 'woo-db-api-cli-'));
   const result = spawnSync(process.execPath, [

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -11,6 +11,7 @@ import {
   assertFuzzProofBundleRequirements,
   assertFuzzReadinessLevel,
   assertGenericFuzzManifest,
+  assertReviewerFacingFuzzRef,
   collectFuzzManifests,
   declaredBenchProfileIds,
   declaredBenchWorkloadIds,
@@ -174,6 +175,64 @@ function assertNoLocalOnlyRefs(value, context = 'value') {
     for (const [key, entry] of Object.entries(value)) {
       assertNoLocalOnlyRefs(entry, `${context}.${key}`);
     }
+  }
+}
+
+function assertNoProofPlaceholders(value, context = 'value') {
+  if (typeof value === 'string') {
+    assert.ok(!value.includes('contract_only_placeholder'), `${context} must not use contract_only_placeholder proof language`);
+    assert.ok(!/^<[^>]+>$/.test(value.trim()), `${context} must not use placeholder proof refs`);
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => assertNoProofPlaceholders(entry, `${context}[${index}]`));
+    return;
+  }
+
+  if (value && typeof value === 'object') {
+    for (const [key, entry] of Object.entries(value)) {
+      assertNoProofPlaceholders(entry, `${context}.${key}`);
+    }
+  }
+}
+
+function assertExecutableReadinessNeedsProofRequirements(readiness, context) {
+  assertProfileReadiness(readiness, context);
+  if (readiness.level === 'executable') {
+    assertFuzzProofBundleRequirements(readiness.proof_bundle_requirements, { file: `${context}.proof_bundle_requirements` });
+    assert.equal(readiness.proof_bundle, undefined, `${context} executable readiness must not include proof_bundle before reviewer-facing refs exist`);
+  }
+}
+
+function assertDbApiCampaignPromotionContract(campaign) {
+  const requiredArtifacts = ['codebox_fuzz_suite_result', 'wordpress_hotspots', 'homeboy_fuzz_coverage', 'homeboy_hotspot_summary', 'coverage_gap_report'];
+  const requiredSchemas = new Map(campaign.required_upstream_artifact_refs.map((artifact) => [artifact.id, artifact.schema]));
+  assert.deepEqual(new Set(requiredSchemas.keys()), new Set(requiredArtifacts), 'DB/API campaign required artifact ids drifted');
+  assert.deepEqual(new Set(campaign.readiness?.proof_bundle_requirements?.required_artifacts || []), new Set(requiredArtifacts), 'DB/API campaign proof bundle required artifacts must match required upstream artifact refs');
+  assert.equal(campaign.readiness?.proof_bundle_requirements?.local_only_refs_allowed, false, 'DB/API campaign proof refs must reject local-only refs');
+  assert.equal(campaign.readiness?.proof_bundle_requirements?.placeholder_refs_allowed, false, 'DB/API campaign proof refs must reject placeholders');
+
+  const promotion = campaign.readiness?.promotion_to_proven;
+  assert.ok(promotion && typeof promotion === 'object' && !Array.isArray(promotion), 'DB/API campaign requires promotion_to_proven contract');
+  assert.equal(promotion.local_only_refs_allowed, false, 'DB/API promotion must reject local-only refs');
+  assert.equal(promotion.placeholder_refs_allowed, false, 'DB/API promotion must reject placeholder refs');
+  assert.equal(promotion.ref_field, 'readiness.proof_bundle.required_artifact_refs', 'DB/API promotion ref field drifted');
+  assert.ok(Array.isArray(promotion.accepted_ref_schemes) && promotion.accepted_ref_schemes.length > 0, 'DB/API promotion requires accepted ref schemes');
+  assert.deepEqual(new Set((promotion.required_artifact_refs || []).map((artifact) => artifact.id)), new Set(requiredArtifacts), 'DB/API promotion required artifact refs drifted');
+  for (const artifact of promotion.required_artifact_refs || []) {
+    assert.equal(artifact.schema, requiredSchemas.get(artifact.id), `DB/API promotion artifact ${artifact.id} schema drifted`);
+    assert.equal(typeof artifact.semantic_key, 'string', `DB/API promotion artifact ${artifact.id} requires semantic_key`);
+  }
+
+  if (campaign.readiness?.level === 'proven') {
+    const proofRefs = campaign.readiness?.proof_bundle?.required_artifact_refs;
+    assert.ok(proofRefs && typeof proofRefs === 'object' && !Array.isArray(proofRefs), 'DB/API proven campaign requires readiness.proof_bundle.required_artifact_refs');
+    for (const artifactId of requiredArtifacts) {
+      assertReviewerFacingFuzzRef(proofRefs[artifactId], `DB/API campaign proof ref ${artifactId}`);
+    }
+  } else {
+    assert.equal(campaign.readiness?.proof_bundle, undefined, 'DB/API declared campaign must not carry a proof_bundle');
   }
 }
 
@@ -377,6 +436,8 @@ assert.ok(codeboxWorkloadRun.before.some((step) => step.command === 'wordpress.e
 assert.ok(codeboxWorkloadRun.steps.some((step) => step.command === 'wp-codebox/run-fuzz-suite'), 'codebox workload must route through public run-fuzz-suite ability');
 assert.equal(codeboxWorkloadRun.artifacts[0]?.metadata?.schema, 'wp-codebox/fuzz-suite-result/v1');
 assert.equal(codeboxWorkloadRun.artifacts[0]?.required, false, 'codebox workload proof artifact must remain optional until captured');
+assert.equal(codeboxWorkloadRun.metadata?.proof_status, 'declared_contract');
+assertNoProofPlaceholders(codeboxWorkloadRun, 'codebox-fuzz-suite-smoke workload');
 
 const codeboxSuite = readJson(packageRoot, 'manifests/codebox-fuzz-suite-smoke.json');
 assert.equal(codeboxSuite.schema, 'wp-codebox/fuzz-suite/v1');
@@ -439,6 +500,8 @@ assert.equal(dbApiFuzzCampaign.readiness?.level, 'declared', 'DB/API fuzz campai
 assert.equal(dbApiFuzzCampaign.readiness?.execution, 'offloaded_fuzz_campaign', 'DB/API fuzz campaign execution mode drifted');
 assertFuzzProofBundleRequirements(dbApiFuzzCampaign.readiness?.proof_bundle_requirements, { file: 'db-api-fuzz-campaign readiness' });
 assertNoLocalOnlyRefs(dbApiFuzzCampaign, 'db-api-fuzz-campaign');
+assertNoProofPlaceholders(dbApiFuzzCampaign, 'db-api-fuzz-campaign');
+assertDbApiCampaignPromotionContract(dbApiFuzzCampaign);
 assert.equal(dbApiFuzzCampaign.postprocess?.command, 'homeboy.artifact-postprocess', 'DB/API fuzz campaign must route postprocess through generic artifact-postprocess');
 assert.equal(dbApiFuzzCampaign.postprocess?.runner_support_status, 'supported', 'DB/API fuzz campaign postprocess must use supported artifact-postprocess binding');
 assert.ok(dbApiFuzzCampaign.postprocess?.blocked_until?.every((condition) => !condition.includes('args.helper')), 'DB/API fuzz campaign postprocess blockers must not claim missing helper/action/input/output/parameters binding');
@@ -507,6 +570,8 @@ assertFuzzProofBundleRequirements(dbApiHotspotArtifactIo.readiness?.proof_bundle
 assert.deepEqual(new Set(dbApiHotspotArtifactIo.expected_inputs.map((input) => input.workload_id)), new Set(dbApiPerformanceFuzzerGapReportInputIds), 'DB/API hotspot artifact IO inputs drifted');
 assert.equal(dbApiHotspotArtifactIo.sample_output?.schema, 'homeboy/woocommerce-performance-hotspots-summary/v1', 'DB/API hotspot sample output schema drifted');
 assert.equal(dbApiHotspotArtifactIo.sample_output?.threshold_policy, 'relative_ranking_only', 'DB/API hotspot sample output must use relative ranking');
+assertExecutableReadinessNeedsProofRequirements(coverageGapReportWorkload.metadata?.readiness, 'coverage-gap-report workload readiness');
+assertExecutableReadinessNeedsProofRequirements(performanceHotspotsWorkload.metadata?.readiness, 'performance-hotspots-artifact-summary workload readiness');
 assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.readiness?.crud?.read?.level, 'executable', 'DB/API rig profile read CRUD boundary must be executable');
 for (const operation of ['create', 'update', 'delete']) {
   assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.readiness?.crud?.[operation]?.level, 'declared', `DB/API rig profile ${operation} CRUD boundary must be declared`);
@@ -616,8 +681,10 @@ assert.equal(targetInventory.targets.performance_hotspots.artifact_io_manifest, 
 assert.equal(codeboxSuite.cases?.[0]?.input?.generated_from?.route_inventory_artifact, 'route_inventory');
 assert.equal(codeboxSuite.cases?.[0]?.input?.generated_from?.request_cases_artifact, 'rest_request_cases');
 assert.equal(codeboxSuite.cases?.[0]?.input?.generated_from?.query_attribution_artifact, 'rest_schema_query_attribution');
-assert.equal(codeboxSuite.cases?.[0]?.metadata?.proof_status, 'contract_only_placeholder');
+assert.equal(codeboxSuite.cases?.[0]?.metadata?.proof_status, 'declared_contract');
 assert.equal(codeboxSuite.metadata?.readiness_level, 'declared');
+assert.equal(codeboxSuite.metadata?.proof_status, 'declared_contract');
+assertNoProofPlaceholders(codeboxSuite, 'codebox suite');
 
 const proofReadyContracts = {
   'rest-namespace-generated-cases': ['namespace-classification', 'generated-safe-get-cases', 'route-gap-attribution'],


### PR DESCRIPTION
## Summary
- Tighten Woo DB/API fuzz proof metadata so promotion to proven requires durable, reviewer-facing artifact refs instead of placeholders or local-only evidence.
- Extend validators to reject proof placeholders/local refs, enforce the DB/API promotion contract, and check coverage/hotspot artifact schema drift.
- Update Woo DB/API fuzzer docs and workload metadata to describe declared/executable/proven boundaries and durable proof ref requirements.

## Tests
- `node --test scripts/fuzz-manifest-helpers.test.mjs`
- `node --test woocommerce/woocommerce/tools/db-api-fuzzer-artifacts.test.mjs`
- `node --test woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs`
- `node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs`
- `node scripts/lint-rig-packages.mjs`
- `node --test scripts/lint-rig-packages.test.mjs`

Homeboy lint could not run because no local Homeboy component is registered for this checkout.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Tightened WooCommerce DB/API fuzz proof metadata, validators, docs, and artifact schema checks.