### PR TITLE
Add Woo stable Lab matrix commands

### DIFF
--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -229,6 +229,41 @@ produces reviewer-facing artifacts. Performance timing remains in
 runner has a `homeboy` binary that exposes the `fuzz` command; do not substitute
 `homeboy bench` for missing fuzz support.
 
+## Stable Lab Matrix
+
+`manifests/stable-workloads.json` names the stable Woo workload IDs used for
+longitudinal hotspot comparison. The IDs are Woo-owned contracts that expand to
+declared `fuzz_workloads.wordpress` entries; Homeboy core only runs those
+workload IDs, persists artifacts, and compares completed runs.
+
+Generate the Lab-only command plan without executing any workload:
+
+```bash
+node woocommerce/woocommerce/tools/stable-workload-lab-commands.mjs \
+  --runner LAB_RUNNER_ID \
+  --artifact-root ARTIFACT_ROOT \
+  --run-id-prefix woo-stable-YYYYMMDD \
+  --tracker-ref github:woocommerce/woocommerce#ISSUE_OR_PR
+```
+
+For a focused proof, pass one or more stable IDs:
+
+```bash
+node woocommerce/woocommerce/tools/stable-workload-lab-commands.mjs \
+  --stable-id rest-db-query-profile,store-api-product-browse \
+  --runner LAB_RUNNER_ID \
+  --artifact-root ARTIFACT_ROOT \
+  --run-id-prefix woo-stable-YYYYMMDD
+```
+
+The generated run commands use `homeboy fuzz run --lab-only --rig
+woocommerce-performance --workload <declared-workload>` with stable run IDs and
+`stable-workload:<id>` tracker refs. After the Lab runs complete, use the
+generated `homeboy runs refs`, `homeboy runs compare`, and `homeboy runs
+hotspots --baseline-run BASELINE_RUN_ID --candidate-run CANDIDATE_RUN_ID`
+commands to compare persisted evidence over time. Keep reviewer-facing proof in
+Homeboy run/artifact refs; local paths and local-only URLs are not proof.
+
 Each Woo fuzz manifest declares the WP Codebox fixture contract in metadata:
 `wp-codebox` runtime, disposable WordPress scope, WooCommerce component, and
 `woocommerce/woocommerce.php` activation. The validator rejects fixture metadata

--- a/woocommerce/woocommerce/manifests/stable-workloads.json
+++ b/woocommerce/woocommerce/manifests/stable-workloads.json
@@ -3,6 +3,8 @@
   "profile_id": "woo-profiling-stabilization",
   "description": "Reviewer-friendly WooCommerce profiling workload names. WooCommerce owns route, admin, and scenario selection here; Homeboy only runs declared workload ids and collects artifacts.",
   "rig": "rigs/woocommerce-performance/rig.json",
+  "lab_command_generator": "tools/stable-workload-lab-commands.mjs",
+  "comparison_commands": ["homeboy runs refs", "homeboy runs compare", "homeboy runs hotspots"],
   "contracts": [
     {
       "id": "rest-db-query-profile",

--- a/woocommerce/woocommerce/tools/stable-workload-lab-commands.mjs
+++ b/woocommerce/woocommerce/tools/stable-workload-lab-commands.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.join(__dirname, '..');
+const manifestPath = path.join(packageRoot, 'manifests/stable-workloads.json');
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+
+const args = process.argv.slice(2);
+const options = parseArgs(args);
+const contracts = selectedContracts(manifest.contracts || [], options.stableIds);
+const runIdPrefix = options.runIdPrefix || `woo-stable-${new Date().toISOString().slice(0, 10).replaceAll('-', '')}`;
+
+const runCommands = [];
+for (const contract of contracts) {
+  contract.entry_workloads.forEach((workloadId, index) => {
+    const command = [
+      'homeboy',
+      'fuzz',
+      'run',
+      '--lab-only',
+      '--rig',
+      'woocommerce-performance',
+      '--workload',
+      workloadId,
+      '--gate-profile',
+      'measurement',
+      '--run-id',
+      `${runIdPrefix}-${contract.id}-${String(index + 1).padStart(2, '0')}-${workloadId}`,
+      '--tracker-ref',
+      `stable-workload:${contract.id}`,
+    ];
+
+    if (options.runner) {
+      command.push('--runner', options.runner);
+    }
+    if (options.artifactRoot) {
+      command.push('--artifact-root', options.artifactRoot);
+    }
+    if (options.detachAfterHandoff) {
+      command.push('--detach-after-handoff');
+    }
+    if (contract.budgets?.max_duration_seconds) {
+      command.push('--max-duration', `${contract.budgets.max_duration_seconds}s`);
+    }
+    for (const trackerRef of options.trackerRefs) {
+      command.push('--tracker-ref', trackerRef);
+    }
+
+    runCommands.push({
+      stable_workload_id: contract.id,
+      workload_id: workloadId,
+      run_id: `${runIdPrefix}-${contract.id}-${String(index + 1).padStart(2, '0')}-${workloadId}`,
+      command,
+    });
+  });
+}
+
+const compareCommands = [
+  {
+    purpose: 'list_recent_refs',
+    command: withLabOptions([
+      'homeboy', 'runs', 'refs',
+      '--kind', 'fuzz',
+      '--component', 'woocommerce',
+      '--rig', 'woocommerce-performance',
+      '--status', 'completed',
+      '--since', options.since,
+      '--limit', String(options.limit),
+      '--aggregate-artifact-kind', 'fuzz.report',
+    ], options),
+  },
+  {
+    purpose: 'trend_elapsed_time',
+    command: withLabOptions([
+      'homeboy', 'runs', 'compare',
+      '--kind', 'fuzz',
+      '--component', 'woocommerce',
+      '--rig', 'woocommerce-performance',
+      '--metric', 'total_elapsed_ms',
+      '--limit', String(options.limit),
+    ], options),
+  },
+  {
+    purpose: 'compare_hotspots_after_two_runs_complete',
+    command: withLabOptions([
+      'homeboy', 'runs', 'hotspots',
+      '--baseline-run', 'BASELINE_RUN_ID',
+      '--candidate-run', 'CANDIDATE_RUN_ID',
+      '--limit', String(options.hotspotLimit),
+    ], options),
+  },
+];
+
+const payload = {
+  schema: 'homeboy-rigs/woocommerce-stable-lab-command-plan/v1',
+  manifest: 'manifests/stable-workloads.json',
+  profile_id: manifest.profile_id,
+  rig_id: 'woocommerce-performance',
+  local_execution: false,
+  run_id_prefix: runIdPrefix,
+  run_commands: runCommands,
+  compare_commands: compareCommands,
+};
+
+if (options.json) {
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+} else {
+  for (const item of runCommands) {
+    process.stdout.write(`# ${item.stable_workload_id} -> ${item.workload_id}\n${shellJoin(item.command)}\n`);
+  }
+  process.stdout.write('\n# Compare persisted evidence after Lab runs complete.\n');
+  for (const item of compareCommands) {
+    process.stdout.write(`# ${item.purpose}\n${shellJoin(item.command)}\n`);
+  }
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    artifactRoot: '',
+    detachAfterHandoff: false,
+    hotspotLimit: 20,
+    json: false,
+    limit: 50,
+    runner: '',
+    runIdPrefix: '',
+    since: '30d',
+    stableIds: [],
+    trackerRefs: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const readValue = (name) => {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error(`${name} requires a value`);
+      }
+      index += 1;
+      return value;
+    };
+
+    switch (arg) {
+      case '--artifact-root':
+        parsed.artifactRoot = readValue(arg);
+        break;
+      case '--detach-after-handoff':
+        parsed.detachAfterHandoff = true;
+        break;
+      case '--hotspot-limit':
+        parsed.hotspotLimit = Number.parseInt(readValue(arg), 10);
+        break;
+      case '--json':
+        parsed.json = true;
+        break;
+      case '--limit':
+        parsed.limit = Number.parseInt(readValue(arg), 10);
+        break;
+      case '--runner':
+        parsed.runner = readValue(arg);
+        break;
+      case '--run-id-prefix':
+        parsed.runIdPrefix = readValue(arg);
+        break;
+      case '--since':
+        parsed.since = readValue(arg);
+        break;
+      case '--stable-id':
+        parsed.stableIds.push(...readValue(arg).split(',').filter(Boolean));
+        break;
+      case '--tracker-ref':
+        parsed.trackerRefs.push(readValue(arg));
+        break;
+      case '--help':
+      case '-h':
+        printHelp();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  for (const [name, value] of [['--limit', parsed.limit], ['--hotspot-limit', parsed.hotspotLimit]]) {
+    if (!Number.isInteger(value) || value < 1) {
+      throw new Error(`${name} must be a positive integer`);
+    }
+  }
+
+  return parsed;
+}
+
+function selectedContracts(contracts, stableIds) {
+  if (stableIds.length === 0) {
+    return contracts;
+  }
+
+  const selected = new Set(stableIds);
+  const filtered = contracts.filter((contract) => selected.has(contract.id));
+  const found = new Set(filtered.map((contract) => contract.id));
+  const missing = [...selected].filter((id) => !found.has(id));
+  if (missing.length > 0) {
+    throw new Error(`Unknown stable workload id(s): ${missing.join(', ')}`);
+  }
+  return filtered;
+}
+
+function withLabOptions(command, options) {
+  const withOptions = [...command, '--lab-only'];
+  if (options.runner) {
+    withOptions.push('--runner', options.runner);
+  }
+  if (options.artifactRoot) {
+    withOptions.push('--artifact-root', options.artifactRoot);
+  }
+  return withOptions;
+}
+
+function shellJoin(command) {
+  return command.map(shellQuote).join(' ');
+}
+
+function shellQuote(value) {
+  if (/^[A-Za-z0-9_./:=,@+-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node tools/stable-workload-lab-commands.mjs [options]\n\n`);
+  process.stdout.write(`Emits Lab-only Homeboy commands for Woo stable workload contracts. It never executes workloads.\n\n`);
+  process.stdout.write(`Options:\n`);
+  process.stdout.write(`  --stable-id <id[,id]>        Limit to one or more stable workload ids. Repeatable.\n`);
+  process.stdout.write(`  --runner <id>                Add a Homeboy Lab runner id to every command.\n`);
+  process.stdout.write(`  --artifact-root <dir>        Add a persisted artifact root to every command.\n`);
+  process.stdout.write(`  --run-id-prefix <id>         Stable proof prefix. Defaults to woo-stable-YYYYMMDD.\n`);
+  process.stdout.write(`  --tracker-ref <kind:id>      Extra tracker ref added to every run command. Repeatable.\n`);
+  process.stdout.write(`  --detach-after-handoff       Return after the Lab daemon accepts each run.\n`);
+  process.stdout.write(`  --since <duration>           Lookback for refs compare command. Default: 30d.\n`);
+  process.stdout.write(`  --limit <n>                  Run-history limit for refs/compare. Default: 50.\n`);
+  process.stdout.write(`  --hotspot-limit <n>          Hotspot compare row limit. Default: 20.\n`);
+  process.stdout.write(`  --json                       Emit structured JSON instead of shell commands.\n`);
+}

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -153,6 +153,8 @@ function assertStableWorkloadContracts(manifest) {
   assert.equal(manifest.schema, 'homeboy-rigs/woocommerce-stable-workloads/v1', 'stable workloads schema drifted');
   assert.equal(manifest.profile_id, 'woo-profiling-stabilization', 'stable workloads profile id drifted');
   assert.equal(manifest.rig, 'rigs/woocommerce-performance/rig.json', 'stable workloads rig ref drifted');
+  assert.equal(manifest.lab_command_generator, 'tools/stable-workload-lab-commands.mjs', 'stable workloads Lab command generator drifted');
+  assert.deepEqual(manifest.comparison_commands, ['homeboy runs refs', 'homeboy runs compare', 'homeboy runs hotspots'], 'stable workload comparison command surface drifted');
 
   const expectedIds = new Set([
     'rest-db-query-profile',


### PR DESCRIPTION
## Summary
- Add a rig-owned command generator for Lab-only Woo stable workload runs.
- Document run and compare workflow for stable profiling evidence.
- Extend manifest validation so the stable matrix command surface cannot drift silently.

## Verification
- node woocommerce/woocommerce/tools/stable-workload-lab-commands.mjs --help
- node woocommerce/woocommerce/tools/stable-workload-lab-commands.mjs --stable-id rest-db-query-profile --runner lab-runner --artifact-root /tmp/homeboy-artifacts --run-id-prefix woo-stable-test --tracker-ref github:woocommerce/woocommerce#000 --json
- node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
- node scripts/lint-rig-packages.mjs
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Drafting the command generator, docs, validation updates, and verification workflow.