### PR TITLE
Prefer local SSI transformer path repository

### DIFF
--- a/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
+++ b/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
@@ -309,7 +309,7 @@ export function composerPathRepositoryConfig(rootComposer, packagePath) {
   return {
     type: 'path',
     url: packagePath,
-    canonical: false,
+    canonical: true,
     options: {
       symlink: false,
       versions: {

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -349,7 +349,7 @@ test('builds Composer path repository override matching SSI constraints', () => 
   assert.deepEqual(config, {
     type: 'path',
     url: '/tmp/blocks-engine/php-transformer',
-    canonical: false,
+    canonical: true,
     options: {
       symlink: false,
       versions: {


### PR DESCRIPTION
## Summary
- Mark the Blocks Engine PHP transformer Composer path repository as canonical.
- Keeps matrix transformer override resolution local instead of falling through to Packagist for a package that is not public there.

## Verification
- `node --test WordPress/static-site-importer/tools/fixture-matrix.test.mjs`
- `node scripts/lint-rig-packages.mjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the matrix Composer override failure and drafting the focused fix.