### PR TITLE
Wire SSI fixture matrix editor-validation to wp.blocks.validateBlock

### DIFF
--- a/WordPress/static-site-importer/lib/fixture-matrix.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix.mjs
@@ -17,6 +17,11 @@ export {
   EDITOR_BLOCK_INVALID_KIND,
   EDITOR_INVALID_BLOCK_SELECTOR_GROUP,
   EDITOR_INVALID_BLOCK_SELECTORS,
+  EDITOR_VALIDATE_BLOCKS_COMMAND,
+  EDITOR_VALIDATE_BLOCKS_SCHEMA,
+  EDITOR_VALIDATION_METHOD,
+  EDITOR_VALIDATION_PROVIDER,
+  DEFAULT_EDITOR_VALIDATION_POST_TYPE,
   VISUAL_PARITY_MISMATCH_KIND,
   LOW_NATIVE_CONVERSION_KIND,
 } from './fixture-matrix/shared/constants.mjs';
@@ -55,7 +60,11 @@ export {
   parseSerializedBlockNames,
 } from './fixture-matrix/collectors/quality-metrics.mjs';
 
-export { collectEditorValidationDiagnostics } from './fixture-matrix/collectors/editor-validation.mjs';
+export {
+  collectEditorValidationDiagnostics,
+  collectEditorValidation,
+  isEditorValidateBlocksPayload,
+} from './fixture-matrix/collectors/editor-validation.mjs';
 
 export {
   collectVisualParityDiagnostics,

--- a/WordPress/static-site-importer/lib/fixture-matrix/collectors/editor-validation.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/collectors/editor-validation.mjs
@@ -10,11 +10,17 @@ import {
   EDITOR_INVALID_BLOCK_SELECTOR_GROUP,
   EDITOR_INVALID_BLOCK_SELECTORS,
   EDITOR_BLOCK_INVALID_DEFAULT_DETAIL,
+  EDITOR_VALIDATE_BLOCKS_SCHEMA,
+  EDITOR_VALIDATION_METHOD,
+  EDITOR_VALIDATION_PROVIDER,
 } from '../shared/constants.mjs';
 import {
   normalizeArray,
   numberValue,
+  firstNumber,
   firstString,
+  compactObject,
+  objectValue,
   diagnosticMessage,
 } from '../shared/utils.mjs';
 
@@ -51,12 +57,78 @@ export function collectEditorValidationDiagnostics(payload) {
 }
 
 function collectEditorValidatedBlocks(payload) {
-  return [
+  const blocks = [
     ...normalizeArray(payload.editor_blocks || payload.editorBlocks),
     ...normalizeArray(payload.editor_validation?.blocks || payload.editorValidation?.blocks),
     ...normalizeArray(payload.editor_validation?.results || payload.editorValidation?.results),
     ...normalizeArray(payload.editor_state?.blocks || payload.editorState?.blocks),
   ];
+  // `wordpress.editor-validate-blocks` (wp.blocks.validateBlock) emits the
+  // per-block `{ name, isValid, issues }` set at the payload top level.
+  if (isEditorValidateBlocksPayload(payload)) {
+    blocks.push(...normalizeArray(payload.results));
+  }
+  return blocks;
+}
+
+// Recognize a `wordpress.editor-validate-blocks` payload (the real
+// `wp.blocks.validateBlock` editor-validation result). Matches either the
+// payload itself or a nested `editor_validation`/`editorValidation` slot.
+export function isEditorValidateBlocksPayload(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  if (value.schema === EDITOR_VALIDATE_BLOCKS_SCHEMA) {
+    return true;
+  }
+  if (value.validation_method === EDITOR_VALIDATION_METHOD || value.validationMethod === EDITOR_VALIDATION_METHOD) {
+    return true;
+  }
+  const hasCounts = ['total_blocks', 'totalBlocks', 'valid_blocks', 'validBlocks', 'invalid_blocks', 'invalidBlocks']
+    .some((key) => Object.hasOwn(value, key));
+  return hasCounts && Array.isArray(value.results);
+}
+
+function editorValidatePayload(payload) {
+  for (const candidate of [payload, payload?.editor_validation, payload?.editorValidation]) {
+    if (isEditorValidateBlocksPayload(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+// Normalize a `wordpress.editor-validate-blocks` payload into the headline
+// editor-validity metrics — `total_blocks` / `valid_blocks` / `invalid_blocks`
+// plus the `validation_method`/`validation_provider`. Counts come from the
+// command's own totals when present, otherwise they are recomputed from the
+// per-block `results`. Returns null when no validateBlock evidence is present
+// (never fabricated). These feed `result.editor_validation`, which the
+// editor-quality collector turns into `editor_valid_block_rate` /
+// `invalid_block_count` distinct from the PHP round-trip.
+export function collectEditorValidation(payload) {
+  const source = editorValidatePayload(objectValue(payload));
+  if (!source) {
+    return null;
+  }
+  const results = normalizeArray(source.results).filter((entry) => entry && typeof entry === 'object');
+  const totalFromResults = results.length;
+  const invalidFromResults = results.filter((block) => isInvalidEditorBlock(block)).length;
+  const total = pickCount(source.total_blocks ?? source.totalBlocks, totalFromResults);
+  const invalid = pickCount(source.invalid_blocks ?? source.invalidBlocks, invalidFromResults);
+  const valid = pickCount(source.valid_blocks ?? source.validBlocks, Math.max(0, total - invalid));
+  return compactObject({
+    validation_method: firstString([source.validation_method, source.validationMethod, EDITOR_VALIDATION_METHOD]),
+    validation_provider: firstString([source.validation_provider, source.validationProvider, EDITOR_VALIDATION_PROVIDER]),
+    total_blocks: total,
+    valid_blocks: valid,
+    invalid_blocks: invalid,
+  });
+}
+
+function pickCount(value, fallback) {
+  const number = firstNumber([value]);
+  return Number.isFinite(number) ? number : numberValue(fallback);
 }
 
 function isInvalidEditorBlock(block) {

--- a/WordPress/static-site-importer/lib/fixture-matrix/collectors/quality-metrics.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/collectors/quality-metrics.mjs
@@ -11,11 +11,13 @@ import {
   NON_NATIVE_FALLBACK_BLOCK_NAMES,
   LOW_NATIVE_CONVERSION_KIND,
   EDITOR_BLOCK_INVALID_KIND,
+  EDITOR_VALIDATION_METHOD,
 } from '../shared/constants.mjs';
 import {
   objectValue,
   numberValue,
   firstNumber,
+  firstString,
   compactObject,
   qualityRatio,
 } from '../shared/utils.mjs';
@@ -335,13 +337,23 @@ function isNativeBlockName(name) {
 
 // Per-fixture editor-quality score. `native_conversion_rate` and
 // `core_html_fallback_ratio` come from the generic block composition;
-// `editor_invalid_count` reuses the #537 `editor_block_invalid` findings.
+// `editor_invalid_count` reuses the `editor_block_invalid` findings. When the
+// fixture carries a real `wp.blocks.validateBlock` result
+// (`result.editor_validation`, from the `wordpress.editor-validate-blocks`
+// command), the headline editor-validity is surfaced as `editor_valid_block_rate`
+// / `invalid_block_count` with the reported `validation_method` — distinct from
+// the PHP round-trip's structural counts.
 export function computeFixtureEditorQuality(result, findings) {
   const composition = objectValue(result.block_composition);
   const blockTotal = numberValue(composition.block_total);
   const editorInvalidCount = findings.filter((finding) => finding.fixture_id === result.fixture_id
     && (finding.loss_class === 'editor_block_invalid' || finding.kind === EDITOR_BLOCK_INVALID_KIND)).length;
   const scored = blockTotal > 0;
+  const editorValidation = objectValue(result.editor_validation);
+  const hasEditorValidation = Object.keys(editorValidation).length > 0;
+  const editorValidatedTotal = numberValue(editorValidation.total_blocks);
+  const editorValidBlocks = numberValue(editorValidation.valid_blocks);
+  const editorInvalidBlocks = numberValue(editorValidation.invalid_blocks);
   return compactObject({
     scored,
     source: result.block_composition ? (composition.source || 'unknown') : 'none',
@@ -351,6 +363,16 @@ export function computeFixtureEditorQuality(result, findings) {
     native_conversion_rate: scored ? qualityRatio(composition.native_block_count, blockTotal) : null,
     core_html_fallback_ratio: scored ? qualityRatio(composition.core_html_block_count, blockTotal) : null,
     editor_invalid_count: editorInvalidCount,
+    ...(hasEditorValidation
+      ? {
+        editor_validated: true,
+        validation_method: firstString([editorValidation.validation_method, EDITOR_VALIDATION_METHOD]),
+        editor_validated_block_total: editorValidatedTotal,
+        editor_valid_block_count: editorValidBlocks,
+        invalid_block_count: editorInvalidBlocks,
+        editor_valid_block_rate: editorValidatedTotal > 0 ? qualityRatio(editorValidBlocks, editorValidatedTotal) : null,
+      }
+      : {}),
   });
 }
 
@@ -367,13 +389,23 @@ export function aggregateEditorQuality(editorQualityList, nativeRateGate = { min
   let coreHtml = 0;
   let editorInvalid = 0;
   let scored = 0;
+  let editorValidatedTotal = 0;
+  let editorValidBlocks = 0;
+  let invalidBlockCount = 0;
+  let editorValidatedFixtures = 0;
   for (const editorQuality of editorQualityList) {
     blockTotal += numberValue(editorQuality.block_total);
     native += numberValue(editorQuality.native_block_count);
     coreHtml += numberValue(editorQuality.core_html_block_count);
     editorInvalid += numberValue(editorQuality.editor_invalid_count);
+    editorValidatedTotal += numberValue(editorQuality.editor_validated_block_total);
+    editorValidBlocks += numberValue(editorQuality.editor_valid_block_count);
+    invalidBlockCount += numberValue(editorQuality.invalid_block_count);
     if (editorQuality.scored) {
       scored += 1;
+    }
+    if (editorQuality.editor_validated) {
+      editorValidatedFixtures += 1;
     }
   }
   return {
@@ -384,6 +416,15 @@ export function aggregateEditorQuality(editorQualityList, nativeRateGate = { min
     editor_invalid_count: editorInvalid,
     native_conversion_rate: qualityRatio(native, blockTotal),
     core_html_fallback_ratio: qualityRatio(coreHtml, blockTotal),
+    // Real `wp.blocks.validateBlock` editor-validity headline, distinct from the
+    // PHP round-trip. `editor_valid_block_rate` is null until at least one
+    // fixture carries a validateBlock result.
+    validation_method: editorValidatedFixtures > 0 ? EDITOR_VALIDATION_METHOD : '',
+    editor_validated_fixture_count: editorValidatedFixtures,
+    editor_validated_block_total: editorValidatedTotal,
+    editor_valid_block_count: editorValidBlocks,
+    invalid_block_count: invalidBlockCount,
+    editor_valid_block_rate: editorValidatedTotal > 0 ? qualityRatio(editorValidBlocks, editorValidatedTotal) : null,
     native_rate_gate: {
       enabled: nativeRateGate.minNativeRate > 0,
       min_native_rate: nativeRateGate.minNativeRate || 0,
@@ -439,16 +480,24 @@ export function accumulateEditorQuality(target, editorQuality) {
   target.native_block_count += numberValue(source.native_block_count);
   target.core_html_block_count += numberValue(source.core_html_block_count);
   target.editor_invalid_count += numberValue(source.editor_invalid_count);
+  target.editor_validated_block_total += numberValue(source.editor_validated_block_total);
+  target.editor_valid_block_count += numberValue(source.editor_valid_block_count);
+  target.invalid_block_count += numberValue(source.invalid_block_count);
   if (source.scored) {
     target.scored_fixture_count += 1;
+  }
+  if (source.editor_validated) {
+    target.editor_validated_fixture_count += 1;
   }
 }
 
 export function finalizeEditorQuality(accumulator) {
   const blockTotal = numberValue(accumulator.block_total);
+  const editorValidatedTotal = numberValue(accumulator.editor_validated_block_total);
   return {
     ...accumulator,
     native_conversion_rate: qualityRatio(accumulator.native_block_count, blockTotal),
     core_html_fallback_ratio: qualityRatio(accumulator.core_html_block_count, blockTotal),
+    editor_valid_block_rate: editorValidatedTotal > 0 ? qualityRatio(accumulator.editor_valid_block_count, editorValidatedTotal) : null,
   };
 }

--- a/WordPress/static-site-importer/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/collectors/run-intake.mjs
@@ -24,7 +24,7 @@ import {
 import { createFixtureMatrix } from '../fixtures.mjs';
 import { dedupeDiagnostics } from '../findings.mjs';
 import { collectQualityMetrics, collectBlockComposition } from './quality-metrics.mjs';
-import { collectEditorValidationDiagnostics } from './editor-validation.mjs';
+import { collectEditorValidationDiagnostics, collectEditorValidation } from './editor-validation.mjs';
 import {
   collectVisualParityDiagnostics,
   collectVisualParityArtifacts,
@@ -70,6 +70,10 @@ function normalizeCollectedFixtureResult({ fixture, payloads, fixtureArtifactsDi
     import_report: merged.import_report || merged.importReport || merged.report || null,
     quality_metrics: collectQualityMetrics(merged),
     block_composition: collectBlockComposition(merged),
+    // Real `wp.blocks.validateBlock` editor-validity from the
+    // `wordpress.editor-validate-blocks` command, distinct from the PHP
+    // round-trip's structural `invalid_block_counts`.
+    editor_validation: collectEditorValidation(merged),
     blocks_engine_diagnostics: collectBlocksEngineDiagnostics(merged),
     invalid_block_counts: collectInvalidBlockCounts(merged),
     missing_assets: collectMissingAssets(merged),
@@ -162,7 +166,7 @@ function hasPayloadData(value) {
 }
 
 function readFixturePayloadFiles(directory) {
-  return ['validation-result.json', 'result.json', 'import-report.json', 'quality.json', 'blocks-engine-diagnostics.json', 'editor-validation.json', 'editor-canvas-summary.json', 'visual-compare.json', 'visual-diff.json', 'visual-parity.json']
+  return ['validation-result.json', 'result.json', 'import-report.json', 'quality.json', 'blocks-engine-diagnostics.json', 'editor-validation.json', 'editor-validate-blocks.json', 'editor-canvas-summary.json', 'visual-compare.json', 'visual-diff.json', 'visual-parity.json']
     .map((fileName) => readJsonFileIfExists(path.join(directory, fileName)))
     .filter(Boolean);
 }

--- a/WordPress/static-site-importer/lib/fixture-matrix/result.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/result.mjs
@@ -173,6 +173,10 @@ export function normalizeFixtureResult(input) {
     // markup is then discarded by never retaining `input` and by bounding the
     // report blobs below. See #554 / bounds.mjs.
     block_composition: input.block_composition || input.blockComposition || collectBlockComposition(input),
+    // Real `wp.blocks.validateBlock` editor-validity (total/valid/invalid blocks
+    // + validation_method), distinct from the PHP round-trip. Round-trips through
+    // re-normalization so editor-quality scoring can read it.
+    editor_validation: input.editor_validation || input.editorValidation || null,
     // Retained report blobs can carry raw serialized markup (e.g.
     // `import_report.materialized_content.block_documents[].post_content`). Bound
     // every retained string so the per-fixture result scales with #findings, not
@@ -455,7 +459,7 @@ function classRollup(key) {
     loss_classes: {},
     repair_buckets: {},
     candidate_repos: {},
-    editor_quality: { scored_fixture_count: 0, block_total: 0, native_block_count: 0, core_html_block_count: 0, editor_invalid_count: 0 },
+    editor_quality: { scored_fixture_count: 0, block_total: 0, native_block_count: 0, core_html_block_count: 0, editor_invalid_count: 0, editor_validated_fixture_count: 0, editor_validated_block_total: 0, editor_valid_block_count: 0, invalid_block_count: 0 },
   };
 }
 

--- a/WordPress/static-site-importer/lib/fixture-matrix/shared/constants.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/shared/constants.mjs
@@ -11,14 +11,21 @@ export const DEFAULT_ENTRYPOINT = 'website/index.html';
 export const DEFAULT_IMPORTER_SLUG = 'static-site-importer';
 
 // Editor-side block validity (JS save-comparison) wiring. The imported post is
-// opened in a real block editor inside the same WP Codebox sandbox the matrix
-// already spins up, then probed for invalid-block warnings. This mirrors the
-// `wp.blocks.validateBlock` pass in
-// `Automattic/studio/bench/studio-agent-site-build.bench.mjs`, but reuses the
-// existing `wordpress.editor-canvas-probe` recipe command rather than rebuilding
-// a validator. The editor renders `.block-editor-warning` /
-// `is-invalid` for blocks whose stored markup no longer matches the block
-// type's `save()` output ("This block contains unexpected or invalid content").
+// validated with the real block editor's `wp.blocks.validateBlock` pass inside
+// the same WP Codebox sandbox the matrix already spins up, via the
+// `wordpress.editor-validate-blocks` command (wp-codebox #1597). That command
+// emits a per-block `{ name, isValid, issues }` result set (schema
+// `wp-codebox/editor-validate-blocks/v1`) plus `total_blocks`/`valid_blocks`/
+// `invalid_blocks` and `validation_method: 'wp.blocks.validateBlock'`, which is
+// the authoritative editor-validity signal for whether stored markup still
+// matches each block type's `save()` output. `collectEditorValidation` /
+// `collectEditorValidationDiagnostics` read that shape back out.
+//
+// The legacy `wordpress.editor-canvas-probe` selector shape
+// (`.block-editor-warning` / `is-invalid` DOM warnings) is still parsed for
+// backward compatibility with older artifacts, but it is no longer produced by
+// the recipe — the canvas probe opened an EMPTY `post-new.php` and never
+// validated imported content.
 export const EDITOR_BLOCK_INVALID_KIND = 'editor_block_invalid';
 export const EDITOR_INVALID_BLOCK_SELECTOR_GROUP = 'editor_block_invalid';
 export const EDITOR_INVALID_BLOCK_SELECTORS = [
@@ -26,6 +33,19 @@ export const EDITOR_INVALID_BLOCK_SELECTORS = [
   '.block-editor-block-list__block.is-invalid',
   '.wp-block[data-block].is-invalid',
 ];
+// The real `wp.blocks.validateBlock` editor-validation command and its output
+// schema/method/provider. The recipe invokes the command against imported
+// content; the collector keys off the schema/method to read the result set.
+export const EDITOR_VALIDATE_BLOCKS_COMMAND = 'wordpress.editor-validate-blocks';
+export const EDITOR_VALIDATE_BLOCKS_SCHEMA = 'wp-codebox/editor-validate-blocks/v1';
+export const EDITOR_VALIDATION_METHOD = 'wp.blocks.validateBlock';
+export const EDITOR_VALIDATION_PROVIDER = 'wordpress-block-editor';
+// When no explicit per-fixture content/post target is available, the command
+// opens the most recently imported post of this type so it validates REAL
+// imported content rather than an empty editor. SSI materializes pages.
+export const DEFAULT_EDITOR_VALIDATION_POST_TYPE = 'page';
+// Legacy empty-post canvas-probe URL. Retained only so callers that still pass
+// an explicit editor URL keep working; the recipe no longer defaults to it.
 export const DEFAULT_EDITOR_VALIDATION_URL = '/wp-admin/post-new.php';
 export const EDITOR_BLOCK_INVALID_DEFAULT_DETAIL = 'This block contains unexpected or invalid content';
 

--- a/WordPress/static-site-importer/lib/fixture-matrix/steps/editor-validation-step.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/steps/editor-validation-step.mjs
@@ -1,31 +1,80 @@
-// Editor-validation recipe step (#537) for the Static Site Importer fixture
-// matrix.
+// Editor-validation recipe step for the Static Site Importer fixture matrix.
 //
-// Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
-// of the matrix modularization (Refs #242).
+// Invokes the real `wp.blocks.validateBlock` editor-validation command
+// (`wordpress.editor-validate-blocks`, wp-codebox #1597) against each imported
+// fixture's content. This replaces the former `wordpress.editor-canvas-probe`
+// step, which opened an EMPTY `post-new.php` and therefore never validated
+// imported markup — it only reported whether the blank editor rendered any
+// invalid-block DOM warnings (always none).
+//
+// The command accepts `content`/`content-file` to validate inline/file markup,
+// or `target`/`post-id`/`post-type`/`url` to open a post. The matrix prefers the
+// most concrete imported-content target a fixture carries, in priority order:
+//   1. inline `content` (the imported post_content), if present;
+//   2. a `content-file` path;
+//   3. the imported `post-id`;
+//   4. an explicit editor `url` (e.g. `post.php?post=<id>&action=edit`);
+//   5. an explicit `target`;
+//   6. otherwise `post-type` so the command opens the most recently imported
+//      post of that type — validating real imported content, not an empty post.
+// `wait-selector`/`wait-timeout` are forwarded when provided. The per-block
+// `{ name, isValid, issues }` results are read back out by
+// `collectEditorValidationDiagnostics` / `collectEditorValidation`.
 
 import {
-  EDITOR_INVALID_BLOCK_SELECTOR_GROUP,
-  EDITOR_INVALID_BLOCK_SELECTORS,
-  DEFAULT_EDITOR_VALIDATION_URL,
+  EDITOR_VALIDATE_BLOCKS_COMMAND,
+  DEFAULT_EDITOR_VALIDATION_POST_TYPE,
 } from '../shared/constants.mjs';
 
-// Compose the existing `wordpress.editor-canvas-probe` recipe command into an
-// editor-validation step. The probe opens the imported post in the real block
-// editor canvas and reports DOM matches for the invalid-block warning selectors,
-// which is exactly the surface Gutenberg renders for JS save-comparison
-// failures. No new wp-codebox capability is introduced — the invalid-block
-// signal is read back out of the probe's `selectorSummary` by
-// `collectEditorValidationDiagnostics`.
+function present(value) {
+  return value !== undefined && value !== null && String(value).trim() !== '';
+}
+
 export function editorBlockValidationStep(input = {}) {
   const fixture = input.fixture || {};
-  const url = input.url || input.editorValidationUrl || fixture.editor_url || fixture.editorUrl || DEFAULT_EDITOR_VALIDATION_URL;
-  const selectorGroups = [{ name: EDITOR_INVALID_BLOCK_SELECTOR_GROUP, selectors: EDITOR_INVALID_BLOCK_SELECTORS }];
+
+  const content = firstPresent([input.content, fixture.editor_content, fixture.editorContent, fixture.post_content, fixture.postContent, fixture.content]);
+  const contentFile = firstPresent([input.contentFile, input.content_file, fixture.editor_content_file, fixture.editorContentFile, fixture.content_file]);
+  const postId = firstPresent([input.postId, input.post_id, fixture.editor_post_id, fixture.editorPostId, fixture.post_id, fixture.postId]);
+  const url = firstPresent([input.url, input.editorValidationUrl, input.editor_validation_url, fixture.editor_url, fixture.editorUrl]);
+  const target = firstPresent([input.target, fixture.editor_target, fixture.editorTarget, fixture.target]);
+  const postType = firstPresent([input.postType, input.post_type, fixture.editor_post_type, fixture.editorPostType, fixture.post_type, fixture.postType]) || DEFAULT_EDITOR_VALIDATION_POST_TYPE;
+
+  const args = [];
+  if (content !== undefined) {
+    args.push(`content=${content}`);
+  } else if (contentFile !== undefined) {
+    args.push(`content-file=${contentFile}`);
+  } else if (postId !== undefined) {
+    args.push(`post-id=${postId}`);
+  } else if (url !== undefined) {
+    args.push(`url=${url}`);
+  } else if (target !== undefined) {
+    args.push(`target=${target}`);
+  } else {
+    args.push(`post-type=${postType}`);
+  }
+
+  const waitSelector = firstPresent([input.waitSelector, input.wait_selector, fixture.editor_wait_selector, fixture.editorWaitSelector]);
+  if (waitSelector !== undefined) {
+    args.push(`wait-selector=${waitSelector}`);
+  }
+  const waitTimeout = firstPresent([input.waitTimeout, input.wait_timeout, fixture.editor_wait_timeout, fixture.editorWaitTimeout]);
+  if (waitTimeout !== undefined) {
+    args.push(`wait-timeout=${waitTimeout}`);
+  }
+
   return {
-    command: 'wordpress.editor-canvas-probe',
-    args: [
-      `url=${url}`,
-      `selector-groups-json=${JSON.stringify(selectorGroups)}`,
-    ],
+    command: EDITOR_VALIDATE_BLOCKS_COMMAND,
+    args,
   };
+}
+
+function firstPresent(values) {
+  for (const value of values) {
+    if (present(value)) {
+      return value;
+    }
+  }
+  return undefined;
 }

--- a/WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -11,7 +11,6 @@ import {
   WEBSITE_ARTIFACT_SCHEMA,
   DEFAULT_ENTRYPOINT,
   DEFAULT_IMPORTER_SLUG,
-  DEFAULT_EDITOR_VALIDATION_URL,
 } from '../shared/constants.mjs';
 import {
   normalizeArray,
@@ -75,7 +74,16 @@ export function buildFixtureMatrixRecipe(input = {}) {
   const mounts = normalizeArray(input.mounts);
   const extraPlugins = [importer.extraPlugin, ...normalizeArray(input.extraPlugins || input.extra_plugins)];
   const editorValidationEnabled = input.editorValidation !== false && input.editor_validation !== false;
-  const editorValidationUrl = input.editorValidationUrl || input.editor_validation_url || DEFAULT_EDITOR_VALIDATION_URL;
+  // Real-content validation options forwarded to the editor-validate-blocks step.
+  // No empty-post default: when nothing concrete is provided, the step opens the
+  // most recently imported post (by post-type) so it validates imported content.
+  const editorValidationOptions = {
+    url: input.editorValidationUrl || input.editor_validation_url,
+    postType: input.editorValidationPostType || input.editor_validation_post_type,
+    target: input.editorValidationTarget || input.editor_validation_target,
+    waitSelector: input.editorValidationWaitSelector || input.editor_validation_wait_selector,
+    waitTimeout: input.editorValidationWaitTimeout || input.editor_validation_wait_timeout,
+  };
   const visualParityEnabled = input.visualParity !== false && input.visual_parity !== false;
   const visualParityRecipeOptions = normalizeVisualParityRecipeOptions(input);
 
@@ -107,7 +115,7 @@ export function buildFixtureMatrixRecipe(input = {}) {
               `command=static-site-importer validate-artifact --artifact=${shellToken(path.join(commandArtifactsDirectory, fixture.id, 'artifact.json'))} --slug=${shellToken(fixture.id)} --name=${shellToken(fixture.label)} --allow-missing-woocommerce --allow-failure`,
             ],
           },
-          ...(editorValidationEnabled ? [editorBlockValidationStep({ fixture, url: editorValidationUrl })] : []),
+          ...(editorValidationEnabled ? [editorBlockValidationStep({ fixture, ...editorValidationOptions })] : []),
           ...(visualParityEnabled ? [visualParityCompareStep({ fixture, ...visualParityRecipeOptions })] : []),
         ]),
       ],

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -30,6 +30,7 @@ import {
   classifyStaticSiteFinding,
   collectBlockComposition,
   collectEditorValidationDiagnostics,
+  collectEditorValidation,
   collectFixtureMatrixRunResults,
   computeFixtureEditorQuality,
   parseSerializedBlockNames,
@@ -37,6 +38,8 @@ import {
   createFixtureMatrix,
   editorBlockValidationStep,
   EDITOR_INVALID_BLOCK_SELECTOR_GROUP,
+  EDITOR_VALIDATE_BLOCKS_COMMAND,
+  EDITOR_VALIDATION_METHOD,
   normalizeFixtureMatrixResult,
   normalizeLossClass,
   VISUAL_PARITY_MISMATCH_KIND,
@@ -1517,7 +1520,7 @@ test('compares finding packet deltas by repair dimensions', () => {
   assert.equal(selectorFamily('#hero .cta'), 'id:hero');
 });
 
-test('recipe runs an editor-canvas-probe editor-validation step after each import', () => {
+test('recipe runs a wp.blocks.validateBlock editor-validation step on imported content after each import', () => {
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'editor-validation-recipe-test' });
   const recipe = buildFixtureMatrixRecipe({
     matrix,
@@ -1529,12 +1532,13 @@ test('recipe runs an editor-canvas-probe editor-validation step after each impor
   assert.equal(recipe.workflow.steps[1].command, 'wordpress.wp-cli');
   assert.match(recipe.workflow.steps[1].args[0], /static-site-importer validate-artifact/);
   const editorStep = recipe.workflow.steps[2];
-  assert.equal(editorStep.command, 'wordpress.editor-canvas-probe');
-  assert.ok(editorStep.args.some((arg) => arg.startsWith('url=')));
-  const selectorGroupsArg = editorStep.args.find((arg) => arg.startsWith('selector-groups-json='));
-  const selectorGroups = JSON.parse(selectorGroupsArg.slice('selector-groups-json='.length));
-  assert.equal(selectorGroups[0].name, EDITOR_INVALID_BLOCK_SELECTOR_GROUP);
-  assert.ok(selectorGroups[0].selectors.includes('.block-editor-warning'));
+  // The real validateBlock command, NOT the empty-post canvas probe.
+  assert.equal(editorStep.command, EDITOR_VALIDATE_BLOCKS_COMMAND);
+  assert.equal(editorStep.command, 'wordpress.editor-validate-blocks');
+  // No empty-post `post-new.php` URL: it validates imported content (the most
+  // recently imported post of the default type) rather than a blank editor.
+  assert.equal(editorStep.args.some((arg) => arg.includes('post-new.php')), false);
+  assert.ok(editorStep.args.includes('post-type=page'));
 
   const disabled = buildFixtureMatrixRecipe({
     matrix,
@@ -1542,13 +1546,32 @@ test('recipe runs an editor-canvas-probe editor-validation step after each impor
     staticSiteImporterPath: '/tmp/static-site-importer',
     editorValidation: false,
   });
-  assert.equal(disabled.workflow.steps.some((step) => step.command === 'wordpress.editor-canvas-probe'), false);
+  assert.equal(disabled.workflow.steps.some((step) => step.command === EDITOR_VALIDATE_BLOCKS_COMMAND), false);
 });
 
-test('editorBlockValidationStep composes the existing editor-canvas-probe command', () => {
-  const step = editorBlockValidationStep({ fixture: { id: 'shop', editor_url: '/wp-admin/post.php?post=42&action=edit' } });
-  assert.equal(step.command, 'wordpress.editor-canvas-probe');
-  assert.ok(step.args.includes('url=/wp-admin/post.php?post=42&action=edit'));
+test('editorBlockValidationStep invokes editor-validate-blocks against the most concrete imported target', () => {
+  // Defaults to opening the most recently imported post by type — real content.
+  const fallback = editorBlockValidationStep({ fixture: { id: 'simple' } });
+  assert.equal(fallback.command, 'wordpress.editor-validate-blocks');
+  assert.deepEqual(fallback.args, ['post-type=page']);
+
+  // An explicit editor URL (e.g. post.php?post=<id>&action=edit) is honored.
+  const byUrl = editorBlockValidationStep({ fixture: { id: 'shop', editor_url: '/wp-admin/post.php?post=42&action=edit' } });
+  assert.equal(byUrl.command, 'wordpress.editor-validate-blocks');
+  assert.ok(byUrl.args.includes('url=/wp-admin/post.php?post=42&action=edit'));
+
+  // An imported post id is preferred over a URL.
+  const byPostId = editorBlockValidationStep({ fixture: { id: 'shop', post_id: 99 } });
+  assert.ok(byPostId.args.includes('post-id=99'));
+
+  // Inline imported content wins over everything else, plus wait passthrough.
+  const byContent = editorBlockValidationStep({
+    content: '<!-- wp:paragraph --><p>Hi</p><!-- /wp:paragraph -->',
+    fixture: { id: 'shop', post_id: 99, editor_wait_selector: '.is-root-container' },
+  });
+  assert.ok(byContent.args.includes('content=<!-- wp:paragraph --><p>Hi</p><!-- /wp:paragraph -->'));
+  assert.ok(byContent.args.includes('wait-selector=.is-root-container'));
+  assert.equal(byContent.args.some((arg) => arg.startsWith('post-id=')), false);
 });
 
 test('editor-canvas-probe invalid-block warnings become gating editor_block_invalid findings', () => {
@@ -1675,6 +1698,103 @@ test('editor_block_invalid findings collected from fixture artifacts gate the ma
   assert.ok(finding, 'expected an editor_block_invalid finding from the canvas-probe artifact');
   assert.equal(finding.loss_acceptance, 'unacceptable');
   assert.equal(result.fixtures[0].status, 'failed');
+});
+
+const ALL_VALID_EDITOR_VALIDATE_BLOCKS = {
+  schema: 'wp-codebox/editor-validate-blocks/v1',
+  validation_method: 'wp.blocks.validateBlock',
+  validation_provider: 'wordpress-block-editor',
+  total_blocks: 3,
+  valid_blocks: 3,
+  invalid_blocks: 0,
+  results: [
+    { name: 'core/heading', isValid: true, issues: [] },
+    { name: 'core/paragraph', isValid: true, issues: [] },
+    { name: 'core/image', isValid: true, issues: [] },
+  ],
+};
+
+test('collectEditorValidation reads the editor-validate-blocks shape into headline metrics', () => {
+  const metrics = collectEditorValidation(ALL_VALID_EDITOR_VALIDATE_BLOCKS);
+  assert.equal(metrics.validation_method, 'wp.blocks.validateBlock');
+  assert.equal(metrics.validation_provider, 'wordpress-block-editor');
+  assert.equal(metrics.total_blocks, 3);
+  assert.equal(metrics.valid_blocks, 3);
+  assert.equal(metrics.invalid_blocks, 0);
+  assert.equal(collectEditorValidation({ unrelated: true }), null);
+});
+
+test('editor-validate-blocks all-valid output reports a 1.0 valid-block rate with zero invalid and no findings', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-editor-validate-valid-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'editor-validate-valid-test' });
+  const fixtureDirectory = path.join(outputDirectory, 'simple-site');
+  mkdirSync(fixtureDirectory, { recursive: true });
+  writeFileSync(
+    path.join(fixtureDirectory, 'editor-validate-blocks.json'),
+    JSON.stringify({ fixture_id: 'simple-site', success: true, ...ALL_VALID_EDITOR_VALIDATE_BLOCKS }),
+  );
+
+  const result = collectFixtureMatrixRunResults({ matrix, outputDirectory });
+  const fixture = result.fixtures[0];
+
+  assert.equal(fixture.editor_quality.editor_validated, true);
+  assert.equal(fixture.editor_quality.validation_method, EDITOR_VALIDATION_METHOD);
+  assert.equal(fixture.editor_quality.validation_method, 'wp.blocks.validateBlock');
+  assert.equal(fixture.editor_quality.editor_valid_block_rate, 1);
+  assert.equal(fixture.editor_quality.invalid_block_count, 0);
+  assert.equal(result.findings.some((finding) => finding.kind === 'editor_block_invalid'), false);
+
+  // Summary-level editor-quality surfaces the real validity, distinct from PHP.
+  assert.equal(result.summary.editor_quality.validation_method, 'wp.blocks.validateBlock');
+  assert.equal(result.summary.editor_quality.editor_valid_block_rate, 1);
+  assert.equal(result.summary.editor_quality.invalid_block_count, 0);
+  assert.equal(result.summary.editor_quality.editor_validated_fixture_count, 1);
+  assert.equal(fixture.status, 'passed');
+});
+
+test('editor-validate-blocks invalid block is counted and surfaced as a gating finding with name and reason', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-editor-validate-invalid-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'editor-validate-invalid-test' });
+  const fixtureDirectory = path.join(outputDirectory, 'simple-site');
+  mkdirSync(fixtureDirectory, { recursive: true });
+  writeFileSync(
+    path.join(fixtureDirectory, 'editor-validate-blocks.json'),
+    JSON.stringify({
+      fixture_id: 'simple-site',
+      success: false,
+      schema: 'wp-codebox/editor-validate-blocks/v1',
+      validation_method: 'wp.blocks.validateBlock',
+      validation_provider: 'wordpress-block-editor',
+      total_blocks: 3,
+      valid_blocks: 2,
+      invalid_blocks: 1,
+      results: [
+        { name: 'core/heading', isValid: true, issues: [] },
+        { name: 'core/columns', isValid: false, issues: ['Block validation failed for "core/columns": content mismatch'] },
+        { name: 'core/paragraph', isValid: true, issues: [] },
+      ],
+    }),
+  );
+
+  const result = collectFixtureMatrixRunResults({ matrix, outputDirectory });
+  const fixture = result.fixtures[0];
+
+  // Real editor-validity: 2/3 valid, one invalid.
+  assert.equal(fixture.editor_quality.validation_method, 'wp.blocks.validateBlock');
+  assert.equal(fixture.editor_quality.invalid_block_count, 1);
+  assert.equal(fixture.editor_quality.editor_valid_block_rate, 0.6667);
+  assert.equal(result.summary.editor_quality.invalid_block_count, 1);
+  assert.equal(result.summary.editor_quality.editor_valid_block_rate, 0.6667);
+
+  // The invalid block flows into a gating editor_block_invalid finding carrying
+  // the block name and the validateBlock issue reason.
+  const finding = result.findings.find((item) => item.kind === 'editor_block_invalid');
+  assert.ok(finding, 'expected an editor_block_invalid finding for the invalid block');
+  assert.equal(finding.observed_block_name, 'core/columns');
+  assert.match(finding.reason, /core\/columns/);
+  assert.match(finding.reason, /content mismatch/);
+  assert.equal(finding.loss_acceptance, 'unacceptable');
+  assert.equal(fixture.status, 'failed');
 });
 
 test('scores editor-quality metrics from generic block composition and rolls them up', () => {


### PR DESCRIPTION
## Summary

Points the Static Site Importer fixture matrix's editor-validation step at wp-codebox's new `wordpress.editor-validate-blocks` command (Automattic/wp-codebox #1597) so a run reports **real** `wp.blocks.validateBlock` editor-validity on **imported content** instead of the old empty-post canvas-probe.

### The problem
The former `editorBlockValidationStep` emitted `wordpress.editor-canvas-probe` against `DEFAULT_EDITOR_VALIDATION_URL = /wp-admin/post-new.php` — a **blank** editor. It never validated imported markup; it only checked whether an empty canvas rendered `.block-editor-warning` DOM nodes (always none). So "editor validation" was theater.

### The change
- **Step** (`steps/editor-validation-step.mjs`): now invokes `wordpress.editor-validate-blocks`. It validates the actual imported post, preferring the most concrete target a fixture carries — inline `content` → `content-file` → `post-id` → editor `url` → `target` — and otherwise opens the most recently imported post by `post-type` (default `page`). No empty-post default anymore. `wait-selector`/`wait-timeout` forwarded when provided.
- **Recipe wiring** (`steps/recipe-builder.mjs`): drops the `post-new.php` default and forwards generic editor-validation options per fixture.
- **Collector** (`collectors/editor-validation.mjs`): recognizes the `wp-codebox/editor-validate-blocks/v1` shape (top-level or nested) and adds `collectEditorValidation`, which normalizes `total_blocks`/`valid_blocks`/`invalid_blocks` + `validation_method`/`validation_provider`. The per-block `{ name, isValid, issues }` results feed the existing gating `editor_block_invalid` findings (now with real block name + validateBlock issue reason).
- **Result/summary** (`collectors/run-intake.mjs`, `result.mjs`, `collectors/quality-metrics.mjs`): the real validity is threaded onto each fixture result and surfaced in `result_summary.editor_quality` as `editor_valid_block_rate`, `invalid_block_count`, `editor_validated_fixture_count`, and `validation_method` — **distinct** from the PHP round-trip's structural `invalid_block_counts` (kept as-is). The legacy canvas-probe selector shape is still parsed for backward compatibility.

### What the step now invokes / reports
- Invokes: `wordpress.editor-validate-blocks` against imported content (post content / post id / latest imported post by type).
- Reports: real `wp.blocks.validateBlock` editor-validity — `editor_valid_block_rate`, `invalid_block_count`, `validation_method: wp.blocks.validateBlock` — at the fixture, class-rollup, and matrix-summary levels; invalid blocks gate as `editor_block_invalid` findings.

## ⚠️ Runner prerequisite (operator action)
At **run time**, the runner's wp-codebox checkout must include Automattic/wp-codebox #1597 for the `wordpress.editor-validate-blocks` command to exist. **Refresh the runner's wp-codebox before the next live matrix run.** This code change and its tests do not require a live runner — tests fake the command output.

## Tests
`node WordPress/static-site-importer/tools/fixture-matrix.test.mjs` → 62 pass / 0 fail.

Added/updated (DI/fake command output, no real sandbox):
- recipe + step assertions switched to `wordpress.editor-validate-blocks` on imported content (no `post-new.php`);
- all-valid output → `editor_valid_block_rate` 1.0, `invalid_block_count` 0, no finding, fixture passes;
- one invalid block → counted (rate 0.6667, invalid 1) and surfaced as a gating `editor_block_invalid` finding with block name + reason, fixture fails;
- `validation_method` reports `wp.blocks.validateBlock`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Opus 4.8 via Claude Code
- **Used for:** Implementing the step/collector/summary wiring and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)