### PR TITLE
Fan out SSI fixture matrix with bounded concurrency

### DIFF
--- a/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
+++ b/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
@@ -16,6 +16,12 @@ import {
 } from '../lib/fixture-matrix.mjs';
 
 const DEFAULT_BATCH_SIZE = 10;
+// Each batch provisions its own WP Codebox sandbox, so batches are independent
+// and safe to fan out in parallel. Default to a modest pool so a local run does
+// not stampede the sandbox provider; the hard cap bounds even an explicit
+// override so a fat-fingered `--concurrency 500` can not exhaust the host.
+const DEFAULT_BATCH_CONCURRENCY = 4;
+const MAX_BATCH_CONCURRENCY = 16;
 const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 
 async function main() {
@@ -105,78 +111,36 @@ export async function runFixtureMatrix(options) {
   let collectedResult = written.result;
   if (options.run) {
     const batchSize = positiveInteger(options.batchSize, DEFAULT_BATCH_SIZE);
+    const concurrency = boundedConcurrency(options.concurrency, DEFAULT_BATCH_CONCURRENCY, MAX_BATCH_CONCURRENCY);
+    const batches = chunk(matrix.fixtures, batchSize);
+    // Each batch spins up its own isolated WP Codebox sandbox, so batches can run
+    // concurrently. `mapWithConcurrency` bounds how many sandboxes are live at
+    // once and returns outcomes in batch order, so the assembled batchRuns /
+    // batchResults / childCommandFailures stay deterministic regardless of which
+    // sandbox finishes first.
+    const batchOutcomes = await mapWithConcurrency(batches, concurrency, (fixtures, batchIndex) => runFixtureMatrixBatch({
+      fixtures,
+      batchIndex,
+      matrix,
+      outputDirectory,
+      staticSiteImporterPath,
+      options,
+    }));
+
     const batchRuns = [];
     const batchResults = [];
     const childCommandFailures = [];
-    for (const [batchIndex, fixtures] of chunk(matrix.fixtures, batchSize).entries()) {
-      const batchNumber = batchIndex + 1;
-      const batchSuffix = String(batchNumber).padStart(3, '0');
-      const batchMatrix = createFixtureMatrix({
-        id: `${matrix.id}-batch-${batchSuffix}`,
-        fixture_root: matrix.fixture_root,
-        entrypoint: matrix.entrypoint,
-        fixtures,
-      });
-      const batchRecipe = buildFixtureMatrixRecipe({
-        matrix: batchMatrix,
-        artifactsDirectory: outputDirectory,
-        playgroundArtifactsDirectory: options.playgroundArtifactsDirectory || '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix',
-        wordpressVersion: options.wordpressVersion,
-        staticSiteImporterPath,
-        staticSiteImporterPlugin: options.staticSiteImporterPlugin,
-        staticSiteImporterSlug: options.staticSiteImporterSlug,
-        ...visualParityRecipeInput(options),
-      });
-      const batchRecipeFile = path.join(outputDirectory, `wp-codebox-static-site-fixture-matrix-batch-${batchSuffix}.json`);
-      const outputFile = path.join(outputDirectory, `wp-codebox-output-batch-${batchSuffix}.json`);
-      const artifactRefs = batchArtifactRefs({ outputDirectory, batchSuffix, batchRecipeFile, outputFile });
-      fs.writeFileSync(batchRecipeFile, `${JSON.stringify(batchRecipe, null, 2)}\n`);
-
-      let batchRuntime = null;
-      let batchError = null;
-      try {
-        batchRuntime = await runWpCodeboxRecipe({
-          recipeFile: batchRecipeFile,
-          artifactsDir: outputDirectory,
-          outputFile,
-          wpCodeboxBin: options.wpCodeboxBin,
-        });
-      } catch (error) {
-        batchError = error;
-        batchRuntime = {
-          exitCode: error?.code ?? 1,
-          outputFile,
-          json: parseJsonText(error?.stdout),
-        };
-        runtimeError ||= error;
-        childCommandFailures.push(buildWpCodeboxChildCommandFailure({
-          error,
-          batchNumber,
-          batchSuffix,
-          batchRecipeFile,
-          outputFile,
-          artifactsDir: outputDirectory,
-          wpCodeboxBin: options.wpCodeboxBin,
-          artifactRefs,
-        }));
+    for (const outcome of batchOutcomes) {
+      batchRuns.push(outcome.batchRun);
+      batchResults.push(outcome.batchResult);
+      if (outcome.childCommandFailure) {
+        childCommandFailures.push(outcome.childCommandFailure);
       }
-      batchRuns.push(fixtureMatrixBatchRunSummary({
-        batchNumber,
-        batchMatrix,
-        fixtures,
-        batchRecipeFile,
-        outputFile,
-        batchRuntime,
-        batchError,
-      }));
-      batchResults.push(collectFixtureMatrixRunResults({
-        matrix: batchMatrix,
-        outputDirectory,
-        outputFile,
-        codeboxOutput: batchRuntime?.json,
-        codeboxError: batchError,
-        visualParity: visualParityGateInput(options),
-      }));
+      // Preserve the original first-failure-by-batch-order semantics: the earliest
+      // batch that failed wins, independent of completion order.
+      if (outcome.error) {
+        runtimeError ||= outcome.error;
+      }
     }
     collectedResult = normalizeFixtureMatrixResult({
       matrix,
@@ -187,6 +151,7 @@ export async function runFixtureMatrix(options) {
     runtime = {
       exitCode: runtimeError ? (batchRuns.find((batch) => batch.exit_code)?.exit_code || 1) : 0,
       batchSize,
+      concurrency,
       batches: batchRuns,
       childCommandFailures,
     };
@@ -210,6 +175,115 @@ export async function runFixtureMatrix(options) {
   };
   fs.writeFileSync(path.join(outputDirectory, 'cli-run.json'), `${JSON.stringify(summary, null, 2)}\n`);
   return { summary, runtimeError, runtime };
+}
+
+// Provision and reconcile a single batch in its own WP Codebox sandbox. Pure with
+// respect to other batches (it only writes batch-scoped recipe/output files and
+// per-fixture artifact subdirectories, all keyed by the unique batch suffix), so
+// many of these can run concurrently without colliding. Returns a stable outcome
+// the caller folds back together in batch order.
+export async function runFixtureMatrixBatch({ fixtures, batchIndex, matrix, outputDirectory, staticSiteImporterPath, options }) {
+  const batchNumber = batchIndex + 1;
+  const batchSuffix = String(batchNumber).padStart(3, '0');
+  const batchMatrix = createFixtureMatrix({
+    id: `${matrix.id}-batch-${batchSuffix}`,
+    fixture_root: matrix.fixture_root,
+    entrypoint: matrix.entrypoint,
+    fixtures,
+  });
+  const batchRecipe = buildFixtureMatrixRecipe({
+    matrix: batchMatrix,
+    artifactsDirectory: outputDirectory,
+    playgroundArtifactsDirectory: options.playgroundArtifactsDirectory || '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix',
+    wordpressVersion: options.wordpressVersion,
+    staticSiteImporterPath,
+    staticSiteImporterPlugin: options.staticSiteImporterPlugin,
+    staticSiteImporterSlug: options.staticSiteImporterSlug,
+    ...visualParityRecipeInput(options),
+  });
+  const batchRecipeFile = path.join(outputDirectory, `wp-codebox-static-site-fixture-matrix-batch-${batchSuffix}.json`);
+  const outputFile = path.join(outputDirectory, `wp-codebox-output-batch-${batchSuffix}.json`);
+  const artifactRefs = batchArtifactRefs({ outputDirectory, batchSuffix, batchRecipeFile, outputFile });
+  fs.writeFileSync(batchRecipeFile, `${JSON.stringify(batchRecipe, null, 2)}\n`);
+
+  let batchRuntime = null;
+  let batchError = null;
+  let childCommandFailure = null;
+  try {
+    batchRuntime = await runWpCodeboxRecipe({
+      recipeFile: batchRecipeFile,
+      artifactsDir: outputDirectory,
+      outputFile,
+      wpCodeboxBin: options.wpCodeboxBin,
+    });
+  } catch (error) {
+    batchError = error;
+    batchRuntime = {
+      exitCode: error?.code ?? 1,
+      outputFile,
+      json: parseJsonText(error?.stdout),
+    };
+    childCommandFailure = buildWpCodeboxChildCommandFailure({
+      error,
+      batchNumber,
+      batchSuffix,
+      batchRecipeFile,
+      outputFile,
+      artifactsDir: outputDirectory,
+      wpCodeboxBin: options.wpCodeboxBin,
+      artifactRefs,
+    });
+  }
+
+  const batchRun = fixtureMatrixBatchRunSummary({
+    batchNumber,
+    batchMatrix,
+    fixtures,
+    batchRecipeFile,
+    outputFile,
+    batchRuntime,
+    batchError,
+  });
+  const batchResult = collectFixtureMatrixRunResults({
+    matrix: batchMatrix,
+    outputDirectory,
+    outputFile,
+    codeboxOutput: batchRuntime?.json,
+    codeboxError: batchError,
+    visualParity: visualParityGateInput(options),
+  });
+
+  return { batchRun, batchResult, error: batchError, childCommandFailure };
+}
+
+// Bounded-concurrency map that preserves input ordering. Spawns at most `limit`
+// workers, each pulling the next index off a shared cursor, so up to `limit`
+// async tasks are in flight at once while `results[i]` always corresponds to
+// `items[i]` regardless of completion order.
+export async function mapWithConcurrency(items, limit, worker) {
+  const results = new Array(items.length);
+  if (items.length === 0) {
+    return results;
+  }
+  const poolSize = Math.max(1, Math.min(limit, items.length));
+  let cursor = 0;
+  const runWorker = async () => {
+    while (true) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= items.length) {
+        return;
+      }
+      results[index] = await worker(items[index], index);
+    }
+  };
+  await Promise.all(Array.from({ length: poolSize }, () => runWorker()));
+  return results;
+}
+
+export function boundedConcurrency(value, fallback, max) {
+  const parsed = positiveInteger(value, fallback);
+  return Math.max(1, Math.min(parsed, max));
 }
 
 function ensureComposerDependencies(pluginPath, options = {}) {
@@ -362,6 +436,7 @@ function runtimeSummary(runtime, runtimeError) {
   return {
     exit_code: runtime.exitCode,
     ...(runtime.batchSize ? { batch_size: runtime.batchSize } : {}),
+    ...(runtime.concurrency ? { concurrency: runtime.concurrency } : {}),
     ...(runtime.batches ? { batches: runtime.batches } : {}),
     ...(runtime.childCommandFailures?.length ? { child_command_failures: runtime.childCommandFailures } : {}),
     error: runtimeError ? runtimeError.message : '',
@@ -475,6 +550,7 @@ function optionsFromEnv(env = process.env) {
     blocksEnginePhpTransformerPath: benchEnv.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH || env.SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH,
     wordpressVersion: benchEnv.SSI_FIXTURE_MATRIX_WORDPRESS_VERSION || env.SSI_FIXTURE_MATRIX_WORDPRESS_VERSION,
     batchSize: benchEnv.SSI_FIXTURE_MATRIX_BATCH_SIZE || env.SSI_FIXTURE_MATRIX_BATCH_SIZE,
+    concurrency: benchEnv.SSI_FIXTURE_MATRIX_CONCURRENCY || env.SSI_FIXTURE_MATRIX_CONCURRENCY,
     run: isTruthy(benchEnv.SSI_FIXTURE_MATRIX_RUN) || isTruthy(env.SSI_FIXTURE_MATRIX_RUN),
     wpCodeboxBin: benchEnv.SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN || env.SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN,
     visualParity: !isFalsy(benchEnv.SSI_FIXTURE_MATRIX_VISUAL_PARITY ?? env.SSI_FIXTURE_MATRIX_VISUAL_PARITY),
@@ -564,7 +640,7 @@ function camelCase(value) {
 }
 
 function printHelp() {
-  process.stdout.write(`Usage: static-site-fixture-matrix [fixture-root] [options]\n\nOptions:\n  --fixture-root <path>              Static-site fixture root. Defaults to this package's fixtures directory.\n  --output-directory <path>          Artifact output directory.\n  --static-site-importer-path <path> Static Site Importer checkout/plugin directory.\n  --static-site-importer-slug <slug> Plugin slug. Defaults to static-site-importer.\n  --static-site-importer-plugin <p>  Plugin activation file. Defaults to static-site-importer/static-site-importer.php.\n  --artifact-root <path>             Generated artifact root to normalize into fixtures.\n  --blocks-engine-php-transformer-path <path>\n                                     Blocks Engine repo root or php-transformer package path for Composer.\n  --entrypoint <file>                Fixture entrypoint. Defaults to index.html.\n  --max-depth <n>                    Fixture discovery depth. Defaults to 2.\n  --wordpress-version <version>      WP Codebox WordPress version. Defaults to latest.\n  --batch-size <n>                   Fixtures per WP Codebox run when --run is used. Defaults to 10.\n  --run                             Execute WP Codebox recipes. Omit locally to only materialize artifacts.\n`);
+  process.stdout.write(`Usage: static-site-fixture-matrix [fixture-root] [options]\n\nOptions:\n  --fixture-root <path>              Static-site fixture root. Defaults to this package's fixtures directory.\n  --output-directory <path>          Artifact output directory.\n  --static-site-importer-path <path> Static Site Importer checkout/plugin directory.\n  --static-site-importer-slug <slug> Plugin slug. Defaults to static-site-importer.\n  --static-site-importer-plugin <p>  Plugin activation file. Defaults to static-site-importer/static-site-importer.php.\n  --artifact-root <path>             Generated artifact root to normalize into fixtures.\n  --blocks-engine-php-transformer-path <path>\n                                     Blocks Engine repo root or php-transformer package path for Composer.\n  --entrypoint <file>                Fixture entrypoint. Defaults to index.html.\n  --max-depth <n>                    Fixture discovery depth. Defaults to 2.\n  --wordpress-version <version>      WP Codebox WordPress version. Defaults to latest.\n  --batch-size <n>                   Fixtures per WP Codebox run when --run is used. Defaults to 10.\n  --concurrency <n>                  Batches (WP Codebox sandboxes) to run in parallel. Defaults to ${DEFAULT_BATCH_CONCURRENCY}, hard-capped at ${MAX_BATCH_CONCURRENCY}.\n  --run                             Execute WP Codebox recipes. Omit locally to only materialize artifacts.\n`);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -5,8 +5,10 @@ import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import runFixtureMatrixBench, {
+  boundedConcurrency,
   composerPathRepositoryConfig,
   fixtureMatrixBatchRunSummary,
+  mapWithConcurrency,
   resolveBlocksEnginePhpTransformerPath,
   runFixtureMatrix,
 } from '../bench/static-site-fixture-matrix.bench.mjs';
@@ -943,11 +945,19 @@ test('fixture matrix dry-run plan surfaces local fallback and dirty workspace wa
 
   assert.equal(plan.namespace, 'proof-run-1');
   assert.equal(plan.temp_root, '/tmp/homeboy-rigs-ssi-fixture-matrix-proof-run-1');
+  // The single-fixture temp corpus drifts from the canonical pin, so the plan
+  // surfaces a non-silent drift warning alongside the routing warnings.
   assert.deepEqual(plan.warnings.map((warning) => warning.code), [
     'local_runner_default',
     'local_fallback_allowed',
     'dirty_lab_workspace_allowed',
+    'canonical_fixture_count_drift',
   ]);
+  assert.equal(plan.fixture_count_matches_canonical, false);
+  assert.match(
+    plan.warnings.find((warning) => warning.code === 'canonical_fixture_count_drift').message,
+    /CANONICAL_FIXTURE_COUNT is \d+/,
+  );
 });
 
 test('operator summary preserves matrix rollups for fanout agents', () => {
@@ -982,6 +992,51 @@ test('operator summary preserves matrix rollups for fanout agents', () => {
   assert.equal(summary.top_pattern_families[0].count, 312);
   assert.equal(summary.fixture_exemplars[0].fixture_id, 'shader-site');
   assert.equal(summary.diagnostic_blind_spots[0].kind, 'missing_source_context');
+});
+
+test('mapWithConcurrency runs bounded N in parallel and preserves input ordering', async () => {
+  const items = Array.from({ length: 10 }, (_value, index) => index);
+  let inFlight = 0;
+  let peakInFlight = 0;
+
+  const results = await mapWithConcurrency(items, 3, async (value) => {
+    inFlight += 1;
+    peakInFlight = Math.max(peakInFlight, inFlight);
+    // Yield so the pool genuinely overlaps work rather than resolving instantly.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    inFlight -= 1;
+    return value * 2;
+  });
+
+  // Up to 3 workers actually overlapped (proves real parallelism), never more.
+  assert.equal(peakInFlight, 3);
+  // Results stay aligned to input order regardless of completion order.
+  assert.deepEqual(results, items.map((value) => value * 2));
+});
+
+test('mapWithConcurrency handles empty input and caps the pool at item count', async () => {
+  assert.deepEqual(await mapWithConcurrency([], 4, async () => 1), []);
+
+  let peakInFlight = 0;
+  let inFlight = 0;
+  const results = await mapWithConcurrency([1, 2], 8, async (value) => {
+    inFlight += 1;
+    peakInFlight = Math.max(peakInFlight, inFlight);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    inFlight -= 1;
+    return value;
+  });
+  assert.deepEqual(results, [1, 2]);
+  assert.equal(peakInFlight, 2);
+});
+
+test('boundedConcurrency clamps to the hard cap and falls back on invalid input', () => {
+  assert.equal(boundedConcurrency('8', 4, 16), 8);
+  assert.equal(boundedConcurrency('500', 4, 16), 16);
+  assert.equal(boundedConcurrency(undefined, 4, 16), 4);
+  assert.equal(boundedConcurrency('0', 4, 16), 4);
+  assert.equal(boundedConcurrency('not-a-number', 4, 16), 4);
+  assert.equal(boundedConcurrency('-3', 4, 16), 4);
 });
 
 test('compares finding packet deltas by repair dimensions', () => {

--- a/WordPress/static-site-importer/tools/run-fixture-matrix.mjs
+++ b/WordPress/static-site-importer/tools/run-fixture-matrix.mjs
@@ -6,7 +6,15 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 export const RIG_ID = 'static-site-importer-fixture-matrix';
-export const CANONICAL_FIXTURE_COUNT = 71;
+// Expected top-level fixture directory count in the canonical corpus
+// (`blocks-engine/fixtures/websites`). This is an intentional drift guard, not a
+// derived value: the corpus lives in a different repo, so deriving the canonical
+// number from whatever happens to be on disk would make the check tautological
+// (always "matches") and defeat its purpose. Bump this deliberately when the
+// corpus grows/shrinks. Source of truth:
+//   git -C blocks-engine ls-tree -d --name-only origin/trunk:fixtures/websites | wc -l
+// Last verified against origin/trunk @ 8ad42fd = 72 directories.
+export const CANONICAL_FIXTURE_COUNT = 72;
 
 const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 
@@ -53,6 +61,7 @@ export function buildFixtureMatrixRunPlan(input) {
       ? { SSI_FIXTURE_MATRIX_BLOCKS_ENGINE_PHP_TRANSFORMER_PATH: options.blocksEnginePhpTransformerPath }
       : {}),
     ...(options.batchSize ? { SSI_FIXTURE_MATRIX_BATCH_SIZE: String(options.batchSize) } : {}),
+    ...(options.concurrency ? { SSI_FIXTURE_MATRIX_CONCURRENCY: String(options.concurrency) } : {}),
     ...(options.wordpressVersion ? { SSI_FIXTURE_MATRIX_WORDPRESS_VERSION: options.wordpressVersion } : {}),
     ...(options.wpCodeboxBin ? { SSI_FIXTURE_MATRIX_WP_CODEBOX_BIN: options.wpCodeboxBin } : {}),
     ...(options.visualParity === false ? { SSI_FIXTURE_MATRIX_VISUAL_PARITY: '0' } : {}),
@@ -62,7 +71,11 @@ export function buildFixtureMatrixRunPlan(input) {
   };
   const fixtureCount = countTopLevelFixtureDirectories(options.fixtureRoot);
   const codeFreshness = buildCodeFreshness(options, options.gitRunner || defaultGitRunner);
-  const warnings = [...buildWarnings(options), ...buildFreshnessWarnings(codeFreshness, options)];
+  const warnings = [
+    ...buildWarnings(options),
+    ...buildCanonicalDriftWarnings(fixtureCount, options.fixtureRoot),
+    ...buildFreshnessWarnings(codeFreshness, options),
+  ];
 
   return {
     schema: 'homeboy-rigs/static-site-importer-fixture-matrix-operator-run/v1',
@@ -165,6 +178,20 @@ function buildWarnings(options) {
       message: '--allow-dirty-lab-workspace permits reusing or overwriting a dirty Lab workspace.',
     }] : []),
   ];
+}
+
+// Surface corpus pin drift instead of letting `fixture_count_matches_canonical`
+// be a silently-ignored boolean. A discovered count below the pin means fixtures
+// went missing (or the wrong root was passed); above the pin means the corpus
+// grew and CANONICAL_FIXTURE_COUNT needs an intentional bump.
+function buildCanonicalDriftWarnings(fixtureCount, fixtureRoot) {
+  if (fixtureCount === CANONICAL_FIXTURE_COUNT) {
+    return [];
+  }
+  return [{
+    code: 'canonical_fixture_count_drift',
+    message: `Discovered ${fixtureCount} top-level fixture director${fixtureCount === 1 ? 'y' : 'ies'} in ${fixtureRoot}, but CANONICAL_FIXTURE_COUNT is ${CANONICAL_FIXTURE_COUNT}. ${fixtureCount > CANONICAL_FIXTURE_COUNT ? 'The corpus grew; bump CANONICAL_FIXTURE_COUNT after confirming the new fixtures are intended.' : 'Fixtures are missing or the wrong fixture root was passed; restore the corpus or correct --fixture-root.'}`,
+  }];
 }
 
 export const CODE_FRESHNESS_SCHEMA = 'homeboy-rigs/static-site-importer-fixture-matrix-code-freshness/v1';
@@ -549,7 +576,7 @@ function sanitizePathSegment(value) {
 }
 
 function printHelp() {
-  process.stdout.write(`Usage: node WordPress/static-site-importer/tools/run-fixture-matrix.mjs --runner <id> --static-site-importer <path> --blocks-engine <path> [options] [-- <bench args>...]\n\nRuns the canonical Static Site Importer fixture matrix through Homeboy/Lab/WP Codebox.\n\nOptions:\n  --static-site-importer <path>       Static Site Importer checkout/plugin path. Required.\n  --blocks-engine <path>              Blocks Engine checkout. Defaults fixture root and PHP transformer override.\n  --fixture-root <path>               Fixture corpus. Defaults to <blocks-engine>/fixtures/websites.\n  --blocks-engine-php-transformer-path <path>\n                                      Override transformer package/repo path. Defaults to --blocks-engine.\n  --runner <id>                       Homeboy Lab runner, for example homeboy-lab.\n  --mode <development-override|release-proof>\n                                      Labels output; default is development-override when transformer override is used.\n  --run-id <id>                       Stable proof label. Defaults to ssi-matrix-<mode>-<timestamp>.\n  --shared-state <dir>                Shared Homeboy bench state directory.\n  --artifact-root <dir>               Homeboy artifact root.\n  --output <file>                     Structured Homeboy bench output file.\n  --batch-size <n>                    SSI fixture matrix WP Codebox batch size.\n  --wordpress-version <version>       WP Codebox WordPress version.\n  --wp-codebox-bin <path>             WP Codebox CLI path.\n  --allow-stale-override              Proceed even when an override checkout is behind/diverged vs upstream.\n  --no-visual-parity                  Skip the wordpress.visual-compare render/diff step.\n  --visual-parity-gate                Make pixel mismatch over the threshold a HARD gate. Default: capture-only.\n  --pixel-threshold <ratio>           Max mismatch ratio (mismatch_pixels/total_pixels) before gating. Default 0.1.\n  --min-native-rate <ratio>           Opt-in: fail fixtures whose native_conversion_rate is below this ratio (0-1, or a percentage like 80). Default: off (metrics only).\n  --lab-only                          Require Lab routing.\n  --allow-local-fallback              Allow selected Lab runner local fallback.\n  --allow-dirty-lab-workspace         Allow runner workspace overwrite.\n  --detach-after-handoff              Return after remote runner accepts the job.\n  --skip-install                      Skip homeboy rig install --reinstall.\n  --skip-sync                         Skip homeboy rig sync.\n  --dry-run                           Print the composed plan without running it.\n\nAny args after -- are passed through to the lower-level bench runner.\n`);
+  process.stdout.write(`Usage: node WordPress/static-site-importer/tools/run-fixture-matrix.mjs --runner <id> --static-site-importer <path> --blocks-engine <path> [options] [-- <bench args>...]\n\nRuns the canonical Static Site Importer fixture matrix through Homeboy/Lab/WP Codebox.\n\nOptions:\n  --static-site-importer <path>       Static Site Importer checkout/plugin path. Required.\n  --blocks-engine <path>              Blocks Engine checkout. Defaults fixture root and PHP transformer override.\n  --fixture-root <path>               Fixture corpus. Defaults to <blocks-engine>/fixtures/websites.\n  --blocks-engine-php-transformer-path <path>\n                                      Override transformer package/repo path. Defaults to --blocks-engine.\n  --runner <id>                       Homeboy Lab runner, for example homeboy-lab.\n  --mode <development-override|release-proof>\n                                      Labels output; default is development-override when transformer override is used.\n  --run-id <id>                       Stable proof label. Defaults to ssi-matrix-<mode>-<timestamp>.\n  --shared-state <dir>                Shared Homeboy bench state directory.\n  --artifact-root <dir>               Homeboy artifact root.\n  --output <file>                     Structured Homeboy bench output file.\n  --batch-size <n>                    SSI fixture matrix WP Codebox batch size.\n  --concurrency <n>                   Parallel WP Codebox sandbox batches. Defaults to 4, hard-capped at 16.\n  --wordpress-version <version>       WP Codebox WordPress version.\n  --wp-codebox-bin <path>             WP Codebox CLI path.\n  --allow-stale-override              Proceed even when an override checkout is behind/diverged vs upstream.\n  --no-visual-parity                  Skip the wordpress.visual-compare render/diff step.\n  --visual-parity-gate                Make pixel mismatch over the threshold a HARD gate. Default: capture-only.\n  --pixel-threshold <ratio>           Max mismatch ratio (mismatch_pixels/total_pixels) before gating. Default 0.1.\n  --min-native-rate <ratio>           Opt-in: fail fixtures whose native_conversion_rate is below this ratio (0-1, or a percentage like 80). Default: off (metrics only).\n  --lab-only                          Require Lab routing.\n  --allow-local-fallback              Allow selected Lab runner local fallback.\n  --allow-dirty-lab-workspace         Allow runner workspace overwrite.\n  --detach-after-handoff              Return after remote runner accepts the job.\n  --skip-install                      Skip homeboy rig install --reinstall.\n  --skip-sync                         Skip homeboy rig sync.\n  --dry-run                           Print the composed plan without running it.\n\nAny args after -- are passed through to the lower-level bench runner.\n`);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {


### PR DESCRIPTION
## What & why

The SSI fixture-matrix runner processed batches in a sequential loop, leaving available cores idle. This change converts that loop to bounded-concurrency fanout, controllable via `--concurrency` / `SSI_FIXTURE_MATRIX_CONCURRENCY` (default 4, capped at 16). It also fixes canonical fixture-count pin drift: the runner now warns on drift rather than silently passing, and the pin is updated 71 -> 72.

## Verification

- 36/36 unit tests pass, including a real-parallelism assertion that proves batches actually run concurrently.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Drafting the implementation and tests under human review.
