### PR TITLE
fix(ssi): preserved_runtime_island acceptable only when runtime carried/mapped

### DIFF
--- a/WordPress/static-site-importer/lib/fixture-matrix.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix.mjs
@@ -52,6 +52,20 @@ const UNACCEPTABLE_LOSS_CLASSES = new Set([
   'fixture_failed',
 ]);
 
+// Loss classes whose acceptability is conditional rather than automatic.
+// `preserved_runtime_island` only earns an acceptable verdict when the finding
+// carries an explicit signal that the interactive runtime/behavior was actually
+// carried or mapped into the WordPress site. "Markup preserved, behavior dead"
+// is a feature-parity failure, not an acceptable loss.
+const RUNTIME_CARRIED_SIGNAL_KEYS = [
+  'runtime_carried',
+  'runtimeCarried',
+  'runtime_mapped',
+  'runtimeMapped',
+  'runtime_mapping',
+  'runtimeMapping',
+];
+
 const FIXTURE_CLASSES = [
   'marketing/static',
   'docs/blog',
@@ -500,7 +514,7 @@ function normalizeDiagnosticFinding(diagnostic, result, index) {
   const repairBucket = raw.repair_bucket || group.group_key;
   const countOnlyDiagnostic = isCountOnlyStaticSiteFixtureDiagnostic({ raw, result, kind, message, selector });
   const lossClass = countOnlyDiagnostic ? 'native_conversion' : classifyLossClass({ raw, kind, group_key: group.group_key, repair_bucket: repairBucket, message, result });
-  const lossAcceptance = ACCEPTABLE_LOSS_CLASSES.has(lossClass) ? 'acceptable' : 'unacceptable';
+  const lossAcceptance = resolveLossAcceptance(lossClass, raw);
   return {
     id: raw.id || `${result.fixture_id || 'fixture'}:${group.group_key}:${index + 1}`,
     kind,
@@ -595,6 +609,42 @@ function classifyLossClass({ raw, kind, group_key, repair_bucket, message, resul
     return 'unsupported_loss';
   }
   return 'native_conversion';
+}
+
+function resolveLossAcceptance(lossClass, raw) {
+  if (lossClass === 'preserved_runtime_island') {
+    // Feature parity: a preserved interactive island is only acceptable when the
+    // required runtime/behavior was actually carried or mapped. Absent that
+    // explicit positive signal, the behavior is dead and the gate must fail.
+    return hasRuntimeCarriedSignal(raw) ? 'acceptable' : 'unacceptable';
+  }
+  return ACCEPTABLE_LOSS_CLASSES.has(lossClass) ? 'acceptable' : 'unacceptable';
+}
+
+function hasRuntimeCarriedSignal(raw) {
+  const rawObject = objectValue(raw);
+  const classification = objectValue(rawObject.classification);
+  return RUNTIME_CARRIED_SIGNAL_KEYS.some((key) => isTruthySignal(rawObject[key]) || isTruthySignal(classification[key]));
+}
+
+function isTruthySignal(value) {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    return !['', 'false', '0', 'no', 'none', 'null', 'undefined'].includes(normalized);
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value !== 0;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (typeof value === 'object') {
+    return Object.keys(value).length > 0;
+  }
+  return Boolean(value);
 }
 
 function normalizeFixture(input) {

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -105,6 +105,7 @@ test('gates fixture matrix failures by unacceptable loss classes', () => {
           {
             kind: 'runtime_dependency_missing_dom_target',
             loss_class: 'preserved_runtime_island',
+            runtime_carried: true,
             source_path: 'website/index.html',
             selector: '#hero canvas',
             message: 'Runtime island preserved for editor-safe import.',
@@ -112,6 +113,7 @@ test('gates fixture matrix failures by unacceptable loss classes', () => {
           {
             kind: 'html_canvas_runtime_fallback',
             loss_class: 'preserved_runtime_island',
+            runtime_carried: true,
             source_path: 'website/index.html',
             selector: '#hero canvas',
             message: 'Blocks Engine reported the same preserved runtime island.',
@@ -144,6 +146,101 @@ test('gates fixture matrix failures by unacceptable loss classes', () => {
   assert.equal(unacceptableResult.summary.failed, 1);
   assert.equal(unacceptableResult.summary.unacceptable_finding_count, 1);
   assert.equal(unacceptableResult.summary.unacceptable_loss_classes.fixture_failed, 1);
+});
+
+test('fails the gate when a preserved_runtime_island carries no runtime-carried signal', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'runtime-island-no-signal-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'html_form_fallback',
+            loss_class: 'preserved_runtime_island',
+            source_path: 'posts/page-contact.post_content',
+            selector: 'form#contact',
+            message: 'Contact form markup preserved but no handler was carried.',
+          },
+        ],
+      },
+    ],
+  });
+
+  const finding = result.findings[0];
+  assert.equal(finding.loss_class, 'preserved_runtime_island');
+  assert.equal(finding.loss_acceptance, 'unacceptable');
+  assert.equal(finding.acceptable_loss, false);
+  assert.equal(result.summary.preserved_runtime_island_count, 1);
+  assert.equal(result.summary.acceptable_finding_count, 0);
+  assert.equal(result.summary.unacceptable_finding_count, 1);
+  assert.equal(result.summary.failed, 1);
+  assert.equal(result.summary.succeeded, 0);
+  assert.equal(result.fixtures[0].status, 'failed');
+});
+
+test('passes the gate when a preserved_runtime_island carries a runtime-carried signal', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'runtime-island-signal-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'html_form_fallback',
+            loss_class: 'preserved_runtime_island',
+            runtime_mapped: 'wp-block-contact-form',
+            source_path: 'posts/page-contact.post_content',
+            selector: 'form#contact',
+            message: 'Contact form markup preserved and behavior mapped to a native block.',
+          },
+        ],
+      },
+    ],
+  });
+
+  const finding = result.findings[0];
+  assert.equal(finding.loss_class, 'preserved_runtime_island');
+  assert.equal(finding.loss_acceptance, 'acceptable');
+  assert.equal(finding.acceptable_loss, true);
+  assert.equal(result.summary.acceptable_finding_count, 1);
+  assert.equal(result.summary.unacceptable_finding_count, 0);
+  assert.equal(result.summary.succeeded, 1);
+  assert.equal(result.summary.failed, 0);
+  assert.equal(result.fixtures[0].status, 'passed');
+});
+
+test('keeps native_conversion findings acceptable without a runtime-carried signal', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'native-conversion-acceptance-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'native_block_conversion',
+            loss_class: 'native_conversion',
+            source_path: 'website/index.html',
+            message: 'Converted natively to editor blocks.',
+          },
+        ],
+      },
+    ],
+  });
+
+  const finding = result.findings[0];
+  assert.equal(finding.loss_class, 'native_conversion');
+  assert.equal(finding.loss_acceptance, 'acceptable');
+  assert.equal(result.summary.acceptable_finding_count, 1);
+  assert.equal(result.summary.unacceptable_finding_count, 0);
+  assert.equal(result.summary.succeeded, 1);
+  assert.equal(result.fixtures[0].status, 'passed');
 });
 
 test('classifies fixtures into generic product taxonomy from metadata and files', () => {


### PR DESCRIPTION
Closes #534

## North star
The SSI fixture matrix scores whether a static site became a **working** WordPress site with full visual **and feature** parity — not just content preservation.

## Problem
`WordPress/static-site-importer/lib/fixture-matrix.mjs` listed `preserved_runtime_island` in `ACCEPTABLE_LOSS_CLASSES`. So an import that preserved interactive markup but **dropped the behavior** (dead contact form, dead hamburger toggle) was scored ACCEPTABLE and the gate PASSED. Under feature parity, "markup preserved, behavior dead" is a parity failure, not an acceptable loss.

## Fix
Per-finding `loss_acceptance` for `preserved_runtime_island` is now computed by a new `resolveLossAcceptance(lossClass, raw)` helper, called where `loss_acceptance` originates in `normalizeDiagnosticFinding`. The matrix always recomputes acceptance there, so the rule is enforced even when findings arrive pre-classified upstream.

A `preserved_runtime_island` finding is **acceptable ONLY** when it carries an explicit positive signal that the runtime/behavior was actually carried or mapped:
- `runtime_carried` / `runtime_mapped` / `runtime_mapping` (plus camelCase variants)
- the same keys nested under `classification.*`

Truthiness is evaluated conservatively (`false`, `0`, `""`, `"no"`, `"none"`, `null` do not count). With **no** such signal the finding is classified as a feature-parity loss (`loss_acceptance = unacceptable`) and the gate fails until the behavior is rebuilt.

`native_conversion` and `editable_approximation` stay acceptable exactly as before. No other loss classes change.

## Tests
`node WordPress/static-site-importer/tools/fixture-matrix.test.mjs` → **27 pass / 0 fail** (24 existing + 3 new):
- preserved_runtime_island **without** a runtime-carried signal → unacceptable, fixture fails the gate.
- preserved_runtime_island **with** a `runtime_mapped` signal → acceptable, fixture passes.
- native_conversion without any signal stays acceptable.

The pre-existing gate test was updated to add `runtime_carried: true` to its preserved-island diagnostics, preserving its original intent (island preserved **and** runtime carried → pass).

## Expected, honest consequence
This will (correctly) make **`73-h44-lacrosse` FAIL the gate again**. Its contact form fires `html_form_fallback` → `preserved_runtime_island` with no runtime-carried signal, and its hamburger toggle has no JS behavior carried. Until those behaviors are rebuilt, the fixture is an honest feature-parity failure rather than a false green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)