### PR TITLE
Improve SSI fixture matrix fanout diagnostics

### DIFF
--- a/WordPress/static-site-importer/lib/fixture-matrix.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix.mjs
@@ -241,10 +241,13 @@ export function normalizeFixtureMatrixResult(input = {}) {
   const findings = dedupeFindings(fixtureResults.flatMap((result) => findingsForFixtureResult(result, { matrix })));
   const actionableFindings = findings.filter(isActionableFinding);
   const grouped = groupFindings(actionableFindings);
+  const acceptableActionableFindings = actionableFindings.filter((finding) => finding.loss_acceptance === 'acceptable');
+  const unacceptableActionableFindings = actionableFindings.filter((finding) => finding.loss_acceptance !== 'acceptable');
   const gatedFixtureResults = fixtureResults.map((result) => applyFixtureQualityGate(result, findings));
   const lossClassCounts = countBy(findings, (finding) => finding.loss_class || 'unsupported_loss');
   const acceptanceCounts = countBy(findings, (finding) => finding.loss_acceptance || 'unacceptable');
   const classRollups = fixtureClassRollups(gatedFixtureResults, findings);
+  const fanoutGroups = buildFanoutGroups(actionableFindings);
 
   return {
     schema: FIXTURE_MATRIX_RESULT_SCHEMA,
@@ -266,6 +269,9 @@ export function normalizeFixtureMatrixResult(input = {}) {
       preserved_runtime_island_count: lossClassCounts.preserved_runtime_island || 0,
       groups: Object.fromEntries(Object.entries(grouped).map(([key, items]) => [key, items.length])),
       top_pattern_families: topPatternFamilies(actionableFindings),
+      top_acceptable_pattern_families: topPatternFamilies(acceptableActionableFindings),
+      top_unacceptable_pattern_families: topPatternFamilies(unacceptableActionableFindings),
+      unacceptable_candidate_repos: candidateRepoRollups(unacceptableActionableFindings),
       fixture_exemplars: fixtureExemplars(actionableFindings),
       diagnostic_blind_spots: diagnosticBlindSpots(actionableFindings),
       fixture_classes: Object.fromEntries(Object.entries(classRollups).map(([key, row]) => [key, row.fixture_count])),
@@ -274,14 +280,7 @@ export function normalizeFixtureMatrixResult(input = {}) {
     },
     fixtures: gatedFixtureResults,
     findings,
-    fanout_groups: Object.entries(grouped).map(([group_key, items], index) => ({
-      group_key,
-      index,
-      count: items.length,
-      top_pattern_families: topPatternFamilies(items, 5),
-      fixture_exemplars: fixtureExemplars(items, 5),
-      findings: items,
-    })),
+    fanout_groups: fanoutGroups.map((group, index) => ({ ...group, index })),
   };
 }
 
@@ -1042,6 +1041,86 @@ function groupFindings(findings) {
     groups[key].push(finding);
     return groups;
   }, {});
+}
+
+function buildFanoutGroups(findings) {
+  const groups = new Map();
+  for (const finding of findings) {
+    const acceptance = finding.loss_acceptance === 'acceptable' ? 'acceptable' : 'unacceptable';
+    const pattern = finding.pattern_family || patternFamily(finding);
+    const candidateRepo = finding.candidate_repo || 'unknown';
+    const key = `${acceptance}:${candidateRepo}:${pattern}`;
+    const row = groups.get(key) || {
+      group_key: key,
+      acceptance,
+      candidate_repo: candidateRepo,
+      pattern_family: pattern,
+      count: 0,
+      top_pattern_families: [],
+      fixture_exemplars: [],
+      findings: [],
+    };
+    row.count += 1;
+    row.findings.push(finding);
+    groups.set(key, row);
+  }
+
+  return [...groups.values()]
+    .map((group) => ({
+      ...group,
+      top_pattern_families: topPatternFamilies(group.findings, 5),
+      fixture_exemplars: fixtureExemplars(group.findings, 5),
+    }))
+    .sort(fanoutGroupSort);
+}
+
+function fanoutGroupSort(left, right) {
+  const acceptanceDelta = acceptanceRank(left.acceptance) - acceptanceRank(right.acceptance);
+  if (acceptanceDelta !== 0) {
+    return acceptanceDelta;
+  }
+  return right.count - left.count
+    || genericBucketRank(left) - genericBucketRank(right)
+    || left.candidate_repo.localeCompare(right.candidate_repo)
+    || left.pattern_family.localeCompare(right.pattern_family);
+}
+
+function acceptanceRank(value) {
+  return value === 'unacceptable' ? 0 : 1;
+}
+
+function genericBucketRank(group) {
+  return group.pattern_family === 'static_site_import_quality:static_site_fixture_diagnostic:(none)' ? 1 : 0;
+}
+
+function candidateRepoRollups(findings, limit = 10) {
+  const repos = new Map();
+  for (const finding of findings) {
+    const key = finding.candidate_repo || 'unknown';
+    const row = repos.get(key) || {
+      candidate_repo: key,
+      count: 0,
+      fixture_ids: [],
+      loss_classes: {},
+      repair_buckets: {},
+      top_pattern_families: [],
+      fixture_exemplars: [],
+      findings: [],
+    };
+    row.count += 1;
+    pushUnique(row.fixture_ids, finding.fixture_id, 10);
+    row.loss_classes[finding.loss_class || 'unsupported_loss'] = (row.loss_classes[finding.loss_class || 'unsupported_loss'] || 0) + 1;
+    row.repair_buckets[finding.repair_bucket || finding.group_key || 'static_site_import_quality'] = (row.repair_buckets[finding.repair_bucket || finding.group_key || 'static_site_import_quality'] || 0) + 1;
+    row.findings.push(finding);
+    row.top_pattern_families = topPatternFamilies(row.findings, 5);
+    row.fixture_exemplars = fixtureExemplars(row.findings, 5);
+    repos.set(key, row);
+  }
+
+  return [...repos.values()]
+    .map(({ findings: _findings, ...row }) => row)
+    .sort((left, right) => right.count - left.count || left.candidate_repo.localeCompare(right.candidate_repo))
+    .slice(0, limit);
 }
 
 function fixtureClassRollups(fixtureResults, findings) {

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -296,6 +296,81 @@ test('suppresses count-only fixture diagnostics from actionable fanout rollups',
   assert.equal(result.fanout_groups[0].findings[0].kind, 'core_html_block');
 });
 
+test('splits acceptable and unacceptable pattern rollups for minion fanout', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-fanout-rollups-'));
+  for (const fixture of ['fixture-alpha', 'fixture-beta', 'fixture-gamma']) {
+    mkdirSync(path.join(root, fixture), { recursive: true });
+    writeFileSync(path.join(root, fixture, 'index.html'), '<main>Fixture</main>');
+  }
+
+  const matrix = createFixtureMatrix({ fixture_root: root, id: 'fanout-rollup-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'fixture-alpha',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'layout_shift',
+            candidate_repo: 'blocks-engine',
+            source_path: 'website/index.html',
+            message: 'Unexpected layout shift in imported hero.',
+          },
+          {
+            kind: 'native_block_conversion',
+            loss_class: 'native_conversion',
+            candidate_repo: 'blocks-engine',
+            source_path: 'website/index.html',
+            message: 'Converted natively to editor blocks.',
+          },
+        ],
+      },
+      {
+        fixture_id: 'fixture-beta',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'layout_shift',
+            candidate_repo: 'blocks-engine',
+            source_path: 'website/index.html',
+            message: 'Unexpected layout shift in imported hero.',
+          },
+        ],
+      },
+      {
+        fixture_id: 'fixture-gamma',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'font_color_loss',
+            candidate_repo: 'static-site-importer',
+            source_path: 'website/index.html',
+            message: 'Font color changed after import.',
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(result.summary.finding_count, 4);
+  assert.equal(result.summary.actionable_finding_count, 4);
+  assert.equal(result.summary.acceptable_finding_count, 1);
+  assert.equal(result.summary.unacceptable_finding_count, 3);
+  assert.equal(result.summary.groups.static_site_import_quality, 4);
+  assert.equal(result.summary.top_acceptable_pattern_families[0].key, 'static_site_import_quality:native_block_conversion:(none)');
+  assert.equal(result.summary.top_unacceptable_pattern_families[0].key, 'static_site_import_quality:layout_shift:(none)');
+  assert.equal(result.summary.top_unacceptable_pattern_families[0].count, 2);
+  assert.equal(result.summary.unacceptable_candidate_repos[0].candidate_repo, 'blocks-engine');
+  assert.equal(result.summary.unacceptable_candidate_repos[0].count, 2);
+  assert.equal(result.summary.unacceptable_candidate_repos[0].top_pattern_families[0].key, 'static_site_import_quality:layout_shift:(none)');
+  assert.equal(result.fanout_groups[0].acceptance, 'unacceptable');
+  assert.equal(result.fanout_groups[0].candidate_repo, 'blocks-engine');
+  assert.equal(result.fanout_groups[0].pattern_family, 'static_site_import_quality:layout_shift:(none)');
+  assert.equal(result.fanout_groups[0].count, 2);
+  assert.notEqual(result.fanout_groups[0].group_key, 'static_site_import_quality');
+});
+
 test('collects SSI finding packet source and observed context from fixture artifacts', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-finding-packet-context-'));
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'packet-context-test' });


### PR DESCRIPTION
## Summary
- Split SSI fixture matrix top pattern families into acceptable and unacceptable surfaces while preserving existing total/actionable/non-actionable counts.
- Add unacceptable per-candidate-repo rollups with loss classes, repair buckets, pattern families, and exemplars for targeted minion assignment.
- Re-rank fanout groups by unacceptable candidate repo + pattern family so high-impact generic families are preferred over broad `static_site_import_quality` buckets.

## Evidence
- Latest evidence: `/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/ssi-post-196-homeboy-bench.json` reports `success:false`, `exit_code:1`, and `failed_fixture_count lte 0 (actual 72)`.
- Existing count-only suppression is already present on `main` via recent SSI diagnostic work; this PR does not change total counts or duplicate that suppression.

## Tests
- `node --test WordPress/static-site-importer/tools/fixture-matrix.test.mjs`

## Expected matrix effect
- `fixture_count`, `finding_count`, `actionable_finding_count`, `non_actionable_finding_count`, acceptable/unacceptable counts, and failed fixture counts remain intact.
- New `summary.top_acceptable_pattern_families` and `summary.top_unacceptable_pattern_families` separate preserved/acceptable losses from repair-blocking losses.
- New `summary.unacceptable_candidate_repos` lets the next minion wave pick candidate repos by unacceptable impact.
- `fanout_groups` now prioritize high-count unacceptable candidate-repo pattern families, avoiding broad assignment to generic `static_site_import_quality` buckets when more specific pattern families are available.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Implementation, focused test coverage, validation, and PR drafting.
