### PR TITLE
Compute native_conversion_rate from import-report block composition

### DIFF
--- a/WordPress/static-site-importer/lib/fixture-matrix.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix.mjs
@@ -47,7 +47,13 @@ export { collectFixtureMatrixRunResults } from './fixture-matrix/collectors/run-
 
 export { classifyStaticSiteFinding, normalizeLossClass } from './fixture-matrix/findings.mjs';
 
-export { collectBlockComposition } from './fixture-matrix/collectors/quality-metrics.mjs';
+export {
+  collectBlockComposition,
+  collectBlockCompositionFromBlockDocuments,
+  collectBlockCompositionFromSerializedBlocks,
+  computeFixtureEditorQuality,
+  parseSerializedBlockNames,
+} from './fixture-matrix/collectors/quality-metrics.mjs';
 
 export { collectEditorValidationDiagnostics } from './fixture-matrix/collectors/editor-validation.mjs';
 

--- a/WordPress/static-site-importer/lib/fixture-matrix/collectors/quality-metrics.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/collectors/quality-metrics.mjs
@@ -30,12 +30,20 @@ export function collectQualityMetrics(payload) {
 }
 
 // Surface the transformer's generic block-composition breakdown from whatever
-// import-artifact slot carries it (a `block_type_counts` / `detectBlockTypes`
-// map, or the nested conversion-report copy SSI preserves). Returns a normalized
+// import-artifact slot carries it. Returns a normalized
 // `{ block_total, native_block_count, core_html_block_count, block_type_counts,
 // source }` shape, or null when no block-composition data is present (never
-// fabricated). When an explicit per-block-type breakdown is unavailable but
-// total/fallback counts are, it derives the composition from those counts.
+// fabricated). Sources are tried most-precise first:
+//   1. an explicit per-block-type breakdown (`block_type_counts` /
+//      `detectBlockTypes` map, or the nested native conversion-report copy);
+//   2. serialized block markup — the materialized `post_content` carries
+//      Gutenberg block comments (`<!-- wp:namespace/name ... -->`) that name each
+//      emitted block, so we parse those names directly;
+//   3. SSI's per-document analysis (`materialized_content` /
+//      `generated_theme` `block_documents[]`), which carries each document's total
+//      `block_count` plus its `core_html_block_count`/`freeform_block_count` —
+//      this is what real Lab/WP Codebox runs emit;
+//   4. the import report's aggregate quality counts.
 export function collectBlockComposition(payload) {
   const breakdown = collectBlockTypeBreakdown(payload);
   if (breakdown && breakdown.total > 0) {
@@ -47,7 +55,9 @@ export function collectBlockComposition(payload) {
       source: 'block_type_breakdown',
     };
   }
-  return blockCompositionFromQualityCounts(payload);
+  return collectBlockCompositionFromSerializedBlocks(payload)
+    || collectBlockCompositionFromBlockDocuments(payload)
+    || blockCompositionFromQualityCounts(payload);
 }
 
 function collectBlockTypeBreakdown(payload) {
@@ -134,6 +144,145 @@ function summarizeBlockTypeCounts(counts) {
     }
   }
   return { total, native, core_html: coreHtml, counts };
+}
+
+// Parse the block composition directly out of serialized Gutenberg block markup
+// (the materialized `post_content`). Every emitted block opens with a
+// `<!-- wp:namespace/name ... -->` comment — core blocks omit the namespace
+// (`<!-- wp:heading -->` is `core/heading`). Closing comments (`<!-- /wp:... -->`)
+// are skipped by the `\s+wp:` anchor, so each block is counted once. Returns the
+// normalized composition shape, or null when no serialized markup is present.
+export function collectBlockCompositionFromSerializedBlocks(payload) {
+  const counts = {};
+  let found = false;
+  for (const markup of serializedBlockSources(payload)) {
+    for (const name of parseSerializedBlockNames(markup)) {
+      counts[name] = (counts[name] || 0) + 1;
+      found = true;
+    }
+  }
+  if (!found) {
+    return null;
+  }
+  const summary = summarizeBlockTypeCounts(counts);
+  if (summary.total <= 0) {
+    return null;
+  }
+  return {
+    block_total: summary.total,
+    native_block_count: summary.native,
+    core_html_block_count: summary.core_html,
+    block_type_counts: summary.counts,
+    source: 'serialized_blocks',
+  };
+}
+
+// Extract the `wp:` block names from a single serialized-blocks string. Core
+// blocks (no namespace) are normalized to their `core/` form so they classify
+// against NATIVE_BLOCK_NAMESPACES consistently with explicit breakdowns.
+export function parseSerializedBlockNames(markup) {
+  if (typeof markup !== 'string' || !markup.includes('<!--')) {
+    return [];
+  }
+  const names = [];
+  const pattern = /<!--\s+wp:([a-z][a-z0-9-]*(?:\/[a-z][a-z0-9-]*)?)/g;
+  let match = pattern.exec(markup);
+  while (match) {
+    const name = normalizeBlockName(match[1]);
+    names.push(name.includes('/') ? name : `core/${name}`);
+    match = pattern.exec(markup);
+  }
+  return names;
+}
+
+// Collect every slot that may carry serialized block markup. SSI does not yet
+// persist raw `post_content` in its report, so this is opportunistic and
+// future-proof: it reads the obvious top-level/quality/import-report string slots
+// plus any per-document markup carried on a `block_documents[]` entry.
+function serializedBlockSources(payload) {
+  const object = objectValue(payload);
+  const quality = collectQualityMetrics(object);
+  const importReport = objectValue(object.import_report || object.importReport || object.report);
+  const strings = [
+    object.post_content,
+    object.postContent,
+    object.serialized_blocks,
+    object.serializedBlocks,
+    object.block_markup,
+    object.blockMarkup,
+    object.rendered_blocks,
+    object.renderedBlocks,
+    quality.post_content,
+    quality.serialized_blocks,
+    importReport.post_content,
+    importReport.serialized_blocks,
+  ];
+  for (const document of blockDocumentEntries(object)) {
+    strings.push(
+      document.post_content,
+      document.block_markup,
+      document.serialized_blocks,
+      document.serialized,
+      document.markup,
+    );
+  }
+  return strings.filter((value) => typeof value === 'string' && value.trim() !== '');
+}
+
+// Derive the composition from SSI's per-document block analysis. Each
+// `block_documents[]` entry records the materialized document's total
+// `block_count` plus the non-native `core_html_block_count`/`freeform_block_count`
+// fallbacks; native is the remainder. The materialized post-content documents are
+// preferred over the generated-theme documents (and never summed together, since
+// SSI records each materialized page in both arrays). Returns null when no
+// per-document totals are present.
+export function collectBlockCompositionFromBlockDocuments(payload) {
+  const documents = blockDocumentEntries(payload);
+  if (documents.length === 0) {
+    return null;
+  }
+  let total = 0;
+  let coreHtml = 0;
+  let freeform = 0;
+  for (const document of documents) {
+    total += numberValue(document.block_count ?? document.blockCount);
+    coreHtml += numberValue(document.core_html_block_count ?? document.coreHtmlBlockCount);
+    freeform += numberValue(document.freeform_block_count ?? document.freeformBlockCount);
+  }
+  if (total <= 0) {
+    return null;
+  }
+  return {
+    block_total: total,
+    native_block_count: Math.max(0, total - coreHtml - freeform),
+    core_html_block_count: coreHtml,
+    block_type_counts: null,
+    source: 'block_documents',
+  };
+}
+
+// The materialized post-content documents are the production-quality signal; fall
+// back to the generated-theme template documents only when no materialized pages
+// were recorded. The two arrays overlap (SSI pushes each materialized page into
+// both), so exactly one is chosen to avoid double counting.
+function blockDocumentEntries(payload) {
+  const object = objectValue(payload);
+  const importReport = objectValue(object.import_report || object.importReport || object.report);
+  const materialized = objectValue(importReport.materialized_content || importReport.materializedContent || object.materialized_content || object.materializedContent);
+  const generatedTheme = objectValue(importReport.generated_theme || importReport.generatedTheme || object.generated_theme || object.generatedTheme);
+  const materializedDocuments = blockDocumentList(materialized.block_documents || materialized.blockDocuments);
+  if (materializedDocuments.length > 0) {
+    return materializedDocuments;
+  }
+  const generatedDocuments = blockDocumentList(generatedTheme.block_documents || generatedTheme.blockDocuments);
+  if (generatedDocuments.length > 0) {
+    return generatedDocuments;
+  }
+  return blockDocumentList(object.block_documents || object.blockDocuments);
+}
+
+function blockDocumentList(value) {
+  return Array.isArray(value) ? value.filter((entry) => entry && typeof entry === 'object') : [];
 }
 
 // Best-effort fallback when no per-block-type breakdown exists but SSI's quality

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -28,8 +28,11 @@ import {
   buildFixtureMatrixRecipe,
   classifyFixture,
   classifyStaticSiteFinding,
+  collectBlockComposition,
   collectEditorValidationDiagnostics,
   collectFixtureMatrixRunResults,
+  computeFixtureEditorQuality,
+  parseSerializedBlockNames,
   collectVisualParityDiagnostics,
   createFixtureMatrix,
   editorBlockValidationStep,
@@ -1416,6 +1419,117 @@ test('scores editor-quality metrics from generic block composition and rolls the
   // Per-class rollup carries the same generic metric.
   assert.equal(result.summary.quality_budgets['docs/blog'].editor_quality.native_conversion_rate, 0.6);
   assert.equal(result.summary.classes['marketing/static'].editor_quality.native_conversion_rate, 0.8);
+});
+
+test('parseSerializedBlockNames extracts wp: block names and normalizes core blocks', () => {
+  const markup = [
+    '<!-- wp:heading -->\n<h2>Title</h2>\n<!-- /wp:heading -->',
+    '<!-- wp:paragraph -->\n<p>Body</p>\n<!-- /wp:paragraph -->',
+    '<!-- wp:jetpack/contact-form {"subject":"x"} -->...<!-- /wp:jetpack/contact-form -->',
+    '<!-- wp:spacer {"height":"20px"} /-->',
+    '<!-- wp:html -->\n<svg></svg>\n<!-- /wp:html -->',
+  ].join('\n');
+
+  assert.deepEqual(parseSerializedBlockNames(markup), [
+    'core/heading',
+    'core/paragraph',
+    'jetpack/contact-form',
+    'core/spacer',
+    'core/html',
+  ]);
+  // Closing comments and non-block content never count, and non-strings are safe.
+  assert.deepEqual(parseSerializedBlockNames('<p>no blocks here</p>'), []);
+  assert.deepEqual(parseSerializedBlockNames(null), []);
+});
+
+test('collectBlockComposition computes native rate from serialized post_content (7 native + 3 core/html => 0.7 / 0.3)', () => {
+  const native = [
+    '<!-- wp:heading -->\n<h2>H</h2>\n<!-- /wp:heading -->',
+    '<!-- wp:paragraph -->\n<p>A</p>\n<!-- /wp:paragraph -->',
+    '<!-- wp:paragraph -->\n<p>B</p>\n<!-- /wp:paragraph -->',
+    '<!-- wp:list -->\n<ul><li>x</li></ul>\n<!-- /wp:list -->',
+    '<!-- wp:image {"id":1} -->\n<figure></figure>\n<!-- /wp:image -->',
+    '<!-- wp:jetpack/contact-form -->...<!-- /wp:jetpack/contact-form -->',
+    '<!-- wp:woocommerce/product-collection -->...<!-- /wp:woocommerce/product-collection -->',
+  ];
+  const coreHtml = [
+    '<!-- wp:html -->\n<svg></svg>\n<!-- /wp:html -->',
+    '<!-- wp:html -->\n<canvas></canvas>\n<!-- /wp:html -->',
+    '<!-- wp:html -->\n<audio></audio>\n<!-- /wp:html -->',
+  ];
+  const composition = collectBlockComposition({ post_content: [...native, ...coreHtml].join('\n') });
+
+  assert.equal(composition.source, 'serialized_blocks');
+  assert.equal(composition.block_total, 10);
+  assert.equal(composition.native_block_count, 7);
+  assert.equal(composition.core_html_block_count, 3);
+
+  // The same composition drives the per-fixture editor-quality score.
+  const editorQuality = computeFixtureEditorQuality({ fixture_id: 'serialized', block_composition: composition }, []);
+  assert.equal(editorQuality.scored, true);
+  assert.equal(editorQuality.native_conversion_rate, 0.7);
+  assert.equal(editorQuality.core_html_fallback_ratio, 0.3);
+});
+
+test('collectBlockComposition derives the rate from SSI import-report block_documents on live runs', () => {
+  // Shape that real Lab/WP Codebox runs emit: SSI records each materialized page's
+  // total block_count plus its core/html + freeform fallback counts. No explicit
+  // block_type_counts map is present, which is why the metric used to stay unscored.
+  const payload = {
+    import_report: {
+      materialized_content: {
+        block_documents: [
+          { source_path: 'posts/page-home.post_content', block_count: 5, core_html_block_count: 1, freeform_block_count: 0 },
+          { source_path: 'posts/page-faq.post_content', block_count: 5, core_html_block_count: 2, freeform_block_count: 0 },
+        ],
+      },
+      // Generated-theme duplicates the materialized pages; must not be double counted.
+      generated_theme: {
+        block_documents: [
+          { source_path: 'posts/page-home.post_content', block_count: 5, core_html_block_count: 1, freeform_block_count: 0 },
+          { source_path: 'posts/page-faq.post_content', block_count: 5, core_html_block_count: 2, freeform_block_count: 0 },
+        ],
+      },
+    },
+  };
+  const composition = collectBlockComposition(payload);
+
+  assert.equal(composition.source, 'block_documents');
+  assert.equal(composition.block_total, 10);
+  assert.equal(composition.core_html_block_count, 3);
+  // native = total - core/html - freeform = 10 - 3 - 0 = 7.
+  assert.equal(composition.native_block_count, 7);
+});
+
+test('native_conversion_rate populates end-to-end from an import-report block_documents payload', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'native-rate-live-run-test' });
+  const result = normalizeFixtureMatrixResult({
+    matrix,
+    results: [
+      {
+        fixture_id: 'simple-site',
+        status: 'passed',
+        import_report: {
+          materialized_content: {
+            block_documents: [
+              // 10 total blocks, 3 of them core/html => 7 native => 0.7 native rate.
+              { source_path: 'posts/page-home.post_content', block_count: 10, core_html_block_count: 3, freeform_block_count: 0 },
+            ],
+          },
+        },
+      },
+    ],
+  });
+
+  const fixture = result.fixtures.find((row) => row.fixture_id === 'simple-site');
+  assert.equal(fixture.editor_quality.scored, true);
+  assert.equal(fixture.editor_quality.source, 'block_documents');
+  assert.equal(fixture.editor_quality.native_conversion_rate, 0.7);
+  assert.equal(fixture.editor_quality.core_html_fallback_ratio, 0.3);
+  // The aggregate now carries a real native rate instead of a 0/0 null.
+  assert.equal(result.summary.editor_quality.native_conversion_rate, 0.7);
+  assert.equal(result.summary.editor_quality.core_html_fallback_ratio, 0.3);
+  assert.equal(result.summary.editor_quality.scored_fixture_count, 1);
 });
 
 test('opt-in native-rate gate fails low-native fixtures while editor_invalid_count reuses #537 findings', () => {


### PR DESCRIPTION
## What

Makes #541's editor-quality metrics (`native_conversion_rate`, `core_html_fallback_ratio`) **actually compute on live matrix runs** instead of staying unscored.

## The bug

#541 defined the metrics, but on real Lab / WP Codebox runs they never populated — `result_summary` carried loss-class counts but no `editor_quality` native rate. The `collectBlockComposition` collector (under `lib/fixture-matrix/collectors/quality-metrics.mjs`) only looked for an explicit `block_type_counts` map or an aggregate total `block_count` — **neither of which SSI emits**.

SSI's import report instead carries per-document block analysis under `import_report.materialized_content.block_documents[]` (and `generated_theme.block_documents[]`), where each entry records the materialized `post_content`'s total `block_count` plus its `core_html_block_count` / `freeform_block_count` fallbacks (built by SSI's theme generator via `parse_blocks()`). Because that slot was never read, every fixture stayed unscored and the aggregate native rate collapsed to a `0/0` null.

## The fix (homeboy-rigs only — collector wiring, no blocks-engine/SSI changes)

Two generic block-composition sources are wired into `collectBlockComposition`:

1. **`parseSerializedBlockNames` / `collectBlockCompositionFromSerializedBlocks`** — parse the `wp:` block-comment names out of any serialized `post_content` markup (core blocks normalize to `core/*`), classifying native vs `core/html` with the existing namespace rule. Gold-standard path when raw block markup is present.
2. **`collectBlockCompositionFromBlockDocuments`** — sum SSI's per-document `block_count` / `core_html_block_count` / `freeform_block_count`, preferring the materialized post-content documents over the generated-theme copies so the overlapping arrays are never double counted. `native = total - core_html - freeform`. **This is what makes the metric compute on live runs.**

No hardcoded block lists beyond the existing native-namespace rule (core/jetpack/woocommerce/automattic/a8c = native; `core/html` = fallback).

## Where the block composition comes from

Verified against the real artifact `artifacts/ssi-corpus-1.homeboy-bench.json`: its persisted `result_summary` has loss-class counts and only `wp:html` fallback *exemplars* — no `editor_quality`, no `block_type_counts`, no total `block_count`. The full per-document composition lives in the per-fixture `import_report` the collector reads at run time (`materialized_content.block_documents[]`), which is exactly the slot this PR now consumes.

## Tests

`node WordPress/static-site-importer/tools/fixture-matrix.test.mjs` — 54 pass (4 new):
- `parseSerializedBlockNames` extracts/normalizes `wp:` names and ignores closing comments
- native rate from serialized `post_content` (**7 native + 3 core/html => 0.7 / 0.3**)
- native rate from an `import_report` `block_documents` payload, de-duplicating the materialized/generated overlap
- end-to-end through `normalizeFixtureMatrixResult` so `summary.editor_quality.native_conversion_rate` populates instead of staying null

Refs #541

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Investigating the data flow, implementing the collector wiring, and writing the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)