### PR TITLE
Add Jetpack stable Lab proof commands

### DIFF
--- a/Automattic/jetpack/README.md
+++ b/Automattic/jetpack/README.md
@@ -26,6 +26,18 @@ homeboy fuzz list --rig jetpack-api-route-inventory
 
 Use offloaded Lab runners for proof campaigns. Listing workloads confirms declarations only; P status requires persisted `homeboy fuzz run` artifacts, coverage gap reports, and non-local proof references.
 
+Generate Lab-only commands for stable Jetpack profiling proof runs:
+
+```sh
+node Automattic/jetpack/tools/stable-workload-lab-commands.mjs \
+  --runner LAB_RUNNER_ID \
+  --artifact-root ARTIFACT_ROOT \
+  --run-id-prefix jetpack-stable-YYYYMMDD \
+  --tracker-ref github:Automattic/jetpack#ISSUE_OR_PR
+```
+
+The generator emits one `homeboy fuzz run --lab-only` command per stable workload entry and compare commands for persisted refs, elapsed-time trends, and hotspot deltas. It does not execute workloads locally.
+
 The rig exposes `smoke`, `fuzzer`, and `full-surface` `fuzz_profiles` for fleet
 orchestration. These profiles only group existing fuzz workload declarations;
 they do not change readiness levels or convert declarations into proof.

--- a/Automattic/jetpack/manifests/stable-workloads.json
+++ b/Automattic/jetpack/manifests/stable-workloads.json
@@ -1,0 +1,77 @@
+{
+  "schema": "homeboy-rigs/jetpack-stable-workloads/v1",
+  "profile_id": "jetpack-arbitrary-plugin-proof",
+  "description": "Reviewer-friendly Jetpack profiling workload names. Jetpack owns route, module, admin, DB, and external HTTP semantics here; Homeboy only runs declared workload ids and collects generic artifacts.",
+  "rig": "rigs/jetpack-api-route-inventory/rig.json",
+  "lab_command_generator": "tools/stable-workload-lab-commands.mjs",
+  "comparison_surfaces": ["fuzz-observations", "fuzz-hotspots", "db-query-hotspots", "coverage-gaps", "guardrail-results"],
+  "contracts": [
+    {
+      "id": "rest-db-query-profile",
+      "readiness": "executable",
+      "entry_workloads": ["generated-rest-request-cases", "rest-db-query-profile"],
+      "observed_surfaces": ["jetpack/v4", "wpcom/v2", "wordpress-database-queries", "connection-state"],
+      "expected_observations": {
+        "min_rest_request_cases": 4,
+        "min_profiled_rest_cases": 4,
+        "required_artifacts": ["rest_request_cases", "rest_db_query_profile"],
+        "required_artifact_fields": ["per_route_query_counts", "query_attribution", "budget_comparison", "connected_state_caveats"]
+      },
+      "budgets": {
+        "max_profiled_rest_cases": 50,
+        "max_queries_per_rest_case": 75,
+        "max_uncached_options_queries_per_case": 12,
+        "max_slow_queries_per_case": 0,
+        "slow_query_threshold_ms": 100,
+        "max_duration_seconds": 600
+      }
+    },
+    {
+      "id": "db-and-module-inventory",
+      "readiness": "executable",
+      "entry_workloads": ["db-inventory", "jetpack-module-option-table-inventory"],
+      "observed_surfaces": ["jetpack-options", "jetpack-modules", "jetpack-sync-tables", "wordpress-options"],
+      "expected_observations": {
+        "min_inventory_artifacts": 2,
+        "required_artifacts": ["db_inventory", "module_option_table_inventory"],
+        "required_artifact_fields": ["option_keys", "table_prefixes", "module_groups", "connected_state_blockers"]
+      },
+      "budgets": {
+        "max_duration_seconds": 600
+      }
+    },
+    {
+      "id": "admin-and-public-coverage",
+      "readiness": "executable",
+      "entry_workloads": ["jetpack-admin-page-coverage", "jetpack-public-module-frontend-coverage"],
+      "browser_scenarios": ["dashboard", "connection", "modules", "settings", "public_post_modules", "public_page_modules"],
+      "observed_surfaces": ["jetpack-admin", "jetpack-modules", "public-module-frontend", "browser-requests"],
+      "expected_observations": {
+        "min_admin_targets": 2,
+        "min_public_module_states": 2,
+        "required_artifacts": ["admin_page_coverage", "public_module_frontend_coverage"],
+        "required_skip_reason_codes": ["connection_required", "credential_unavailable", "destructive_action"]
+      },
+      "budgets": {
+        "max_admin_pages": 40,
+        "max_external_service_requests": 0,
+        "max_duration_seconds": 900
+      }
+    },
+    {
+      "id": "external-http-guardrail",
+      "readiness": "executable",
+      "entry_workloads": ["jetpack-external-http-guardrail"],
+      "observed_surfaces": ["wpcom-boundary", "sync-dispatch", "module-service-api", "synthetic-blocked-probe"],
+      "expected_observations": {
+        "min_guardrail_probes": 1,
+        "required_artifacts": ["external_http_guardrail"],
+        "required_status_outcomes": ["blocked_synthetic_probe", "classified_wpcom_boundary"]
+      },
+      "budgets": {
+        "max_live_external_service_calls": 0,
+        "max_duration_seconds": 600
+      }
+    }
+  ]
+}

--- a/Automattic/jetpack/tools/stable-workload-lab-commands.mjs
+++ b/Automattic/jetpack/tools/stable-workload-lab-commands.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.join(__dirname, '..');
+const manifestPath = path.join(packageRoot, 'manifests/stable-workloads.json');
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+
+const options = parseArgs(process.argv.slice(2));
+const contracts = selectedContracts(manifest.contracts || [], options.stableIds);
+const runIdPrefix = options.runIdPrefix || `jetpack-stable-${new Date().toISOString().slice(0, 10).replaceAll('-', '')}`;
+
+const runCommands = [];
+for (const contract of contracts) {
+  contract.entry_workloads.forEach((workloadId, index) => {
+    const command = [
+      'homeboy',
+      'fuzz',
+      'run',
+      '--lab-only',
+      '--rig',
+      'jetpack-api-route-inventory',
+      '--workload',
+      workloadId,
+      '--gate-profile',
+      'measurement',
+      '--run-id',
+      `${runIdPrefix}-${contract.id}-${String(index + 1).padStart(2, '0')}-${workloadId}`,
+      '--tracker-ref',
+      `stable-workload:${contract.id}`,
+    ];
+
+    if (options.runner) {
+      command.push('--runner', options.runner);
+    }
+    if (options.artifactRoot) {
+      command.push('--artifact-root', options.artifactRoot);
+    }
+    if (options.detachAfterHandoff) {
+      command.push('--detach-after-handoff');
+    }
+    if (contract.budgets?.max_duration_seconds) {
+      command.push('--max-duration', `${contract.budgets.max_duration_seconds}s`);
+    }
+    for (const trackerRef of options.trackerRefs) {
+      command.push('--tracker-ref', trackerRef);
+    }
+
+    runCommands.push({
+      stable_workload_id: contract.id,
+      workload_id: workloadId,
+      run_id: `${runIdPrefix}-${contract.id}-${String(index + 1).padStart(2, '0')}-${workloadId}`,
+      command,
+    });
+  });
+}
+
+const compareCommands = [
+  {
+    purpose: 'list_recent_refs',
+    command: withLabOptions([
+      'homeboy', 'runs', 'refs',
+      '--kind', 'fuzz',
+      '--component', 'jetpack',
+      '--rig', 'jetpack-api-route-inventory',
+      '--status', 'completed',
+      '--since', options.since,
+      '--limit', String(options.limit),
+      '--aggregate-artifact-kind', 'fuzz.report',
+    ], options),
+  },
+  {
+    purpose: 'trend_elapsed_time',
+    command: withLabOptions([
+      'homeboy', 'runs', 'compare',
+      '--kind', 'fuzz',
+      '--component', 'jetpack',
+      '--rig', 'jetpack-api-route-inventory',
+      '--metric', 'total_elapsed_ms',
+      '--limit', String(options.limit),
+    ], options),
+  },
+  {
+    purpose: 'compare_hotspots_after_two_runs_complete',
+    command: withLabOptions([
+      'homeboy', 'runs', 'hotspots',
+      '--baseline-run', 'BASELINE_RUN_ID',
+      '--candidate-run', 'CANDIDATE_RUN_ID',
+      '--limit', String(options.hotspotLimit),
+    ], options),
+  },
+];
+
+const payload = {
+  schema: 'homeboy-rigs/jetpack-stable-lab-command-plan/v1',
+  manifest: 'manifests/stable-workloads.json',
+  profile_id: manifest.profile_id,
+  rig_id: 'jetpack-api-route-inventory',
+  local_execution: false,
+  run_id_prefix: runIdPrefix,
+  run_commands: runCommands,
+  compare_commands: compareCommands,
+};
+
+if (options.json) {
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+} else {
+  for (const item of runCommands) {
+    process.stdout.write(`# ${item.stable_workload_id} -> ${item.workload_id}\n${shellJoin(item.command)}\n`);
+  }
+  process.stdout.write('\n# Compare persisted evidence after Lab runs complete.\n');
+  for (const item of compareCommands) {
+    process.stdout.write(`# ${item.purpose}\n${shellJoin(item.command)}\n`);
+  }
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    artifactRoot: '',
+    detachAfterHandoff: false,
+    hotspotLimit: 20,
+    json: false,
+    limit: 50,
+    runner: '',
+    runIdPrefix: '',
+    since: '30d',
+    stableIds: [],
+    trackerRefs: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const readValue = (name) => {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error(`${name} requires a value`);
+      }
+      index += 1;
+      return value;
+    };
+
+    switch (arg) {
+      case '--artifact-root':
+        parsed.artifactRoot = readValue(arg);
+        break;
+      case '--detach-after-handoff':
+        parsed.detachAfterHandoff = true;
+        break;
+      case '--hotspot-limit':
+        parsed.hotspotLimit = Number.parseInt(readValue(arg), 10);
+        break;
+      case '--json':
+        parsed.json = true;
+        break;
+      case '--limit':
+        parsed.limit = Number.parseInt(readValue(arg), 10);
+        break;
+      case '--runner':
+        parsed.runner = readValue(arg);
+        break;
+      case '--run-id-prefix':
+        parsed.runIdPrefix = readValue(arg);
+        break;
+      case '--since':
+        parsed.since = readValue(arg);
+        break;
+      case '--stable-id':
+        parsed.stableIds.push(...readValue(arg).split(',').filter(Boolean));
+        break;
+      case '--tracker-ref':
+        parsed.trackerRefs.push(readValue(arg));
+        break;
+      case '--help':
+      case '-h':
+        printHelp();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  for (const [name, value] of [['--limit', parsed.limit], ['--hotspot-limit', parsed.hotspotLimit]]) {
+    if (!Number.isInteger(value) || value < 1) {
+      throw new Error(`${name} must be a positive integer`);
+    }
+  }
+
+  return parsed;
+}
+
+function selectedContracts(contracts, stableIds) {
+  if (stableIds.length === 0) {
+    return contracts;
+  }
+
+  const selected = new Set(stableIds);
+  const filtered = contracts.filter((contract) => selected.has(contract.id));
+  const found = new Set(filtered.map((contract) => contract.id));
+  const missing = [...selected].filter((id) => !found.has(id));
+  if (missing.length > 0) {
+    throw new Error(`Unknown stable workload id(s): ${missing.join(', ')}`);
+  }
+  return filtered;
+}
+
+function withLabOptions(command, options) {
+  const withOptions = [...command, '--lab-only'];
+  if (options.runner) {
+    withOptions.push('--runner', options.runner);
+  }
+  if (options.artifactRoot) {
+    withOptions.push('--artifact-root', options.artifactRoot);
+  }
+  return withOptions;
+}
+
+function shellJoin(command) {
+  return command.map(shellQuote).join(' ');
+}
+
+function shellQuote(value) {
+  if (/^[A-Za-z0-9_./:=,@+-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node tools/stable-workload-lab-commands.mjs [options]\n\n`);
+  process.stdout.write(`Emits Lab-only Homeboy commands for Jetpack stable workload contracts. It never executes workloads.\n\n`);
+  process.stdout.write(`Options:\n`);
+  process.stdout.write(`  --stable-id <id[,id]>        Limit to one or more stable workload ids. Repeatable.\n`);
+  process.stdout.write(`  --runner <id>                Add a Homeboy Lab runner id to every command.\n`);
+  process.stdout.write(`  --artifact-root <dir>        Add a persisted artifact root to every command.\n`);
+  process.stdout.write(`  --run-id-prefix <id>         Stable proof prefix. Defaults to jetpack-stable-YYYYMMDD.\n`);
+  process.stdout.write(`  --tracker-ref <kind:id>      Extra tracker ref added to every run command. Repeatable.\n`);
+  process.stdout.write(`  --detach-after-handoff       Return after the Lab daemon accepts each run.\n`);
+  process.stdout.write(`  --since <duration>           Lookback for refs compare command. Default: 30d.\n`);
+  process.stdout.write(`  --limit <n>                  Run-history limit for refs/compare. Default: 50.\n`);
+  process.stdout.write(`  --hotspot-limit <n>          Hotspot compare row limit. Default: 20.\n`);
+  process.stdout.write(`  --json                       Emit structured JSON instead of shell commands.\n`);
+}

--- a/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
+++ b/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
@@ -21,6 +21,7 @@ const apiRig = readJson(packageRoot, 'rigs/jetpack-api-route-inventory/rig.json'
 const browserRig = readJson(packageRoot, 'rigs/jetpack-browser-coverage/rig.json');
 const fullSurfaceCoverage = readJson(packageRoot, 'manifests/full-surface-coverage.json');
 const restRouteCoverage = readJson(packageRoot, 'manifests/rest-route-coverage.json');
+const stableWorkloads = readJson(packageRoot, 'manifests/stable-workloads.json');
 const generatedRestCases = readJson(packageRoot, 'bench/generated-rest-request-cases.workload.json');
 const dbInventory = readJson(packageRoot, 'bench/db-inventory.workload.json');
 const fuzzManifests = collectFuzzManifests(packageRoot);
@@ -52,10 +53,20 @@ const expectedBrowserScenarios = new Set([
   'public_page_modules',
 ]);
 
+const expectedStableWorkloadIds = new Set([
+  'admin-and-public-coverage',
+  'db-and-module-inventory',
+  'external-http-guardrail',
+  'rest-db-query-profile',
+]);
+
 assertFullSurfaceCoverageManifest(fullSurfaceCoverage, { file: 'Jetpack full-surface coverage' });
 assert.equal(fuzzManifests.length, expectedFuzzIds.size, 'expected one Jetpack fuzz manifest per declared API fuzz workload');
 assert.equal(apiRig.bench_workloads, undefined, 'Jetpack fuzz coverage must not use bench_workloads as a fallback');
 assert.equal(apiRig.bench_profiles, undefined, 'Jetpack fuzz coverage must not use bench_profiles as a fallback');
+assert.equal(stableWorkloads.schema, 'homeboy-rigs/jetpack-stable-workloads/v1', 'Jetpack stable workload schema drifted');
+assert.equal(stableWorkloads.rig, 'rigs/jetpack-api-route-inventory/rig.json', 'Jetpack stable workloads must target API inventory rig');
+assert.equal(stableWorkloads.lab_command_generator, 'tools/stable-workload-lab-commands.mjs', 'Jetpack stable workload generator drifted');
 
 const declaredIds = declaredFuzzIds(apiRig);
 const benchWorkloadIds = declaredBenchWorkloadIds(apiRig);
@@ -71,6 +82,7 @@ assert.deepEqual(declaredIds, expectedFuzzIds, 'rig fuzz_workloads.wordpress ids
 assert.deepEqual(profileFuzzIds, expectedFuzzIds, 'Jetpack full-surface fuzz workload mapping drifted');
 assert.deepEqual(new Set(profile.browser_requests), expectedBrowserScenarios, 'Jetpack full-surface browser scenarios drifted');
 assert.deepEqual(new Set(browserRig.trace_profiles['full-surface']), new Set(['jetpack-browser-coverage']), 'Jetpack browser full-surface trace profile drifted');
+assertJetpackStableWorkloads(stableWorkloads, expectedStableWorkloadIds, expectedFuzzIds);
 
 for (const scenario of expectedBrowserScenarios) {
   assert.ok(
@@ -343,6 +355,23 @@ function assertArtifactContains(manifest, artifactName, expectedFields) {
   for (const field of expectedFields) {
     assert.ok(caseArtifact.metadata?.contains?.includes(field), `${manifest.id} case artifact ${artifactName} must contain ${field}`);
     assert.ok(expectedArtifact.contains?.includes(field), `${manifest.id} expected artifact ${artifactName} must contain ${field}`);
+  }
+}
+
+function assertJetpackStableWorkloads(manifest, expectedIds, expectedFuzzIds) {
+  assert.deepEqual(new Set(manifest.contracts.map((contract) => contract.id)), expectedIds, 'Jetpack stable workload ids drifted');
+  assert.ok(Array.isArray(manifest.comparison_surfaces) && manifest.comparison_surfaces.includes('fuzz-hotspots'), 'Jetpack stable workloads must compare fuzz hotspots');
+
+  for (const contract of manifest.contracts) {
+    assert.equal(contract.readiness, 'executable', `${contract.id} must be executable`);
+    assert.ok(Array.isArray(contract.entry_workloads) && contract.entry_workloads.length > 0, `${contract.id} must declare entry workloads`);
+    assert.ok(Array.isArray(contract.observed_surfaces) && contract.observed_surfaces.length > 0, `${contract.id} must declare observed surfaces`);
+    assert.ok(contract.expected_observations?.required_artifacts?.length > 0, `${contract.id} must require artifacts`);
+    assert.ok(contract.budgets?.max_duration_seconds > 0, `${contract.id} must declare max duration budget`);
+
+    for (const workloadId of contract.entry_workloads) {
+      assert.ok(expectedFuzzIds.has(workloadId), `${contract.id} entry workload ${workloadId} must be a declared Jetpack fuzz workload`);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add Jetpack-owned stable workload contracts for REST DB profiling, DB/module inventory, admin/public coverage, and external HTTP guardrails.
- Add a Lab-only command generator for Jetpack stable workload proof runs and persisted comparison commands.
- Extend Jetpack manifest validation so stable workload IDs, entry workloads, required artifacts, and duration budgets cannot drift silently.

## Verification
- node Automattic/jetpack/tools/stable-workload-lab-commands.mjs --help
- node Automattic/jetpack/tools/stable-workload-lab-commands.mjs --stable-id rest-db-query-profile --runner lab-runner --artifact-root /tmp/homeboy-artifacts --run-id-prefix jetpack-stable-test --tracker-ref github:Automattic/jetpack#000 --json
- node Automattic/jetpack/tools/validate-fuzz-manifests.mjs
- node scripts/lint-rig-packages.mjs
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Drafting the Jetpack stable workload contracts, Lab command generator, validation checks, and verification workflow.