### PR TITLE
Deterministic preserved-runtime-island loss-class alias in SSI gate

### DIFF
--- a/WordPress/static-site-importer/lib/fixture-matrix.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix.mjs
@@ -45,7 +45,7 @@ export {
 
 export { collectFixtureMatrixRunResults } from './fixture-matrix/collectors/run-intake.mjs';
 
-export { classifyStaticSiteFinding } from './fixture-matrix/findings.mjs';
+export { classifyStaticSiteFinding, normalizeLossClass } from './fixture-matrix/findings.mjs';
 
 export { collectBlockComposition } from './fixture-matrix/collectors/quality-metrics.mjs';
 

--- a/WordPress/static-site-importer/lib/fixture-matrix/findings.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/findings.mjs
@@ -255,7 +255,7 @@ export function dedupeFindings(findings) {
   });
 }
 
-function normalizeLossClass(value) {
+export function normalizeLossClass(value) {
   const normalized = String(value || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
   const aliases = {
     acceptable: 'native_conversion',
@@ -264,6 +264,11 @@ function normalizeLossClass(value) {
     editable: 'editable_approximation',
     editable_approximation: 'editable_approximation',
     preserved_runtime_island: 'preserved_runtime_island',
+    // The php-transformer emits the loss class as `runtime_island_preserved`
+    // (see blocks-engine php-transformer FallbackDiagnostic/HtmlTransformer). Alias
+    // it to the canonical `preserved_runtime_island` so the explicit-normalization
+    // path wins deterministically instead of relying on the wording regex below.
+    runtime_island_preserved: 'preserved_runtime_island',
     runtime_island: 'preserved_runtime_island',
     unsupported: 'unsupported_loss',
     unsupported_loss: 'unsupported_loss',

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -34,6 +34,7 @@ import {
   editorBlockValidationStep,
   EDITOR_INVALID_BLOCK_SELECTOR_GROUP,
   normalizeFixtureMatrixResult,
+  normalizeLossClass,
   VISUAL_PARITY_MISMATCH_KIND,
   visualParityCompareStep,
   writeFixtureMatrixArtifacts,
@@ -217,6 +218,52 @@ test('passes the gate when a preserved_runtime_island carries a runtime-carried 
   assert.equal(finding.acceptable_loss, true);
   assert.equal(result.summary.acceptable_finding_count, 1);
   assert.equal(result.summary.unacceptable_finding_count, 0);
+  assert.equal(result.summary.succeeded, 1);
+  assert.equal(result.summary.failed, 0);
+  assert.equal(result.fixtures[0].status, 'passed');
+});
+
+test('normalizes the transformer-emitted runtime_island_preserved loss class to the canonical preserved_runtime_island', () => {
+  // The php-transformer emits `runtime_island_preserved` (FallbackDiagnostic /
+  // HtmlTransformer). The alias must deterministically canonicalize it without
+  // relying on the wording regex fallback.
+  assert.equal(normalizeLossClass('runtime_island_preserved'), 'preserved_runtime_island');
+  assert.equal(normalizeLossClass('preserved_runtime_island'), 'preserved_runtime_island');
+  assert.equal(normalizeLossClass('runtime_island'), 'preserved_runtime_island');
+});
+
+test('classifies a transformer runtime_island_preserved finding as acceptable without relying on message wording', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'runtime-island-preserved-alias-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'failed',
+        diagnostics: [
+          {
+            kind: 'html_script_fallback',
+            // Exact string emitted by the php-transformer; carries no
+            // "runtime island" wording in kind/message so acceptance must come
+            // from the explicit alias, not the wording regex fallback.
+            loss_class: 'runtime_island_preserved',
+            runtime_carried: true,
+            source_path: 'website/index.html',
+            selector: 'script#app',
+            message: 'Script kept verbatim.',
+          },
+        ],
+      },
+    ],
+  });
+
+  const finding = result.findings[0];
+  assert.equal(finding.loss_class, 'preserved_runtime_island');
+  assert.equal(finding.loss_acceptance, 'acceptable');
+  assert.equal(finding.acceptable_loss, true);
+  assert.equal(result.summary.acceptable_finding_count, 1);
+  assert.equal(result.summary.unacceptable_finding_count, 0);
+  assert.equal(result.summary.preserved_runtime_island_count, 1);
   assert.equal(result.summary.succeeded, 1);
   assert.equal(result.summary.failed, 0);
   assert.equal(result.fixtures[0].status, 'passed');


### PR DESCRIPTION
## What
Makes preserved-runtime-island acceptance in the SSI fixture-matrix gate **deterministic** instead of dependent on message-wording regex.

The php-transformer emits `loss_class => 'runtime_island_preserved'`, but the gate's `normalizeLossClass` alias table only keyed on `preserved_runtime_island` / `runtime_island`. So explicit normalization returned empty and acceptance fell back to regex-matching wording in `kind`/`group_key`/`repair_bucket`/`message`. This adds the missing alias so the explicit loss-class field wins.

## Why it matters
This is the gate path for the script-island strategy: a preserved runtime island (script kept verbatim with its JS carried) must classify as the acceptable `preserved_runtime_island` class. Acceptance now keys on the explicit emitted field, not prose. The conditional check (`resolveLossAcceptance` requires `runtime_carried`) is unchanged — preserved-but-dropped islands remain unacceptable, which is correct.

## Changes (`WordPress/static-site-importer/lib/fixture-matrix.mjs`)
- Added `runtime_island_preserved: 'preserved_runtime_island'` to the `normalizeLossClass` alias table (with a comment citing the transformer source). Regex-wording fallback retained as a safety net. Exported `normalizeLossClass` for direct unit testing.

## Verification
- `node --test WordPress/static-site-importer/tools/fixture-matrix.test.mjs` → 42/42 pass (2 new: direct alias unit + gate-level acceptance of a `runtime_island_preserved` finding with non-wording message).
- `node scripts/lint-rig-packages.mjs WordPress/static-site-importer` → passed.
- Confirmed the aliased string is the exact value emitted by `php-transformer` (`FallbackDiagnostic`/`HtmlTransformer`/`ConversionReportProjection`).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Drafting the fix and tests under human review.
