### PR TITLE
Wire hbex visual-compare (pixel parity) into the SSI fixture matrix and gate on it

### DIFF
--- a/WordPress/static-site-importer/README.md
+++ b/WordPress/static-site-importer/README.md
@@ -130,6 +130,8 @@ The workload composes these generic surfaces:
   commands.
 - WP Codebox `wordpress.editor-canvas-probe` command for the editor-side block
   validity step (see below).
+- WP Codebox `wordpress.visual-compare` command for the pixel visual-parity step
+  (see below).
 
 SSI-specific behavior remains here: plugin slug/defaults, fixture artifact
 packing, `static-site-importer validate-artifact` command construction,
@@ -167,6 +169,47 @@ the studio bench, wp-codebox's `editor-actions`/`inspectState` would need to
 emit `getBlocks()` `isValid` (or run `wp.blocks.validateBlock`); the probe path
 used here detects invalid blocks via the warning DOM without any wp-codebox
 change, which `collectEditorValidationDiagnostics` already consumes.
+
+## Pixel Visual Parity Gate
+
+Structural, feature, and editor-block validity all run *without ever rendering a
+browser*. After each fixture's import step, `buildFixtureMatrixRecipe` appends a
+`wordpress.visual-compare` step that renders the fixture's original static source
+vs the imported WordPress candidate in the same WP Codebox sandbox and emits
+`source.png`/`candidate.png`/`diff.png` plus `mismatch_pixels`/`total_pixels`
+(`wp-codebox/visual-compare/v1`). This is the exact recipe command the reusable
+`runVisualParityWorkload` helper composes in homeboy-extensions — the matrix
+emits it inline rather than spinning up a separate sandbox, so no new wp-codebox
+capability is introduced.
+
+`collectVisualParityDiagnostics` reads the comparison back out (from either the
+raw `wp-codebox/visual-compare/v1` diff or a normalized
+`homeboy/VisualParityArtifact/v1` artifact) and emits a `visual_parity_mismatch`
+diagnostic when `mismatch_pixels / total_pixels` exceeds the threshold (or a
+dimension mismatch is reported). Findings route to the visual-parity repair
+bucket (`candidate_repo: blocks-engine`, `repair_mode: visual-parity`). The
+screenshots, diff, and metrics are also captured into the SSI
+`visual_parity_artifacts` slot (`static-site-importer/visual-parity-artifacts/v1`)
+on the fixture result, even when the gate is off.
+
+Gating is **opt-in**, because pixel diffs can be flaky. By default a mismatch is
+captured but non-gating (the `visual_parity_mismatch` loss class resolves to
+`acceptable`). Pass `--visual-parity-gate` (run wrapper) /
+`SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE=1` to make a mismatch-over-threshold a
+HARD gate (the loss class flips to the unacceptable, fixture-failing form, the
+same conditional-acceptance pattern as `preserved_runtime_island`). The mismatch
+threshold is configurable via `--pixel-threshold` /
+`SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD` (default `0.1`, also passed as
+the per-pixel `threshold=` arg so a higher value loosens the gate monotonically).
+Set `--no-visual-parity` / `visualParity: false` to omit the step entirely.
+
+Live caveat: a full visual-parity render requires a healthy Lab runner (the
+runner currently has a controller/daemon version drift). The wiring and the
+finding-parsing/threshold/gating logic are unit-tested in
+`tools/fixture-matrix.test.mjs`. Wiring the exact servable source URL per fixture
+is the remaining live-run enablement; the step uses generic, configurable
+source/candidate URLs with per-fixture overrides today, mirroring how the editor
+step uses a configurable URL rather than resolving each imported post.
 
 ## Generated Artifact Intake Contract
 

--- a/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
+++ b/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
@@ -95,6 +95,7 @@ export async function runFixtureMatrix(options) {
     staticSiteImporterPath,
     staticSiteImporterPlugin: options.staticSiteImporterPlugin,
     staticSiteImporterSlug: options.staticSiteImporterSlug,
+    ...visualParityRecipeInput(options),
   });
   const recipeFile = path.join(outputDirectory, 'wp-codebox-static-site-fixture-matrix-recipe.json');
   fs.writeFileSync(recipeFile, `${JSON.stringify(recipe, null, 2)}\n`);
@@ -124,6 +125,7 @@ export async function runFixtureMatrix(options) {
         staticSiteImporterPath,
         staticSiteImporterPlugin: options.staticSiteImporterPlugin,
         staticSiteImporterSlug: options.staticSiteImporterSlug,
+        ...visualParityRecipeInput(options),
       });
       const batchRecipeFile = path.join(outputDirectory, `wp-codebox-static-site-fixture-matrix-batch-${batchSuffix}.json`);
       const outputFile = path.join(outputDirectory, `wp-codebox-output-batch-${batchSuffix}.json`);
@@ -173,6 +175,7 @@ export async function runFixtureMatrix(options) {
         outputFile,
         codeboxOutput: batchRuntime?.json,
         codeboxError: batchError,
+        visualParity: visualParityGateInput(options),
       }));
     }
     collectedResult = normalizeFixtureMatrixResult({
@@ -472,6 +475,29 @@ function optionsFromEnv(env = process.env) {
     batchSize: benchEnv.SSI_FIXTURE_MATRIX_BATCH_SIZE || env.SSI_FIXTURE_MATRIX_BATCH_SIZE,
     run: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_RUN) || isTruthy(env.SSI_FIXTURE_MATRIX_RUN),
     wpCodeboxBin: benchEnv.SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN || env.SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN,
+    visualParity: !isFalsy(benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY ?? env.SSI_FIXTURE_MATRIX_VISUAL_PARITY),
+    visualParityGate: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE) || isTruthy(env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE),
+    pixelThreshold: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD,
+    visualParityCandidateUrl: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_CANDIDATE_URL || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_CANDIDATE_URL,
+    visualParitySourceBaseUrl: benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY_SOURCE_BASE_URL || env.SSI_FIXTURE_MATRIX_VISUAL_PARITY_SOURCE_BASE_URL,
+  };
+}
+
+// Visual-parity options shared by the recipe (capture step) and the result
+// collector (gating). Enable defaults on; gating defaults off (opt-in).
+function visualParityRecipeInput(options) {
+  return {
+    visualParity: options.visualParity !== false,
+    pixelThreshold: options.pixelThreshold,
+    visualParityCandidateUrl: options.visualParityCandidateUrl,
+    visualParitySourceBaseUrl: options.visualParitySourceBaseUrl,
+  };
+}
+
+function visualParityGateInput(options) {
+  return {
+    threshold: options.pixelThreshold,
+    gate: options.visualParityGate === true,
   };
 }
 
@@ -488,6 +514,10 @@ function settingsBenchEnv(env = process.env) {
 
 function isTruthy(value) {
   return value === true || value === '1' || value === 'true';
+}
+
+function isFalsy(value) {
+  return value === false || value === '0' || value === 'false' || value === 'no' || value === 'off';
 }
 
 function chunk(items, size) {

--- a/WordPress/static-site-importer/lib/fixture-matrix.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix.mjs
@@ -27,6 +27,25 @@ export const EDITOR_INVALID_BLOCK_SELECTORS = [
 const DEFAULT_EDITOR_VALIDATION_URL = '/wp-admin/post-new.php';
 const EDITOR_BLOCK_INVALID_DEFAULT_DETAIL = 'This block contains unexpected or invalid content';
 
+// Pixel visual-parity wiring. After import, the same WP Codebox sandbox renders
+// the fixture's original static source vs the imported WordPress output via the
+// existing `wordpress.visual-compare` recipe command (the same command the
+// reusable `runVisualParityWorkload` helper composes in homeboy-extensions). The
+// command emits `source.png`/`candidate.png`/`diff.png` plus
+// `mismatch_pixels`/`total_pixels`, which `collectVisualParityDiagnostics` reads
+// back out. No new wp-codebox capability is introduced. Capture is on by
+// default; gating on mismatch-over-threshold is opt-in (pixel diffs can be
+// flaky) and is expressed as the conditional `visual_parity_mismatch` loss class.
+export const VISUAL_PARITY_MISMATCH_KIND = 'visual_parity_mismatch';
+const DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD = 0.1;
+const DEFAULT_VISUAL_PARITY_CANDIDATE_URL = '/';
+const DEFAULT_VISUAL_PARITY_SOURCE_BASE_URL = '/wp-content/uploads/static-site-importer-fixture-matrix';
+const DEFAULT_VISUAL_PARITY_VIEWPORT = { width: 1280, height: 1600 };
+const DEFAULT_VISUAL_PARITY_WAIT_FOR = 'domcontentloaded';
+// A finding only gates when it carries an explicit opt-in gate signal; absent
+// that, a mismatch is captured but non-gating (capture-only default).
+const VISUAL_PARITY_GATE_SIGNAL_KEYS = ['gate', 'visual_parity_gate', 'visualParityGate'];
+
 const DEFAULT_FINDING_GROUPS = {
   // Editor-side block invalidity routes to the Blocks Engine feature/visual
   // parity bucket and must gate. Listed first so the `editor_block_invalid`
@@ -36,6 +55,14 @@ const DEFAULT_FINDING_GROUPS = {
     patterns: [/editor_block_invalid/i, /editor block validation/i, /block-editor-warning/i, /this block contains unexpected or invalid content/i],
     candidate_repo: 'blocks-engine',
     repair_mode: 'editor-block-validation-parity',
+  },
+  // Pixel visual-parity mismatches route to a dedicated visual-parity repair
+  // bucket. Listed early so the `visual_parity_mismatch` kind classifies here
+  // rather than falling into a generic group.
+  visual_parity_mismatch: {
+    patterns: [/visual_parity_mismatch/i, /visual parity/i, /pixel (?:diff|mismatch|parity)/i],
+    candidate_repo: 'blocks-engine',
+    repair_mode: 'visual-parity',
   },
   button_style_loss: {
     patterns: [/default gray button/i, /button.*gray/i, /button.*style/i],
@@ -68,6 +95,10 @@ const ACCEPTABLE_LOSS_CLASSES = new Set([
   'native_conversion',
   'editable_approximation',
   'preserved_runtime_island',
+  // Visual-parity mismatches are capture-only (acceptable) by default; they only
+  // become unacceptable when an explicit gate signal is present. See
+  // `resolveLossAcceptance`. This mirrors the conditional `preserved_runtime_island`.
+  'visual_parity_mismatch',
 ]);
 
 const UNACCEPTABLE_LOSS_CLASSES = new Set([
@@ -223,6 +254,8 @@ export function buildFixtureMatrixRecipe(input = {}) {
   const extraPlugins = [importer.extraPlugin, ...normalizeArray(input.extraPlugins || input.extra_plugins)];
   const editorValidationEnabled = input.editorValidation !== false && input.editor_validation !== false;
   const editorValidationUrl = input.editorValidationUrl || input.editor_validation_url || DEFAULT_EDITOR_VALIDATION_URL;
+  const visualParityEnabled = input.visualParity !== false && input.visual_parity !== false;
+  const visualParityRecipeOptions = normalizeVisualParityRecipeOptions(input);
 
   if (playgroundArtifactsDirectory) {
     mounts.push({
@@ -253,6 +286,7 @@ export function buildFixtureMatrixRecipe(input = {}) {
             ],
           },
           ...(editorValidationEnabled ? [editorBlockValidationStep({ fixture, url: editorValidationUrl })] : []),
+          ...(visualParityEnabled ? [visualParityCompareStep({ fixture, ...visualParityRecipeOptions })] : []),
         ]),
       ],
     },
@@ -279,6 +313,61 @@ export function editorBlockValidationStep(input = {}) {
       `url=${url}`,
       `selector-groups-json=${JSON.stringify(selectorGroups)}`,
     ],
+  };
+}
+
+// Compose the existing `wordpress.visual-compare` recipe command into a
+// per-fixture visual-parity step. This is the same command the reusable
+// `runVisualParityWorkload` helper composes in homeboy-extensions; the matrix
+// emits it inline alongside the import/editor steps rather than spinning up a
+// separate sandbox. It renders the fixture's static source vs the imported
+// WordPress candidate and writes `source.png`/`candidate.png`/`diff.png` plus
+// the `mismatch_pixels`/`total_pixels` comparison that
+// `collectVisualParityDiagnostics` reads back out. Source/candidate URLs are
+// generic and configurable (with per-fixture overrides) — the exact servable
+// source URL is the remaining live-run wiring, mirroring how the #537 editor
+// step uses a configurable URL rather than resolving each imported post.
+export function visualParityCompareStep(input = {}) {
+  const fixture = input.fixture || {};
+  const options = normalizeVisualParityRecipeOptions(input);
+  const sourceUrl = input.sourceUrl
+    || input.source_url
+    || fixture.source_url
+    || fixture.sourceUrl
+    || `${options.sourceBaseUrl.replace(/\/+$/, '')}/${fixture.id || 'fixture'}/${String(options.sourceEntry).replace(/^\/+/, '')}`;
+  const candidateUrl = input.candidateUrl
+    || input.candidate_url
+    || fixture.candidate_url
+    || fixture.candidateUrl
+    || options.candidateUrl;
+  return {
+    command: 'wordpress.visual-compare',
+    args: [
+      `source-url=${sourceUrl}`,
+      `candidate-url=${candidateUrl}`,
+      `source-label=${fixture.id ? `${fixture.id}-source` : 'source'}`,
+      `candidate-label=${fixture.id ? `${fixture.id}-candidate` : 'candidate'}`,
+      `viewport=${options.viewport.width}x${options.viewport.height}`,
+      `full-page=${options.fullPage ? 'true' : 'false'}`,
+      `wait-for=${options.waitFor}`,
+      `threshold=${options.pixelThreshold}`,
+    ],
+  };
+}
+
+function normalizeVisualParityRecipeOptions(input = {}) {
+  const viewport = objectValue(input.visualParityViewport || input.visual_parity_viewport || input.viewport);
+  return {
+    pixelThreshold: finiteNumber(input.pixelThreshold ?? input.pixel_threshold ?? input.visualParityPixelThreshold ?? input.visual_parity_pixel_threshold, DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD),
+    candidateUrl: input.visualParityCandidateUrl || input.visual_parity_candidate_url || input.candidateUrl || DEFAULT_VISUAL_PARITY_CANDIDATE_URL,
+    sourceBaseUrl: input.visualParitySourceBaseUrl || input.visual_parity_source_base_url || input.sourceBaseUrl || DEFAULT_VISUAL_PARITY_SOURCE_BASE_URL,
+    sourceEntry: input.visualParitySourceEntry || input.visual_parity_source_entry || input.sourceEntry || 'index.html',
+    viewport: {
+      width: finiteNumber(viewport.width, DEFAULT_VISUAL_PARITY_VIEWPORT.width),
+      height: finiteNumber(viewport.height, DEFAULT_VISUAL_PARITY_VIEWPORT.height),
+    },
+    fullPage: input.visualParityFullPage !== false && input.visual_parity_full_page !== false && input.fullPage !== false,
+    waitFor: input.visualParityWaitFor || input.visual_parity_wait_for || input.waitFor || DEFAULT_VISUAL_PARITY_WAIT_FOR,
   };
 }
 
@@ -395,13 +484,14 @@ export function collectFixtureMatrixRunResults(input = {}) {
   const codeboxOutput = input.codeboxOutput || input.codebox_output || readJsonFileIfExists(input.outputFile || input.output_file) || null;
   const codeboxError = input.codeboxError || input.codebox_error || null;
   const runtimePayloads = collectRuntimePayloads(codeboxOutput);
+  const visualParity = normalizeVisualParityGateOptions(input.visualParity || input.visual_parity || input);
   const results = matrix.fixtures.map((fixture) => {
     const fixtureArtifactsDirectory = path.join(outputDirectory, fixture.id);
     const payloads = [
       ...runtimePayloads.filter((payload) => fixtureIdentity(payload) === fixture.id),
       ...readFixturePayloadFiles(fixtureArtifactsDirectory),
     ];
-    return normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError });
+    return normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity });
   });
 
   return normalizeFixtureMatrixResult({ matrix, results });
@@ -648,6 +738,9 @@ function classifyLossClass({ raw, kind, group_key, repair_bucket, message, resul
   if (kind === 'fixture_failed' || group_key === 'fixture_failed') {
     return 'fixture_failed';
   }
+  if (group_key === 'visual_parity_mismatch' || kind === VISUAL_PARITY_MISMATCH_KIND || /visual parity mismatch|pixel (?:diff|mismatch)/i.test(haystack)) {
+    return 'visual_parity_mismatch';
+  }
   if (group_key === 'editor_block_invalid' || kind === EDITOR_BLOCK_INVALID_KIND || /editor block validation|block-editor-warning|this block contains unexpected or invalid content/i.test(haystack)) {
     return 'editor_block_invalid';
   }
@@ -676,7 +769,19 @@ function resolveLossAcceptance(lossClass, raw) {
     // explicit positive signal, the behavior is dead and the gate must fail.
     return hasRuntimeCarriedSignal(raw) ? 'acceptable' : 'unacceptable';
   }
+  if (lossClass === 'visual_parity_mismatch') {
+    // Opt-in gate: a pixel mismatch is captured but non-gating by default
+    // (capture-only). It only becomes an unacceptable, gating finding when the
+    // run explicitly opted into gating (the parser stamps a gate signal).
+    return hasVisualParityGateSignal(raw) ? 'unacceptable' : 'acceptable';
+  }
   return ACCEPTABLE_LOSS_CLASSES.has(lossClass) ? 'acceptable' : 'unacceptable';
+}
+
+function hasVisualParityGateSignal(raw) {
+  const rawObject = objectValue(raw);
+  const classification = objectValue(rawObject.classification);
+  return VISUAL_PARITY_GATE_SIGNAL_KEYS.some((key) => isTruthySignal(rawObject[key]) || isTruthySignal(classification[key]));
 }
 
 function hasRuntimeCarriedSignal(raw) {
@@ -769,13 +874,14 @@ function normalizeFixtureResult(input) {
     diagnostics: normalizeArray(input.diagnostics || input.findings || input.messages),
     artifact_refs: normalizeArray(input.artifact_refs || input.artifactRefs),
     artifacts: input.artifacts || {},
+    visual_parity_artifacts: input.visual_parity_artifacts || input.visualParityArtifacts || null,
     raw: input,
   };
 }
 
-function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError }) {
+function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDirectory, codeboxError, visualParity }) {
   const merged = mergeObjects(payloads);
-  const diagnostics = collectFixtureDiagnostics(merged);
+  const diagnostics = collectFixtureDiagnostics(merged, { visualParity });
   const error = firstString([
     merged.error,
     merged.message && isFailurePayload(merged) ? merged.message : '',
@@ -798,11 +904,12 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
     diagnostics,
     artifact_refs: collectFixtureArtifactRefs(merged, fixtureArtifactsDirectory),
     artifacts: merged.artifacts || {},
+    visual_parity_artifacts: collectVisualParityArtifacts(merged),
     raw: { payloads },
   });
 }
 
-function collectFixtureDiagnostics(payload) {
+function collectFixtureDiagnostics(payload, options = {}) {
   const diagnostics = [
     ...normalizeArray(payload.diagnostics),
     ...normalizeArray(payload.fixture_diagnostics?.diagnostics || payload.fixtureDiagnostics?.diagnostics),
@@ -816,6 +923,7 @@ function collectFixtureDiagnostics(payload) {
     ...collectRuntimeTargetGaps(payload).map((gap) => ({ kind: 'runtime_target_gap', ...objectValue(gap), message: diagnosticMessage(gap) || 'Runtime target gap detected.' })),
     ...collectMissingAssets(payload).map((asset) => ({ kind: missingAssetKind(asset), ...objectValue(asset), message: diagnosticMessage(asset) || 'Missing imported asset.' })),
     ...collectEditorValidationDiagnostics(payload),
+    ...collectVisualParityDiagnostics(payload, options.visualParity),
   ];
   const invalidBlockCount = Object.values(collectInvalidBlockCounts(payload)).reduce((sum, value) => sum + numberValue(value), 0);
   if (invalidBlockCount > 0) {
@@ -1043,7 +1151,7 @@ function hasPayloadData(value) {
 }
 
 function readFixturePayloadFiles(directory) {
-  return ['validation-result.json', 'result.json', 'import-report.json', 'quality.json', 'blocks-engine-diagnostics.json', 'editor-validation.json', 'editor-canvas-summary.json']
+  return ['validation-result.json', 'result.json', 'import-report.json', 'quality.json', 'blocks-engine-diagnostics.json', 'editor-validation.json', 'editor-canvas-summary.json', 'visual-compare.json', 'visual-diff.json', 'visual-parity.json']
     .map((fileName) => readJsonFileIfExists(path.join(directory, fileName)))
     .filter(Boolean);
 }
@@ -1258,6 +1366,157 @@ function isEditorInvalidBlockGroup(group) {
     return true;
   }
   return /block-editor-warning|is-invalid/.test(String(group.selector || ''));
+}
+
+// Turn `wordpress.visual-compare` evidence into `visual_parity_mismatch`
+// diagnostics. A comparison whose mismatch ratio (mismatch_pixels/total_pixels)
+// exceeds the threshold — or that reports a dimension mismatch — emits a
+// diagnostic. When the run opted into gating, the diagnostic carries a `gate`
+// signal so it resolves to the unacceptable `visual_parity_mismatch` loss class
+// and fails the fixture; otherwise it is captured but non-gating (capture-only
+// default, since pixel diffs can be flaky). Matches at or under the threshold
+// emit nothing.
+export function collectVisualParityDiagnostics(payload, options = {}) {
+  const { threshold, gate } = normalizeVisualParityGateOptions(options);
+  const diagnostics = [];
+  for (const comparison of collectVisualParityComparisons(payload)) {
+    if (comparison.mismatch_ratio <= threshold && !comparison.dimension_mismatch) {
+      continue;
+    }
+    const percent = (comparison.mismatch_ratio * 100).toFixed(2);
+    const thresholdPercent = (threshold * 100).toFixed(2);
+    diagnostics.push({
+      kind: VISUAL_PARITY_MISMATCH_KIND,
+      ...(gate ? { gate: true, visual_parity_gate: true } : {}),
+      source_path: comparison.source_path || '',
+      observed_output: `${percent}% pixels differ (${comparison.mismatch_pixels}/${comparison.total_pixels})`,
+      mismatch_pixels: comparison.mismatch_pixels,
+      total_pixels: comparison.total_pixels,
+      mismatch_ratio: comparison.mismatch_ratio,
+      threshold,
+      dimension_mismatch: comparison.dimension_mismatch,
+      artifact_refs: visualParityArtifactRefs(comparison),
+      message: comparison.dimension_mismatch
+        ? `Visual parity dimension mismatch between source and imported output (${comparison.mismatch_pixels}/${comparison.total_pixels} pixels, ${percent}%).`
+        : `Pixel visual parity mismatch: ${comparison.mismatch_pixels}/${comparison.total_pixels} pixels (${percent}%) exceed the ${thresholdPercent}% threshold.`,
+    });
+  }
+  return diagnostics;
+}
+
+export function normalizeVisualParityGateOptions(options = {}) {
+  const source = objectValue(options);
+  return {
+    threshold: clampRatio(finiteNumber(source.threshold ?? source.pixelThreshold ?? source.pixel_threshold ?? source.visualParityPixelThreshold ?? source.visual_parity_pixel_threshold, DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD)),
+    gate: isTruthySignal(source.gate ?? source.visualParityGate ?? source.visual_parity_gate),
+  };
+}
+
+function clampRatio(value) {
+  if (!Number.isFinite(value) || value < 0) {
+    return DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD;
+  }
+  return value > 1 ? 1 : value;
+}
+
+// Collect candidate visual-compare records from either the normalized
+// `homeboy/VisualParityArtifact/v1` artifact (summary.*), the raw
+// `wp-codebox/visual-compare/v1` diff (comparison.*), or loosely-shaped payloads.
+function collectVisualParityComparisons(payload) {
+  const candidates = [
+    ...normalizeArray(payload.visual_parity || payload.visualParity),
+    ...normalizeArray(payload.visual_parity_artifacts || payload.visualParityArtifacts),
+    ...normalizeArray(payload.visual_compare || payload.visualCompare),
+    ...normalizeArray(payload.visual_diff || payload.visualDiff),
+    ...normalizeArray(payload.visual_parity?.comparisons || payload.visualParity?.comparisons),
+  ];
+  if (isVisualParityPayload(payload)) {
+    candidates.push(payload);
+  }
+  return candidates.map(normalizeVisualParityComparison).filter(Boolean);
+}
+
+function isVisualParityPayload(payload) {
+  const value = objectValue(payload);
+  if (typeof value.schema === 'string' && /visual.?compare|visualparityartifact/i.test(value.schema)) {
+    return true;
+  }
+  return Boolean(value.comparison && typeof value.comparison === 'object')
+    || (objectValue(value.summary).mismatch_pixels !== undefined)
+    || (objectValue(value.summary).total_pixels !== undefined);
+}
+
+function normalizeVisualParityComparison(value) {
+  const obj = objectValue(value);
+  const summary = objectValue(obj.summary);
+  const comparison = objectValue(obj.comparison);
+  const mismatchPixels = firstNumber([summary.mismatch_pixels, summary.mismatchPixels, comparison.mismatchPixels, comparison.mismatch_pixels, obj.mismatch_pixels, obj.mismatchPixels]);
+  const totalPixels = firstNumber([summary.total_pixels, summary.totalPixels, comparison.totalPixels, comparison.total_pixels, obj.total_pixels, obj.totalPixels]);
+  const explicitRatio = firstNumber([summary.mismatch_ratio, summary.mismatchRatio, comparison.mismatchRatio, comparison.mismatch_ratio, obj.mismatch_ratio, obj.mismatchRatio]);
+  const dimensionMismatch = Boolean(summary.dimension_mismatch ?? comparison.dimensionMismatch ?? comparison.dimension_mismatch ?? obj.dimension_mismatch);
+  const hasMetrics = [mismatchPixels, totalPixels, explicitRatio].some((metric) => Number.isFinite(metric));
+  if (!hasMetrics && !dimensionMismatch) {
+    return null;
+  }
+  const safeMismatch = Number.isFinite(mismatchPixels) ? mismatchPixels : 0;
+  const safeTotal = Number.isFinite(totalPixels) ? totalPixels : 0;
+  const ratio = safeTotal > 0 ? safeMismatch / safeTotal : (Number.isFinite(explicitRatio) ? explicitRatio : 0);
+  const files = objectValue(obj.files);
+  const artifacts = objectValue(obj.artifacts);
+  const sourceObject = objectValue(obj.source);
+  return {
+    mismatch_pixels: safeMismatch,
+    total_pixels: safeTotal,
+    mismatch_ratio: ratio,
+    dimension_mismatch: dimensionMismatch,
+    source_path: firstString([sourceObject.path, sourceObject.url, obj.source_path, obj.sourcePath]),
+    source_screenshot: firstString([artifacts.source_screenshot, files.sourceScreenshot, obj.source_screenshot, obj.sourceScreenshot]),
+    candidate_screenshot: firstString([artifacts.candidate_screenshot, artifacts.imported_screenshot, files.candidateScreenshot, obj.candidate_screenshot, obj.candidateScreenshot]),
+    diff_screenshot: firstString([artifacts.diff_screenshot, files.diffScreenshot, obj.diff_screenshot, obj.diffScreenshot]),
+    visual_diff: firstString([artifacts.visual_diff, files.visualDiff, obj.visual_diff, obj.visualDiff]),
+  };
+}
+
+function visualParityArtifactRefs(comparison) {
+  return [
+    ['source_screenshot', comparison.source_screenshot],
+    ['candidate_screenshot', comparison.candidate_screenshot],
+    ['diff_screenshot', comparison.diff_screenshot],
+    ['visual_diff', comparison.visual_diff],
+  ]
+    .filter(([, ref]) => Boolean(ref))
+    .map(([id, ref]) => artifactRef(id, ref, 'visual-parity'));
+}
+
+// Capture visual-compare evidence into the SSI `visual_parity_artifacts` slot
+// shape so screenshots, the diff, and the mismatch metrics surface on the
+// fixture result even when gating is off. Returns null when no visual data was
+// produced (the runtime did not render).
+function collectVisualParityArtifacts(payload) {
+  const comparisons = collectVisualParityComparisons(payload);
+  if (comparisons.length === 0) {
+    return null;
+  }
+  const comparison = comparisons[0];
+  const slot = (ref, kind, reason) => (ref
+    ? { status: 'captured', kind, ref: artifactRef(kind, ref, 'visual-parity') }
+    : { status: 'pending', kind, capture_state: 'not_captured', reason });
+  return {
+    schema: 'static-site-importer/visual-parity-artifacts/v1',
+    owner: 'codebox_runtime',
+    metrics: compactObject({
+      mismatch_pixels: comparison.mismatch_pixels,
+      total_pixels: comparison.total_pixels,
+      mismatch_ratio: comparison.mismatch_ratio,
+      dimension_mismatch: comparison.dimension_mismatch,
+    }),
+    artifacts: {
+      source_screenshot: slot(comparison.source_screenshot, 'source_screenshot', 'Source screenshot was not captured by the runtime.'),
+      imported_screenshot: slot(comparison.candidate_screenshot, 'imported_screenshot', 'Imported WordPress screenshot was not captured by the runtime.'),
+      diff_screenshot: slot(comparison.diff_screenshot, 'diff_screenshot', 'Diff screenshot was not captured by the runtime.'),
+      visual_diff: slot(comparison.visual_diff, 'visual_diff', 'Visual diff output was not captured by the runtime.'),
+    },
+  };
 }
 
 function groupFindings(findings) {
@@ -1500,6 +1759,19 @@ function numberValue(value) {
   return Number.isFinite(number) ? number : 0;
 }
 
+function firstNumber(values) {
+  for (const value of values) {
+    if (value === undefined || value === null || value === '') {
+      continue;
+    }
+    const number = Number(value);
+    if (Number.isFinite(number)) {
+      return number;
+    }
+  }
+  return NaN;
+}
+
 function firstString(values) {
   return values.map((value) => String(value || '').trim()).find(Boolean) || '';
 }
@@ -1560,6 +1832,9 @@ function normalizeLossClass(value) {
     invalid_block_content: 'invalid_block_content',
     editor_block_invalid: 'editor_block_invalid',
     editor_invalid_block: 'editor_block_invalid',
+    visual_parity_mismatch: 'visual_parity_mismatch',
+    visual_parity: 'visual_parity_mismatch',
+    pixel_mismatch: 'visual_parity_mismatch',
     missing_asset: 'missing_asset',
     missing_assets: 'missing_asset',
     missing_output: 'missing_output',

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -27,10 +27,13 @@ import {
   classifyStaticSiteFinding,
   collectEditorValidationDiagnostics,
   collectFixtureMatrixRunResults,
+  collectVisualParityDiagnostics,
   createFixtureMatrix,
   editorBlockValidationStep,
   EDITOR_INVALID_BLOCK_SELECTOR_GROUP,
   normalizeFixtureMatrixResult,
+  VISUAL_PARITY_MISMATCH_KIND,
+  visualParityCompareStep,
   writeFixtureMatrixArtifacts,
 } from '../lib/fixture-matrix.mjs';
 import { materializeGeneratedArtifactFixtures } from '../lib/artifact-intake.mjs';
@@ -1166,4 +1169,148 @@ test('editor_block_invalid findings collected from fixture artifacts gate the ma
   assert.ok(finding, 'expected an editor_block_invalid finding from the canvas-probe artifact');
   assert.equal(finding.loss_acceptance, 'unacceptable');
   assert.equal(result.fixtures[0].status, 'failed');
+});
+
+test('recipe runs a wordpress.visual-compare visual-parity step after each import', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-parity-recipe-test' });
+  const recipe = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+    pixelThreshold: 0.05,
+  });
+
+  // [activate, validate(simple-site), editor-validation(simple-site), visual-compare(simple-site)]
+  const visualStep = recipe.workflow.steps[3];
+  assert.equal(visualStep.command, 'wordpress.visual-compare');
+  assert.ok(visualStep.args.some((arg) => arg.startsWith('source-url=')));
+  assert.ok(visualStep.args.some((arg) => arg.startsWith('candidate-url=')));
+  assert.ok(visualStep.args.includes('threshold=0.05'));
+
+  const disabled = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+    visualParity: false,
+  });
+  assert.equal(disabled.workflow.steps.some((step) => step.command === 'wordpress.visual-compare'), false);
+});
+
+test('visualParityCompareStep composes the existing wordpress.visual-compare command with per-fixture overrides', () => {
+  const step = visualParityCompareStep({
+    fixture: { id: 'shop', source_url: 'http://127.0.0.1:4173/shop/index.html', candidate_url: '/?p=42' },
+    pixelThreshold: 0.2,
+  });
+  assert.equal(step.command, 'wordpress.visual-compare');
+  assert.ok(step.args.includes('source-url=http://127.0.0.1:4173/shop/index.html'));
+  assert.ok(step.args.includes('candidate-url=/?p=42'));
+  assert.ok(step.args.includes('threshold=0.2'));
+  assert.ok(step.args.includes('source-label=shop-source'));
+  assert.ok(step.args.includes('candidate-label=shop-candidate'));
+});
+
+test('(a) visual-compare mismatch at/under threshold produces no finding', () => {
+  const payload = {
+    schema: 'wp-codebox/visual-compare/v1',
+    comparison: { mismatchPixels: 1000, totalPixels: 2048000, dimensionMismatch: false },
+  };
+  // ratio ~0.0005, threshold 0.1 -> captured, no diagnostic.
+  assert.deepEqual(collectVisualParityDiagnostics(payload, { threshold: 0.1, gate: true }), []);
+
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-parity-under-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{ fixture_id: 'simple-site', status: 'passed', diagnostics: collectVisualParityDiagnostics(payload, { threshold: 0.1, gate: true }) }],
+  });
+  assert.equal(result.findings.some((finding) => finding.kind === VISUAL_PARITY_MISMATCH_KIND), false);
+  assert.equal(result.fixtures[0].status, 'passed');
+});
+
+test('(b) visual-compare mismatch over threshold with gate on becomes a gating unacceptable finding', () => {
+  const payload = {
+    schema: 'homeboy/VisualParityArtifact/v1',
+    summary: { mismatch_pixels: 600000, total_pixels: 2048000, dimension_mismatch: false },
+    artifacts: { source_screenshot: 'files/browser/visual-compare/source.png', candidate_screenshot: 'files/browser/visual-compare/candidate.png', diff_screenshot: 'files/browser/visual-compare/diff.png' },
+  };
+  const diagnostics = collectVisualParityDiagnostics(payload, { threshold: 0.1, gate: true });
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0].kind, VISUAL_PARITY_MISMATCH_KIND);
+  assert.equal(diagnostics[0].gate, true);
+
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-parity-gate-on-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{ fixture_id: 'simple-site', status: 'passed', diagnostics }],
+  });
+  const finding = result.findings.find((item) => item.kind === VISUAL_PARITY_MISMATCH_KIND);
+  assert.ok(finding, 'expected a visual_parity_mismatch finding');
+  assert.equal(finding.group_key, 'visual_parity_mismatch');
+  assert.equal(finding.repair_bucket, 'visual_parity_mismatch');
+  assert.equal(finding.candidate_repo, 'blocks-engine');
+  assert.equal(finding.loss_class, 'visual_parity_mismatch');
+  assert.equal(finding.loss_acceptance, 'unacceptable');
+  assert.equal(result.summary.unacceptable_finding_count, 1);
+  assert.equal(result.fixtures[0].status, 'failed');
+});
+
+test('(c) visual-compare mismatch over threshold with gate off is captured but non-gating', () => {
+  const payload = {
+    schema: 'homeboy/VisualParityArtifact/v1',
+    summary: { mismatch_pixels: 600000, total_pixels: 2048000, dimension_mismatch: false },
+  };
+  const diagnostics = collectVisualParityDiagnostics(payload, { threshold: 0.1, gate: false });
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0].gate, undefined);
+
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-parity-gate-off-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [{ fixture_id: 'simple-site', status: 'passed', diagnostics }],
+  });
+  const finding = result.findings.find((item) => item.kind === VISUAL_PARITY_MISMATCH_KIND);
+  assert.ok(finding, 'expected a captured visual_parity_mismatch finding');
+  assert.equal(finding.loss_acceptance, 'acceptable');
+  assert.equal(result.summary.unacceptable_finding_count, 0);
+  assert.equal(result.fixtures[0].status, 'passed');
+});
+
+test('visual-compare artifacts collected from fixture files gate the matrix when gating is opted in', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-parity-artifact-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-parity-artifact-test' });
+  const fixtureDirectory = path.join(outputDirectory, 'simple-site');
+  mkdirSync(fixtureDirectory, { recursive: true });
+  writeFileSync(path.join(fixtureDirectory, 'visual-diff.json'), JSON.stringify({
+    schema: 'wp-codebox/visual-compare/v1',
+    comparison: { mismatchPixels: 700000, totalPixels: 2048000, dimensionMismatch: false },
+    files: {
+      sourceScreenshot: 'files/browser/visual-compare/source.png',
+      candidateScreenshot: 'files/browser/visual-compare/candidate.png',
+      diffScreenshot: 'files/browser/visual-compare/diff.png',
+      visualDiff: 'files/browser/visual-compare/visual-diff.json',
+    },
+  }));
+
+  const gated = collectFixtureMatrixRunResults({ matrix, outputDirectory, visualParity: { threshold: 0.1, gate: true } });
+  const finding = gated.findings.find((item) => item.kind === VISUAL_PARITY_MISMATCH_KIND);
+  assert.ok(finding, 'expected a visual_parity_mismatch finding from the visual-compare artifact');
+  assert.equal(finding.loss_acceptance, 'unacceptable');
+  assert.equal(gated.fixtures[0].status, 'failed');
+  // The visual_parity_artifacts slot captures screenshots + diff + metrics.
+  assert.equal(gated.fixtures[0].visual_parity_artifacts.schema, 'static-site-importer/visual-parity-artifacts/v1');
+  assert.equal(gated.fixtures[0].visual_parity_artifacts.artifacts.diff_screenshot.status, 'captured');
+  assert.equal(gated.fixtures[0].visual_parity_artifacts.metrics.mismatch_pixels, 700000);
+
+  // Same artifact, gate off (default) -> captured, non-gating.
+  const captured = collectFixtureMatrixRunResults({ matrix, outputDirectory });
+  const capturedFinding = captured.findings.find((item) => item.kind === VISUAL_PARITY_MISMATCH_KIND);
+  assert.ok(capturedFinding, 'expected the mismatch to still be captured');
+  assert.equal(capturedFinding.loss_acceptance, 'acceptable');
+  assert.equal(captured.fixtures[0].status, 'passed');
+});
+
+test('visual-compare dimension mismatch gates even with zero pixel metrics when gating is on', () => {
+  const payload = { comparison: { mismatchPixels: 0, totalPixels: 0, dimensionMismatch: true } };
+  const diagnostics = collectVisualParityDiagnostics(payload, { gate: true });
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0].dimension_mismatch, true);
 });

--- a/WordPress/static-site-importer/tools/run-fixture-matrix.mjs
+++ b/WordPress/static-site-importer/tools/run-fixture-matrix.mjs
@@ -55,6 +55,9 @@ export function buildFixtureMatrixRunPlan(input) {
     ...(options.batchSize ? { SSI_FIXTURE_MATRIX_BATCH_SIZE: String(options.batchSize) } : {}),
     ...(options.wordpressVersion ? { SSI_FIXTURE_MATRIX_WORDPRESS_VERSION: options.wordpressVersion } : {}),
     ...(options.wpCodeboxBin ? { SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN: options.wpCodeboxBin } : {}),
+    ...(options.visualParity === false ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY: '0' } : {}),
+    ...(options.visualParityGate ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE: '1' } : {}),
+    ...(options.pixelThreshold ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD: String(options.pixelThreshold) } : {}),
   };
   const fixtureCount = countTopLevelFixtureDirectories(options.fixtureRoot);
   const codeFreshness = buildCodeFreshness(options, options.gitRunner || defaultGitRunner);
@@ -79,6 +82,12 @@ export function buildFixtureMatrixRunPlan(input) {
     shared_state: options.sharedState,
     namespace: options.namespace,
     allow_stale_override: Boolean(options.allowStaleOverride),
+    visual_parity: {
+      enabled: options.visualParity !== false,
+      // Opt-in hard gate; default capture-only because pixel diffs can be flaky.
+      gate: Boolean(options.visualParityGate),
+      pixel_threshold: options.pixelThreshold ? Number(options.pixelThreshold) : null,
+    },
     code_freshness: codeFreshness,
     transformer_commit: resolveTransformerCommit(codeFreshness),
     warnings,
@@ -427,7 +436,7 @@ function parseArgs(args) {
     if (arg.startsWith('--')) {
       const [rawKey, rawValue] = arg.slice(2).split('=');
       const key = camelCase(rawKey);
-      const booleanKeys = new Set(['dryRun', 'skipInstall', 'skipSync', 'labOnly', 'allowLocalFallback', 'detachAfterHandoff', 'allowDirtyLabWorkspace', 'allowStaleOverride']);
+      const booleanKeys = new Set(['dryRun', 'skipInstall', 'skipSync', 'labOnly', 'allowLocalFallback', 'detachAfterHandoff', 'allowDirtyLabWorkspace', 'allowStaleOverride', 'visualParityGate']);
       if (booleanKeys.has(key)) {
         options[key] = true;
         continue;
@@ -532,7 +541,7 @@ function sanitizePathSegment(value) {
 }
 
 function printHelp() {
-  process.stdout.write(`Usage: node WordPress/static-site-importer/tools/run-fixture-matrix.mjs --runner <id> --static-site-importer <path> --blocks-engine <path> [options] [-- <bench args>...]\n\nRuns the canonical Static Site Importer fixture matrix through Homeboy/Lab/WP Codebox.\n\nOptions:\n  --static-site-importer <path>       Static Site Importer checkout/plugin path. Required.\n  --blocks-engine <path>              Blocks Engine checkout. Defaults fixture root and PHP transformer override.\n  --fixture-root <path>               Fixture corpus. Defaults to <blocks-engine>/fixtures/websites.\n  --blocks-engine-php-transformer-path <path>\n                                      Override transformer package/repo path. Defaults to --blocks-engine.\n  --runner <id>                       Homeboy Lab runner, for example homeboy-lab.\n  --mode <development-override|release-proof>\n                                      Labels output; default is development-override when transformer override is used.\n  --run-id <id>                       Stable proof label. Defaults to ssi-matrix-<mode>-<timestamp>.\n  --shared-state <dir>                Shared Homeboy bench state directory.\n  --artifact-root <dir>               Homeboy artifact root.\n  --output <file>                     Structured Homeboy bench output file.\n  --batch-size <n>                    SSI fixture matrix WP Codebox batch size.\n  --wordpress-version <version>       WP Codebox WordPress version.\n  --wp-codebox-bin <path>             WP Codebox CLI path.\n  --allow-stale-override              Proceed even when an override checkout is behind/diverged vs upstream.\n  --lab-only                          Require Lab routing.\n  --allow-local-fallback              Allow selected Lab runner local fallback.\n  --allow-dirty-lab-workspace         Allow runner workspace overwrite.\n  --detach-after-handoff              Return after remote runner accepts the job.\n  --skip-install                      Skip homeboy rig install --reinstall.\n  --skip-sync                         Skip homeboy rig sync.\n  --dry-run                           Print the composed plan without running it.\n\nAny args after -- are passed through to the lower-level bench runner.\n`);
+  process.stdout.write(`Usage: node WordPress/static-site-importer/tools/run-fixture-matrix.mjs --runner <id> --static-site-importer <path> --blocks-engine <path> [options] [-- <bench args>...]\n\nRuns the canonical Static Site Importer fixture matrix through Homeboy/Lab/WP Codebox.\n\nOptions:\n  --static-site-importer <path>       Static Site Importer checkout/plugin path. Required.\n  --blocks-engine <path>              Blocks Engine checkout. Defaults fixture root and PHP transformer override.\n  --fixture-root <path>               Fixture corpus. Defaults to <blocks-engine>/fixtures/websites.\n  --blocks-engine-php-transformer-path <path>\n                                      Override transformer package/repo path. Defaults to --blocks-engine.\n  --runner <id>                       Homeboy Lab runner, for example homeboy-lab.\n  --mode <development-override|release-proof>\n                                      Labels output; default is development-override when transformer override is used.\n  --run-id <id>                       Stable proof label. Defaults to ssi-matrix-<mode>-<timestamp>.\n  --shared-state <dir>                Shared Homeboy bench state directory.\n  --artifact-root <dir>               Homeboy artifact root.\n  --output <file>                     Structured Homeboy bench output file.\n  --batch-size <n>                    SSI fixture matrix WP Codebox batch size.\n  --wordpress-version <version>       WP Codebox WordPress version.\n  --wp-codebox-bin <path>             WP Codebox CLI path.\n  --allow-stale-override              Proceed even when an override checkout is behind/diverged vs upstream.\n  --no-visual-parity                  Skip the wordpress.visual-compare render/diff step.\n  --visual-parity-gate                Make pixel mismatch over the threshold a HARD gate. Default: capture-only.\n  --pixel-threshold <ratio>           Max mismatch ratio (mismatch_pixels/total_pixels) before gating. Default 0.1.\n  --lab-only                          Require Lab routing.\n  --allow-local-fallback              Allow selected Lab runner local fallback.\n  --allow-dirty-lab-workspace         Allow runner workspace overwrite.\n  --detach-after-handoff              Return after remote runner accepts the job.\n  --skip-install                      Skip homeboy rig install --reinstall.\n  --skip-sync                         Skip homeboy rig sync.\n  --dry-run                           Print the composed plan without running it.\n\nAny args after -- are passed through to the lower-level bench runner.\n`);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {


### PR DESCRIPTION
Closes #536

## What this does
The SSI fixture matrix validated structural + feature + (since #537) editor-block validity, but **never rendered a browser**: no source render, no WP-output render, no pixel diff. This wires the existing hbex visual-compare into the matrix so a run renders source vs the imported WordPress output, captures screenshots + a pixel diff, and (opt-in) gates on mismatch over a threshold.

## Reuse (no new screenshot infra, no wp-codebox change)
- Emits the existing `wordpress.visual-compare` wp-codebox recipe command — the same command homeboy-extensions' reusable `runVisualParityWorkload` composes (`source.png`/`candidate.png`/`diff.png` + `mismatch_pixels`/`total_pixels`, `wp-codebox/visual-compare/v1`). The matrix emits it inline in the recipe rather than spinning up a separate sandbox. Confirmed `wordpress.visual-compare` is a registered wp-codebox command and my arg names (`source-url`, `candidate-url`, `source-label`, `candidate-label`, `viewport`, `full-page`, `wait-for`, `threshold`) exactly match its parser. **wp-codebox needed no changes.**
- Captures the result into the SSI `visual_parity_artifacts` slot (`static-site-importer/visual-parity-artifacts/v1`).

## Where the step runs
`buildFixtureMatrixRecipe` appends a `wordpress.visual-compare` step after each fixture's import step (and alongside #537's editor-canvas-probe step), mirroring that exact pattern. Materialized recipe per fixture: `[wp-cli activate, wp-cli validate-artifact, editor-canvas-probe, visual-compare]`. On by default; `--no-visual-parity` omits it.

## Capture + gating behavior
- `collectVisualParityDiagnostics` parses the comparison (raw `wp-codebox/visual-compare/v1` **or** normalized `homeboy/VisualParityArtifact/v1`) and emits a `visual_parity_mismatch` finding when `mismatch_pixels/total_pixels` exceeds the threshold (or a dimension mismatch), routed to a visual-parity repair bucket (`candidate_repo: blocks-engine`, `repair_mode: visual-parity`).
- **Gating is opt-in** (pixel diffs can be flaky). The `visual_parity_mismatch` loss class is capture-only (`acceptable`, non-gating) by default and flips to unacceptable/fixture-failing only when the run opts in — `--visual-parity-gate` / `SSI_FIXTURE_MATRIX_VISUAL_PARITY_GATE=1`. This is the same conditional-acceptance pattern as `preserved_runtime_island` (#535's honest-acceptance logic), so #535 is preserved.
- Threshold configurable via `--pixel-threshold` / `SSI_FIXTURE_MATRIX_VISUAL_PARITY_PIXEL_THRESHOLD` (default `0.1`).
- Does not regress the editor-validation step (#537), the freshness guard (#530), or honest acceptance (#535).

## Tests / evidence
`node WordPress/static-site-importer/tools/fixture-matrix.test.mjs` -> **40/40 pass** (7 new), including:
- recipe includes the `wordpress.visual-compare` step (and `visualParity: false` omits it)
- (a) mismatch at/under threshold -> no finding
- (b) over threshold + gate on -> unacceptable, gating finding (fixture fails)
- (c) over threshold + gate off -> captured, non-gating (fixture passes)
- artifact-file collection gates + populates the `visual_parity_artifacts` slot; dimension mismatch gates
- wrapper `--dry-run` composes cleanly (default capture-only; `--visual-parity-gate`/`--pixel-threshold` inject the right bench settings; `--no-visual-parity` injects the disable setting)

## Live-run caveat
Live end-to-end is **runner-gated**: the Lab runner has a controller/daemon version drift (`0.266.0` vs `0.266.1`). The wiring + parsing/threshold/gating logic are fully unit-tested; no live run was faked. Wiring the exact servable per-fixture source URL is the remaining live-run enablement — the step uses generic, configurable source/candidate URLs with per-fixture overrides today, mirroring how #537's editor step uses a configurable URL rather than resolving each imported post.

DO NOT MERGE pending review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)