### PR TITLE
Classify fixture-path SSI diagnostics as count-only

### DIFF
--- a/WordPress/static-site-importer/lib/fixture-matrix.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix.mjs
@@ -499,7 +499,7 @@ function normalizeDiagnosticFinding(diagnostic, result, index) {
   const selector = raw.selector || rawSource.selector || rawReproduction.selector || '';
   const sourcePath = raw.source_path || raw.path || rawSource.path || rawReproduction.source_path || result.fixture_path || '';
   const repairBucket = raw.repair_bucket || group.group_key;
-  const countOnlyDiagnostic = isCountOnlyStaticSiteFixtureDiagnostic({ raw, kind, message, selector });
+  const countOnlyDiagnostic = isCountOnlyStaticSiteFixtureDiagnostic({ raw, result, kind, message, selector });
   const lossClass = countOnlyDiagnostic ? 'native_conversion' : classifyLossClass({ raw, kind, group_key: group.group_key, repair_bucket: repairBucket, message, result });
   const lossAcceptance = ACCEPTABLE_LOSS_CLASSES.has(lossClass) ? 'acceptable' : 'unacceptable';
   return {
@@ -537,19 +537,20 @@ function isActionableFinding(finding) {
   return finding.actionable !== false;
 }
 
-function isCountOnlyStaticSiteFixtureDiagnostic({ raw, kind, message, selector }) {
+function isCountOnlyStaticSiteFixtureDiagnostic({ raw, result, kind, message, selector }) {
   if (kind !== 'static_site_fixture_diagnostic' || selector) {
     return false;
   }
 
   const rawObject = raw && typeof raw === 'object' ? raw : {};
+  const sourcePath = rawObject.source_path || rawObject.path;
+  const sourceIsFixturePath = sourcePath && result?.fixture_path && path.resolve(String(sourcePath)) === path.resolve(String(result.fixture_path));
   const hasActionableContext = Boolean(
     rawObject.code
     || rawObject.type
     || rawObject.reason_code
     || rawObject.detail
-    || rawObject.source_path
-    || rawObject.path
+    || (sourcePath && !sourceIsFixturePath)
     || rawObject.source?.selector
     || rawObject.source?.snippet
     || rawObject.observed?.output

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -294,6 +294,47 @@ test('suppresses count-only fixture diagnostics from actionable fanout rollups',
   assert.equal(result.fanout_groups[0].findings[0].kind, 'core_html_block');
 });
 
+test('suppresses pre-normalized count-only fixture diagnostics with fixture source paths', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'pre-normalized-count-only-diagnostic-test' });
+  const fixturePath = matrix.fixtures[0].fixture_path;
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        fixture_path: fixturePath,
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'static_site_fixture_diagnostic',
+            group_key: 'static_site_import_quality',
+            repair_bucket: 'static_site_import_quality',
+            source_path: fixturePath,
+            reason: '2',
+          },
+          {
+            kind: 'core_html_block',
+            repair_bucket: 'fallback_block',
+            selector: 'input#email',
+            source_path: 'posts/page-contact.post_content',
+            message: 'generated_document_contains_core_html',
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(result.summary.finding_count, 2);
+  assert.equal(result.summary.actionable_finding_count, 1);
+  assert.equal(result.summary.non_actionable_finding_count, 1);
+  assert.equal(result.findings.find((finding) => finding.kind === 'static_site_fixture_diagnostic').actionability, 'count_only');
+  assert.equal(result.summary.top_pattern_families.some((family) => family.key === 'static_site_import_quality:static_site_fixture_diagnostic:(none)'), false);
+  assert.equal(result.summary.fixture_exemplars.some((exemplar) => exemplar.kind === 'static_site_fixture_diagnostic'), false);
+  assert.equal(result.summary.diagnostic_blind_spots.some((spot) => spot.exemplars.some((exemplar) => exemplar.kind === 'static_site_fixture_diagnostic')), false);
+  assert.equal(result.fanout_groups.length, 1);
+  assert.equal(result.fanout_groups[0].findings.some((finding) => finding.kind === 'static_site_fixture_diagnostic'), false);
+});
+
 test('collects SSI finding packet source and observed context from fixture artifacts', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-finding-packet-context-'));
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'packet-context-test' });


### PR DESCRIPTION
## Summary
- Treat pre-normalized `static_site_fixture_diagnostic` rows whose only source context is the fixture directory as count-only diagnostics.
- Keep total finding/count accounting intact while excluding those rows from actionable top pattern families, exemplars, blind spots, and fanout groups.
- Add regression coverage for the latest SSI fixture matrix evidence shape.

## Evidence
- Latest fixture matrix bench evidence: `ssi-post-196-homeboy-bench.json` reported `success:false`, `exit_code:1`, and gate failure `failed_fixture_count lte 0 (actual 72)`.
- The actionable rollups were polluted by `static_site_import_quality:static_site_fixture_diagnostic:(none)` count 72 because re-read/pre-normalized packet rows carried `source_path` equal to the fixture directory.
- Current Blocks Engine `origin/trunk` fixture root inspection found 72 top-level fixture directories and 72 discoverable `index.html` fixtures. The highest prefix is `73-h44-lacrosse`, but `1-*` is absent, so 72 appears expected for current discovery.

## Tests
- `node --test WordPress/static-site-importer/tools/fixture-matrix.test.mjs`

## Expected next-run effect
- `failed_fixture_count` should remain 72 until fixture quality improves.
- Count-only `static_site_fixture_diagnostic` rows should still contribute to total/non-actionable counts.
- `static_site_import_quality:static_site_fixture_diagnostic:(none)` should no longer appear in actionable top pattern families, fixture exemplars, diagnostic blind spot exemplars, or minion fanout groups.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Root-cause analysis of SSI matrix evidence classification, implementation, focused test coverage, and PR drafting.
