### PR TITLE
Run SSI fixture matrix as a single pass

### DIFF
--- a/WordPress/static-site-importer/README.md
+++ b/WordPress/static-site-importer/README.md
@@ -56,7 +56,7 @@ lower-level bench:
 
 - `homeboy rig install <this package> --id static-site-importer-fixture-matrix --reinstall`
 - `homeboy rig sync static-site-importer-fixture-matrix`
-- `homeboy bench --rig static-site-importer-fixture-matrix --profile fixture-matrix`
+- `homeboy bench --rig static-site-importer-fixture-matrix --profile fixture-matrix --iterations 1`
 
 It sets the SSI matrix bench environment for the canonical fixture root, Static
 Site Importer checkout, WP Codebox execution, shared state, and optional Blocks
@@ -64,6 +64,10 @@ Engine PHP transformer override. By default, `--blocks-engine` also supplies the
 release-free transformer override path. Use `--blocks-engine-php-transformer-path`
 to point at a different repo/package, or run a final release/bump proof with
 `--mode release-proof` and the released SSI dependency installed.
+
+The fixture matrix is a deterministic transformer feedback gate, not a
+performance benchmark. The rig and wrapper run a single Homeboy bench iteration
+by default; use repeated runs only for explicitly separate performance work.
 
 Output is a JSON operator summary with the run ID, fixture count, pass/fail
 counts, finding count, top buckets/kinds when present in Homeboy output, artifact

--- a/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
+++ b/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { runWpCodeboxRecipe } from '../../../shared/wp-codebox/recipe.mjs';
+import { runWpCodeboxRecipe, wpCodeboxCommand, wpCodeboxBin } from '../../../shared/wp-codebox/recipe.mjs';
 import { materializeGeneratedArtifactFixtures } from '../lib/artifact-intake.mjs';
 import {
   buildFixtureMatrixRecipe,
@@ -36,6 +36,7 @@ export default async function runFixtureMatrixBench() {
   const options = { ...optionsFromEnv(), ...parseArgs(process.argv.slice(2)) };
   const { summary, runtimeError } = await runFixtureMatrix(options);
   if (runtimeError) {
+    attachChildCommandFailures(runtimeError, summary.runtime?.child_command_failures || []);
     throw runtimeError;
   }
 
@@ -65,7 +66,7 @@ export default async function runFixtureMatrixBench() {
   };
 }
 
-async function runFixtureMatrix(options) {
+export async function runFixtureMatrix(options) {
   const outputDirectory = path.resolve(options.outputDirectory || path.join(process.cwd(), 'artifacts', 'static-site-importer-fixture-matrix'));
   const intake = options.artifactRoot
     ? materializeGeneratedArtifactFixtures({
@@ -105,6 +106,7 @@ async function runFixtureMatrix(options) {
     const batchSize = positiveInteger(options.batchSize, DEFAULT_BATCH_SIZE);
     const batchRuns = [];
     const batchResults = [];
+    const childCommandFailures = [];
     for (const [batchIndex, fixtures] of chunk(matrix.fixtures, batchSize).entries()) {
       const batchNumber = batchIndex + 1;
       const batchSuffix = String(batchNumber).padStart(3, '0');
@@ -125,6 +127,7 @@ async function runFixtureMatrix(options) {
       });
       const batchRecipeFile = path.join(outputDirectory, `wp-codebox-static-site-fixture-matrix-batch-${batchSuffix}.json`);
       const outputFile = path.join(outputDirectory, `wp-codebox-output-batch-${batchSuffix}.json`);
+      const artifactRefs = batchArtifactRefs({ outputDirectory, batchSuffix, batchRecipeFile, outputFile });
       fs.writeFileSync(batchRecipeFile, `${JSON.stringify(batchRecipe, null, 2)}\n`);
 
       let batchRuntime = null;
@@ -144,12 +147,24 @@ async function runFixtureMatrix(options) {
           json: parseJsonText(error?.stdout),
         };
         runtimeError ||= error;
+        childCommandFailures.push(buildWpCodeboxChildCommandFailure({
+          error,
+          batchNumber,
+          batchSuffix,
+          batchRecipeFile,
+          outputFile,
+          artifactsDir: outputDirectory,
+          wpCodeboxBin: options.wpCodeboxBin,
+          artifactRefs,
+        }));
       }
       batchRuns.push({
         batch: batchNumber,
+        batch_id: `${matrix.id}-batch-${batchSuffix}`,
         fixture_count: fixtures.length,
         recipe_file: batchRecipeFile,
         output_file: outputFile,
+        artifact_refs: artifactRefs,
         exit_code: batchRuntime?.exitCode ?? 0,
         error: batchError ? batchError.message : '',
       });
@@ -169,6 +184,7 @@ async function runFixtureMatrix(options) {
       exitCode: runtimeError ? (batchRuns.find((batch) => batch.exit_code)?.exit_code || 1) : 0,
       batchSize,
       batches: batchRuns,
+      childCommandFailures,
     };
     writeFixtureMatrixResultArtifacts({ outputDirectory, matrix, result: collectedResult });
   }
@@ -183,6 +199,7 @@ async function runFixtureMatrix(options) {
     output_directory: outputDirectory,
     recipe_file: recipeFile,
     artifact_refs: written.artifact_refs,
+    ...(runtime?.childCommandFailures?.length ? { child_command_failures: runtime.childCommandFailures } : {}),
     result_file: path.join(outputDirectory, 'static-site-fixture-matrix-result.json'),
     result_summary: collectedResult.summary,
     runtime: runtime ? runtimeSummary(runtime, runtimeError) : null,
@@ -319,8 +336,73 @@ function runtimeSummary(runtime, runtimeError) {
     exit_code: runtime.exitCode,
     ...(runtime.batchSize ? { batch_size: runtime.batchSize } : {}),
     ...(runtime.batches ? { batches: runtime.batches } : {}),
+    ...(runtime.childCommandFailures?.length ? { child_command_failures: runtime.childCommandFailures } : {}),
     error: runtimeError ? runtimeError.message : '',
   };
+}
+
+function attachChildCommandFailures(error, childCommandFailures) {
+  if (!childCommandFailures.length) {
+    return;
+  }
+  error.child_command_failures = childCommandFailures;
+}
+
+function buildWpCodeboxChildCommandFailure({ error, batchNumber, batchSuffix, batchRecipeFile, outputFile, artifactsDir, wpCodeboxBin: bin, artifactRefs }) {
+  const command = wpCodeboxRecipeRunCommand({ recipeFile: batchRecipeFile, artifactsDir, outputFile, wpCodeboxBin: bin });
+  return {
+    schema: 'homeboy/child-command-failure/v1',
+    kind: 'child_command_failed',
+    label: `WP Codebox recipe-run batch ${batchSuffix}`,
+    batch: batchNumber,
+    batch_id: `batch-${batchSuffix}`,
+    command,
+    exit_status: exitStatus(error),
+    stdout_tail: tailText(error?.stdout),
+    stderr_tail: tailText(error?.stderr),
+    artifact_refs: artifactRefs,
+    message: error?.message || 'WP Codebox recipe-run failed',
+  };
+}
+
+function wpCodeboxRecipeRunCommand({ recipeFile, artifactsDir, outputFile, wpCodeboxBin: bin }) {
+  const base = wpCodeboxCommand(bin || wpCodeboxBin());
+  const argv = [
+    base.command,
+    ...(base.args || []),
+    'recipe-run',
+    recipeFile,
+    '--artifacts-dir', artifactsDir,
+    '--output', outputFile,
+  ];
+  return { argv };
+}
+
+function batchArtifactRefs({ outputDirectory, batchSuffix, batchRecipeFile, outputFile }) {
+  return {
+    artifacts_directory: outputDirectory,
+    recipe_file: batchRecipeFile,
+    output_file: outputFile,
+    cli_run: path.join(outputDirectory, 'cli-run.json'),
+    matrix: path.join(outputDirectory, 'matrix.json'),
+    result: path.join(outputDirectory, 'static-site-fixture-matrix-result.json'),
+    summary: path.join(outputDirectory, 'summary.json'),
+    finding_packets: path.join(outputDirectory, 'finding-packets.json'),
+    batch_recipe: path.join(outputDirectory, `wp-codebox-static-site-fixture-matrix-batch-${batchSuffix}.json`),
+    batch_output: path.join(outputDirectory, `wp-codebox-output-batch-${batchSuffix}.json`),
+  };
+}
+
+function exitStatus(error) {
+  const status = error?.status ?? error?.exitCode ?? error?.code;
+  return Number.isInteger(status) ? status : 1;
+}
+
+function tailText(value, maxLines = 40) {
+  if (!value) {
+    return '';
+  }
+  return String(value).split(/\r?\n/).slice(-maxLines).join('\n');
 }
 
 function parseArgs(args) {

--- a/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
+++ b/WordPress/static-site-importer/rigs/static-site-importer-fixture-matrix/rig.json
@@ -21,6 +21,7 @@
   },
   "bench": {
     "default_component": "static-site-importer",
+    "iterations": 1,
     "warmup_iterations": 0,
     "result_gates": {
       "failed_fixture_count": { "lte": 0 }

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -4,9 +4,10 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
-import {
+import runFixtureMatrixBench, {
   composerPathRepositoryConfig,
   resolveBlocksEnginePhpTransformerPath,
+  runFixtureMatrix,
 } from '../bench/static-site-fixture-matrix.bench.mjs';
 import {
   buildFixtureMatrixRunPlan,
@@ -392,7 +393,7 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   assert.ok(plan.steps.some((step) => step.args.includes('sync')));
 
   const benchStep = plan.steps.at(-1);
-  assert.deepEqual(benchStep.args.slice(0, 5), ['bench', '--rig', 'static-site-importer-fixture-matrix', '--profile', 'fixture-matrix']);
+  assert.deepEqual(benchStep.args.slice(0, 7), ['bench', '--rig', 'static-site-importer-fixture-matrix', '--profile', 'fixture-matrix', '--iterations', '1']);
   assert.equal(benchStep.command, '/tmp/homeboy-latest');
   assert.ok(benchStep.args.includes('--runner'));
   assert.ok(benchStep.args.includes('homeboy-lab'));
@@ -413,6 +414,99 @@ test('builds one-command canonical Blocks Engine fixture matrix plan', () => {
   assert.deepEqual(releasePlan.dependency_overrides, {});
   assert.equal(releasePlan.steps.at(-1).args.some((arg) => arg.includes('SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH')), false);
 });
+
+test('fixture matrix records generic child command failures for failed WP Codebox batches', async () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-codebox-failure-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const fixtureRoot = path.join(root, 'fixtures');
+  const outputDirectory = path.join(root, 'artifacts');
+  const helperPath = path.join(root, 'wp-codebox-recipe-helper.cjs');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(path.join(fixtureRoot, 'failing-fixture'), { recursive: true });
+  writeFileSync(path.join(fixtureRoot, 'failing-fixture', 'index.html'), '<h1>Failing fixture</h1>');
+  writeFileSync(helperPath, `
+function wpCodeboxBin() { return '/tmp/wp-codebox'; }
+function wpCodeboxCommand(bin) { return { command: bin, args: [] }; }
+async function runWpCodeboxRecipe() {
+  const error = new Error('recipe-run failed');
+  error.code = 17;
+  error.stdout = 'stdout line 1\\nstdout line 2';
+  error.stderr = 'stderr line 1\\nstderr line 2';
+  throw error;
+}
+module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
+`, 'utf8');
+  const previousHelper = process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
+  const previousFixtureRoot = process.env.SSI_FIXTURE_MATRIX_FIXTURE_ROOT;
+  const previousOutputDirectory = process.env.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY;
+  const previousImporterPath = process.env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH;
+  const previousRun = process.env.SSI_FIXTURE_MATRIX_RUN;
+  const previousBatchSize = process.env.SSI_FIXTURE_MATRIX_BATCH_SIZE;
+  process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER = helperPath;
+
+  try {
+    const { summary, runtimeError } = await runFixtureMatrix({
+      fixtureRoot,
+      outputDirectory,
+      staticSiteImporterPath: staticSiteImporter,
+      run: true,
+      batchSize: 1,
+    });
+    const failure = summary.runtime.child_command_failures[0];
+
+    assert.equal(runtimeError.message, 'recipe-run failed');
+    assert.equal(summary.runtime.exit_code, 17);
+    assert.equal(failure.schema, 'homeboy/child-command-failure/v1');
+    assert.equal(failure.exit_status, 17);
+    assert.equal(failure.batch_id, 'batch-001');
+    assert.deepEqual(failure.command.argv, [
+      '/tmp/wp-codebox',
+      'recipe-run',
+      failure.artifact_refs.batch_recipe,
+      '--artifacts-dir', outputDirectory,
+      '--output', failure.artifact_refs.batch_output,
+    ]);
+    assert.equal(failure.stdout_tail, 'stdout line 1\nstdout line 2');
+    assert.equal(failure.stderr_tail, 'stderr line 1\nstderr line 2');
+    assert.equal(failure.artifact_refs.artifacts_directory, outputDirectory);
+    assert.equal(failure.artifact_refs.output_file, failure.artifact_refs.batch_output);
+    assert.ok(readFileSync(path.join(outputDirectory, 'cli-run.json'), 'utf8').includes('child_command_failures'));
+
+    process.env.SSI_FIXTURE_MATRIX_FIXTURE_ROOT = fixtureRoot;
+    process.env.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY = path.join(root, 'bench-export-artifacts');
+    process.env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH = staticSiteImporter;
+    process.env.SSI_FIXTURE_MATRIX_RUN = '1';
+    process.env.SSI_FIXTURE_MATRIX_BATCH_SIZE = '1';
+    await assert.rejects(
+      () => runFixtureMatrixBench(),
+      (error) => {
+        assert.equal(error.message, 'recipe-run failed');
+        assert.equal(error.child_command_failures[0].exit_status, 17);
+        assert.equal(error.child_command_failures[0].artifact_refs.artifacts_directory, process.env.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY);
+        return true;
+      }
+    );
+  } finally {
+    if (previousHelper === undefined) {
+      delete process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
+    } else {
+      process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER = previousHelper;
+    }
+    restoreEnv('SSI_FIXTURE_MATRIX_FIXTURE_ROOT', previousFixtureRoot);
+    restoreEnv('SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY', previousOutputDirectory);
+    restoreEnv('SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH', previousImporterPath);
+    restoreEnv('SSI_FIXTURE_MATRIX_RUN', previousRun);
+    restoreEnv('SSI_FIXTURE_MATRIX_BATCH_SIZE', previousBatchSize);
+  }
+});
+
+function restoreEnv(key, value) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
 
 test('fixture matrix dry-run plan surfaces local fallback and dirty workspace warnings', () => {
   const root = mkdtempSync(path.join(tmpdir(), 'ssi-warning-plan-'));

--- a/WordPress/static-site-importer/tools/run-fixture-matrix.mjs
+++ b/WordPress/static-site-importer/tools/run-fixture-matrix.mjs
@@ -157,6 +157,7 @@ function buildSteps(options, settings) {
     'bench',
     '--rig', RIG_ID,
     '--profile', 'fixture-matrix',
+    '--iterations', '1',
     '--path', options.staticSiteImporter,
     '--shared-state', options.sharedState,
     '--run-id', options.runId,


### PR DESCRIPTION
## Summary
- Make the SSI fixture matrix rig and operator wrapper run one Homeboy bench iteration by default.
- Record WP Codebox recipe-run batch failures as generic child_command_failures with argv, exit status, stdout/stderr tails, batch id, and artifact refs.
- Document the fixture matrix as deterministic transformer feedback rather than a performance benchmark.

## Tests
- node --test WordPress/static-site-importer/tools/fixture-matrix.test.mjs
- node --test scripts/lint-rig-packages.test.mjs scripts/fuzz-manifest-helpers.test.mjs shared/wordpress-helper-loader.test.mjs shared/wp-codebox/artifacts.test.mjs WordPress/static-site-importer/tools/fixture-matrix.test.mjs
- node scripts/lint-rig-packages.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the SSI fixture matrix rig semantics, implementing the single-pass/default failure evidence changes, adding focused tests, and drafting this PR description.