### PR TITLE
WP Codebox recipe-run: watchdog/timeout + child stderr propagation

### DIFF
--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -842,7 +842,11 @@ module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
     });
     const failure = summary.runtime.child_command_failures[0];
 
-    assert.equal(runtimeError.message, 'recipe-run failed');
+    // #560: the child's real stderr (+ stdout tail) is folded into the thrown
+    // error message so the cause propagates instead of a bare command line.
+    assert.match(runtimeError.message, /^recipe-run failed/);
+    assert.match(runtimeError.message, /stderr:\nstderr line 1\nstderr line 2/);
+    assert.match(runtimeError.message, /stdout \(tail\):\nstdout line 1\nstdout line 2/);
     assert.equal(summary.runtime.exit_code, 17);
     assert.equal(failure.schema, 'homeboy/child-command-failure/v1');
     assert.equal(failure.exit_status, 17);
@@ -868,7 +872,8 @@ module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
     await assert.rejects(
       () => runFixtureMatrixBench(),
       (error) => {
-        assert.equal(error.message, 'recipe-run failed');
+        assert.match(error.message, /^recipe-run failed/);
+        assert.match(error.message, /stderr:\nstderr line 1\nstderr line 2/);
         assert.equal(error.child_command_failures[0].exit_status, 17);
         assert.equal(error.child_command_failures[0].artifact_refs.artifacts_directory, process.env.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY);
         return true;

--- a/shared/bounds.mjs
+++ b/shared/bounds.mjs
@@ -1,0 +1,22 @@
+// Generic output-size bounding for shared rig helpers.
+//
+// Captured child output (stderr/stdout tails folded into a thrown error, see
+// #560) can be arbitrarily large. Retaining it unbounded reintroduces the V8
+// per-string ceiling (~512MB) that #554/#555 fixed for the fixture matrix, this
+// time on the failure path. These helpers cap any retained string so the failure
+// payload stays human-readable and orders of magnitude below that ceiling.
+
+// Per-string ceiling for any retained text field. Matches the fixture-matrix
+// bound (#555) so failure tails are consistent across the rigs.
+export const MAX_RETAINED_STRING_LENGTH = 2048;
+
+const TRUNCATION_NOTICE = '…[truncated]';
+
+// Truncate a single string to `max` characters, appending a visible notice so a
+// consumer can tell the value was clipped. Non-strings pass through untouched.
+export function truncateString(value, max = MAX_RETAINED_STRING_LENGTH) {
+  if (typeof value !== 'string' || value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, max)}${TRUNCATION_NOTICE}`;
+}

--- a/shared/wp-codebox/recipe.mjs
+++ b/shared/wp-codebox/recipe.mjs
@@ -1,4 +1,5 @@
 import { loadWordPressHelperModule } from '../wordpress-helper-loader.mjs';
+import { truncateString } from '../bounds.mjs';
 
 function loadRecipeHelper() {
   return loadWordPressHelperModule({
@@ -17,6 +18,129 @@ export function wpCodeboxCommand(bin = wpCodeboxBin()) {
   return loadRecipeHelper().wpCodeboxCommand(bin);
 }
 
-export async function runWpCodeboxRecipe(options) {
-  return loadRecipeHelper().runWpCodeboxRecipe(options);
+// Default wall-clock cap for a single recipe-run before the watchdog kills it and
+// surfaces a failed batch (#559). A wedged run (duplicate, idle child, no output
+// progress) otherwise hangs the whole bench indefinitely and orphans the rig
+// lock — one observed wedge idled 28+ minutes. 20 minutes is generous for a full
+// batch (sandbox provision + WP boot + multi-fixture import) while bounding
+// "forever". Override per-call with `timeoutMs`, globally with
+// HOMEBOY_WP_CODEBOX_RECIPE_TIMEOUT_MS, or disable with a non-positive value.
+export const DEFAULT_RECIPE_TIMEOUT_MS = 20 * 60 * 1000;
+
+// Conventional timeout exit status (matches GNU `timeout`). Numeric so the bench
+// records it as an integer exit_status and propagates a valid process exit code.
+const WATCHDOG_TIMEOUT_EXIT_CODE = 124;
+
+// In-flight recipe-runs keyed by their recipe file. A second call for the SAME
+// batch while the first child is still alive returns the in-flight promise
+// instead of spawning a duplicate recipe-run — the #559 duplicate-process root
+// (a retry/respawn that never reaped the prior child). The entry is cleared once
+// the run settles, so a later retry of the same batch is allowed.
+const inFlightRecipeRuns = new Map();
+
+function resolveTimeoutMs(options, env = process.env) {
+  const explicit = Number(options?.timeoutMs);
+  if (Number.isFinite(explicit)) {
+    return explicit > 0 ? explicit : 0;
+  }
+  const rawEnv = env.HOMEBOY_WP_CODEBOX_RECIPE_TIMEOUT_MS;
+  if (rawEnv !== undefined && rawEnv !== '') {
+    const fromEnv = Number(rawEnv);
+    if (Number.isFinite(fromEnv)) {
+      return fromEnv > 0 ? fromEnv : 0;
+    }
+  }
+  return DEFAULT_RECIPE_TIMEOUT_MS;
+}
+
+// Fold the child's real stderr (+ a bounded stdout tail) into the thrown error
+// message so the cause propagates into the bench output and homeboy's
+// `stderr_tail` instead of a bare "Command failed: node … recipe-run …" (#560).
+// The captured text is bounded (#555 truncation) so this can not reintroduce the
+// V8 string-length issue. The original `.stdout`/`.stderr`/`.code`/`.signal`
+// fields are preserved so the structured child-command failure the bench builds
+// from them is unchanged.
+function enrichRecipeError(error) {
+  if (!error || typeof error !== 'object') {
+    return error;
+  }
+  const baseMessage = error.message || 'WP Codebox recipe-run failed';
+  const stderrTail = truncateString(typeof error.stderr === 'string' ? error.stderr.trim() : '');
+  const stdoutTail = truncateString(typeof error.stdout === 'string' ? error.stdout.trim() : '');
+  const parts = [baseMessage];
+  if (stderrTail) {
+    parts.push(`stderr:\n${stderrTail}`);
+  }
+  if (stdoutTail) {
+    parts.push(`stdout (tail):\n${stdoutTail}`);
+  }
+  error.message = parts.join('\n\n');
+  return error;
+}
+
+async function runWatchedRecipe(options) {
+  const timeoutMs = resolveTimeoutMs(options);
+  const controller = new AbortController();
+
+  // Pass the abort signal + wall cap to the runner so a cooperating helper can
+  // SIGKILL and reap the OS child. The wrapper enforces the cap regardless, so a
+  // wedged run can never hang the bench even if the helper ignores the signal.
+  const helperPromise = Promise.resolve().then(() => loadRecipeHelper().runWpCodeboxRecipe({
+    ...options,
+    signal: controller.signal,
+    timeoutMs,
+  }));
+  // Defensive: never let a late helper rejection (after the watchdog already won
+  // the race) surface as an unhandled rejection.
+  helperPromise.catch(() => {});
+
+  if (!timeoutMs) {
+    try {
+      return await helperPromise;
+    } catch (error) {
+      throw enrichRecipeError(error);
+    }
+  }
+
+  let timer;
+  const timeout = new Promise((_resolve, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      const error = new Error(`WP Codebox recipe-run exceeded ${timeoutMs}ms wall cap and was killed by the watchdog`);
+      error.code = WATCHDOG_TIMEOUT_EXIT_CODE;
+      error.killed = true;
+      error.signal = 'SIGKILL';
+      error.timeout_ms = timeoutMs;
+      reject(error);
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([helperPromise, timeout]);
+  } catch (error) {
+    throw enrichRecipeError(error);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function runWpCodeboxRecipe(options = {}) {
+  const recipeKey = options?.recipeFile ? String(options.recipeFile) : '';
+  if (recipeKey && inFlightRecipeRuns.has(recipeKey)) {
+    return inFlightRecipeRuns.get(recipeKey);
+  }
+
+  const promise = runWatchedRecipe(options);
+  if (!recipeKey) {
+    return promise;
+  }
+
+  inFlightRecipeRuns.set(recipeKey, promise);
+  try {
+    return await promise;
+  } finally {
+    if (inFlightRecipeRuns.get(recipeKey) === promise) {
+      inFlightRecipeRuns.delete(recipeKey);
+    }
+  }
 }

--- a/shared/wp-codebox/recipe.test.mjs
+++ b/shared/wp-codebox/recipe.test.mjs
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { runWpCodeboxRecipe, DEFAULT_RECIPE_TIMEOUT_MS } from './recipe.mjs';
+import { MAX_RETAINED_STRING_LENGTH } from '../bounds.mjs';
+
+// Inject a fake recipe-run helper through the existing DI seam
+// (HOMEBOY_WP_CODEBOX_RECIPE_HELPER) so these tests exercise the wrapper's
+// watchdog / stderr-propagation / dedupe behavior without a real WP Codebox
+// sandbox. Each call writes a uniquely named CJS helper so require() caching
+// never serves a stale module across tests.
+let helperSeq = 0;
+function installFakeHelper(body) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'wp-codebox-recipe-helper-'));
+  helperSeq += 1;
+  const helperPath = path.join(dir, `helper-${helperSeq}.cjs`);
+  writeFileSync(helperPath, body, 'utf8');
+  process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER = helperPath;
+  return helperPath;
+}
+
+function clearHelper(previous) {
+  if (previous === undefined) {
+    delete process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
+  } else {
+    process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER = previous;
+  }
+}
+
+test('watchdog kills a wedged recipe-run and surfaces a failed batch instead of hanging', async () => {
+  const previous = process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
+  const flag = path.join(mkdtempSync(path.join(tmpdir(), 'recipe-watchdog-')), 'aborted.txt');
+  // A wedged child: the helper never settles. A cooperating helper would kill the
+  // OS child on abort; here it records that the wrapper aborted the signal.
+  installFakeHelper(`
+const fs = require('node:fs');
+module.exports = {
+  async runWpCodeboxRecipe(options) {
+    options.signal.addEventListener('abort', () => {
+      fs.writeFileSync(${JSON.stringify(flag)}, 'aborted');
+    });
+    return new Promise(() => {});
+  },
+};
+`);
+  try {
+    const started = Date.now();
+    await assert.rejects(
+      () => runWpCodeboxRecipe({ recipeFile: '/tmp/batch-watchdog.json', artifactsDir: '/tmp/art', timeoutMs: 50 }),
+      (error) => {
+        assert.match(error.message, /exceeded 50ms wall cap/);
+        // Numeric, GNU-timeout-style code so the bench records an integer
+        // exit_status and a failed (not hung) batch.
+        assert.equal(error.code, 124);
+        assert.equal(error.killed, true);
+        assert.equal(error.signal, 'SIGKILL');
+        assert.equal(error.timeout_ms, 50);
+        return true;
+      }
+    );
+    // It rejected promptly rather than hanging on the never-settling child.
+    assert.ok(Date.now() - started < 5000, 'watchdog rejected well before any hang');
+    // The wrapper aborted the signal it handed the helper (cooperating-kill path).
+    assert.equal(readFileSync(flag, 'utf8'), 'aborted');
+  } finally {
+    clearHelper(previous);
+  }
+});
+
+test('a failing child stderr (and stdout tail) propagates into the thrown error, bounded', async () => {
+  const previous = process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
+  const hugeStderr = 'E'.repeat(MAX_RETAINED_STRING_LENGTH + 500);
+  installFakeHelper(`
+module.exports = {
+  async runWpCodeboxRecipe() {
+    const error = new Error('Command failed: node index.js recipe-run');
+    error.code = 7;
+    error.stderr = ${JSON.stringify(hugeStderr)};
+    error.stdout = 'partial stdout line';
+    throw error;
+  },
+};
+`);
+  try {
+    await assert.rejects(
+      () => runWpCodeboxRecipe({ recipeFile: '/tmp/batch-stderr.json', artifactsDir: '/tmp/art' }),
+      (error) => {
+        // Real cause now in the message (#560), not just the command line.
+        assert.match(error.message, /^Command failed: node index\.js recipe-run/);
+        assert.match(error.message, /stderr:\nE{100}/);
+        assert.match(error.message, /stdout \(tail\):\npartial stdout line/);
+        // Bounded (#555): the message carries at most the cap + notice, not the
+        // full oversized stderr.
+        assert.ok(error.message.includes('…[truncated]'));
+        assert.ok(!error.message.includes('E'.repeat(MAX_RETAINED_STRING_LENGTH + 1)));
+        // Structured fields preserved so the bench's child-command failure is
+        // unchanged.
+        assert.equal(error.code, 7);
+        assert.equal(error.stderr, hugeStderr);
+        assert.equal(error.stdout, 'partial stdout line');
+        return true;
+      }
+    );
+  } finally {
+    clearHelper(previous);
+  }
+});
+
+test('the success path is an unchanged passthrough of the helper result', async () => {
+  const previous = process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
+  installFakeHelper(`
+const RESULT = { stdout: '{"ok":true}', stderr: '', json: { ok: true } };
+module.exports = {
+  async runWpCodeboxRecipe() { return RESULT; },
+};
+`);
+  try {
+    const result = await runWpCodeboxRecipe({ recipeFile: '/tmp/batch-ok.json', artifactsDir: '/tmp/art' });
+    assert.deepEqual(result, { stdout: '{"ok":true}', stderr: '', json: { ok: true } });
+  } finally {
+    clearHelper(previous);
+  }
+});
+
+test('duplicate-process guard: a concurrent run of the same batch does not spawn a second recipe-run', async () => {
+  const previous = process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
+  const counter = path.join(mkdtempSync(path.join(tmpdir(), 'recipe-dedupe-')), 'count.txt');
+  writeFileSync(counter, '0', 'utf8');
+  installFakeHelper(`
+const fs = require('node:fs');
+module.exports = {
+  async runWpCodeboxRecipe() {
+    const next = Number(fs.readFileSync(${JSON.stringify(counter)}, 'utf8')) + 1;
+    fs.writeFileSync(${JSON.stringify(counter)}, String(next));
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    return { invoked: next };
+  },
+};
+`);
+  try {
+    const recipeFile = '/tmp/batch-dedupe.json';
+    const [first, second] = await Promise.all([
+      runWpCodeboxRecipe({ recipeFile, artifactsDir: '/tmp/art' }),
+      runWpCodeboxRecipe({ recipeFile, artifactsDir: '/tmp/art' }),
+    ]);
+    // The helper ran once; the second concurrent call reused the in-flight run.
+    assert.equal(readFileSync(counter, 'utf8'), '1');
+    assert.deepEqual(first, { invoked: 1 });
+    assert.equal(first, second);
+
+    // After the run settles the guard is cleared, so a later run is allowed.
+    const third = await runWpCodeboxRecipe({ recipeFile, artifactsDir: '/tmp/art' });
+    assert.equal(readFileSync(counter, 'utf8'), '2');
+    assert.deepEqual(third, { invoked: 2 });
+  } finally {
+    clearHelper(previous);
+  }
+});
+
+test('the watchdog default cap is a sane positive wall bound', () => {
+  assert.ok(Number.isInteger(DEFAULT_RECIPE_TIMEOUT_MS));
+  assert.ok(DEFAULT_RECIPE_TIMEOUT_MS > 0);
+});


### PR DESCRIPTION
Closes #559
Closes #560

Both issues live in `runWpCodeboxRecipe`, which `shared/wp-codebox/recipe.mjs` exports and the SSI fixture-matrix bench (and other rigs) call. The wrapper now adds three failure-path-only behaviors around the WP Codebox recipe-run helper. The success path stays a pure passthrough of the helper result.

## #559 — watchdog / timeout on a wedged recipe-run
- A configurable wall-clock cap races each recipe-run. Default **20 minutes** (`DEFAULT_RECIPE_TIMEOUT_MS`), overridable per-call with the `timeoutMs` option or globally with `HOMEBOY_WP_CODEBOX_RECIPE_TIMEOUT_MS`; a non-positive value disables it.
- On expiry the wrapper aborts the `AbortSignal` it hands the helper (so a cooperating runner can SIGKILL + reap the OS child) and rejects with a numeric, GNU-`timeout`-style **code 124** plus `killed`/`signal`/`timeout_ms` markers. The bench treats that as a **failed batch** (existing per-batch isolation + #555 bounding apply) so the run proceeds instead of hanging forever and orphaning the rig lock. One observed wedge idled 28+ minutes; the cap turns "hang forever" into "one batch fails, the rest proceed."

### Duplicate-process guard
- An in-process registry keyed by recipe file de-dupes concurrent runs of the **same batch**: a second call while the first child is alive returns the in-flight promise instead of spawning a second recipe-run (the #559 duplicate-process root: a retry/respawn that never reaped the prior child). The entry clears on settle, so a later legitimate retry is allowed.

## #560 — propagate the child stderr in the thrown error
- On any failure (helper-thrown or watchdog) the child's real **stderr** plus a **stdout tail** are folded into the thrown `Error.message`, so the real cause reaches the bench output and homeboy's `stderr_tail` instead of a bare `Command failed: node … recipe-run …` (which previously forced manual log-grepping and caused a wrong "OOM" diagnosis).
- Captured text is truncated via a new generic `shared/bounds.mjs` (same 2048-char cap as the #555 fixture-matrix bound) so this can **not** reintroduce the V8 `Invalid string length` issue. The original `.stdout` / `.stderr` / `.code` fields are preserved, so the bench's structured `child_command_failures` payload is unchanged.

## Note on OS-level reap
The wrapper enforces the wall cap and signals abort regardless, so the bench can never hang. Fully **SIGKILL-ing and reaping the OS child** additionally requires the `homeboy-extension-wordpress` recipe helper to honor the `signal`/`timeoutMs` it is now passed (it currently ignores them). That is the upstream-owned piece and a natural follow-up in homeboy-extensions; this PR is forward-compatible with it.

## Tests
- New `shared/wp-codebox/recipe.test.mjs` (via the existing `HOMEBOY_WP_CODEBOX_RECIPE_HELPER` DI seam, no real sandbox): watchdog kills a never-settling fake child and surfaces a failed batch (not a hang); a failing child's stderr/stdout tail appears in the thrown message and is bounded to the cap; the success path is an unchanged passthrough; the duplicate guard runs the same batch once for concurrent calls and re-allows after settle. 5/5 pass.
- `node WordPress/static-site-importer/tools/fixture-matrix.test.mjs` green (59/59); its recipe-run failure test now asserts the enriched (#560) message.
- `node scripts/lint-rig-packages.mjs` and the shared loader tests pass.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 (Claude Code)
- **Used for:** Investigating the recipe-run flow and implementing the watchdog, duplicate guard, bounded stderr propagation, and tests.