### PR TITLE
Add Jetpack stable Lab proof workloads

### DIFF
--- a/Automattic/jetpack/README.md
+++ b/Automattic/jetpack/README.md
@@ -26,6 +26,18 @@ homeboy fuzz list --rig jetpack-api-route-inventory
 
 Use offloaded Lab runners for proof campaigns. Listing workloads confirms declarations only; P status requires persisted `homeboy fuzz run` artifacts, coverage gap reports, and non-local proof references.
 
+Generate Lab-only commands for stable Jetpack profiling proof runs:
+
+```sh
+node Automattic/jetpack/tools/stable-workload-lab-commands.mjs \
+  --runner LAB_RUNNER_ID \
+  --artifact-root ARTIFACT_ROOT \
+  --run-id-prefix jetpack-stable-YYYYMMDD \
+  --tracker-ref github:Automattic/jetpack#ISSUE_OR_PR
+```
+
+The generator emits one `homeboy fuzz run --lab-only` command per stable workload entry and compare commands for persisted refs, elapsed-time trends, and hotspot deltas. It does not execute workloads locally.
+
 The rig exposes `smoke`, `fuzzer`, and `full-surface` `fuzz_profiles` for fleet
 orchestration. These profiles only group existing fuzz workload declarations;
 they do not change readiness levels or convert declarations into proof.

--- a/Automattic/jetpack/bench/generated-rest-request-cases.php
+++ b/Automattic/jetpack/bench/generated-rest-request-cases.php
@@ -1,0 +1,306 @@
+<?php
+/**
+ * WP Codebox-backed Jetpack generated safe REST request workload.
+ *
+ * Executes the static GET-only Jetpack REST request case plan and emits request
+ * results plus skip-reason artifacts for the stable workload evidence contract.
+ */
+return function (): array {
+	$started = microtime( true );
+	$run_id  = 'generated-rest-request-cases-' . getmypid() . '-' . time();
+
+	$jetpack_entrypoint = WP_PLUGIN_DIR . '/jetpack/jetpack.php';
+	if ( ! file_exists( $jetpack_entrypoint ) ) {
+		throw new RuntimeException( 'Jetpack plugin entrypoint is not mounted.' );
+	}
+
+	if ( ! defined( 'JETPACK__PLUGIN_FILE' ) ) {
+		require_once $jetpack_entrypoint;
+	}
+	if ( ! function_exists( 'is_plugin_active' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+	if ( ! is_plugin_active( 'jetpack/jetpack.php' ) ) {
+		activate_plugin( 'jetpack/jetpack.php' );
+	}
+
+	$workload_path = __DIR__ . '/generated-rest-request-cases.workload.json';
+	$workload_json = is_readable( $workload_path ) ? file_get_contents( $workload_path ) : jetpack_homeboy_generated_rest_request_cases_config();
+	$workload      = json_decode( $workload_json, true );
+	if ( ! is_array( $workload ) || ! isset( $workload['rest_request_cases'] ) || ! is_array( $workload['rest_request_cases'] ) ) {
+		throw new RuntimeException( 'Jetpack generated REST workload config is invalid.' );
+	}
+
+	$server = rest_get_server();
+	do_action( 'rest_api_init', $server );
+	$routes = $server->get_routes();
+	ksort( $routes );
+	$jetpack_route_sample = array_slice(
+		array_values(
+			array_filter(
+				array_keys( $routes ),
+				static fn ( $route ) => str_starts_with( $route, '/jetpack/v4' ) || str_starts_with( $route, '/wpcom/v2' )
+			)
+		),
+		0,
+		20
+	);
+
+	$administrator_id = 0;
+	$administrators   = get_users(
+		array(
+			'role'   => 'administrator',
+			'number' => 1,
+			'fields' => 'ID',
+		)
+	);
+	if ( ! empty( $administrators ) ) {
+		$administrator_id = (int) $administrators[0];
+	}
+
+	$responses    = array();
+	$skip_reasons = array();
+	$case_count   = 0;
+
+	foreach ( $workload['rest_request_cases'] as $case ) {
+		++$case_count;
+		$case_id     = (string) ( $case['id'] ?? 'unnamed-case' );
+		$path        = (string) ( $case['path'] ?? '' );
+		$method      = strtoupper( (string) ( $case['method'] ?? 'GET' ) );
+		$skip_reason = isset( $case['skip_reason'] ) ? (string) $case['skip_reason'] : '';
+
+		if ( 'GET' !== $method ) {
+			$skip_reasons[] = array(
+				'id'          => $case_id,
+				'path'        => $path,
+				'reason_code' => 'no_safe_read_method',
+			);
+			continue;
+		}
+
+		if ( $skip_reason ) {
+			$skip_reasons[] = array(
+				'id'          => $case_id,
+				'path'        => $path,
+				'reason_code' => $skip_reason,
+			);
+			continue;
+		}
+
+		if ( ! isset( $routes[ $path ] ) ) {
+			$skip_reasons[] = array(
+				'id'          => $case_id,
+				'path'        => $path,
+				'reason_code' => 'route_absent',
+			);
+			continue;
+		}
+
+		$previous_user_id = get_current_user_id();
+		if ( ! empty( $case['auth_required'] ) && $administrator_id > 0 ) {
+			wp_set_current_user( $administrator_id );
+		} else {
+			wp_set_current_user( 0 );
+		}
+
+		$request = new WP_REST_Request( $method, $path );
+		foreach ( (array) ( $case['params'] ?? array() ) as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+
+		$response          = rest_do_request( $request );
+		$status            = (int) $response->get_status();
+		$expected_statuses = array_map( 'intval', (array) ( $case['expected_statuses'] ?? array() ) );
+		$responses[]       = array(
+			'id'               => $case_id,
+			'path'             => $path,
+			'method'           => $method,
+			'persona'          => (string) ( $case['persona'] ?? '' ),
+			'permission_class' => (string) ( $case['permission_class'] ?? '' ),
+			'status'           => $status,
+			'expected_status'  => in_array( $status, $expected_statuses, true ),
+		);
+
+		wp_set_current_user( $previous_user_id );
+	}
+
+	$summary = array(
+		'generated_case_count' => $case_count,
+		'response_count'       => count( $responses ),
+		'skipped_case_count'   => count( $skip_reasons ),
+		'available_route_count' => count( $routes ),
+		'jetpack_route_sample' => $jetpack_route_sample,
+		'skip_reasons'         => $skip_reasons,
+		'total_elapsed_ms'     => ( microtime( true ) - $started ) * 1000,
+	);
+
+	$artifacts    = array();
+	$shared_state = getenv( 'WP_CODEBOX_BENCH_SHARED_STATE' );
+	if ( $shared_state ) {
+		$artifact_dir = rtrim( $shared_state, '/' ) . '/generated-rest-request-cases';
+		wp_mkdir_p( $artifact_dir );
+
+		$request_cases_path = $artifact_dir . '/rest_request_cases.json';
+		file_put_contents(
+			$request_cases_path,
+			wp_json_encode(
+				array(
+					'schema'          => 'homeboy/wordpress-rest-request-cases/v1',
+					'run_id'          => $run_id,
+					'plugin'          => 'jetpack',
+					'generation'      => array(
+						'source'       => 'static-generated-rest-request-cases.workload.json',
+						'safe_methods' => array( 'GET' ),
+						'namespaces'    => array( 'jetpack/v4', 'wpcom/v2' ),
+					),
+					'cases'           => $workload['rest_request_cases'],
+					'responses'       => $responses,
+					'metrics'         => $summary,
+				),
+				JSON_PRETTY_PRINT
+			) . "\n"
+		);
+
+		$skip_reasons_path = $artifact_dir . '/rest_skip_reasons.json';
+		file_put_contents(
+			$skip_reasons_path,
+			wp_json_encode(
+				array(
+					'schema'       => 'homeboy/wordpress-rest-skip-reasons/v1',
+					'run_id'       => $run_id,
+					'plugin'       => 'jetpack',
+					'skip_reasons' => $skip_reasons,
+					'metrics'      => array( 'skipped_case_count' => count( $skip_reasons ) ),
+				),
+				JSON_PRETTY_PRINT
+			) . "\n"
+		);
+
+		$artifacts = array(
+			'rest_request_cases' => array( 'path' => $request_cases_path, 'kind' => 'json' ),
+			'rest_skip_reasons'  => array( 'path' => $skip_reasons_path, 'kind' => 'json' ),
+		);
+	}
+
+	return array(
+		'metrics'   => $summary,
+		'metadata'  => array(
+			'runner'              => 'wp-codebox',
+			'workload'            => 'generated-rest-request-cases',
+			'coverage_shape'      => 'static safe Jetpack jetpack/v4 and wpcom/v2 GET request cases with connected-service skips classified',
+			'skip_reason_codes'   => $workload['metadata']['skip_reason_codes'] ?? array(),
+			'real_wpcom_credentials_allowed' => false,
+		),
+		'artifacts' => $artifacts,
+	);
+};
+
+function jetpack_homeboy_generated_rest_request_cases_config(): string {
+	return <<<'JSON'
+{
+  "id": "generated-rest-request-cases",
+  "source": "config",
+  "rest_request_cases": [
+    {
+      "id": "jetpack-namespace-root",
+      "method": "GET",
+      "path": "/jetpack/v4",
+      "capture-response": true,
+      "permission_class": "public_route_index",
+      "persona": "anonymous",
+      "auth_required": false,
+      "mutating": false,
+      "expected_statuses": [200, 401, 403, 404]
+    },
+    {
+      "id": "jetpack-options-backup",
+      "method": "GET",
+      "path": "/jetpack/v4/options/backup",
+      "capture-response": true,
+      "permission_class": "site_token_or_boundary_denial",
+      "persona": "anonymous",
+      "auth_required": false,
+      "mutating": false,
+      "params": { "name": "siteurl" },
+      "expected_statuses": [200, 400, 401, 403, 404]
+    },
+    {
+      "id": "jetpack-database-object-backup",
+      "method": "GET",
+      "path": "/jetpack/v4/database-object/backup",
+      "capture-response": true,
+      "permission_class": "site_token_or_boundary_denial",
+      "persona": "anonymous",
+      "auth_required": false,
+      "mutating": false,
+      "params": { "object_type": "woocommerce_attribute", "object_id": 1 },
+      "expected_statuses": [200, 400, 401, 403, 404]
+    },
+    {
+      "id": "jetpack-connection",
+      "method": "GET",
+      "path": "/jetpack/v4/connection",
+      "capture-response": true,
+      "permission_class": "connected_site_required",
+      "persona": "connected-site-placeholder",
+      "auth_required": true,
+      "mutating": false,
+      "skip_reason": "connected_required",
+      "expected_statuses": [200, 401, 403, 404]
+    },
+    {
+      "id": "jetpack-connection-status",
+      "method": "GET",
+      "path": "/jetpack/v4/connection/status",
+      "capture-response": true,
+      "permission_class": "connected_site_required",
+      "persona": "connected-site-placeholder",
+      "auth_required": true,
+      "mutating": false,
+      "skip_reason": "connected_required",
+      "expected_statuses": [200, 401, 403, 404]
+    },
+    {
+      "id": "wpcom-publicize-services",
+      "method": "GET",
+      "path": "/wpcom/v2/publicize/services",
+      "capture-response": true,
+      "permission_class": "public_read_or_wpcom_dependent",
+      "persona": "anonymous",
+      "auth_required": false,
+      "mutating": false,
+      "skip_reason": "wpcom_dependent",
+      "expected_statuses": [200, 401, 403, 404]
+    },
+    {
+      "id": "wpcom-site-settings",
+      "method": "GET",
+      "path": "/wpcom/v2/sites/example.wordpress.com/settings",
+      "capture-response": true,
+      "permission_class": "wpcom_dependent",
+      "persona": "connected-site-placeholder",
+      "auth_required": true,
+      "mutating": false,
+      "placeholder_parameters": { "site": "example.wordpress.com" },
+      "skip_reason": "credential_unavailable",
+      "expected_statuses": [401, 403, 404],
+      "boundary": "No live WordPress.com credentials are supplied in the fixture; forbidden or skipped is expected."
+    }
+  ],
+  "metadata": {
+    "runner": "wp-codebox",
+    "workload": "generated-rest-request-cases",
+    "coverage_shape": "generated safe Jetpack REST request cases",
+    "manifest": "manifests/rest-route-coverage.json",
+    "method_allowlist": ["GET"],
+    "mutating_methods_allowed": false,
+    "real_wpcom_credentials_allowed": false,
+    "personas": ["anonymous", "administrator", "connected-site-placeholder"],
+    "skip_reason_codes": ["connected_required", "credential_unavailable", "route_absent", "wpcom_dependent"],
+    "required_artifacts": ["rest_request_cases", "rest_skip_reasons"],
+    "optional_artifacts": ["connected_site_response_samples", "wpcom_credentialed_response_samples"],
+    "permission_classifications": ["public_route_index", "public_read_or_wpcom_dependent", "site_token_or_boundary_denial", "connected_site_required", "wpcom_dependent"]
+  }
+}
+JSON;
+}

--- a/Automattic/jetpack/bench/generated-rest-request-cases.workload.json
+++ b/Automattic/jetpack/bench/generated-rest-request-cases.workload.json
@@ -3,50 +3,39 @@
   "source": "config",
   "rest_request_cases": [
     {
-      "id": "jetpack-site",
+      "id": "jetpack-namespace-root",
       "method": "GET",
-      "path": "/jetpack/v4/site",
+      "path": "/jetpack/v4",
       "capture-response": true,
-      "permission_class": "authenticated_local",
-      "persona": "administrator",
-      "auth_required": true,
+      "permission_class": "public_route_index",
+      "persona": "anonymous",
+      "auth_required": false,
       "mutating": false,
-      "expected_statuses": [200, 401, 403]
-    },
-    {
-      "id": "jetpack-modules",
-      "method": "GET",
-      "path": "/jetpack/v4/modules",
-      "capture-response": true,
-      "permission_class": "authenticated_local",
-      "persona": "administrator",
-      "auth_required": true,
-      "mutating": false,
-      "expected_statuses": [200, 401, 403]
-    },
-    {
-      "id": "jetpack-module-stats",
-      "method": "GET",
-      "path": "/jetpack/v4/modules/stats",
-      "capture-response": true,
-      "permission_class": "authenticated_local",
-      "persona": "administrator",
-      "auth_required": true,
-      "mutating": false,
-      "optional": true,
-      "skip_reason": "route_absent",
       "expected_statuses": [200, 401, 403, 404]
     },
     {
-      "id": "jetpack-settings",
+      "id": "jetpack-options-backup",
       "method": "GET",
-      "path": "/jetpack/v4/settings",
+      "path": "/jetpack/v4/options/backup",
       "capture-response": true,
-      "permission_class": "administrator_required",
-      "persona": "administrator",
-      "auth_required": true,
+      "permission_class": "site_token_or_boundary_denial",
+      "persona": "anonymous",
+      "auth_required": false,
       "mutating": false,
-      "expected_statuses": [200, 401, 403]
+      "params": { "name": "siteurl" },
+      "expected_statuses": [200, 400, 401, 403, 404]
+    },
+    {
+      "id": "jetpack-database-object-backup",
+      "method": "GET",
+      "path": "/jetpack/v4/database-object/backup",
+      "capture-response": true,
+      "permission_class": "site_token_or_boundary_denial",
+      "persona": "anonymous",
+      "auth_required": false,
+      "mutating": false,
+      "params": { "object_type": "woocommerce_attribute", "object_id": 1 },
+      "expected_statuses": [200, 400, 401, 403, 404]
     },
     {
       "id": "jetpack-connection",
@@ -111,6 +100,6 @@
     "skip_reason_codes": ["connected_required", "credential_unavailable", "route_absent", "wpcom_dependent"],
     "required_artifacts": ["rest_request_cases", "rest_skip_reasons"],
     "optional_artifacts": ["connected_site_response_samples", "wpcom_credentialed_response_samples"],
-    "permission_classifications": ["public_read_or_wpcom_dependent", "authenticated_local", "administrator_required", "connected_site_required", "wpcom_dependent"]
+    "permission_classifications": ["public_route_index", "public_read_or_wpcom_dependent", "site_token_or_boundary_denial", "connected_site_required", "wpcom_dependent"]
   }
 }

--- a/Automattic/jetpack/bench/rest-db-query-profile.workload.json
+++ b/Automattic/jetpack/bench/rest-db-query-profile.workload.json
@@ -8,10 +8,9 @@
       "sampleLimit": 50,
       "queryLengthLimit": 500,
       "rest_request_cases": [
-        { "id": "jetpack-site", "method": "GET", "path": "/jetpack/v4/site", "permission_class": "authenticated_local" },
-        { "id": "jetpack-modules", "method": "GET", "path": "/jetpack/v4/modules", "permission_class": "authenticated_local" },
-        { "id": "jetpack-module-stats", "method": "GET", "path": "/jetpack/v4/modules/stats", "permission_class": "authenticated_local" },
-        { "id": "jetpack-settings", "method": "GET", "path": "/jetpack/v4/settings", "permission_class": "administrator_required" },
+        { "id": "jetpack-namespace-root", "method": "GET", "path": "/jetpack/v4", "permission_class": "public_route_index" },
+        { "id": "jetpack-options-backup", "method": "GET", "path": "/jetpack/v4/options/backup", "permission_class": "site_token_or_boundary_denial", "params": { "name": "siteurl" } },
+        { "id": "jetpack-database-object-backup", "method": "GET", "path": "/jetpack/v4/database-object/backup", "permission_class": "site_token_or_boundary_denial", "params": { "object_type": "woocommerce_attribute", "object_id": 1 } },
         { "id": "jetpack-connection", "method": "GET", "path": "/jetpack/v4/connection", "permission_class": "connected_site_required" },
         { "id": "wpcom-publicize-services", "method": "GET", "path": "/wpcom/v2/publicize/services", "permission_class": "public_read_or_wpcom_dependent" }
       ]

--- a/Automattic/jetpack/fuzz/generated-rest-request-cases.json
+++ b/Automattic/jetpack/fuzz/generated-rest-request-cases.json
@@ -10,7 +10,7 @@
   "metadata": {
     "kind": "wordpress-plugin-fuzz",
     "wordpress_runner": "wp-codebox",
-    "workload_path": "${package.root}/bench/generated-rest-request-cases.workload.json",
+    "workload_path": "${package.root}/bench/generated-rest-request-cases.php",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report",
     "readiness": {
@@ -28,8 +28,8 @@
     }
   },
   "target": { "type": "wordpress-plugin", "slug": "jetpack", "component": "jetpack" },
-  "workload": { "runner": "wp-codebox", "type": "json", "path": "${package.root}/bench/generated-rest-request-cases.workload.json", "entry": "generated-rest-request-cases" },
-  "cases": [{ "case_id": "generated-rest-request-cases:default", "surface_ids": ["jetpack-rest-routes"], "operations": ["generated-rest-case-plan", "request-case-execution"], "inputs": { "methods": ["GET"], "personas": ["anonymous", "administrator", "connected-site-placeholder"], "skip_reason_codes": ["connected_required", "credential_unavailable", "route_absent", "wpcom_dependent"], "real_wpcom_credentials_allowed": false, "mutating_methods_allowed": false }, "phases": { "setup": [{ "command": "wordpress.ensure-plugin-active", "args": ["plugin=jetpack/jetpack.php"] }], "action": [{ "command": "wordpress.run-workload", "args": ["path=${package.root}/bench/generated-rest-request-cases.workload.json", "type=json"] }], "assert": [{ "command": "wordpress.collect-workload-result", "args": ["artifact=rest_request_cases"] }, { "command": "wordpress.collect-workload-result", "args": ["artifact=rest_skip_reasons"] }] }, "artifacts": [{ "name": "rest_request_cases", "path": "generated-rest-request-cases/rest_request_cases.json", "required": true, "metadata": { "semantic_key": "fuzz.report" } }, { "name": "rest_skip_reasons", "path": "generated-rest-request-cases/rest_skip_reasons.json", "required": true, "metadata": { "semantic_key": "fuzz.skip_reasons" } }], "metadata": { "safety_class": "read_only" } }],
+  "workload": { "runner": "wp-codebox", "type": "php", "path": "${package.root}/bench/generated-rest-request-cases.php", "entry": "generated-rest-request-cases" },
+  "cases": [{ "case_id": "generated-rest-request-cases:default", "surface_ids": ["jetpack-rest-routes"], "operations": ["generated-rest-case-plan", "request-case-execution"], "inputs": { "methods": ["GET"], "personas": ["anonymous", "administrator", "connected-site-placeholder"], "skip_reason_codes": ["connected_required", "credential_unavailable", "route_absent", "wpcom_dependent"], "real_wpcom_credentials_allowed": false, "mutating_methods_allowed": false }, "artifacts": [{ "name": "rest_request_cases", "path": "generated-rest-request-cases/rest_request_cases.json", "required": true, "metadata": { "semantic_key": "fuzz.report" } }, { "name": "rest_skip_reasons", "path": "generated-rest-request-cases/rest_skip_reasons.json", "required": true, "metadata": { "semantic_key": "fuzz.skip_reasons" } }], "metadata": { "safety_class": "read_only" }, "intent": { "schema": "homeboy/fuzz-workload-intent/v1", "type": "wordpress-plugin-workload", "plugin": { "activation": "jetpack/jetpack.php" }, "execute": { "workload_ref": "default", "path": "${package.root}/bench/generated-rest-request-cases.php", "type": "php", "entry": "generated-rest-request-cases" }, "collect": [{ "artifact": "rest_request_cases" }, { "artifact": "rest_skip_reasons" }] } }],
   "limits": { "max_cases": 80, "max_duration_seconds": 600 },
   "coverage": { "surface_ids": ["jetpack-rest-routes"], "operations": ["generated-rest-case-plan", "request-case-execution"] },
   "artifacts": { "expected": [{ "name": "rest_request_cases", "role": "fuzz_report", "semantic_key": "fuzz.report", "required": true }, { "name": "rest_skip_reasons", "role": "skip_reason_report", "semantic_key": "fuzz.skip_reasons", "required": true }] }

--- a/Automattic/jetpack/manifests/rest-route-coverage.json
+++ b/Automattic/jetpack/manifests/rest-route-coverage.json
@@ -29,14 +29,14 @@
     "route_absent",
     "wpcom_dependent"
   ],
-  "route_prefixes": [
-    "/jetpack/v4/",
-    "/jetpack/v4/connection",
-    "/jetpack/v4/modules",
-    "/jetpack/v4/site",
-    "/jetpack/v4/settings",
-    "/wpcom/v2/"
-  ],
+    "route_prefixes": [
+      "/jetpack/v4",
+      "/jetpack/v4/connection",
+      "/jetpack/v4/database-object/backup",
+      "/jetpack/v4/options/backup",
+      "/jetpack/v4/site",
+      "/wpcom/v2/"
+    ],
   "coverage_groups": [
     {
       "id": "connection",
@@ -44,19 +44,20 @@
       "route_prefixes": [
         "/jetpack/v4/connection"
       ],
-      "permission_classifications": ["authenticated_local", "connected_site_required", "wpcom_credentials_unavailable"],
+      "permission_classifications": ["connected_site_required", "wpcom_credentials_unavailable"],
       "generated_case_ids": ["jetpack-connection", "jetpack-connection-status"],
       "boundary_expectations": ["No live WordPress.com OAuth credentials are provisioned", "WP.com-dependent failures are classified instead of bypassed"]
     },
     {
-      "id": "module-settings",
-      "description": "Module and settings endpoints used by wp-admin Jetpack screens.",
+      "id": "registered-local-routes",
+      "description": "Registered Jetpack routes that execute without live WordPress.com credentials in WP Codebox.",
       "route_prefixes": [
-        "/jetpack/v4/modules",
-        "/jetpack/v4/settings"
+        "/jetpack/v4",
+        "/jetpack/v4/database-object/backup",
+        "/jetpack/v4/options/backup"
       ],
-      "permission_classifications": ["authenticated_local", "administrator_required", "module_may_require_connection"],
-      "generated_case_ids": ["jetpack-modules", "jetpack-module-stats", "jetpack-settings"]
+      "permission_classifications": ["public_route_index", "site_token_or_boundary_denial"],
+      "generated_case_ids": ["jetpack-namespace-root", "jetpack-options-backup", "jetpack-database-object-backup"]
     },
     {
       "id": "site-data",
@@ -66,15 +67,14 @@
         "/wpcom/v2/"
       ],
       "permission_classifications": ["public_read", "authenticated_local", "wpcom_dependent"],
-      "generated_case_ids": ["jetpack-site", "wpcom-publicize-services", "wpcom-site-settings"],
+      "generated_case_ids": ["wpcom-publicize-services", "wpcom-site-settings"],
       "boundary_expectations": ["Public WP.com compatibility routes are GET-only in generated cases", "Credentialed WP.com routes record skipped_or_forbidden without real service calls"]
     }
   ],
   "required_generated_cases": [
-    { "id": "jetpack-site", "method": "GET", "path": "/jetpack/v4/site", "permission_class": "authenticated_local", "persona": "administrator" },
-    { "id": "jetpack-modules", "method": "GET", "path": "/jetpack/v4/modules", "permission_class": "authenticated_local", "persona": "administrator" },
-    { "id": "jetpack-module-stats", "method": "GET", "path": "/jetpack/v4/modules/stats", "permission_class": "authenticated_local", "persona": "administrator", "optional_if_module_absent": true, "skip_reason": "route_absent" },
-    { "id": "jetpack-settings", "method": "GET", "path": "/jetpack/v4/settings", "permission_class": "administrator_required", "persona": "administrator" },
+    { "id": "jetpack-namespace-root", "method": "GET", "path": "/jetpack/v4", "permission_class": "public_route_index", "persona": "anonymous" },
+    { "id": "jetpack-options-backup", "method": "GET", "path": "/jetpack/v4/options/backup", "permission_class": "site_token_or_boundary_denial", "persona": "anonymous", "params": { "name": "siteurl" } },
+    { "id": "jetpack-database-object-backup", "method": "GET", "path": "/jetpack/v4/database-object/backup", "permission_class": "site_token_or_boundary_denial", "persona": "anonymous", "params": { "object_type": "woocommerce_attribute", "object_id": 1 } },
     { "id": "jetpack-connection", "method": "GET", "path": "/jetpack/v4/connection", "permission_class": "connected_site_required", "persona": "connected-site-placeholder", "skip_reason": "connected_required" },
     { "id": "jetpack-connection-status", "method": "GET", "path": "/jetpack/v4/connection/status", "permission_class": "connected_site_required", "persona": "connected-site-placeholder", "skip_reason": "connected_required" },
     { "id": "wpcom-publicize-services", "method": "GET", "path": "/wpcom/v2/publicize/services", "permission_class": "public_read_or_wpcom_dependent", "persona": "anonymous", "skip_reason": "wpcom_dependent" },

--- a/Automattic/jetpack/manifests/stable-workloads.json
+++ b/Automattic/jetpack/manifests/stable-workloads.json
@@ -1,0 +1,77 @@
+{
+  "schema": "homeboy-rigs/jetpack-stable-workloads/v1",
+  "profile_id": "jetpack-arbitrary-plugin-proof",
+  "description": "Reviewer-friendly Jetpack profiling workload names. Jetpack owns route, module, admin, DB, and external HTTP semantics here; Homeboy only runs declared workload ids and collects generic artifacts.",
+  "rig": "rigs/jetpack-api-route-inventory/rig.json",
+  "lab_command_generator": "tools/stable-workload-lab-commands.mjs",
+  "comparison_surfaces": ["fuzz-observations", "fuzz-hotspots", "db-query-hotspots", "coverage-gaps", "guardrail-results"],
+  "contracts": [
+    {
+      "id": "rest-db-query-profile",
+      "readiness": "executable",
+      "entry_workloads": ["generated-rest-request-cases", "rest-db-query-profile"],
+      "observed_surfaces": ["jetpack/v4", "wpcom/v2", "wordpress-database-queries", "connection-state"],
+      "expected_observations": {
+        "min_rest_request_cases": 4,
+        "min_profiled_rest_cases": 4,
+        "required_artifacts": ["rest_request_cases", "rest_db_query_profile"],
+        "required_artifact_fields": ["per_route_query_counts", "query_attribution", "budget_comparison", "connected_state_caveats"]
+      },
+      "budgets": {
+        "max_profiled_rest_cases": 50,
+        "max_queries_per_rest_case": 75,
+        "max_uncached_options_queries_per_case": 12,
+        "max_slow_queries_per_case": 0,
+        "slow_query_threshold_ms": 100,
+        "max_duration_seconds": 600
+      }
+    },
+    {
+      "id": "db-and-module-inventory",
+      "readiness": "executable",
+      "entry_workloads": ["db-inventory", "jetpack-module-option-table-inventory"],
+      "observed_surfaces": ["jetpack-options", "jetpack-modules", "jetpack-sync-tables", "wordpress-options"],
+      "expected_observations": {
+        "min_inventory_artifacts": 2,
+        "required_artifacts": ["db_inventory", "module_option_table_inventory"],
+        "required_artifact_fields": ["option_keys", "table_prefixes", "module_groups", "connected_state_blockers"]
+      },
+      "budgets": {
+        "max_duration_seconds": 600
+      }
+    },
+    {
+      "id": "admin-and-public-coverage",
+      "readiness": "executable",
+      "entry_workloads": ["jetpack-admin-page-coverage", "jetpack-public-module-frontend-coverage"],
+      "browser_scenarios": ["dashboard", "connection", "modules", "settings", "public_post_modules", "public_page_modules"],
+      "observed_surfaces": ["jetpack-admin", "jetpack-modules", "public-module-frontend", "browser-requests"],
+      "expected_observations": {
+        "min_admin_targets": 2,
+        "min_public_module_states": 2,
+        "required_artifacts": ["admin_page_coverage", "public_module_frontend_coverage"],
+        "required_skip_reason_codes": ["connection_required", "credential_unavailable", "destructive_action"]
+      },
+      "budgets": {
+        "max_admin_pages": 40,
+        "max_external_service_requests": 0,
+        "max_duration_seconds": 900
+      }
+    },
+    {
+      "id": "external-http-guardrail",
+      "readiness": "executable",
+      "entry_workloads": ["jetpack-external-http-guardrail"],
+      "observed_surfaces": ["wpcom-boundary", "sync-dispatch", "module-service-api", "synthetic-blocked-probe"],
+      "expected_observations": {
+        "min_guardrail_probes": 1,
+        "required_artifacts": ["external_http_guardrail"],
+        "required_status_outcomes": ["blocked_synthetic_probe", "classified_wpcom_boundary"]
+      },
+      "budgets": {
+        "max_live_external_service_calls": 0,
+        "max_duration_seconds": 600
+      }
+    }
+  ]
+}

--- a/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
+++ b/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
@@ -5,6 +5,7 @@
     "jetpack": {
       "component_id": "jetpack",
       "default_ref": "origin/trunk",
+      "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__JETPACK_API_ROUTE_INVENTORY__JETPACK}",
       "path_setting": "HOMEBOY_RIG_COMPONENT_PATH__JETPACK_API_ROUTE_INVENTORY__JETPACK",
       "checkout_root": "${env.HOMEBOY_RIG_COMPONENT_CHECKOUT_ROOT__JETPACK_API_ROUTE_INVENTORY__JETPACK}",
       "branch": "trunk",

--- a/Automattic/jetpack/tools/stable-workload-lab-commands.mjs
+++ b/Automattic/jetpack/tools/stable-workload-lab-commands.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.join(__dirname, '..');
+const manifestPath = path.join(packageRoot, 'manifests/stable-workloads.json');
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+
+const options = parseArgs(process.argv.slice(2));
+const contracts = selectedContracts(manifest.contracts || [], options.stableIds);
+const runIdPrefix = options.runIdPrefix || `jetpack-stable-${new Date().toISOString().slice(0, 10).replaceAll('-', '')}`;
+
+const runCommands = [];
+for (const contract of contracts) {
+  contract.entry_workloads.forEach((workloadId, index) => {
+    const command = [
+      'homeboy',
+      'fuzz',
+      'run',
+      '--lab-only',
+      '--rig',
+      'jetpack-api-route-inventory',
+      '--workload',
+      workloadId,
+      '--gate-profile',
+      'measurement',
+      '--run-id',
+      `${runIdPrefix}-${contract.id}-${String(index + 1).padStart(2, '0')}-${workloadId}`,
+      '--tracker-ref',
+      `stable-workload:${contract.id}`,
+    ];
+
+    if (options.runner) {
+      command.push('--runner', options.runner);
+    }
+    if (options.artifactRoot) {
+      command.push('--artifact-root', options.artifactRoot);
+    }
+    if (options.detachAfterHandoff) {
+      command.push('--detach-after-handoff');
+    }
+    if (contract.budgets?.max_duration_seconds) {
+      command.push('--max-duration', `${contract.budgets.max_duration_seconds}s`);
+    }
+    for (const trackerRef of options.trackerRefs) {
+      command.push('--tracker-ref', trackerRef);
+    }
+
+    runCommands.push({
+      stable_workload_id: contract.id,
+      workload_id: workloadId,
+      run_id: `${runIdPrefix}-${contract.id}-${String(index + 1).padStart(2, '0')}-${workloadId}`,
+      command,
+    });
+  });
+}
+
+const compareCommands = [
+  {
+    purpose: 'list_recent_refs',
+    command: withLabOptions([
+      'homeboy', 'runs', 'refs',
+      '--kind', 'fuzz',
+      '--component', 'jetpack',
+      '--rig', 'jetpack-api-route-inventory',
+      '--status', 'completed',
+      '--since', options.since,
+      '--limit', String(options.limit),
+      '--aggregate-artifact-kind', 'fuzz.report',
+    ], options),
+  },
+  {
+    purpose: 'trend_elapsed_time',
+    command: withLabOptions([
+      'homeboy', 'runs', 'compare',
+      '--kind', 'fuzz',
+      '--component', 'jetpack',
+      '--rig', 'jetpack-api-route-inventory',
+      '--metric', 'total_elapsed_ms',
+      '--limit', String(options.limit),
+    ], options),
+  },
+  {
+    purpose: 'compare_hotspots_after_two_runs_complete',
+    command: withLabOptions([
+      'homeboy', 'runs', 'hotspots',
+      '--baseline-run', 'BASELINE_RUN_ID',
+      '--candidate-run', 'CANDIDATE_RUN_ID',
+      '--limit', String(options.hotspotLimit),
+    ], options),
+  },
+];
+
+const payload = {
+  schema: 'homeboy-rigs/jetpack-stable-lab-command-plan/v1',
+  manifest: 'manifests/stable-workloads.json',
+  profile_id: manifest.profile_id,
+  rig_id: 'jetpack-api-route-inventory',
+  local_execution: false,
+  run_id_prefix: runIdPrefix,
+  run_commands: runCommands,
+  compare_commands: compareCommands,
+};
+
+if (options.json) {
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+} else {
+  for (const item of runCommands) {
+    process.stdout.write(`# ${item.stable_workload_id} -> ${item.workload_id}\n${shellJoin(item.command)}\n`);
+  }
+  process.stdout.write('\n# Compare persisted evidence after Lab runs complete.\n');
+  for (const item of compareCommands) {
+    process.stdout.write(`# ${item.purpose}\n${shellJoin(item.command)}\n`);
+  }
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    artifactRoot: '',
+    detachAfterHandoff: false,
+    hotspotLimit: 20,
+    json: false,
+    limit: 50,
+    runner: '',
+    runIdPrefix: '',
+    since: '30d',
+    stableIds: [],
+    trackerRefs: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const readValue = (name) => {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error(`${name} requires a value`);
+      }
+      index += 1;
+      return value;
+    };
+
+    switch (arg) {
+      case '--artifact-root':
+        parsed.artifactRoot = readValue(arg);
+        break;
+      case '--detach-after-handoff':
+        parsed.detachAfterHandoff = true;
+        break;
+      case '--hotspot-limit':
+        parsed.hotspotLimit = Number.parseInt(readValue(arg), 10);
+        break;
+      case '--json':
+        parsed.json = true;
+        break;
+      case '--limit':
+        parsed.limit = Number.parseInt(readValue(arg), 10);
+        break;
+      case '--runner':
+        parsed.runner = readValue(arg);
+        break;
+      case '--run-id-prefix':
+        parsed.runIdPrefix = readValue(arg);
+        break;
+      case '--since':
+        parsed.since = readValue(arg);
+        break;
+      case '--stable-id':
+        parsed.stableIds.push(...readValue(arg).split(',').filter(Boolean));
+        break;
+      case '--tracker-ref':
+        parsed.trackerRefs.push(readValue(arg));
+        break;
+      case '--help':
+      case '-h':
+        printHelp();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  for (const [name, value] of [['--limit', parsed.limit], ['--hotspot-limit', parsed.hotspotLimit]]) {
+    if (!Number.isInteger(value) || value < 1) {
+      throw new Error(`${name} must be a positive integer`);
+    }
+  }
+
+  return parsed;
+}
+
+function selectedContracts(contracts, stableIds) {
+  if (stableIds.length === 0) {
+    return contracts;
+  }
+
+  const selected = new Set(stableIds);
+  const filtered = contracts.filter((contract) => selected.has(contract.id));
+  const found = new Set(filtered.map((contract) => contract.id));
+  const missing = [...selected].filter((id) => !found.has(id));
+  if (missing.length > 0) {
+    throw new Error(`Unknown stable workload id(s): ${missing.join(', ')}`);
+  }
+  return filtered;
+}
+
+function withLabOptions(command, options) {
+  const withOptions = [...command, '--lab-only'];
+  if (options.runner) {
+    withOptions.push('--runner', options.runner);
+  }
+  if (options.artifactRoot) {
+    withOptions.push('--artifact-root', options.artifactRoot);
+  }
+  return withOptions;
+}
+
+function shellJoin(command) {
+  return command.map(shellQuote).join(' ');
+}
+
+function shellQuote(value) {
+  if (/^[A-Za-z0-9_./:=,@+-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node tools/stable-workload-lab-commands.mjs [options]\n\n`);
+  process.stdout.write(`Emits Lab-only Homeboy commands for Jetpack stable workload contracts. It never executes workloads.\n\n`);
+  process.stdout.write(`Options:\n`);
+  process.stdout.write(`  --stable-id <id[,id]>        Limit to one or more stable workload ids. Repeatable.\n`);
+  process.stdout.write(`  --runner <id>                Add a Homeboy Lab runner id to every command.\n`);
+  process.stdout.write(`  --artifact-root <dir>        Add a persisted artifact root to every command.\n`);
+  process.stdout.write(`  --run-id-prefix <id>         Stable proof prefix. Defaults to jetpack-stable-YYYYMMDD.\n`);
+  process.stdout.write(`  --tracker-ref <kind:id>      Extra tracker ref added to every run command. Repeatable.\n`);
+  process.stdout.write(`  --detach-after-handoff       Return after the Lab daemon accepts each run.\n`);
+  process.stdout.write(`  --since <duration>           Lookback for refs compare command. Default: 30d.\n`);
+  process.stdout.write(`  --limit <n>                  Run-history limit for refs/compare. Default: 50.\n`);
+  process.stdout.write(`  --hotspot-limit <n>          Hotspot compare row limit. Default: 20.\n`);
+  process.stdout.write(`  --json                       Emit structured JSON instead of shell commands.\n`);
+}

--- a/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
+++ b/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
@@ -21,6 +21,7 @@ const apiRig = readJson(packageRoot, 'rigs/jetpack-api-route-inventory/rig.json'
 const browserRig = readJson(packageRoot, 'rigs/jetpack-browser-coverage/rig.json');
 const fullSurfaceCoverage = readJson(packageRoot, 'manifests/full-surface-coverage.json');
 const restRouteCoverage = readJson(packageRoot, 'manifests/rest-route-coverage.json');
+const stableWorkloads = readJson(packageRoot, 'manifests/stable-workloads.json');
 const generatedRestCases = readJson(packageRoot, 'bench/generated-rest-request-cases.workload.json');
 const dbInventory = readJson(packageRoot, 'bench/db-inventory.workload.json');
 const fuzzManifests = collectFuzzManifests(packageRoot);
@@ -52,10 +53,20 @@ const expectedBrowserScenarios = new Set([
   'public_page_modules',
 ]);
 
+const expectedStableWorkloadIds = new Set([
+  'admin-and-public-coverage',
+  'db-and-module-inventory',
+  'external-http-guardrail',
+  'rest-db-query-profile',
+]);
+
 assertFullSurfaceCoverageManifest(fullSurfaceCoverage, { file: 'Jetpack full-surface coverage' });
 assert.equal(fuzzManifests.length, expectedFuzzIds.size, 'expected one Jetpack fuzz manifest per declared API fuzz workload');
 assert.equal(apiRig.bench_workloads, undefined, 'Jetpack fuzz coverage must not use bench_workloads as a fallback');
 assert.equal(apiRig.bench_profiles, undefined, 'Jetpack fuzz coverage must not use bench_profiles as a fallback');
+assert.equal(stableWorkloads.schema, 'homeboy-rigs/jetpack-stable-workloads/v1', 'Jetpack stable workload schema drifted');
+assert.equal(stableWorkloads.rig, 'rigs/jetpack-api-route-inventory/rig.json', 'Jetpack stable workloads must target API inventory rig');
+assert.equal(stableWorkloads.lab_command_generator, 'tools/stable-workload-lab-commands.mjs', 'Jetpack stable workload generator drifted');
 
 const declaredIds = declaredFuzzIds(apiRig);
 const benchWorkloadIds = declaredBenchWorkloadIds(apiRig);
@@ -71,6 +82,7 @@ assert.deepEqual(declaredIds, expectedFuzzIds, 'rig fuzz_workloads.wordpress ids
 assert.deepEqual(profileFuzzIds, expectedFuzzIds, 'Jetpack full-surface fuzz workload mapping drifted');
 assert.deepEqual(new Set(profile.browser_requests), expectedBrowserScenarios, 'Jetpack full-surface browser scenarios drifted');
 assert.deepEqual(new Set(browserRig.trace_profiles['full-surface']), new Set(['jetpack-browser-coverage']), 'Jetpack browser full-surface trace profile drifted');
+assertJetpackStableWorkloads(stableWorkloads, expectedStableWorkloadIds, expectedFuzzIds);
 
 for (const scenario of expectedBrowserScenarios) {
   assert.ok(
@@ -343,6 +355,23 @@ function assertArtifactContains(manifest, artifactName, expectedFields) {
   for (const field of expectedFields) {
     assert.ok(caseArtifact.metadata?.contains?.includes(field), `${manifest.id} case artifact ${artifactName} must contain ${field}`);
     assert.ok(expectedArtifact.contains?.includes(field), `${manifest.id} expected artifact ${artifactName} must contain ${field}`);
+  }
+}
+
+function assertJetpackStableWorkloads(manifest, expectedIds, expectedFuzzIds) {
+  assert.deepEqual(new Set(manifest.contracts.map((contract) => contract.id)), expectedIds, 'Jetpack stable workload ids drifted');
+  assert.ok(Array.isArray(manifest.comparison_surfaces) && manifest.comparison_surfaces.includes('fuzz-hotspots'), 'Jetpack stable workloads must compare fuzz hotspots');
+
+  for (const contract of manifest.contracts) {
+    assert.equal(contract.readiness, 'executable', `${contract.id} must be executable`);
+    assert.ok(Array.isArray(contract.entry_workloads) && contract.entry_workloads.length > 0, `${contract.id} must declare entry workloads`);
+    assert.ok(Array.isArray(contract.observed_surfaces) && contract.observed_surfaces.length > 0, `${contract.id} must declare observed surfaces`);
+    assert.ok(contract.expected_observations?.required_artifacts?.length > 0, `${contract.id} must require artifacts`);
+    assert.ok(contract.budgets?.max_duration_seconds > 0, `${contract.id} must declare max duration budget`);
+
+    for (const workloadId of contract.entry_workloads) {
+      assert.ok(expectedFuzzIds.has(workloadId), `${contract.id} entry workload ${workloadId} must be a declared Jetpack fuzz workload`);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add Jetpack stable workload docs and command generation for Lab-only proof runs.
- Convert generated REST request cases to a WP Codebox PHP workload so response and skip artifacts are emitted.
- Use registered Jetpack REST routes that execute without live WordPress.com credentials and keep connected/WP.com-dependent routes as explicit skipped boundary cases.
- Add explicit Jetpack component path metadata for Lab component staging.

## Evidence
- `jetpack-stable-20260627-generated-rest-request-cases-r11` passed with `response_count: 3`, `skipped_case_count: 4`, `available_route_count: 140`.
- `fuzz_results`: `runner-artifact://homeboy-lab/jetpack-stable-20260627-generated-rest-request-cases-r11/07a10fa3-aaab-43f8-85a4-7ebba166a408`
- `fuzz_result_envelope`: `runner-artifact://homeboy-lab/jetpack-stable-20260627-generated-rest-request-cases-r11/07f06ad2-c2ef-4608-abe9-ac21bced3bb2`
- `jetpack-stable-20260627-rest-db-query-profile-r1` passed with observed DB profiler metrics across five sampled Jetpack routes; all reported `query_count: 0` and `query_time_ms: 0`.
- `fuzz_results`: `runner-artifact://homeboy-lab/jetpack-stable-20260627-rest-db-query-profile-r1/b1c1f64d-951c-4f8b-9cf7-ddc84d913dd9`
- `fuzz_result_envelope`: `runner-artifact://homeboy-lab/jetpack-stable-20260627-rest-db-query-profile-r1/0614a354-fd4d-4098-86ba-f1a9460c95cf`

## Validation
- `php -l Automattic/jetpack/bench/generated-rest-request-cases.php`
- `node Automattic/jetpack/tools/validate-fuzz-manifests.mjs`
- `node scripts/lint-rig-packages.mjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Updating the Jetpack rig workload contracts, running Lab validation, inspecting artifacts, and drafting this PR description.