### PR TITLE
Report SSI matrix batch child failures

### DIFF
--- a/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
+++ b/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
@@ -145,14 +145,15 @@ async function runFixtureMatrix(options) {
         };
         runtimeError ||= error;
       }
-      batchRuns.push({
-        batch: batchNumber,
-        fixture_count: fixtures.length,
-        recipe_file: batchRecipeFile,
-        output_file: outputFile,
-        exit_code: batchRuntime?.exitCode ?? 0,
-        error: batchError ? batchError.message : '',
-      });
+      batchRuns.push(fixtureMatrixBatchRunSummary({
+        batchNumber,
+        batchMatrix,
+        fixtures,
+        batchRecipeFile,
+        outputFile,
+        batchRuntime,
+        batchError,
+      }));
       batchResults.push(collectFixtureMatrixRunResults({
         matrix: batchMatrix,
         outputDirectory,
@@ -303,6 +304,29 @@ export function composerPathRepositoryConfig(rootComposer, packagePath) {
   };
 }
 
+export function fixtureMatrixBatchRunSummary(input = {}) {
+  const batchError = input.batchError || null;
+  const batchRuntime = input.batchRuntime || null;
+  const fixtureIds = normalizeFixtureIds(input.fixtures);
+  return {
+    batch: input.batchNumber,
+    batch_id: input.batchMatrix?.id || '',
+    fixture_ids: fixtureIds,
+    fixture_count: fixtureIds.length,
+    recipe_file: input.batchRecipeFile || '',
+    output_file: input.outputFile || '',
+    exit_code: batchRuntime?.exitCode ?? 0,
+    error: batchError ? batchError.message : '',
+    stderr_tail: batchError ? textTail(batchError.stderr) : '',
+    stdout_tail: batchError ? textTail(batchError.stdout) : '',
+    parsed_output: Boolean(batchRuntime?.json),
+  };
+}
+
+function normalizeFixtureIds(fixtures) {
+  return Array.isArray(fixtures) ? fixtures.map((fixture) => fixture.id).filter(Boolean) : [];
+}
+
 function composerPathRepositoryVersion(rootComposer) {
   const constraint = rootComposer?.require?.['automattic/blocks-engine-php-transformer'];
   if (typeof constraint !== 'string') {
@@ -405,6 +429,13 @@ function parseJsonText(text) {
   } catch {
     return null;
   }
+}
+
+function textTail(value, maxLength = 4000) {
+  if (typeof value !== 'string' || value.length === 0) {
+    return '';
+  }
+  return value.length > maxLength ? value.slice(value.length - maxLength) : value;
 }
 
 function camelCase(value) {

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -6,6 +6,7 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import {
   composerPathRepositoryConfig,
+  fixtureMatrixBatchRunSummary,
   resolveBlocksEnginePhpTransformerPath,
 } from '../bench/static-site-fixture-matrix.bench.mjs';
 import {
@@ -355,6 +356,31 @@ test('builds Composer path repository override matching SSI constraints', () => 
       },
     },
   });
+});
+
+test('summarizes failed WP Codebox batches with fixture ids and child output tails', () => {
+  const stderr = `${'x'.repeat(4100)}stderr failure for fixture-beta`;
+  const stdout = 'stdout includes child JSON/error context';
+  const summary = fixtureMatrixBatchRunSummary({
+    batchNumber: 2,
+    batchMatrix: { id: 'matrix-batch-002' },
+    fixtures: [{ id: 'fixture-alpha' }, { id: 'fixture-beta' }],
+    batchRecipeFile: '/tmp/wp-codebox-static-site-fixture-matrix-batch-002.json',
+    outputFile: '/tmp/wp-codebox-output-batch-002.json',
+    batchRuntime: { exitCode: 1, json: { ok: false } },
+    batchError: { message: 'recipe-run failed', stderr, stdout },
+  });
+
+  assert.equal(summary.batch, 2);
+  assert.equal(summary.batch_id, 'matrix-batch-002');
+  assert.deepEqual(summary.fixture_ids, ['fixture-alpha', 'fixture-beta']);
+  assert.equal(summary.fixture_count, 2);
+  assert.equal(summary.exit_code, 1);
+  assert.equal(summary.error, 'recipe-run failed');
+  assert.equal(summary.parsed_output, true);
+  assert.equal(summary.stderr_tail.length, 4000);
+  assert.match(summary.stderr_tail, /stderr failure for fixture-beta$/);
+  assert.equal(summary.stdout_tail, stdout);
 });
 
 test('builds one-command canonical Blocks Engine fixture matrix plan', () => {


### PR DESCRIPTION
## Summary
- Add fixture ids, batch id, stdout/stderr tails, parsed-output status, and existing recipe/output paths to SSI fixture matrix batch runtime summaries.
- Keep the change generic in the matrix evidence layer so failed WP Codebox batches produce transformer-actionable evidence on the next run.
- Add targeted Node test coverage for failed batch summaries.

## Evidence assessment
Persisted Homeboy run `e95c878b-4a3d-4d54-ab1c-fc7353f85b89` is not sufficient to identify a concrete SSI/html-to-blocks transformer fix. `runs evidence` exposes only `bench_results`, `resource_summary`, and memory timelines. Downloaded `bench_results` has empty `scenarios` and only a top-level `WORKLOAD_ERROR` tail naming `wp-codebox-static-site-fixture-matrix-batch-002.json`; it does not include fixture ids or child stdout/stderr. Downloaded `resource_summary` is process telemetry and contains no matching failure tokens for `WORKLOAD_ERROR`, `recipe-run`, fixture ids, stdout, or stderr.

## Tests
- `node --test WordPress/static-site-importer/tools/fixture-matrix.test.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigating Homeboy persisted artifacts, implementing the evidence summary change, and drafting this PR description.
