### PR TITLE
Summarize bench gate-FAIL instead of throwing in run-fixture-matrix

### DIFF
--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -17,6 +17,7 @@ import {
   buildFixtureMatrixRunPlan,
   CANONICAL_FIXTURE_COUNT,
   resolvePathFreshness,
+  summarizeBenchRun,
   summarizeRun,
 } from './run-fixture-matrix.mjs';
 import {
@@ -1039,6 +1040,90 @@ test('operator summary preserves matrix rollups for fanout agents', () => {
   assert.equal(summary.top_pattern_families[0].count, 312);
   assert.equal(summary.fixture_exemplars[0].fixture_id, 'shader-site');
   assert.equal(summary.diagnostic_blind_spots[0].kind, 'missing_source_context');
+});
+
+test('summarizeBenchRun emits the operator summary on a gate-FAIL instead of throwing', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-bench-gate-fail-'));
+  const outputFile = path.join(root, 'homeboy-bench.json');
+  writeFileSync(outputFile, JSON.stringify({
+    run_id: 'ssi-live-2',
+    result_summary: {
+      succeeded: 0,
+      failed: 2,
+      finding_count: 22,
+      groups: { runtime_target_gap: 18, dropped_images: 4 },
+    },
+    artifacts: { run: 'homeboy-runs:ssi-live-2', report: 'https://example.test/report.json' },
+  }));
+
+  const plan = {
+    mode: 'development-override',
+    run_id: 'planned-run',
+    fixture_count: 2,
+    output_file: outputFile,
+  };
+
+  // The bench exited non-zero (gate-FAIL) but wrote a valid result payload.
+  let result;
+  assert.doesNotThrow(() => {
+    result = summarizeBenchRun({ plan, benchStatus: 1, benchLabel: 'Run SSI fixture matrix bench' });
+  });
+
+  assert.equal(result.gateFailed, true);
+  assert.equal(result.summary.status, 'failed');
+  assert.equal(result.summary.run_id, 'ssi-live-2');
+  assert.equal(result.summary.passed_fixture_count, 0);
+  assert.equal(result.summary.failed_fixture_count, 2);
+  assert.equal(result.summary.finding_count, 22);
+  assert.deepEqual(result.summary.top_buckets[0], { key: 'runtime_target_gap', count: 18 });
+  assert.deepEqual(result.summary.artifact_urls, ['homeboy-runs:ssi-live-2', 'https://example.test/report.json']);
+});
+
+test('summarizeBenchRun reports a clean pass when the bench exits zero', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-bench-pass-'));
+  const outputFile = path.join(root, 'homeboy-bench.json');
+  writeFileSync(outputFile, JSON.stringify({
+    run_id: 'ssi-pass',
+    result_summary: { succeeded: 2, failed: 0, finding_count: 0 },
+  }));
+
+  const result = summarizeBenchRun({
+    plan: { mode: 'release-proof', run_id: 'planned-run', fixture_count: 2, output_file: outputFile },
+    benchStatus: 0,
+    benchLabel: 'Run SSI fixture matrix bench',
+  });
+
+  assert.equal(result.gateFailed, false);
+  assert.equal(result.summary.status, 'passed');
+  assert.equal(result.summary.passed_fixture_count, 2);
+  assert.equal(result.summary.failed_fixture_count, 0);
+});
+
+test('summarizeBenchRun still throws when a non-zero bench produced no parseable result', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-bench-crash-'));
+  const missingOutput = path.join(root, 'never-written.json');
+
+  // No output file at all -> genuine crash, keep throwing.
+  assert.throws(
+    () => summarizeBenchRun({
+      plan: { mode: 'development-override', run_id: 'planned-run', output_file: missingOutput },
+      benchStatus: 1,
+      benchLabel: 'Run SSI fixture matrix bench',
+    }),
+    /Run SSI fixture matrix bench failed with exit 1/,
+  );
+
+  // Output exists but is unparseable / carries no result payload -> still a crash.
+  const garbageOutput = path.join(root, 'garbage.json');
+  writeFileSync(garbageOutput, 'not json at all');
+  assert.throws(
+    () => summarizeBenchRun({
+      plan: { mode: 'development-override', run_id: 'planned-run', output_file: garbageOutput },
+      benchStatus: 1,
+      benchLabel: 'Run SSI fixture matrix bench',
+    }),
+    /failed with exit 1/,
+  );
 });
 
 test('mapWithConcurrency runs bounded N in parallel and preserves input ordering', async () => {

--- a/WordPress/static-site-importer/tools/run-fixture-matrix.mjs
+++ b/WordPress/static-site-importer/tools/run-fixture-matrix.mjs
@@ -43,12 +43,27 @@ async function main() {
 
   fs.mkdirSync(path.dirname(plan.output_file), { recursive: true });
 
-  for (const step of plan.steps) {
+  // Install/sync run first; a non-zero exit there is a genuine setup failure and
+  // should still abort via runCommand's throw.
+  const benchStep = plan.steps.at(-1);
+  for (const step of plan.steps.slice(0, -1)) {
     runCommand(step);
   }
 
-  const summary = summarizeRun(plan);
+  // The bench step exits non-zero on a gate-FAIL (one or more fixtures failed).
+  // That is an expected, summarizable outcome — not a fatal error — so capture
+  // its exit status instead of throwing. summarizeBenchRun only throws when the
+  // bench genuinely crashed (no parseable result payload written to --output).
+  const benchStatus = runStep(benchStep);
+  const { summary, gateFailed } = summarizeBenchRun({
+    plan,
+    benchStatus,
+    benchLabel: benchStep.label,
+  });
   process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  if (gateFailed) {
+    process.exitCode = 1;
+  }
 }
 
 export function buildFixtureMatrixRunPlan(input) {
@@ -421,26 +436,64 @@ function withCommonRouting(args, options) {
 }
 
 function runCommand(step) {
-  process.stderr.write(`\n# ${step.label}\n${shellCommand(step)}\n`);
-  const result = spawnSync(step.command, step.args, { stdio: 'inherit' });
-  if (result.status !== 0) {
-    throw new Error(`${step.label} failed with exit ${result.status}`);
+  const status = runStep(step);
+  if (status !== 0) {
+    throw new Error(`${step.label} failed with exit ${status}`);
   }
 }
 
-export function summarizeRun(plan) {
+// Run a step and return its exit status without throwing, so callers can decide
+// whether a non-zero exit is fatal (setup) or an expected outcome (bench gate).
+function runStep(step) {
+  process.stderr.write(`\n# ${step.label}\n${shellCommand(step)}\n`);
+  const result = spawnSync(step.command, step.args, { stdio: 'inherit' });
+  return result.status;
+}
+
+// A bench gate-FAIL exits non-zero but still writes a parseable result payload
+// to --output. Distinguish that (summarizable) from a genuine crash (no output
+// or unparseable) so the operator always gets the summary on a failing run.
+// On crash, preserve the historical throw/error behavior.
+export function summarizeBenchRun({ plan, benchStatus, benchLabel = 'bench step' }) {
+  if (benchStatus !== 0 && !benchProducedResult(plan.output_file)) {
+    throw new Error(`${benchLabel} failed with exit ${benchStatus}`);
+  }
+  const gateFailed = benchStatus !== 0;
+  return {
+    gateFailed,
+    summary: summarizeRun(plan, { status: gateFailed ? 'failed' : 'passed' }),
+  };
+}
+
+// The bench RAN if --output exists, parses, and carries a result payload
+// (a `result_summary` somewhere in the tree). That presence is the signal the
+// gate evaluated a real run rather than the process crashing before writing
+// results.
+function benchProducedResult(outputFile) {
+  const output = readJson(outputFile);
+  if (!output || typeof output !== 'object') {
+    return false;
+  }
+  return findFirstKey(output, 'result_summary') !== undefined;
+}
+
+export function summarizeRun(plan, { status } = {}) {
   const output = readJson(plan.output_file);
   const resultSummary = findFirstKey(output, 'result_summary') || {};
   const artifacts = findFirstKey(output, 'artifacts') || findFirstKey(output, 'artifact_refs') || {};
+  const failedFixtureCount = Number(resultSummary.failed || 0);
   return {
     schema: 'homeboy-rigs/static-site-importer-fixture-matrix-operator-summary/v1',
+    // Explicit gate outcome; falls back to the failed count when not provided
+    // so the field is always present on success and failure alike.
+    status: status || (failedFixtureCount > 0 ? 'failed' : 'passed'),
     mode: plan.mode,
     run_id: findFirstKey(output, 'run_id') || plan.run_id,
     code_freshness: plan.code_freshness || null,
     transformer_commit: plan.transformer_commit || resolveTransformerCommit(plan.code_freshness),
     fixture_count: Number(findFirstKey(output, 'fixture_count') || plan.fixture_count || 0),
     passed_fixture_count: Number(resultSummary.succeeded || resultSummary.passed || 0),
-    failed_fixture_count: Number(resultSummary.failed || 0),
+    failed_fixture_count: failedFixtureCount,
     finding_count: Number(resultSummary.finding_count || 0),
     top_buckets: topObjectCounts(resultSummary.buckets || resultSummary.groups || {}),
     top_kinds: topObjectCounts(resultSummary.kinds || {}),


### PR DESCRIPTION
Closes #550

## Problem
`WordPress/static-site-importer/tools/run-fixture-matrix.mjs` ran every step through `runCommand`, which throws on any non-zero exit. A bench **gate-FAIL** (a fixture failed -> exit 1) is a legitimate, expected outcome, but the throw aborted before the operator summary printed. On a failing run (the important case) the operator got a stack trace and no readable result and had to hand-parse the bench JSON.

## Fix
- `main` now runs install/sync via the throwing `runCommand`, and the bench step via a new non-throwing `runStep` that returns the exit status.
- New exported `summarizeBenchRun({ plan, benchStatus, benchLabel })` distinguishes:
  - **gate-FAIL** — bench exited non-zero AND wrote a parseable result payload (a `result_summary` is present in `--output`): build + print the SAME operator summary as success, now carrying `status: failed`, then set `process.exitCode = 1` AFTER printing.
  - **crash** — non-zero exit with no output / unparseable / no result payload: preserve the historical `throw`.
- `summarizeRun` gained a `status` field (explicit, falling back to the failed count) so the summary always reports pass/fail.

## Tests
`node WordPress/static-site-importer/tools/fixture-matrix.test.mjs` — 50 pass / 0 fail. Added cases: gate-FAIL emits the operator summary (`status: failed`, passed/failed/finding counts, top buckets, artifact URLs) without throwing; clean pass reports `status: passed`; a non-zero bench with no/unparseable output still throws. Verified `--dry-run` still composes the plan.