### PR TITLE
Bound fixture-matrix output independent of fixture count (#554)

### DIFF
--- a/WordPress/static-site-importer/lib/fixture-matrix/findings.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/findings.mjs
@@ -21,6 +21,7 @@ import {
   objectValue,
   isTruthySignal,
 } from './shared/utils.mjs';
+import { truncateString } from './shared/bounds.mjs';
 
 export function classifyStaticSiteFinding(input = {}) {
   const haystack = [input.kind, input.type, input.code, input.category, input.repair_bucket, input.group_key, input.message, input.reason, input.detail]
@@ -79,9 +80,14 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
     selector,
     selector_family: selectorFamily(selector),
     pattern_family: patternFamily({ ...raw, kind, group_key: group.group_key, repair_bucket: repairBucket, selector }),
-    reason: message,
-    source_snippet: raw.source_html_preview || raw.html_excerpt || rawSource.snippet || '',
-    observed_output: raw.emitted_block_preview || rawObserved.output || '',
+    // Bound the free-text payload fields: a source snippet / observed block
+    // output can carry an entire serialized `post_content` body, which at lane
+    // scale balloons the aggregate past V8's per-string limit (#554). Truncate
+    // to a sane cap so per-finding size is bounded; classification/metrics above
+    // are derived from the full diagnostic before truncation.
+    reason: truncateString(message),
+    source_snippet: truncateString(raw.source_html_preview || raw.html_excerpt || rawSource.snippet || ''),
+    observed_output: truncateString(raw.emitted_block_preview || rawObserved.output || ''),
     observed_block_name: raw.block_name || rawObserved.block_name || '',
     repair_mode: raw.repair_mode || group.repair_mode,
     candidate_repo: raw.candidate_repo || group.candidate_repo,
@@ -91,7 +97,10 @@ export function normalizeDiagnosticFinding(diagnostic, result, index) {
     actionability: countOnlyDiagnostic ? 'count_only' : 'actionable',
     actionable: !countOnlyDiagnostic,
     artifact_refs: normalizeArray(raw.artifact_refs),
-    raw,
+    // The full raw diagnostic is intentionally NOT retained on the finding: it
+    // duplicates the (already-bounded) classified fields and can carry raw
+    // serialized markup. All classification above is computed from `raw` before
+    // this point; downstream consumers read the bounded top-level fields.
   };
 }
 

--- a/WordPress/static-site-importer/lib/fixture-matrix/result.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/result.mjs
@@ -23,6 +23,7 @@ import {
   writeJsonFile,
   artifactRef,
 } from './shared/utils.mjs';
+import { boundBlob } from './shared/bounds.mjs';
 import {
   createFixtureMatrix,
   classifyFixture,
@@ -167,19 +168,26 @@ export function normalizeFixtureResult(input) {
     status,
     success: status === 'passed',
     error: input.error || input.message || '',
-    ssi_validation: input.ssi_validation || input.ssiValidation || null,
-    import_report: input.import_report || input.importReport || null,
-    quality_metrics: input.quality_metrics || input.qualityMetrics || {},
+    // Block composition is computed from the FULL input (which may carry
+    // serialized `post_content`/block markup) into bounded COUNTS first; the raw
+    // markup is then discarded by never retaining `input` and by bounding the
+    // report blobs below. See #554 / bounds.mjs.
     block_composition: input.block_composition || input.blockComposition || collectBlockComposition(input),
-    blocks_engine_diagnostics: normalizeArray(input.blocks_engine_diagnostics || input.blocksEngineDiagnostics),
+    // Retained report blobs can carry raw serialized markup (e.g.
+    // `import_report.materialized_content.block_documents[].post_content`). Bound
+    // every retained string so the per-fixture result scales with #findings, not
+    // with raw content volume. Counts/metrics inside these blobs are untouched.
+    ssi_validation: boundBlob(input.ssi_validation || input.ssiValidation || null),
+    import_report: boundBlob(input.import_report || input.importReport || null),
+    quality_metrics: boundBlob(input.quality_metrics || input.qualityMetrics || {}),
+    blocks_engine_diagnostics: boundBlob(normalizeArray(input.blocks_engine_diagnostics || input.blocksEngineDiagnostics)),
     invalid_block_counts: input.invalid_block_counts || input.invalidBlockCounts || {},
-    missing_assets: normalizeArray(input.missing_assets || input.missingAssets),
-    runtime_target_gaps: normalizeArray(input.runtime_target_gaps || input.runtimeTargetGaps),
-    diagnostics: normalizeArray(input.diagnostics || input.findings || input.messages),
+    missing_assets: boundBlob(normalizeArray(input.missing_assets || input.missingAssets)),
+    runtime_target_gaps: boundBlob(normalizeArray(input.runtime_target_gaps || input.runtimeTargetGaps)),
+    diagnostics: boundBlob(normalizeArray(input.diagnostics || input.findings || input.messages)),
     artifact_refs: normalizeArray(input.artifact_refs || input.artifactRefs),
     artifacts: input.artifacts || {},
     visual_parity_artifacts: input.visual_parity_artifacts || input.visualParityArtifacts || null,
-    raw: input,
   };
 }
 

--- a/WordPress/static-site-importer/lib/fixture-matrix/shared/bounds.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/shared/bounds.mjs
@@ -1,0 +1,61 @@
+// Output-size bounding for the Static Site Importer fixture matrix (#554).
+//
+// The matrix assembles one aggregate result that is serialized with
+// JSON.stringify (per-fixture results + findings + result_summary). The
+// block-composition parsing added in #552 reads serialized `post_content` /
+// Gutenberg block markup; if that raw bulk is retained on each fixture result,
+// a lane-scale run (~30+ fixtures) serializes into a string that exceeds V8's
+// hard ~512MB per-string ceiling and throws `Invalid string length` (peak RSS
+// 11.2 GB observed at 30 fixtures).
+//
+// These helpers bound the RETAINED output independent of fixture count: raw
+// serialized markup is discarded after COUNTS are computed, and every retained
+// string field is truncated to a sane cap. Metrics (native_conversion_rate,
+// loss classes, finding counts, block counts, tags/complexity) are never
+// touched — this drops raw BULK, not metrics.
+
+// Per-string ceiling for any retained text field (source snippets, observed
+// output, reasons, and any deep string inside a retained report blob). Generous
+// enough to keep findings human-readable while orders of magnitude below V8's
+// per-string limit, so the aggregate scales with #fixtures/#patterns rather
+// than with raw content volume.
+export const MAX_RETAINED_STRING_LENGTH = 2048;
+
+// Depth guard for the recursive blob bounder. Retained report blobs are shallow
+// in practice; this only stops object/array recursion from running away on a
+// pathological structure. Strings are truncated at every depth regardless.
+const MAX_BOUND_DEPTH = 16;
+
+const TRUNCATION_NOTICE = '…[truncated]';
+
+// Truncate a single string to `max` characters, appending a visible notice so a
+// consumer can tell the value was clipped. Non-strings pass through untouched.
+export function truncateString(value, max = MAX_RETAINED_STRING_LENGTH) {
+  if (typeof value !== 'string' || value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, max)}${TRUNCATION_NOTICE}`;
+}
+
+// Recursively truncate every string inside an arbitrary JSON-ish blob so a
+// single retained value (e.g. a serialized `post_content` body, or a
+// `block_documents[].post_content` carried on an import report) can not balloon
+// the aggregate output. Object/array shape, keys, and all non-string values
+// (counts, numbers, booleans) are preserved exactly — only string VALUES are
+// bounded. Returns the blob unchanged when there is nothing to bound.
+export function boundBlob(value, max = MAX_RETAINED_STRING_LENGTH, depth = 0) {
+  if (typeof value === 'string') {
+    return truncateString(value, max);
+  }
+  if (!value || typeof value !== 'object' || depth >= MAX_BOUND_DEPTH) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => boundBlob(entry, max, depth + 1));
+  }
+  const bounded = {};
+  for (const [key, entry] of Object.entries(value)) {
+    bounded[key] = boundBlob(entry, max, depth + 1);
+  }
+  return bounded;
+}

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -1760,3 +1760,96 @@ test('visual-compare dimension mismatch gates even with zero pixel metrics when 
   assert.equal(diagnostics.length, 1);
   assert.equal(diagnostics[0].dimension_mismatch, true);
 });
+
+// #554: at lane scale (~30+ fixtures) the aggregate result used to retain each
+// fixture's raw serialized `post_content`/block markup (via `raw: input` and the
+// #552 block-composition path) plus uncapped finding snippets, so JSON.stringify
+// of the assembled result exceeded V8's ~512MB per-string ceiling and threw
+// `Invalid string length`. The output must now be bounded by #fixtures/#findings,
+// not by raw content volume.
+test('bounds the assembled output regardless of per-fixture raw content volume (#554)', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-bounded-output-'));
+  const fixtureCount = 40;
+  // ~5MB serialized post_content + many large finding snippets per fixture, so
+  // the raw input dwarfs any safe serialized-output bound.
+  const hugePostContent = '<!-- wp:paragraph --><p>'.concat('x'.repeat(5 * 1024 * 1024), '</p><!-- /wp:paragraph -->');
+  const hugeSnippet = '<section>'.concat('y'.repeat(200 * 1024), '</section>');
+  let rawContentBytes = 0;
+
+  const results = [];
+  for (let index = 0; index < fixtureCount; index += 1) {
+    const id = `marketing-${String(index).padStart(3, '0')}`;
+    const directory = path.join(root, id);
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(path.join(directory, 'index.html'), '<h1>Landing</h1>');
+    writeFileSync(path.join(directory, 'fixture.json'), JSON.stringify({ class: 'marketing/static' }));
+
+    // Many findings, each carrying a large source snippet / observed output.
+    const diagnostics = [];
+    for (let findingIndex = 0; findingIndex < 12; findingIndex += 1) {
+      diagnostics.push({
+        kind: 'runtime_dependency_missing_dom_target',
+        repair_bucket: 'runtime_target_gap',
+        candidate_repo: 'blocks-engine',
+        source_path: `website/page-${findingIndex}.html`,
+        selector: `#widget-${findingIndex}`,
+        source_html_preview: hugeSnippet,
+        emitted_block_preview: hugeSnippet,
+        message: `Runtime target missing for widget ${findingIndex}: ${hugeSnippet}`,
+      });
+      rawContentBytes += hugeSnippet.length * 2 + hugeSnippet.length;
+    }
+
+    results.push({
+      fixture_id: id,
+      status: 'failed',
+      // The #552 block-composition path: counts come from block_type_counts; the
+      // raw markup below must NOT survive into the assembled output.
+      block_type_counts: { 'core/paragraph': 7, 'core/html': 3 },
+      post_content: hugePostContent,
+      import_report: {
+        materialized_content: {
+          block_documents: [
+            { source_path: 'posts/page-home.post_content', block_count: 10, core_html_block_count: 3, freeform_block_count: 0, post_content: hugePostContent },
+          ],
+        },
+      },
+      diagnostics,
+    });
+    rawContentBytes += hugePostContent.length * 2;
+  }
+
+  const matrix = createFixtureMatrix({ fixture_root: root, id: 'bounded-output-scale-test' });
+  assert.equal(matrix.fixtures.length, fixtureCount);
+
+  const result = normalizeFixtureMatrixResult({ matrix, results });
+
+  // The assembled aggregate must serialize without throwing `Invalid string
+  // length`, and stay well under a safe bound regardless of raw content volume.
+  let serialized;
+  assert.doesNotThrow(() => { serialized = JSON.stringify(result); }, 'assembled result must JSON.stringify successfully');
+  const serializedBytes = Buffer.byteLength(serialized, 'utf8');
+  const FIFTY_MB = 50 * 1024 * 1024;
+  assert.ok(serializedBytes < FIFTY_MB, `serialized output ${serializedBytes} bytes must stay under ${FIFTY_MB} bytes`);
+  // The raw inputs are an order of magnitude larger than the bound: output size
+  // is decoupled from raw content volume, not merely "small for this fixture set".
+  assert.ok(rawContentBytes > 200 * 1024 * 1024, 'sanity: the raw inputs must dwarf the output bound');
+  assert.ok(serializedBytes * 10 < rawContentBytes, 'output must be bounded independently of raw content volume');
+
+  // Raw bulk is dropped: no `raw` blob is retained on fixtures or findings, and
+  // no full-length serialized body survives.
+  assert.ok(result.fixtures.every((fixture) => fixture.raw === undefined), 'fixture results must not retain raw input');
+  assert.ok(result.findings.every((finding) => finding.raw === undefined), 'findings must not retain the raw diagnostic');
+  assert.ok(result.findings.every((finding) => finding.source_snippet.length < hugeSnippet.length), 'finding snippets must be truncated');
+  const retainedPostContent = result.fixtures[0].import_report.materialized_content.block_documents[0].post_content;
+  assert.ok(retainedPostContent.length < hugePostContent.length, 'retained report markup must be truncated');
+
+  // Metrics survive the bounding intact: native rate, block counts, and finding
+  // counts are computed from the full input before raw bulk is dropped.
+  assert.equal(result.summary.editor_quality.block_total, fixtureCount * 10);
+  assert.equal(result.summary.editor_quality.native_block_count, fixtureCount * 7);
+  assert.equal(result.summary.editor_quality.core_html_block_count, fixtureCount * 3);
+  assert.equal(result.summary.editor_quality.native_conversion_rate, 0.7);
+  assert.equal(result.summary.fixture_count, fixtureCount);
+  assert.ok(result.summary.finding_count >= fixtureCount, 'every fixture must contribute findings');
+});


### PR DESCRIPTION
Closes #554

## Problem
Running the SSI fixture matrix at lane scale (`--class marketing/static`, ~30 fixtures) crashed with `WORKLOAD_ERROR: static-site-fixture-matrix — iteration 1/1 threw: Invalid string length`, peak RSS 11.2 GB. `Invalid string length` is V8's hard ~512MB per-string ceiling, hit when the assembled aggregate is serialized with `JSON.stringify`. It ran fine at 2 and 12 fixtures and broke at 30.

## Root cause — what was retained at full size
The aggregate scaled with **raw content volume**, not with #fixtures/#findings:

- `normalizeFixtureResult` retained `raw: input` on **every** fixture result — the entire input, including serialized `post_content` / Gutenberg block markup (the block-composition path added in #552) and `import_report.materialized_content.block_documents[]` carrying each document's `post_content`.
- `normalizeDiagnosticFinding` retained each finding's full `raw` diagnostic plus **uncapped** `source_snippet` / `observed_output`, which can each carry an entire serialized body.

At ~30 fixtures with real content, the combined per-fixture results + findings serialized past the 512MB string limit.

## Fix — bound the output, keep every metric
- New `lib/fixture-matrix/shared/bounds.mjs`: `truncateString` + a recursive `boundBlob` that truncates every retained **string** to a sane cap (2048 chars) while preserving object/array shape and all numeric counts.
- `normalizeFixtureResult`: **stop retaining `raw: input`**; bound the retained report blobs (`import_report`, `ssi_validation`, `quality_metrics`, `diagnostics`, `blocks_engine_diagnostics`, `missing_assets`, `runtime_target_gaps`). Block composition is still computed from the **full** input into bounded COUNTS first, then the raw markup is discarded.
- `normalizeDiagnosticFinding`: **drop the retained `raw` diagnostic**; truncate `source_snippet` / `observed_output` / `reason`. Classification and metrics are still derived from the full diagnostic before truncation.

`native_conversion_rate`, loss classes, finding counts, block counts, and tags/complexity are unchanged. Exemplars were already capped (top-N per family/group); this PR removes the remaining raw-bulk sources (`raw` blobs + uncapped strings) those exemplars and per-fixture results pulled from.

## Verification
- `node WordPress/static-site-importer/tools/fixture-matrix.test.mjs` — **56/56 green** (55 existing + 1 new).
- New scale test: 40 fixtures each carrying ~5MB serialized `post_content` and 12 large finding snippets (raw inputs > 200MB total) → asserts the assembled result `JSON.stringify`s **without throwing** and the serialized output stays **under 50MB** (and is >10x smaller than the raw inputs — bounded independent of content volume), while `native_conversion_rate` (0.7), block counts, and finding counts still compute correctly.
- Confirmed the new test **fails against the pre-fix code** (retained `raw` + untruncated snippets) and passes with the fix.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (Claude Code)
- **Used for:** Tracing the data flow, implementing the output bounding, and writing the scale test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)