### PR TITLE
Validate the imported post in block-validity proof layer (real block counts)

### DIFF
--- a/WordPress/static-site-importer/lib/fixture-matrix/collectors/run-intake.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/collectors/run-intake.mjs
@@ -155,7 +155,23 @@ function visitRuntimePayloads(value, inheritedFixtureId, payloads, seen) {
       payloads.push({ fixture_id: fixtureId, ...parsed });
     }
   }
-  for (const child of Array.isArray(value) ? value : Object.values(value)) {
+  if (Array.isArray(value)) {
+    // Recipe steps run in per-fixture order ([import, editor-validate, ...]);
+    // the import step carries the fixture slug while the editor step does not.
+    // Thread the last-seen fixture id forward across sibling executions so the
+    // editor result inherits the fixture it validated. (`new Set()` per element
+    // is unnecessary; `seen` already guards re-entry.)
+    let carried = inheritedFixtureId;
+    for (const child of value) {
+      const childFixtureId = (child && typeof child === 'object') ? (fixtureIdentity(child) || carried) : carried;
+      visitRuntimePayloads(child, childFixtureId, payloads, seen);
+      if (childFixtureId) {
+        carried = childFixtureId;
+      }
+    }
+    return;
+  }
+  for (const child of Object.values(value)) {
     visitRuntimePayloads(child, fixtureId, payloads, seen);
   }
 }
@@ -182,7 +198,35 @@ function fixtureIdentity(payload) {
     || payload?.request?.importArgs?.slug
     || payload?.metadata?.fixture_id
     || payload?.metadata?.fixtureId
+    || fixtureIdFromExecutionArgs(payload)
     || '';
+}
+
+// Derive the fixture slug from a wp-codebox execution's args. The import step is
+// `wordpress.wp-cli command=static-site-importer validate-artifact --slug=<id>
+// --artifact=.../<id>/artifact.json`, so its slug is the only place the fixture
+// id appears on the (otherwise id-less) per-fixture executions. The
+// editor-validate-blocks step that follows carries no id of its own; surfacing
+// the slug here lets `visitRuntimePayloads` thread it forward to that step.
+function fixtureIdFromExecutionArgs(payload) {
+  const args = payload?.args;
+  if (!Array.isArray(args)) {
+    return '';
+  }
+  for (const arg of args) {
+    if (typeof arg !== 'string') {
+      continue;
+    }
+    const slug = arg.match(/--slug=([^\s]+)/);
+    if (slug) {
+      return slug[1];
+    }
+    const artifact = arg.match(/--artifact=\S*\/([^/\s]+)\/artifact\.json/);
+    if (artifact) {
+      return artifact[1];
+    }
+  }
+  return '';
 }
 
 function collectInvalidBlockCounts(payload) {

--- a/WordPress/static-site-importer/lib/fixture-matrix/shared/constants.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/shared/constants.mjs
@@ -40,9 +40,17 @@ export const EDITOR_VALIDATE_BLOCKS_COMMAND = 'wordpress.editor-validate-blocks'
 export const EDITOR_VALIDATE_BLOCKS_SCHEMA = 'wp-codebox/editor-validate-blocks/v1';
 export const EDITOR_VALIDATION_METHOD = 'wp.blocks.validateBlock';
 export const EDITOR_VALIDATION_PROVIDER = 'wordpress-block-editor';
-// When no explicit per-fixture content/post target is available, the command
-// opens the most recently imported post of this type so it validates REAL
-// imported content rather than an empty editor. SSI materializes pages.
+// Default editor-validation target when a fixture carries no explicit
+// content/post target. `front-page` resolves, inside the WP Codebox sandbox at
+// runtime, to the site's static front page (`page_on_front`) — which SSI's
+// import points at the imported home page — and opens
+// `post.php?post=<id>&action=edit` so the command validates the REAL imported
+// front page's blocks. (A bare `post-type` resolved to an EMPTY
+// `post-new.php?post_type=<type>` editor, reporting `total_blocks: 0` and
+// proving nothing about imported markup — see wp-codebox `editorOpenTargetFromArgs`.)
+export const DEFAULT_EDITOR_VALIDATION_TARGET = 'front-page';
+// Retained for callers that still forward an explicit editor post type; the
+// default target no longer keys off it.
 export const DEFAULT_EDITOR_VALIDATION_POST_TYPE = 'page';
 // Legacy empty-post canvas-probe URL. Retained only so callers that still pass
 // an explicit editor URL keep working; the recipe no longer defaults to it.

--- a/WordPress/static-site-importer/lib/fixture-matrix/steps/editor-validation-step.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/steps/editor-validation-step.mjs
@@ -8,26 +8,25 @@
 // invalid-block DOM warnings (always none).
 //
 // The command accepts `content`/`content-file` to validate inline/file markup,
-// or `target`/`post-id`/`post-type`/`url` to open a post. The matrix prefers the
-// most concrete imported-content target a fixture carries, in priority order:
+// or `target`/`post-id`/`url` to open a post. The matrix prefers the most
+// concrete imported-content target a fixture carries, in priority order:
 //   1. inline `content` (the imported post_content), if present;
 //   2. a `content-file` path;
 //   3. the imported `post-id`;
 //   4. an explicit editor `url` (e.g. `post.php?post=<id>&action=edit`);
 //   5. an explicit `target`;
-//   6. otherwise bare `post-type`.
+//   6. otherwise `target=front-page` (the default).
 //
-// LIVE-WIRING GAP (verified against wp-codebox editor-actions.ts
-// `editorOpenTargetFromArgs`): a bare `post-type` with no concrete target does
-// NOT open the most recently imported post. wp-codebox resolves it to
-// `kind: post-new` → an EMPTY `post-new.php?post_type=<type>` editor, so the
-// validation runs against zero blocks (`total_blocks: 0`) and proves nothing
-// about imported markup. To assert real imported-output block validity, a
-// fixture must carry one of (1)-(4) — most robustly the imported `post-id` (or
-// an inline `content` snapshot of the imported post_content). Surfacing the
-// imported post id out of the in-sandbox `validate-artifact` import step, then
-// threading it into this step, is the remaining enablement for a true
-// imported-content block-validity gate.
+// IMPORTED-CONTENT TARGETING: the imported front page's post id is not known when
+// the recipe is built (the import runs later, inside the sandbox), so the default
+// resolves at runtime. SSI's `validate-artifact` import materializes the
+// fixture's pages and sets `page_on_front` to the imported home page; wp-codebox's
+// `editorOpenTargetFromArgs` + `resolveEditorOpenTarget` turn `target=front-page`
+// into `post.php?post=<page_on_front>&action=edit` by querying the running
+// WordPress, so the command validates the REAL imported front page's blocks.
+// (Previously the default emitted a bare `post-type`, which wp-codebox resolved to
+// an EMPTY `post-new.php?post_type=<type>` editor — `total_blocks: 0`, proving
+// nothing about imported markup. This is the wiring that closed that gap.)
 //
 // `wait-selector`/`wait-timeout` are forwarded when provided. The per-block
 // `{ name, isValid, issues }` results are read back out by
@@ -35,7 +34,7 @@
 
 import {
   EDITOR_VALIDATE_BLOCKS_COMMAND,
-  DEFAULT_EDITOR_VALIDATION_POST_TYPE,
+  DEFAULT_EDITOR_VALIDATION_TARGET,
 } from '../shared/constants.mjs';
 
 function present(value) {
@@ -50,7 +49,6 @@ export function editorBlockValidationStep(input = {}) {
   const postId = firstPresent([input.postId, input.post_id, fixture.editor_post_id, fixture.editorPostId, fixture.post_id, fixture.postId]);
   const url = firstPresent([input.url, input.editorValidationUrl, input.editor_validation_url, fixture.editor_url, fixture.editorUrl]);
   const target = firstPresent([input.target, fixture.editor_target, fixture.editorTarget, fixture.target]);
-  const postType = firstPresent([input.postType, input.post_type, fixture.editor_post_type, fixture.editorPostType, fixture.post_type, fixture.postType]) || DEFAULT_EDITOR_VALIDATION_POST_TYPE;
 
   const args = [];
   if (content !== undefined) {
@@ -64,7 +62,14 @@ export function editorBlockValidationStep(input = {}) {
   } else if (target !== undefined) {
     args.push(`target=${target}`);
   } else {
-    args.push(`post-type=${postType}`);
+    // Default to the site's static front page. SSI's import (`validate-artifact`)
+    // materializes the fixture's pages and points `page_on_front` at the imported
+    // home page, so `target=front-page` lets wp-codebox resolve that exact post id
+    // at runtime and open `post.php?post=<page_on_front>&action=edit`. That
+    // validates the REAL imported front page's blocks — not the empty
+    // `post-new.php?post_type=<type>` editor a bare `post-type` arg opens
+    // (total_blocks: 0, proving nothing about imported markup).
+    args.push(`target=${DEFAULT_EDITOR_VALIDATION_TARGET}`);
   }
 
   const waitSelector = firstPresent([input.waitSelector, input.wait_selector, fixture.editor_wait_selector, fixture.editorWaitSelector]);

--- a/WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -75,8 +75,9 @@ export function buildFixtureMatrixRecipe(input = {}) {
   const extraPlugins = [importer.extraPlugin, ...normalizeArray(input.extraPlugins || input.extra_plugins)];
   const editorValidationEnabled = input.editorValidation !== false && input.editor_validation !== false;
   // Real-content validation options forwarded to the editor-validate-blocks step.
-  // No empty-post default: when nothing concrete is provided, the step opens the
-  // most recently imported post (by post-type) so it validates imported content.
+  // No empty-post default: when nothing concrete is provided, the step targets
+  // `front-page`, which wp-codebox resolves to the imported static front page
+  // (`page_on_front`) at runtime so it validates real imported content.
   const editorValidationOptions = {
     url: input.editorValidationUrl || input.editor_validation_url,
     postType: input.editorValidationPostType || input.editor_validation_post_type,

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -1563,10 +1563,12 @@ test('recipe runs a wp.blocks.validateBlock editor-validation step on imported c
   // The real validateBlock command, NOT the empty-post canvas probe.
   assert.equal(editorStep.command, EDITOR_VALIDATE_BLOCKS_COMMAND);
   assert.equal(editorStep.command, 'wordpress.editor-validate-blocks');
-  // No empty-post `post-new.php` URL: it validates imported content (the most
-  // recently imported post of the default type) rather than a blank editor.
+  // No empty-post `post-new.php` URL and no bare `post-type` (which wp-codebox
+  // resolves to an empty post-new editor): it targets the imported static front
+  // page so it validates real imported content rather than a blank editor.
   assert.equal(editorStep.args.some((arg) => arg.includes('post-new.php')), false);
-  assert.ok(editorStep.args.includes('post-type=page'));
+  assert.equal(editorStep.args.some((arg) => arg.startsWith('post-type=')), false);
+  assert.ok(editorStep.args.includes('target=front-page'));
 
   const disabled = buildFixtureMatrixRecipe({
     matrix,
@@ -1578,10 +1580,11 @@ test('recipe runs a wp.blocks.validateBlock editor-validation step on imported c
 });
 
 test('editorBlockValidationStep invokes editor-validate-blocks against the most concrete imported target', () => {
-  // Defaults to opening the most recently imported post by type — real content.
+  // Defaults to the imported static front page (resolved at runtime from
+  // page_on_front by wp-codebox) — real imported content, not an empty editor.
   const fallback = editorBlockValidationStep({ fixture: { id: 'simple' } });
   assert.equal(fallback.command, 'wordpress.editor-validate-blocks');
-  assert.deepEqual(fallback.args, ['post-type=page']);
+  assert.deepEqual(fallback.args, ['target=front-page']);
 
   // An explicit editor URL (e.g. post.php?post=<id>&action=edit) is honored.
   const byUrl = editorBlockValidationStep({ fixture: { id: 'shop', editor_url: '/wp-admin/post.php?post=42&action=edit' } });
@@ -1778,6 +1781,68 @@ test('editor-validate-blocks all-valid output reports a 1.0 valid-block rate wit
   assert.equal(result.summary.editor_quality.invalid_block_count, 0);
   assert.equal(result.summary.editor_quality.editor_validated_fixture_count, 1);
   assert.equal(fixture.status, 'passed');
+});
+
+test('editor-validate-blocks result from a codebox execution is associated to the fixture via the import step slug', () => {
+  // Real shape: the per-fixture wp-codebox executions run in order
+  // ([..., validate-artifact, editor-validate-blocks]). The editor step carries
+  // NO fixture id of its own and emits its result as JSON on `result.stdout`,
+  // so the collector must derive the fixture from the import step's --slug and
+  // thread it forward to the editor execution. This is the wiring that makes a
+  // `target=front-page` run report real imported-block counts.
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-editor-validate-codebox-'));
+  const matrix = createFixtureMatrix({
+    fixture_root: fixtureRoot,
+    id: 'editor-validate-codebox-test',
+    fixtures: [{ id: 'simple-site', fixture_path: path.join(fixtureRoot, 'simple-site'), directory: path.join(fixtureRoot, 'simple-site') }],
+  });
+  const codeboxOutput = {
+    success: true,
+    schema: 'wp-codebox/recipe-run-result/v1',
+    executions: [
+      {
+        command: 'wordpress.wp-cli',
+        args: ['command=static-site-importer validate-artifact --artifact=/wordpress/wp-content/uploads/x/simple-site/artifact.json --slug=simple-site --name=Simple --allow-missing-woocommerce --allow-failure'],
+        result: { schema: 'wp-codebox/runtime-command-result/v1', status: 'ok', stdout: JSON.stringify({ success: true, fixture_id: 'simple-site', import_report: { theme_slug: 'simple-site' } }) },
+      },
+      {
+        command: 'wordpress.editor-validate-blocks',
+        args: ['target=front-page'],
+        result: {
+          schema: 'wp-codebox/runtime-command-result/v1',
+          status: 'ok',
+          stdout: JSON.stringify({
+            schema: 'wp-codebox/editor-validate-blocks/v1',
+            validation_method: 'wp.blocks.validateBlock',
+            validation_provider: 'wordpress-block-editor',
+            total_blocks: 5,
+            valid_blocks: 4,
+            invalid_blocks: 1,
+            results: [
+              { name: 'core/navigation', isValid: false, issues: ['Block validation failed for "core/navigation"'] },
+              { name: 'core/heading', isValid: true, issues: [] },
+              { name: 'core/paragraph', isValid: true, issues: [] },
+              { name: 'core/image', isValid: true, issues: [] },
+              { name: 'core/spacer', isValid: true, issues: [] },
+            ],
+          }),
+        },
+      },
+    ],
+  };
+
+  const result = collectFixtureMatrixRunResults({ matrix, outputDirectory, codeboxOutput });
+  const fixture = result.fixtures[0];
+
+  // The real validateBlock counts are surfaced on the fixture, not lost.
+  assert.equal(fixture.editor_validation.total_blocks, 5);
+  assert.equal(fixture.editor_validation.valid_blocks, 4);
+  assert.equal(fixture.editor_validation.invalid_blocks, 1);
+  assert.equal(fixture.editor_quality.validation_method, 'wp.blocks.validateBlock');
+  // The one invalid block becomes a gating editor_block_invalid finding.
+  const finding = result.findings.find((item) => item.kind === 'editor_block_invalid');
+  assert.ok(finding, 'expected an editor_block_invalid finding from the codebox editor-validate result');
+  assert.equal(finding.loss_acceptance, 'unacceptable');
 });
 
 test('editor-validate-blocks invalid block is counted and surfaced as a gating finding with name and reason', () => {


### PR DESCRIPTION
## What
Makes the SSI fixture-matrix block-validity proof layer validate the ACTUAL imported post instead of an empty `post-new.php` (which reported `total_blocks: 0`).

## Change
- `lib/fixture-matrix/steps/editor-validation-step.mjs`: default target `post-type=page` → `target=front-page` (depends on wp-codebox #1611). New `DEFAULT_EDITOR_VALIDATION_TARGET` constant.
- `lib/fixture-matrix/collectors/run-intake.mjs`: the id-less editor-validate execution now derives its fixture slug from the preceding `validate-artifact` step's args and threads it across the per-fixture execution sequence, so block counts land on the right fixture and invalid blocks become gating `editor_block_invalid` findings.
- Tests updated + association test; 64 rigs tests pass.

## REAL numbers (live WP Codebox run, 15-saas + 38-medical-clinic; editor opened the real imported posts)
| fixture | total_blocks | valid | invalid |
|---|---|---|---|
| 15-saas | 249 | 203 | 46 |
| 38-medical-clinic | 204 | 169 | 35 |

Summary: `editor_valid_block_rate: 0.821`, `invalid_block_count: 81` across 453 blocks. Previously `total_blocks: 0`. **This surfaces a real ~18%% invalid-block rate the gate was blind to.**

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Diagnosis, wiring, and live verification under human review.