### PR TITLE
Reconcile rig-package lint ignore set with homeboy core

### DIFF
--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -13,7 +13,15 @@ const args = process.argv.slice(2);
 const strictFuzzReadiness = args.includes('--strict-fuzz-readiness');
 const rootArg = args.find((arg) => !arg.startsWith('--'));
 const root = rootArg ? resolve(process.cwd(), rootArg) : process.cwd();
-const ignoredDirectories = new Set(['.git', '.claude', '.datamachine', '.opencode', 'node_modules', 'vendor']);
+// Keep this set a superset of homeboy core's `IGNORED_DIRECTORIES`
+// (src/core/rig/lint.rs) so a rig package never passes one linter and fails the
+// other. Core ignores `.sampleplugin` (generated WP Codebox sample-plugin
+// scaffolds); homeboy-rigs additionally has a real top-level `.datamachine/`.
+// The unified policy is the union of both. Converging this linter onto the core
+// primitive is tracked in Extra-Chill/homeboy#6783; the lint-only entry point
+// CI needs to consume `run_package_lint` (and the matching core `.datamachine`
+// ignore) is tracked in Extra-Chill/homeboy#6825.
+const ignoredDirectories = new Set(['.git', '.claude', '.sampleplugin', '.datamachine', '.opencode', 'node_modules', 'vendor']);
 const phpFiles = [];
 const rigFiles = [];
 const jsonFiles = [];


### PR DESCRIPTION
## What

Reconcile the ignore-directory set in `scripts/lint-rig-packages.mjs` with homeboy core's `IGNORED_DIRECTORIES` (`src/core/rig/lint.rs`). The two rig-package linters had drifted: the `.mjs` ignored `.datamachine`, core ignored `.sampleplugin`, neither ignored both — so the same rig package could pass one linter and fail the other (Extra-Chill/homeboy#6783).

This makes the `.mjs` ignore set the **union** of both — a strict superset of core's set — so this linter never trips on a directory core would skip:

```
.git .claude .sampleplugin .datamachine .opencode node_modules vendor
```

`.datamachine` is a real top-level rigs-side product dir; `.sampleplugin` matches core's generated WP Codebox sample-plugin scaffolds.

## Why this is only the ignore-set half

The original goal was to make CI invoke `homeboy rig check` and strip the generic walk / conflict-marker / JSON-parse / ignore-list logic the core primitive owns. That is **blocked upstream** and was not done here, to avoid dropping coverage or burying a workaround:

`homeboy rig check` couples the static package lint (`run_package_lint`) with live, environment-dependent evaluation — `evaluate_requirements` + the rig's `check` pipeline (HTTP/command/file probes against `${components.*.path}`). Proven against homeboy 0.266.2:

```
homeboy rig check WordPress/gutenberg/rigs/gutenberg-api-route-inventory/rig.json
-> rig-package-lint: conflict markers   pass
-> rig-package-lint: JSON specs parse   pass
-> rig-package-lint: template specs     pass
-> requirement: Gutenberg checkout exists  FAIL ("could not resolve component 'gutenberg'")
=> success: false, exit 1
```

In CI no component checkouts exist, so every rig fails the requirement step regardless of package-lint health. There is no `homeboy rig lint` and no `rig check --lint-only`, so CI cannot consume just the static lint without scraping internal step `kind` strings (a fragile shim). Filed as **Extra-Chill/homeboy#6825** with the proposed lint-only entry point + the matching core `.datamachine` ignore reconciliation. Once that lands, this linter can drop its generic walk/conflict/JSON logic and keep only the product-specific assertions (`php -l`, `/Users/chubes` + `~/Developer` path portability, TSRMLS/Playground patch ban, WP Codebox CLI discovery dedup, `shared_paths` shape, bench↔fuzz cross-ref).

## Verification

`node scripts/lint-rig-packages.mjs` before and after — identical: `20 PHP, 25 rigs, 57 fuzz workloads, 259 source files`, exit 0. Adding `.sampleplugin` changes no observable output (no such dir present), confirming behavior-preserving; no coverage dropped.

Refs Extra-Chill/homeboy#6783, Extra-Chill/homeboy#6825.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (1M context) via Claude Code
- **Used for:** Investigating the homeboy core / homeboy-rigs linter divergence, empirically verifying that `homeboy rig check` is not usable as a CI package linter, filing the upstream gap issue, and reconciling the ignore-directory set.
