### PR TITLE
Define stable Woo profiling workloads

### DIFF
--- a/woocommerce/woocommerce/fuzz/rest-db-query-profile.json
+++ b/woocommerce/woocommerce/fuzz/rest-db-query-profile.json
@@ -18,7 +18,45 @@
     "wordpress_runner": "wp-codebox",
     "workload_path": "${package.root}/bench/rest-db-query-profile.workload.json",
     "expected_artifact_role": "fuzz_report",
-    "expected_artifact_semantic_key": "fuzz.report", "readiness": { "level": "executable", "coverage_contract": "REST DB query profile coverage is executable as a read_only fuzz workload for rest-query-profile, query-shape-attribution. Proven status still requires reviewer-facing run artifacts and gap reports.", "upstream_blockers": ["reviewer-facing fuzz run artifacts and gap reports are required before proven status"] },
+    "expected_artifact_semantic_key": "fuzz.report",
+    "product_budgets": {
+      "max_profiled_rest_cases": 80,
+      "max_queries_per_rest_case": 150,
+      "max_slow_queries_per_case": 0,
+      "slow_query_threshold_ms": 100
+    },
+    "observed_surfaces": [
+      "wc/store/v1",
+      "wc/v3",
+      "wc-admin",
+      "wc-analytics",
+      "wordpress-database-queries"
+    ],
+    "hotspot_classes": [
+      "route-query-count",
+      "duplicate-db-query",
+      "slow-db-query",
+      "lookup-table-read",
+      "option-read",
+      "permission-check-query"
+    ],
+    "query_attribution_expectations": {
+      "group_by": [
+        "rest_route",
+        "http_method",
+        "status_class",
+        "table_family",
+        "hotspot_class"
+      ],
+      "required_fields": [
+        "query_count",
+        "duplicate_query_count",
+        "slow_query_count",
+        "tables",
+        "callers"
+      ]
+    },
+    "readiness": { "level": "executable", "coverage_contract": "REST DB query profile coverage is executable as a read_only fuzz workload for rest-query-profile, query-shape-attribution. Proven status still requires reviewer-facing run artifacts and gap reports.", "upstream_blockers": ["reviewer-facing fuzz run artifacts and gap reports are required before proven status"] },
     "fixture": {
       "runtime": "wp-codebox",
       "scope": "disposable-wordpress",
@@ -48,13 +86,32 @@
         "rest-query-profile",
         "query-shape-attribution"
       ],
+      "inputs": {
+        "profiled_namespaces": [
+          "wc/store/v1",
+          "wc/v3",
+          "wc-admin",
+          "wc-analytics"
+        ],
+        "budget_keys": [
+          "max_queries_per_rest_case",
+          "max_slow_queries_per_case"
+        ],
+        "query_attribution_required": true,
+        "external_service_calls_allowed": false
+      },
       "artifacts": [
         {
           "name": "rest_db_query_profile",
           "path": "rest-db-query-profile/rest_db_query_profile.json",
           "required": true,
           "metadata": {
-            "semantic_key": "fuzz.report"
+            "semantic_key": "fuzz.report",
+            "contains": [
+              "per_route_query_counts",
+              "query_attribution",
+              "budget_comparison"
+            ]
           }
         }
       ],
@@ -101,7 +158,12 @@
         "name": "rest_db_query_profile",
         "role": "fuzz_report",
         "semantic_key": "fuzz.report",
-        "required": true
+        "required": true,
+        "contains": [
+          "per_route_query_counts",
+          "query_attribution",
+          "budget_comparison"
+        ]
       }
     ]
   }

--- a/woocommerce/woocommerce/manifests/stable-workloads.json
+++ b/woocommerce/woocommerce/manifests/stable-workloads.json
@@ -1,0 +1,104 @@
+{
+  "schema": "homeboy-rigs/woocommerce-stable-workloads/v1",
+  "profile_id": "woo-profiling-stabilization",
+  "description": "Reviewer-friendly WooCommerce profiling workload names. WooCommerce owns route, admin, and scenario selection here; Homeboy only runs declared workload ids and collects artifacts.",
+  "rig": "rigs/woocommerce-performance/rig.json",
+  "contracts": [
+    {
+      "id": "rest-db-query-profile",
+      "readiness": "executable",
+      "entry_workloads": ["generated-rest-request-cases", "rest-db-query-profile"],
+      "observed_surfaces": ["wc/store/v1", "wc/v3", "wc-admin", "wc-analytics", "wordpress-database-queries"],
+      "expected_observations": {
+        "min_rest_request_cases": 8,
+        "min_profiled_rest_cases": 8,
+        "required_artifacts": ["rest_request_cases", "rest_db_query_profile"],
+        "required_artifact_fields": ["per_route_query_counts", "query_attribution", "budget_comparison"]
+      },
+      "budgets": {
+        "max_profiled_rest_cases": 80,
+        "max_queries_per_rest_case": 150,
+        "max_slow_queries_per_case": 0,
+        "slow_query_threshold_ms": 100,
+        "max_duration_seconds": 900
+      }
+    },
+    {
+      "id": "store-api-product-browse",
+      "readiness": "executable",
+      "entry_workloads": ["generated-rest-request-cases", "rest-db-query-profile", "rest-schema-query-attribution"],
+      "browser_scenarios": ["shop", "product"],
+      "observed_surfaces": ["wc/store/v1/products", "wc/store/v1/products/categories", "wc/store/v1/products/tags", "wc/store/v1/products/attributes", "wc/store/v1/products/reviews", "wc/store/v1/products/collection-data"],
+      "expected_observations": {
+        "min_rest_request_cases": 6,
+        "min_captured_responses": 6,
+        "min_profiled_rest_cases": 6,
+        "required_artifacts": ["rest_request_cases", "rest_db_query_profile", "rest_schema_query_attribution"],
+        "required_status_outcomes": ["public_read_success"]
+      },
+      "budgets": {
+        "max_queries_per_rest_case": 150,
+        "max_slow_queries_per_case": 0,
+        "slow_query_threshold_ms": 100,
+        "max_duration_seconds": 900
+      }
+    },
+    {
+      "id": "cart-and-checkout",
+      "readiness": "executable",
+      "entry_workloads": ["generated-rest-request-cases", "cart-session-overwrite-race", "checkout-concurrent-create-order", "checkout-shipping-cache"],
+      "browser_scenarios": ["cart", "checkout"],
+      "observed_surfaces": ["wc/store/v1/cart", "wc/store/v1/checkout", "woocommerce-ajax-checkout", "woocommerce-checkout-create-order", "woocommerce-cart-session"],
+      "expected_observations": {
+        "min_rest_request_cases": 2,
+        "min_checkout_iterations": 3,
+        "min_concurrent_checkout_requests": 2,
+        "required_artifacts": ["rest_request_cases", "raw_result"],
+        "required_status_outcomes": ["public_session_read_success"]
+      },
+      "budgets": {
+        "max_external_payment_requests": 0,
+        "max_duplicate_completed_orders": 0,
+        "max_duration_seconds": 900
+      }
+    },
+    {
+      "id": "admin-orders",
+      "readiness": "executable",
+      "entry_workloads": ["admin-page-coverage", "rest-permission-boundary-matrix"],
+      "browser_scenarios": ["orders_admin"],
+      "observed_surfaces": ["wp-admin/admin.php?page=wc-orders", "woocommerce-admin-pages", "wc/v3/orders"],
+      "expected_observations": {
+        "min_admin_targets": 1,
+        "min_admin_visits": 1,
+        "required_roles": ["administrator", "shop_manager"],
+        "required_artifacts": ["admin_page_coverage", "permission_boundary_matrix"],
+        "required_skip_reason_codes": ["permission_boundary", "unsafe_query_arg_delete", "unsafe_query_arg_trash"]
+      },
+      "budgets": {
+        "max_admin_pages": 80,
+        "max_destructive_actions_executed": 0,
+        "max_duration_seconds": 900
+      }
+    },
+    {
+      "id": "product-search-filtering",
+      "readiness": "executable",
+      "entry_workloads": ["generated-rest-request-cases", "layered-nav-count-cache", "layered-nav-catalog-crawl", "rest-schema-query-attribution"],
+      "browser_scenarios": ["shop", "product"],
+      "observed_surfaces": ["wc/store/v1/products", "wc/store/v1/products/collection-data", "woocommerce-layered-nav-widget", "woocommerce-product-archive"],
+      "expected_observations": {
+        "min_rest_request_cases": 2,
+        "min_crawled_facet_urls": 1,
+        "required_artifacts": ["rest_request_cases", "raw_result", "rest_schema_query_attribution"],
+        "required_hotspot_classes": ["facet-url-crawl", "transient-entry-cap-guardrail"]
+      },
+      "budgets": {
+        "max_facet_url_cases": 25,
+        "max_slow_queries_per_case": 0,
+        "slow_query_threshold_ms": 100,
+        "max_duration_seconds": 900
+      }
+    }
+  ]
+}

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -201,6 +201,7 @@
       "description": "Focused WooCommerce DB/API performance fuzzer profile built only from declared REST inventory, generated REST cases, REST DB query profile, DB inventory, schema/query attribution, and performance hotspot summary workloads.",
       "campaign_manifest": "manifests/db-api-fuzz-campaign.json",
       "gap_report_manifest": "manifests/db-api-performance-fuzzer-gap-report.json",
+      "stable_workload_contracts_manifest": "manifests/stable-workloads.json",
       "source_gap_report": "manifests/full-surface-coverage.json#gap_report",
       "required_primitives": [
         "wordpress.inventory-rest-routes",

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -36,6 +36,7 @@ const dbApiHotspotArtifactIo = readJson(packageRoot, 'manifests/db-api-hotspot-a
 const blockInventoryRenderingFuzz = readJson(packageRoot, 'manifests/block-inventory-rendering-fuzz.json');
 const adminActionInventory = readJson(packageRoot, 'manifests/admin-action-inventory.json');
 const targetInventory = readJson(packageRoot, 'manifests/target-inventory.json');
+const stableWorkloads = readJson(packageRoot, 'manifests/stable-workloads.json');
 const coverageGapReportWorkload = readJson(packageRoot, 'bench/coverage-gap-report.workload.json');
 const performanceHotspotsWorkload = readJson(packageRoot, 'bench/performance-hotspots-artifact-summary.workload.json');
 const runtimeDependencyHelper = path.join(packageRoot, 'tools/prepare-runtime-dependency.sh');
@@ -146,6 +147,45 @@ function assertDeclaredOrExternalDiscoveryWorkload(workloadId, context) {
     declaredIds.has(workloadId) || externalDiscoveryWorkloadIds.has(workloadId),
     `${context} references unknown workload ${workloadId}`
   );
+}
+
+function assertStableWorkloadContracts(manifest) {
+  assert.equal(manifest.schema, 'homeboy-rigs/woocommerce-stable-workloads/v1', 'stable workloads schema drifted');
+  assert.equal(manifest.profile_id, 'woo-profiling-stabilization', 'stable workloads profile id drifted');
+  assert.equal(manifest.rig, 'rigs/woocommerce-performance/rig.json', 'stable workloads rig ref drifted');
+
+  const expectedIds = new Set([
+    'rest-db-query-profile',
+    'store-api-product-browse',
+    'cart-and-checkout',
+    'admin-orders',
+    'product-search-filtering',
+  ]);
+  const contracts = new Map((manifest.contracts || []).map((contract) => [contract.id, contract]));
+  assert.deepEqual(new Set(contracts.keys()), expectedIds, 'stable workload ids drifted');
+
+  for (const [contractId, contract] of contracts) {
+    assert.equal(contract.readiness, 'executable', `${contractId} stable workload must be executable`);
+    assert.ok(Array.isArray(contract.entry_workloads) && contract.entry_workloads.length > 0, `${contractId} requires entry workloads`);
+    for (const workloadId of contract.entry_workloads) {
+      assert.ok(declaredIds.has(workloadId), `${contractId} entry workload ${workloadId} must be declared in fuzz_workloads.wordpress`);
+    }
+    assert.ok(Array.isArray(contract.observed_surfaces) && contract.observed_surfaces.length > 0, `${contractId} requires observed surfaces`);
+
+    const observations = contract.expected_observations;
+    assert.ok(observations && typeof observations === 'object' && !Array.isArray(observations), `${contractId} requires expected observations`);
+    assert.ok(Array.isArray(observations.required_artifacts) && observations.required_artifacts.length > 0, `${contractId} requires artifact observations`);
+    assert.ok(Object.entries(observations).some(([, value]) => typeof value === 'number' && value > 0), `${contractId} requires at least one positive observation floor`);
+
+    const budgets = contract.budgets;
+    assert.ok(budgets && typeof budgets === 'object' && !Array.isArray(budgets), `${contractId} requires budgets`);
+    assert.ok(Object.entries(budgets).some(([, value]) => typeof value === 'number' && value >= 0), `${contractId} requires numeric budgets`);
+    assert.ok(Object.values(budgets).some((value) => value === 0), `${contractId} must include at least one zero-useful-work guardrail budget`);
+  }
+
+  assert.deepEqual(contracts.get('rest-db-query-profile').entry_workloads, ['generated-rest-request-cases', 'rest-db-query-profile'], 'REST DB profile stable workload entry drifted');
+  assert.deepEqual(contracts.get('cart-and-checkout').browser_scenarios, ['cart', 'checkout'], 'cart-and-checkout scenario contract drifted');
+  assert.deepEqual(contracts.get('admin-orders').browser_scenarios, ['orders_admin'], 'admin-orders scenario contract drifted');
 }
 
 function assertCampaignPostprocessOutput(workload, output, context) {
@@ -595,8 +635,10 @@ assertFuzzProofBundleRequirements(codeboxSuite.target?.metadata?.proof_bundle_re
 assert.equal(codeboxSuite.metadata?.public_result_contract, 'wp-codebox/fuzz-suite-result/v1', 'Codebox suite must declare the public fuzz-suite result contract');
 assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.campaign_manifest, 'manifests/db-api-fuzz-campaign.json', 'DB/API profile must link the campaign declaration');
 assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.gap_report_manifest, 'manifests/db-api-performance-fuzzer-gap-report.json', 'DB/API profile must link the standalone gap report declaration');
+assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.stable_workload_contracts_manifest, 'manifests/stable-workloads.json', 'DB/API profile must link stable workload contracts');
 assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.source_gap_report, 'manifests/full-surface-coverage.json#gap_report', 'DB/API profile must identify the source full-surface gap report');
 assertProfileReadiness(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.readiness, 'fuzz_profile_metadata.db-api-performance-fuzzer.readiness');
+assertStableWorkloadContracts(stableWorkloads);
 assert.equal(dbApiPerformanceFuzzerGapReport.schema, 'homeboy-rigs/wordpress-coverage-gap-report-workload/v1', 'DB/API gap report workload schema drifted');
 assert.equal(dbApiPerformanceFuzzerGapReport.id, 'woocommerce-db-api-performance-fuzzer-gap-report', 'DB/API gap report workload id drifted');
 assert.equal(dbApiPerformanceFuzzerGapReport.profile_id, 'db-api-performance-fuzzer', 'DB/API gap report workload must target the DB/API fuzzer profile');
@@ -755,6 +797,17 @@ assert.deepEqual(productBatchManifest.metadata?.payload_fixtures?.family_ids, ['
 assert.equal(productBatchManifest.metadata?.payload_fixtures?.delete?.level, 'declared', 'product batch import delete payload fixture must remain declared');
 assert.ok(productBatchManifest.route_families.includes('wc/v3/products/batch'), 'product batch import must list products batch route family');
 assert.ok(productBatchManifest.route_families.includes('wc/v3/products/<product_id>/variations/batch'), 'product batch import must list variations batch route family');
+
+const restDbQueryProfileManifest = fuzzManifests.find(({ manifest }) => manifest.id === 'rest-db-query-profile')?.manifest;
+assert.equal(restDbQueryProfileManifest.metadata?.product_budgets?.max_profiled_rest_cases, restDbQueryProfileManifest.case_budget, 'REST DB query profile case budget drifted');
+assert.equal(restDbQueryProfileManifest.metadata?.product_budgets?.max_slow_queries_per_case, 0, 'REST DB query profile must budget zero slow queries per case');
+assert.ok(restDbQueryProfileManifest.metadata?.observed_surfaces?.includes('wc/store/v1'), 'REST DB query profile must observe Store API routes');
+assert.ok(restDbQueryProfileManifest.metadata?.observed_surfaces?.includes('wc-admin'), 'REST DB query profile must observe Woo admin REST routes');
+assert.ok(restDbQueryProfileManifest.metadata?.query_attribution_expectations?.required_fields?.includes('callers'), 'REST DB query profile must require caller attribution');
+assert.equal(restDbQueryProfileManifest.cases?.[0]?.inputs?.query_attribution_required, true, 'REST DB query profile must require query attribution');
+assert.equal(restDbQueryProfileManifest.cases?.[0]?.inputs?.external_service_calls_allowed, false, 'REST DB query profile must not allow external service calls');
+assert.ok(restDbQueryProfileManifest.cases?.[0]?.artifacts?.[0]?.metadata?.contains?.includes('budget_comparison'), 'REST DB query profile artifact must include budget comparison');
+assert.ok(restDbQueryProfileManifest.artifacts?.expected?.[0]?.contains?.includes('query_attribution'), 'REST DB query profile expected artifact must include query attribution');
 
 assert.equal(restCrudRouteFamilyCatalog.schema, 'homeboy-rigs/woocommerce-rest-crud-route-family-catalog/v1', 'REST CRUD route-family catalog schema drifted');
 assert.equal(restCrudRouteFamilyCatalog.owner_profile, 'product-rest-crud-fuzzer', 'REST CRUD route-family catalog owner profile drifted');


### PR DESCRIPTION
## Summary
- Add Woo-owned stable profiling workload contracts for REST DB profiling, Store API browse, cart/checkout, admin orders, and product filtering.
- Require observation/artifact expectations so green runs cannot silently do zero useful profiling work.
- Extend manifest validation for the stable workload contract file.

## Verification
- node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Drafting the workload contracts, validation updates, and verification workflow.