### PR TITLE
Make SSI fixture-matrix proof layers runnable (+ document content-targeting gaps)

### DIFF
--- a/WordPress/static-site-importer/README.md
+++ b/WordPress/static-site-importer/README.md
@@ -172,8 +172,9 @@ The workload composes these generic surfaces:
   execution when `--run` is explicitly provided.
 - WP Codebox `workspace-recipe/v1` steps using generic `wordpress.wp-cli`
   commands.
-- WP Codebox `wordpress.editor-canvas-probe` command for the editor-side block
-  validity step (see below).
+- WP Codebox `wordpress.editor-validate-blocks` command (#1597) for the
+  editor-side block validity step (see below). Requires a wp-codebox build that
+  includes #1597; older builds reject the recipe at schema validation.
 - WP Codebox `wordpress.visual-compare` command for the pixel visual-parity step
   (see below).
 
@@ -189,13 +190,22 @@ JS save-comparison validation, which is what surfaces the "This block contains
 unexpected or invalid content" warning users actually see.
 
 After each fixture's import step, `buildFixtureMatrixRecipe` appends a
-`wordpress.editor-canvas-probe` step that opens the imported post in the real
-block editor canvas (same WP Codebox sandbox) and probes the
-`editor_block_invalid` selector group (`.block-editor-warning`,
-`.block-editor-block-list__block.is-invalid`). This reuses the existing
-wp-codebox editor command and mirrors the `wp.blocks.validateBlock` pass in
-`Automattic/studio/bench/studio-agent-site-build.bench.mjs` rather than
-rebuilding a validator.
+`wordpress.editor-validate-blocks` step (#1597) that runs the editor's real
+`wp.blocks.validateBlock` pass (same WP Codebox sandbox) and emits per-block
+`{ name, isValid, issues }` results plus `total_blocks`/`valid_blocks`/
+`invalid_blocks`. This reuses the existing wp-codebox editor-validation command
+rather than rebuilding a validator.
+
+Live-wiring gap (verified by a real local recipe-run): the matrix currently
+passes only a bare `post-type=<type>` target. wp-codebox's
+`editorOpenTargetFromArgs` resolves a bare `post-type` to an EMPTY
+`post-new.php?post_type=<type>` editor, so the pass validates `total_blocks: 0`
+and proves nothing about the imported markup. To assert real imported-output
+block validity the step must receive a concrete target — most robustly the
+imported `post-id` surfaced out of the in-sandbox `validate-artifact` step (or
+an inline `content` snapshot of the imported post_content). See
+`lib/fixture-matrix/steps/editor-validation-step.mjs` for the target priority
+order and the remaining enablement.
 
 `collectEditorValidationDiagnostics` reads the probe's `selectorSummary`
 (invalid-warning matches) — and, when present, per-block `isValid`/`validateBlock`
@@ -205,14 +215,13 @@ Blocks Engine feature/visual-parity bucket (`candidate_repo: blocks-engine`,
 `editor_block_invalid` loss class, so the honest gate fails the fixture. Valid
 blocks emit nothing. Set `editorValidation: false` to omit the step.
 
-Live caveat: a full editor-validation pass requires a healthy Lab runner (the
-runner currently has a controller/daemon version drift). The wiring and the
-finding-parsing/gating logic are unit-tested in
-`tools/fixture-matrix.test.mjs`. For per-block name/clientId fidelity equal to
-the studio bench, wp-codebox's `editor-actions`/`inspectState` would need to
-emit `getBlocks()` `isValid` (or run `wp.blocks.validateBlock`); the probe path
-used here detects invalid blocks via the warning DOM without any wp-codebox
-change, which `collectEditorValidationDiagnostics` already consumes.
+Live caveat: the `editor-validate-blocks` step runs locally in WP Codebox today
+(see "Running the matrix locally" below) — a real local recipe-run executed the
+step and returned `validation_method: wp.blocks.validateBlock`,
+`blockTypesRegistered: 109`. The wiring and the finding-parsing/gating logic are
+unit-tested in `tools/fixture-matrix.test.mjs`. The remaining enablement for a
+true imported-content assertion is targeting the imported post rather than a
+blank editor (gap documented above).
 
 ## Pixel Visual Parity Gate
 
@@ -247,13 +256,55 @@ threshold is configurable via `--pixel-threshold` /
 the per-pixel `threshold=` arg so a higher value loosens the gate monotonically).
 Set `--no-visual-parity` / `visualParity: false` to omit the step entirely.
 
-Live caveat: a full visual-parity render requires a healthy Lab runner (the
-runner currently has a controller/daemon version drift). The wiring and the
-finding-parsing/threshold/gating logic are unit-tested in
-`tools/fixture-matrix.test.mjs`. Wiring the exact servable source URL per fixture
-is the remaining live-run enablement; the step uses generic, configurable
-source/candidate URLs with per-fixture overrides today, mirroring how the editor
-step uses a configurable URL rather than resolving each imported post.
+Live caveat (verified by a real local recipe-run): the `wordpress.visual-compare`
+step renders and pixel-diffs locally in WP Codebox, but the source/candidate URLs
+are not yet wired to the imported output. The step composes
+`source-url=/wp-content/uploads/static-site-importer-fixture-matrix/<id>/index.html`
+and `candidate-url=/` by default. The fixture source HTML is never staged into a
+servable path, so the source capture hangs until the 120s browser timeout and the
+comparison returns `stage: capture-failed` with no mismatch metrics; the candidate
+URL is the homepage, not the imported page. The wiring and the
+finding-parsing/threshold/gating logic are fully unit-tested in
+`tools/fixture-matrix.test.mjs`. The remaining live-run enablement is: (1) stage
+each fixture's source under a servable path (e.g. mount it into
+`wp-content/uploads/...`) and point `source-url` at it, and (2) resolve
+`candidate-url` to the imported post's permalink.
+
+## Running the matrix locally
+
+`homeboy bench` auto-offloads to a connected default Lab runner whenever one is
+configured — even with no `--runner` flag. The offload translates
+component/checkout paths into the remote workspace but forwards
+`--shared-state`/`--artifact-root` verbatim, so local-only paths fail on the
+runner (`Permission denied`). To run the matrix on this machine against local
+checkouts, a local fixture root, and a local WP Codebox, pass `--local` to
+`tools/run-fixture-matrix.mjs` (it injects `--force-hot --allow-local-hot` into
+every routed Homeboy step):
+
+```
+node WordPress/static-site-importer/tools/run-fixture-matrix.mjs \
+  --local \
+  --static-site-importer <ssi-checkout> \
+  --blocks-engine <blocks-engine-checkout> \
+  --fixture-root <dir-of-fixture-subdirs> \
+  --wp-codebox-bin <wp-codebox>/packages/cli/dist/index.js
+```
+
+Notes:
+- The `editor-validate-blocks` step (#1597) requires a wp-codebox build that
+  includes #1597. The build homeboy materializes at
+  `~/.cache/homeboy/wp-codebox/source` can lag upstream `main`; if it predates
+  #1597 the recipe is rejected at schema validation
+  (`steps[N].command must be equal to one of the allowed values`). Point
+  `--wp-codebox-bin` at a current-`main` build to unblock it.
+- The rig `check` pipeline asserts the SSI checkout exists
+  (`<ssi>/static-site-importer.php`). If the checkout/worktree was removed (e.g.
+  by workspace hygiene), the bench fails with `rig.pipeline_failed` on the
+  `check` step — recreate the checkout before running.
+- Fixture roots must contain real fixture subdirectories. Symlinked fixture dirs
+  are skipped by discovery (`Dirent.isDirectory()` is false for symlinks), so the
+  matrix silently finds zero fixtures and the gate falsely "passes" with
+  `fixture_count: 0`. Copy fixtures in rather than symlinking.
 
 ## Editor-Quality Metrics
 

--- a/WordPress/static-site-importer/lib/fixture-matrix/steps/editor-validation-step.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/steps/editor-validation-step.mjs
@@ -15,8 +15,20 @@
 //   3. the imported `post-id`;
 //   4. an explicit editor `url` (e.g. `post.php?post=<id>&action=edit`);
 //   5. an explicit `target`;
-//   6. otherwise `post-type` so the command opens the most recently imported
-//      post of that type — validating real imported content, not an empty post.
+//   6. otherwise bare `post-type`.
+//
+// LIVE-WIRING GAP (verified against wp-codebox editor-actions.ts
+// `editorOpenTargetFromArgs`): a bare `post-type` with no concrete target does
+// NOT open the most recently imported post. wp-codebox resolves it to
+// `kind: post-new` → an EMPTY `post-new.php?post_type=<type>` editor, so the
+// validation runs against zero blocks (`total_blocks: 0`) and proves nothing
+// about imported markup. To assert real imported-output block validity, a
+// fixture must carry one of (1)-(4) — most robustly the imported `post-id` (or
+// an inline `content` snapshot of the imported post_content). Surfacing the
+// imported post id out of the in-sandbox `validate-artifact` import step, then
+// threading it into this step, is the remaining enablement for a true
+// imported-content block-validity gate.
+//
 // `wait-selector`/`wait-timeout` are forwarded when provided. The per-block
 // `{ name, isValid, issues }` results are read back out by
 // `collectEditorValidationDiagnostics` / `collectEditorValidation`.

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -1061,7 +1061,7 @@ test('fixture matrix dry-run plan surfaces local fallback and dirty workspace wa
   // The single-fixture temp corpus drifts from the canonical pin, so the plan
   // surfaces a non-silent drift warning alongside the routing warnings.
   assert.deepEqual(plan.warnings.map((warning) => warning.code), [
-    'local_runner_default',
+    'lab_auto_offload_risk',
     'local_fallback_allowed',
     'dirty_lab_workspace_allowed',
     'canonical_fixture_count_drift',
@@ -1071,6 +1071,34 @@ test('fixture matrix dry-run plan surfaces local fallback and dirty workspace wa
     plan.warnings.find((warning) => warning.code === 'canonical_fixture_count_drift').message,
     /CANONICAL_FIXTURE_COUNT is \d+/,
   );
+});
+
+test('--local forces hot local execution and suppresses the auto-offload-risk warning', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-local-plan-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const fixtureRoot = path.join(root, 'fixtures');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(path.join(fixtureRoot, 'fixture-a'), { recursive: true });
+
+  const plan = buildFixtureMatrixRunPlan({
+    staticSiteImporter,
+    fixtureRoot,
+    local: true,
+    skipInstall: true,
+    skipSync: true,
+  });
+
+  // The auto-offload risk warning is gone; the forced-local note replaces it.
+  const codes = plan.warnings.map((warning) => warning.code);
+  assert.ok(!codes.includes('lab_auto_offload_risk'));
+  assert.ok(codes.includes('forced_local_execution'));
+  assert.equal(plan.local, true);
+
+  // The bench step carries --force-hot --allow-local-hot so homeboy bench stays
+  // local instead of offloading local-only paths to a connected Lab runner.
+  const benchStep = plan.steps.at(-1);
+  assert.ok(benchStep.args.includes('--force-hot'));
+  assert.ok(benchStep.args.includes('--allow-local-hot'));
 });
 
 test('operator summary preserves matrix rollups for fanout agents', () => {

--- a/WordPress/static-site-importer/tools/run-fixture-matrix.mjs
+++ b/WordPress/static-site-importer/tools/run-fixture-matrix.mjs
@@ -102,6 +102,7 @@ export function buildFixtureMatrixRunPlan(input) {
     mode: options.mode,
     rig: RIG_ID,
     runner: options.runner,
+    local: Boolean(options.local),
     run_id: options.runId,
     static_site_importer: options.staticSiteImporter,
     blocks_engine: options.blocksEngine,
@@ -185,9 +186,13 @@ function defaultTempRoot(namespace) {
 
 function buildWarnings(options) {
   return [
-    ...(!options.runner && !options.labOnly ? [{
-      code: 'local_runner_default',
-      message: 'No --runner/--lab-only routing was provided; the plan will use the local Homeboy runner.',
+    ...(!options.runner && !options.labOnly && !options.local ? [{
+      code: 'lab_auto_offload_risk',
+      message: 'No --runner/--lab-only/--local routing was provided. `homeboy bench` auto-offloads to a connected default Lab runner, where local --shared-state/--artifact-root paths will fail. Pass --local to force local (hot) execution against local checkouts and a local WP Codebox, or --runner/--lab-only to route to a runner with the paths present.',
+    }] : []),
+    ...(options.local ? [{
+      code: 'forced_local_execution',
+      message: '--local forces hot local execution (--force-hot --allow-local-hot); the bench will not offload to a Lab runner even if one is connected.',
     }] : []),
     ...(options.allowLocalFallback ? [{
       code: 'local_fallback_allowed',
@@ -422,6 +427,18 @@ function buildSteps(options, settings) {
 
 function withCommonRouting(args, options) {
   const routed = [...args];
+  // Force local (hot) execution. `homeboy bench` auto-offloads to a default Lab
+  // runner whenever one is connected, even with no --runner flag. The offload
+  // translates component/checkout paths into the remote workspace but passes
+  // --shared-state / --artifact-root through verbatim, so a local absolute path
+  // (e.g. /private/tmp/... or /Users/...) fails on the Linux runner with
+  // "Permission denied" / "No such file". --force-hot --allow-local-hot together
+  // keep the run on this machine so the local checkouts, fixture root, and
+  // shared-state/artifact-root paths all resolve. This is the only way to run
+  // the matrix against local-only paths and a local WP Codebox.
+  if (options.local) {
+    routed.push('--force-hot', '--allow-local-hot');
+  }
   if (options.runner) {
     routed.push('--runner', options.runner);
   }
@@ -529,7 +546,7 @@ function parseArgs(args) {
     if (arg.startsWith('--')) {
       const [rawKey, rawValue] = arg.slice(2).split('=');
       const key = camelCase(rawKey);
-      const booleanKeys = new Set(['dryRun', 'skipInstall', 'skipSync', 'labOnly', 'allowLocalFallback', 'detachAfterHandoff', 'allowDirtyLabWorkspace', 'allowStaleOverride', 'visualParityGate']);
+      const booleanKeys = new Set(['dryRun', 'skipInstall', 'skipSync', 'labOnly', 'local', 'allowLocalFallback', 'detachAfterHandoff', 'allowDirtyLabWorkspace', 'allowStaleOverride', 'visualParityGate']);
       if (booleanKeys.has(key)) {
         options[key] = true;
         continue;
@@ -634,7 +651,7 @@ function sanitizePathSegment(value) {
 }
 
 function printHelp() {
-  process.stdout.write(`Usage: node WordPress/static-site-importer/tools/run-fixture-matrix.mjs --runner <id> --static-site-importer <path> --blocks-engine <path> [options] [-- <bench args>...]\n\nRuns the canonical Static Site Importer fixture matrix through Homeboy/Lab/WP Codebox.\n\nOptions:\n  --static-site-importer <path>       Static Site Importer checkout/plugin path. Required.\n  --blocks-engine <path>              Blocks Engine checkout. Defaults fixture root and PHP transformer override.\n  --fixture-root <path>               Fixture corpus. Defaults to <blocks-engine>/fixtures/websites.\n  --blocks-engine-php-transformer-path <path>\n                                      Override transformer package/repo path. Defaults to --blocks-engine.\n  --runner <id>                       Homeboy Lab runner, for example homeboy-lab.\n  --mode <development-override|release-proof>\n                                      Labels output; default is development-override when transformer override is used.\n  --run-id <id>                       Stable proof label. Defaults to ssi-matrix-<mode>-<timestamp>.\n  --shared-state <dir>                Shared Homeboy bench state directory.\n  --artifact-root <dir>               Homeboy artifact root.\n  --output <file>                     Structured Homeboy bench output file.\n  --batch-size <n>                    SSI fixture matrix WP Codebox batch size.\n  --concurrency <n>                   Parallel WP Codebox sandbox batches. Defaults to 4, hard-capped at 16.\n  --wordpress-version <version>       WP Codebox WordPress version.\n  --wp-codebox-bin <path>             WP Codebox CLI path.\n  --allow-stale-override              Proceed even when an override checkout is behind/diverged vs upstream.\n  --no-visual-parity                  Skip the wordpress.visual-compare render/diff step.\n  --visual-parity-gate                Make pixel mismatch over the threshold a HARD gate. Default: capture-only.\n  --pixel-threshold <ratio>           Max mismatch ratio (mismatch_pixels/total_pixels) before gating. Default 0.1.\n  --min-native-rate <ratio>           Opt-in: fail fixtures whose native_conversion_rate is below this ratio (0-1, or a percentage like 80). Default: off (metrics only).\n  --class <fixture-class>             Run only the given manifest class lane (e.g. marketing/static). Default: all classes.\n  --tag <tag>                         Run only fixtures whose manifest tags include this tag. Default: all fixtures.\n  --lab-only                          Require Lab routing.\n  --allow-local-fallback              Allow selected Lab runner local fallback.\n  --allow-dirty-lab-workspace         Allow runner workspace overwrite.\n  --detach-after-handoff              Return after remote runner accepts the job.\n  --skip-install                      Skip homeboy rig install --reinstall.\n  --skip-sync                         Skip homeboy rig sync.\n  --dry-run                           Print the composed plan without running it.\n\nAny args after -- are passed through to the lower-level bench runner.\n`);
+  process.stdout.write(`Usage: node WordPress/static-site-importer/tools/run-fixture-matrix.mjs --runner <id> --static-site-importer <path> --blocks-engine <path> [options] [-- <bench args>...]\n\nRuns the canonical Static Site Importer fixture matrix through Homeboy/Lab/WP Codebox.\n\nOptions:\n  --static-site-importer <path>       Static Site Importer checkout/plugin path. Required.\n  --blocks-engine <path>              Blocks Engine checkout. Defaults fixture root and PHP transformer override.\n  --fixture-root <path>               Fixture corpus. Defaults to <blocks-engine>/fixtures/websites.\n  --blocks-engine-php-transformer-path <path>\n                                      Override transformer package/repo path. Defaults to --blocks-engine.\n  --runner <id>                       Homeboy Lab runner, for example homeboy-lab.\n  --local                             Force hot local execution (--force-hot --allow-local-hot). Use this to run against local checkouts, a local fixture root, and a local WP Codebox; without it, homeboy bench auto-offloads to a connected default Lab runner where local --shared-state/--artifact-root paths fail.\n  --mode <development-override|release-proof>\n                                      Labels output; default is development-override when transformer override is used.\n  --run-id <id>                       Stable proof label. Defaults to ssi-matrix-<mode>-<timestamp>.\n  --shared-state <dir>                Shared Homeboy bench state directory.\n  --artifact-root <dir>               Homeboy artifact root.\n  --output <file>                     Structured Homeboy bench output file.\n  --batch-size <n>                    SSI fixture matrix WP Codebox batch size.\n  --concurrency <n>                   Parallel WP Codebox sandbox batches. Defaults to 4, hard-capped at 16.\n  --wordpress-version <version>       WP Codebox WordPress version.\n  --wp-codebox-bin <path>             WP Codebox CLI path.\n  --allow-stale-override              Proceed even when an override checkout is behind/diverged vs upstream.\n  --no-visual-parity                  Skip the wordpress.visual-compare render/diff step.\n  --visual-parity-gate                Make pixel mismatch over the threshold a HARD gate. Default: capture-only.\n  --pixel-threshold <ratio>           Max mismatch ratio (mismatch_pixels/total_pixels) before gating. Default 0.1.\n  --min-native-rate <ratio>           Opt-in: fail fixtures whose native_conversion_rate is below this ratio (0-1, or a percentage like 80). Default: off (metrics only).\n  --class <fixture-class>             Run only the given manifest class lane (e.g. marketing/static). Default: all classes.\n  --tag <tag>                         Run only fixtures whose manifest tags include this tag. Default: all fixtures.\n  --lab-only                          Require Lab routing.\n  --allow-local-fallback              Allow selected Lab runner local fallback.\n  --allow-dirty-lab-workspace         Allow runner workspace overwrite.\n  --detach-after-handoff              Return after remote runner accepts the job.\n  --skip-install                      Skip homeboy rig install --reinstall.\n  --skip-sync                         Skip homeboy rig sync.\n  --dry-run                           Print the composed plan without running it.\n\nAny args after -- are passed through to the lower-level bench runner.\n`);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {


### PR DESCRIPTION
## What
Makes the SSI fixture-matrix proof layers (visual-parity + editor block-validity, already merged on `main` via #538/#537/#562) actually runnable, and documents two real content-targeting gaps found by running them.

## Changes
- `tools/run-fixture-matrix.mjs` + test: new `--local` flag injecting `--force-hot --allow-local-hot` into routed steps, fixing the lab auto-offload that broke local shared-state/artifact paths (`Permission denied` on the remote). Replaces the misleading `local_runner_default` warning with `lab_auto_offload_risk`.
- `editor-validation-step.mjs`: corrected a factually-wrong comment claiming bare `post-type` opens the imported post.
- README: "Running the matrix locally" — the `--local` / wp-codebox-#1597-freshness / rig-check / symlink pitfalls, plus the two verified proof-layer gaps with real evidence.

## Verified gaps (real runs, documented not shimmed)
- **Block validity** ran via `wp.blocks.validateBlock` (109 block types registered) but `total_blocks: 0` — it validates an empty `post-new.php`, not the imported post. Needs the imported post-id threaded from `validate-artifact` into `editor-validate-blocks`.
- **Visual parity** ran `wordpress.visual-compare` but `source-capture exceeded 120000ms` — the fixture source HTML is never staged to a servable path, and `candidate-url=/` is the homepage not the imported page.
- wp-codebox materialized cache was 159 commits stale (predating the `editor-validate-blocks` command #1597); used `--wp-codebox-bin` to a current build rather than mutating the shared cache.

## Follow-ups (own tracked PRs against current wp-codebox contract)
1. Thread imported post-id into block-validity. 2. Stage fixture source + resolve candidate permalink for visual-parity. 3. Refresh wp-codebox cache freshness.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Root-cause diagnosis, runnability fix, and documentation under human review.
