### PR TITLE
Classify count-only SSI fixture diagnostics

### DIFF
--- a/WordPress/static-site-importer/lib/fixture-matrix.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix.mjs
@@ -239,7 +239,8 @@ export function normalizeFixtureMatrixResult(input = {}) {
     fixture,
   ));
   const findings = dedupeFindings(fixtureResults.flatMap((result) => findingsForFixtureResult(result, { matrix })));
-  const grouped = groupFindings(findings);
+  const actionableFindings = findings.filter(isActionableFinding);
+  const grouped = groupFindings(actionableFindings);
   const gatedFixtureResults = fixtureResults.map((result) => applyFixtureQualityGate(result, findings));
   const lossClassCounts = countBy(findings, (finding) => finding.loss_class || 'unsupported_loss');
   const acceptanceCounts = countBy(findings, (finding) => finding.loss_acceptance || 'unacceptable');
@@ -255,6 +256,8 @@ export function normalizeFixtureMatrixResult(input = {}) {
       failed: gatedFixtureResults.filter((result) => result.status === 'failed').length,
       not_run: gatedFixtureResults.filter((result) => result.raw_status === 'not_run').length,
       finding_count: findings.length,
+      actionable_finding_count: actionableFindings.length,
+      non_actionable_finding_count: findings.length - actionableFindings.length,
       acceptable_finding_count: acceptanceCounts.acceptable || 0,
       unacceptable_finding_count: acceptanceCounts.unacceptable || 0,
       loss_classes: lossClassCounts,
@@ -262,9 +265,9 @@ export function normalizeFixtureMatrixResult(input = {}) {
       unacceptable_loss_classes: Object.fromEntries(Object.entries(lossClassCounts).filter(([key]) => UNACCEPTABLE_LOSS_CLASSES.has(key))),
       preserved_runtime_island_count: lossClassCounts.preserved_runtime_island || 0,
       groups: Object.fromEntries(Object.entries(grouped).map(([key, items]) => [key, items.length])),
-      top_pattern_families: topPatternFamilies(findings),
-      fixture_exemplars: fixtureExemplars(findings),
-      diagnostic_blind_spots: diagnosticBlindSpots(findings),
+      top_pattern_families: topPatternFamilies(actionableFindings),
+      fixture_exemplars: fixtureExemplars(actionableFindings),
+      diagnostic_blind_spots: diagnosticBlindSpots(actionableFindings),
       fixture_classes: Object.fromEntries(Object.entries(classRollups).map(([key, row]) => [key, row.fixture_count])),
       classes: classRollups,
       quality_budgets: qualityBudgetSummaries(classRollups),
@@ -496,7 +499,8 @@ function normalizeDiagnosticFinding(diagnostic, result, index) {
   const selector = raw.selector || rawSource.selector || rawReproduction.selector || '';
   const sourcePath = raw.source_path || raw.path || rawSource.path || rawReproduction.source_path || result.fixture_path || '';
   const repairBucket = raw.repair_bucket || group.group_key;
-  const lossClass = classifyLossClass({ raw, kind, group_key: group.group_key, repair_bucket: repairBucket, message, result });
+  const countOnlyDiagnostic = isCountOnlyStaticSiteFixtureDiagnostic({ raw, kind, message, selector });
+  const lossClass = countOnlyDiagnostic ? 'native_conversion' : classifyLossClass({ raw, kind, group_key: group.group_key, repair_bucket: repairBucket, message, result });
   const lossAcceptance = ACCEPTABLE_LOSS_CLASSES.has(lossClass) ? 'acceptable' : 'unacceptable';
   return {
     id: raw.id || `${result.fixture_id || 'fixture'}:${group.group_key}:${index + 1}`,
@@ -522,9 +526,35 @@ function normalizeDiagnosticFinding(diagnostic, result, index) {
     loss_class: lossClass,
     loss_acceptance: lossAcceptance,
     acceptable_loss: lossAcceptance === 'acceptable',
+    actionability: countOnlyDiagnostic ? 'count_only' : 'actionable',
+    actionable: !countOnlyDiagnostic,
     artifact_refs: normalizeArray(raw.artifact_refs),
     raw,
   };
+}
+
+function isActionableFinding(finding) {
+  return finding.actionable !== false;
+}
+
+function isCountOnlyStaticSiteFixtureDiagnostic({ raw, kind, message, selector }) {
+  if (kind !== 'static_site_fixture_diagnostic' || selector) {
+    return false;
+  }
+
+  const rawObject = raw && typeof raw === 'object' ? raw : {};
+  const hasActionableContext = Boolean(
+    rawObject.code
+    || rawObject.type
+    || rawObject.reason_code
+    || rawObject.detail
+    || rawObject.source_path
+    || rawObject.path
+    || rawObject.source?.selector
+    || rawObject.source?.snippet
+    || rawObject.observed?.output
+  );
+  return !hasActionableContext && /^\d+(?:\.\d+)?$/.test(String(message || '').trim());
 }
 
 function classifyLossClass({ raw, kind, group_key, repair_bucket, message, result }) {

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -261,6 +261,39 @@ test('aggregates pattern families, fixture exemplars, and diagnostic blind spots
   assert.ok(result.summary.diagnostic_blind_spots.some((spot) => spot.kind === 'generic_finding_family'));
 });
 
+test('suppresses count-only fixture diagnostics from actionable fanout rollups', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'count-only-diagnostic-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'failed',
+        diagnostics: [
+          2,
+          {
+            kind: 'core_html_block',
+            repair_bucket: 'fallback_block',
+            selector: 'input#email',
+            source_path: 'posts/page-contact.post_content',
+            message: 'generated_document_contains_core_html',
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(result.summary.finding_count, 2);
+  assert.equal(result.summary.actionable_finding_count, 1);
+  assert.equal(result.summary.non_actionable_finding_count, 1);
+  assert.equal(result.findings.find((finding) => finding.kind === 'static_site_fixture_diagnostic').actionability, 'count_only');
+  assert.equal(result.summary.top_pattern_families[0].key, 'fallback_block:core_html_block:input');
+  assert.equal(result.summary.top_pattern_families.some((family) => family.key === 'static_site_import_quality:static_site_fixture_diagnostic:(none)'), false);
+  assert.equal(result.fanout_groups.length, 1);
+  assert.equal(result.fanout_groups[0].findings.length, 1);
+  assert.equal(result.fanout_groups[0].findings[0].kind, 'core_html_block');
+});
+
 test('collects SSI finding packet source and observed context from fixture artifacts', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-finding-packet-context-'));
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'packet-context-test' });


### PR DESCRIPTION
## Summary
- classify numeric `static_site_fixture_diagnostic` entries as count-only, non-actionable findings
- keep total finding counts intact while excluding count-only noise from actionable pattern families, exemplars, blind spots, and fanout groups
- add focused coverage for suppressing `static_site_import_quality:static_site_fixture_diagnostic:(none)` from actionable rollups

## Expected effect
- the SSI fixture matrix summary no longer promotes count-only `static_site_fixture_diagnostic:(none)` as the top actionable pattern family
- paired with Extra-Chill/homeboy#6739, a single-pass matrix run with `failed_fixture_count > 0` fails the Homeboy bench via the rig-declared result gate

## Tests
- `node --test "WordPress/static-site-importer/tools/fixture-matrix.test.mjs"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Root-cause inspection, implementation, and focused test drafting.
