### PR TITLE
Stage fixture source + target imported page in visual-parity proof layer (real mismatch ratio)

### DIFF
--- a/WordPress/static-site-importer/README.md
+++ b/WordPress/static-site-importer/README.md
@@ -256,19 +256,35 @@ threshold is configurable via `--pixel-threshold` /
 the per-pixel `threshold=` arg so a higher value loosens the gate monotonically).
 Set `--no-visual-parity` / `visualParity: false` to omit the step entirely.
 
-Live caveat (verified by a real local recipe-run): the `wordpress.visual-compare`
-step renders and pixel-diffs locally in WP Codebox, but the source/candidate URLs
-are not yet wired to the imported output. The step composes
-`source-url=/wp-content/uploads/static-site-importer-fixture-matrix/<id>/index.html`
-and `candidate-url=/` by default. The fixture source HTML is never staged into a
-servable path, so the source capture hangs until the 120s browser timeout and the
-comparison returns `stage: capture-failed` with no mismatch metrics; the candidate
-URL is the homepage, not the imported page. The wiring and the
-finding-parsing/threshold/gating logic are fully unit-tested in
-`tools/fixture-matrix.test.mjs`. The remaining live-run enablement is: (1) stage
-each fixture's source under a servable path (e.g. mount it into
-`wp-content/uploads/...`) and point `source-url` at it, and (2) resolve
-`candidate-url` to the imported post's permalink.
+Source/candidate wiring (verified by real local recipe-runs): the
+`wordpress.visual-compare` step renders and pixel-diffs locally in WP Codebox
+against the real two pages. `writeFixtureMatrixArtifacts` stages each fixture's
+ORIGINAL static source (index.html + css/js/images) into
+`<artifacts>/<id>/source/...`, and that artifacts directory is mounted into the
+sandbox at the WordPress uploads path, so the source is served by the same
+in-sandbox WordPress origin as the candidate. The step composes
+`source-url=/wp-content/uploads/static-site-importer-fixture-matrix/<id>/source/index.html`
+(served, HTTP 200) and `candidate-url=/`. Because each fixture's import step runs
+with `activate=true` — which sets `show_on_front=page` + `page_on_front` to the
+imported front page — and the recipe interleaves `[import, visual-compare]` per
+fixture, `/` resolves to THIS fixture's imported front page at capture time, the
+real imported WordPress output. A fixture can override `source_url`/`candidate_url`
+to target a specific staged page or imported permalink. The wiring,
+source-staging, finding-parsing, threshold, and gating logic are unit-tested in
+`tools/fixture-matrix.test.mjs`.
+
+Sandbox egress note: a captured page that references external resources (Google
+Fonts, CDNs) would otherwise hang an egress-free sandbox until the 120s browser
+timeout. `wordpress.visual-compare` aborts cross-origin requests during capture by
+default (`block-external-requests`, wp-codebox) so both source and candidate
+render deterministically (offline, system-font fallback) and the comparison
+completes fast. Real measured ratios (15-saas, 38-medical-clinic, default
+viewport): the imported candidate currently diverges sharply from the source
+(0.94 and 0.44 mismatch ratios with dimension drift) — dominated by oversized
+inline SVG icons that lose CSS sizing and a frontend theme stylesheet that is not
+applied to the rendered page. The gate is capture-only by default
+(`--visual-parity-gate` to enforce); at any reasonable `--pixel-threshold` these
+imports are nowhere near the 1:1 project gate.
 
 ## Running the matrix locally
 

--- a/WordPress/static-site-importer/lib/fixture-matrix.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix.mjs
@@ -35,6 +35,8 @@ export {
 export {
   buildFixtureArtifact,
   buildFixtureMatrixRecipe,
+  stageFixtureSource,
+  wordpressServedPath,
   normalizeStaticSiteImporterPlugin,
 } from './fixture-matrix/steps/recipe-builder.mjs';
 

--- a/WordPress/static-site-importer/lib/fixture-matrix/result.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/result.mjs
@@ -47,7 +47,7 @@ import {
   accumulateEditorQuality,
   finalizeEditorQuality,
 } from './collectors/quality-metrics.mjs';
-import { buildFixtureArtifact } from './steps/recipe-builder.mjs';
+import { buildFixtureArtifact, stageFixtureSource } from './steps/recipe-builder.mjs';
 
 export function normalizeFixtureMatrixResult(input = {}) {
   const matrix = input.matrix || createFixtureMatrix(input);
@@ -205,6 +205,9 @@ export function writeFixtureMatrixArtifacts(input = {}) {
     const fixtureDirectory = path.join(outputDirectory, fixture.id);
     fs.mkdirSync(fixtureDirectory, { recursive: true });
     writeJsonFile(path.join(fixtureDirectory, 'artifact.json'), buildFixtureArtifact(fixture, input));
+    // Stage the raw source site alongside artifact.json so the in-sandbox
+    // WordPress origin can serve it for the visual-parity `source-url`.
+    stageFixtureSource(fixture, fixtureDirectory, input);
   }
 
   writeJsonFile(path.join(outputDirectory, 'matrix.json'), matrix);

--- a/WordPress/static-site-importer/lib/fixture-matrix/shared/constants.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/shared/constants.mjs
@@ -80,8 +80,29 @@ export const NON_NATIVE_FALLBACK_BLOCK_NAMES = new Set([CORE_HTML_BLOCK_NAME, 'c
 export const LOW_NATIVE_CONVERSION_KIND = 'native_conversion_rate_below_min';
 
 export const DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD = 0.1;
+// Candidate (imported WordPress output) URL. The per-fixture import step runs
+// with activate=true, which sets `show_on_front=page` + `page_on_front` to the
+// imported front page (see Static_Site_Importer_Theme_Generator::front_page_id).
+// Because the recipe interleaves [import, editor-validate, visual-compare] per
+// fixture, `/` resolves to THIS fixture's imported front page at the moment the
+// visual-compare runs — the real imported page, not an unrelated WP homepage. A
+// fixture can still override `candidate_url`/`candidate-url` to target a specific
+// imported permalink (e.g. `/?page_id=<id>` or a pretty permalink).
 export const DEFAULT_VISUAL_PARITY_CANDIDATE_URL = '/';
+// Base web path under which the fixture's ORIGINAL static source is staged and
+// served by the SAME in-sandbox WordPress origin the candidate uses. The matrix
+// copies each fixture's raw source files (index.html + css/js/images) into
+// `<artifacts>/<fixture-id>/<VISUAL_PARITY_SOURCE_SUBDIR>/...`, and that artifacts
+// directory is mounted into the sandbox at the WordPress uploads path below, so
+// the files are reachable at `<base>/<fixture-id>/<subdir>/index.html`. Serving
+// the source from the same origin (rather than a host 127.0.0.1 port, which the
+// in-sandbox browser cannot reach) is what lets `source-url` actually load
+// instead of hanging to the 120s capture timeout.
 export const DEFAULT_VISUAL_PARITY_SOURCE_BASE_URL = '/wp-content/uploads/static-site-importer-fixture-matrix';
+// Subdirectory (under each fixture's artifacts dir) holding the staged raw source
+// site. Kept separate from the per-fixture `artifact.json` import payload so the
+// served source tree mirrors the fixture's own relative asset paths exactly.
+export const VISUAL_PARITY_SOURCE_SUBDIR = 'source';
 export const DEFAULT_VISUAL_PARITY_VIEWPORT = { width: 1280, height: 1600 };
 export const DEFAULT_VISUAL_PARITY_WAIT_FOR = 'domcontentloaded';
 // A finding only gates when it carries an explicit opt-in gate signal; absent

--- a/WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -11,6 +11,7 @@ import {
   WEBSITE_ARTIFACT_SCHEMA,
   DEFAULT_ENTRYPOINT,
   DEFAULT_IMPORTER_SLUG,
+  VISUAL_PARITY_SOURCE_SUBDIR,
 } from '../shared/constants.mjs';
 import {
   normalizeArray,
@@ -65,6 +66,30 @@ export function buildFixtureArtifact(fixture, options = {}) {
   };
 }
 
+// Stage a fixture's ORIGINAL static source (index.html + css/js/images) into the
+// matrix artifacts tree so the in-sandbox WordPress origin can serve it for the
+// visual-parity `source-url`. Files land at
+// `<fixtureDirectory>/<VISUAL_PARITY_SOURCE_SUBDIR>/<relative_path>`, preserving
+// each fixture's own relative asset layout so the served page resolves its CSS,
+// JS, and images exactly as the original did. The fixture's `artifact.json`
+// import payload is unchanged; this is a parallel, web-servable copy of the raw
+// source. Returns the list of staged relative paths. Without this, `source-url`
+// points at an unserved path and the visual-compare source capture hangs to the
+// 120s timeout (the #563 visual-parity gap).
+export function stageFixtureSource(fixture, fixtureDirectory, options = {}) {
+  const normalized = normalizeFixture(fixture);
+  const files = collectFixtureFiles(normalized.directory, options);
+  const sourceRoot = path.join(fixtureDirectory, VISUAL_PARITY_SOURCE_SUBDIR);
+  const staged = [];
+  for (const file of files) {
+    const destination = path.join(sourceRoot, file.relative_path);
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.copyFileSync(file.absolute_path, destination);
+    staged.push(file.relative_path);
+  }
+  return staged;
+}
+
 export function buildFixtureMatrixRecipe(input = {}) {
   const matrix = input.matrix || createFixtureMatrix(input);
   const artifactsDirectory = input.artifactsDirectory || input.artifacts_directory || '/artifacts/static-site-importer-fixture-matrix';
@@ -85,7 +110,19 @@ export function buildFixtureMatrixRecipe(input = {}) {
     waitTimeout: input.editorValidationWaitTimeout || input.editor_validation_wait_timeout,
   };
   const visualParityEnabled = input.visualParity !== false && input.visual_parity !== false;
-  const visualParityRecipeOptions = normalizeVisualParityRecipeOptions(input);
+  // Keep the visual-parity `source-url` base aligned with where the staged source
+  // is actually served from. The staged source lives in the artifacts dir mounted
+  // into the sandbox at `playgroundArtifactsDirectory`; its WordPress-served web
+  // path is that target with the docroot (`/wordpress`) prefix stripped. When the
+  // operator hasn't pinned an explicit source base url, derive it from the mount
+  // target so a custom uploads path still resolves.
+  const derivedSourceBaseUrl = playgroundArtifactsDirectory
+    ? wordpressServedPath(playgroundArtifactsDirectory)
+    : '';
+  const visualParityRecipeOptions = normalizeVisualParityRecipeOptions({
+    ...(derivedSourceBaseUrl ? { sourceBaseUrl: derivedSourceBaseUrl } : {}),
+    ...input,
+  });
 
   if (playgroundArtifactsDirectory) {
     mounts.push({
@@ -124,6 +161,16 @@ export function buildFixtureMatrixRecipe(input = {}) {
       directory: artifactsDirectory,
     },
   };
+}
+
+// Convert an in-sandbox WordPress filesystem path into its web-served path by
+// stripping the docroot prefix. WP Codebox installs WordPress at `/wordpress`, so
+// `/wordpress/wp-content/uploads/foo` is served at `/wp-content/uploads/foo`. A
+// path already rooted at `/wp-content` (no `/wordpress` prefix) is returned as-is.
+export function wordpressServedPath(filesystemPath, docroot = '/wordpress') {
+  const normalized = `/${String(filesystemPath).replace(/\\/g, '/').replace(/^\/+/, '').replace(/\/+$/, '')}`;
+  const prefix = `${docroot.replace(/\/+$/, '')}/`;
+  return normalized.startsWith(prefix) ? `/${normalized.slice(prefix.length)}` : normalized;
 }
 
 export function normalizeStaticSiteImporterPlugin(input = {}) {

--- a/WordPress/static-site-importer/lib/fixture-matrix/steps/visual-parity-step.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/steps/visual-parity-step.mjs
@@ -9,6 +9,7 @@ import {
   DEFAULT_VISUAL_PARITY_SOURCE_BASE_URL,
   DEFAULT_VISUAL_PARITY_VIEWPORT,
   DEFAULT_VISUAL_PARITY_WAIT_FOR,
+  VISUAL_PARITY_SOURCE_SUBDIR,
 } from '../shared/constants.mjs';
 import { objectValue, finiteNumber } from '../shared/utils.mjs';
 
@@ -19,18 +20,31 @@ import { objectValue, finiteNumber } from '../shared/utils.mjs';
 // separate sandbox. It renders the fixture's static source vs the imported
 // WordPress candidate and writes `source.png`/`candidate.png`/`diff.png` plus
 // the `mismatch_pixels`/`total_pixels` comparison that
-// `collectVisualParityDiagnostics` reads back out. Source/candidate URLs are
-// generic and configurable (with per-fixture overrides) — the exact servable
-// source URL is the remaining live-run wiring, mirroring how the #537 editor
-// step uses a configurable URL rather than resolving each imported post.
+// `collectVisualParityDiagnostics` reads back out.
+//
+// SOURCE URL: the raw fixture source is staged into the matrix artifacts tree at
+// `<fixture-id>/<VISUAL_PARITY_SOURCE_SUBDIR>/...` (see `stageFixtureSource`),
+// and that tree is mounted into the sandbox at the WordPress uploads path, so the
+// default `source-url` resolves to `<base>/<fixture-id>/source/<entry>` served by
+// the SAME in-sandbox WordPress origin as the candidate. The previous default
+// pointed at an unstaged path, so source capture hung to the 120s timeout.
+//
+// CANDIDATE URL: defaults to `/`, which (because each fixture's import step runs
+// with activate=true → `page_on_front` set, and the recipe interleaves import →
+// visual-compare per fixture) resolves to THIS fixture's imported front page at
+// capture time — the real imported WordPress output. Both URLs accept per-fixture
+// overrides (`source_url`/`candidate_url` on the fixture, or `sourceUrl`/
+// `candidateUrl` on the step input) to target a specific staged page or imported
+// permalink.
 export function visualParityCompareStep(input = {}) {
   const fixture = input.fixture || {};
   const options = normalizeVisualParityRecipeOptions(input);
+  const sourceEntry = `${VISUAL_PARITY_SOURCE_SUBDIR}/${String(options.sourceEntry).replace(/^\/+/, '')}`;
   const sourceUrl = input.sourceUrl
     || input.source_url
     || fixture.source_url
     || fixture.sourceUrl
-    || `${options.sourceBaseUrl.replace(/\/+$/, '')}/${fixture.id || 'fixture'}/${String(options.sourceEntry).replace(/^\/+/, '')}`;
+    || `${options.sourceBaseUrl.replace(/\/+$/, '')}/${fixture.id || 'fixture'}/${sourceEntry}`;
   const candidateUrl = input.candidateUrl
     || input.candidate_url
     || fixture.candidate_url

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -42,8 +42,10 @@ import {
   EDITOR_VALIDATION_METHOD,
   normalizeFixtureMatrixResult,
   normalizeLossClass,
+  stageFixtureSource,
   VISUAL_PARITY_MISMATCH_KIND,
   visualParityCompareStep,
+  wordpressServedPath,
   writeFixtureMatrixArtifacts,
 } from '../lib/fixture-matrix.mjs';
 import { materializeGeneratedArtifactFixtures } from '../lib/artifact-intake.mjs';
@@ -2063,6 +2065,63 @@ test('visualParityCompareStep composes the existing wordpress.visual-compare com
   assert.ok(step.args.includes('threshold=0.2'));
   assert.ok(step.args.includes('source-label=shop-source'));
   assert.ok(step.args.includes('candidate-label=shop-candidate'));
+});
+
+test('default visual-parity source-url targets the staged source/ subdir on the served uploads path', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-parity-source-url-test' });
+  const recipe = buildFixtureMatrixRecipe({
+    matrix,
+    artifactsDirectory: '/tmp/artifacts',
+    playgroundArtifactsDirectory: '/wordpress/wp-content/uploads/static-site-importer-fixture-matrix',
+    staticSiteImporterPath: '/tmp/static-site-importer',
+  });
+
+  // [activate, validate(simple-site), editor-validation(simple-site), visual-compare(simple-site)]
+  const visualStep = recipe.workflow.steps[3];
+  const sourceArg = visualStep.args.find((arg) => arg.startsWith('source-url='));
+  assert.equal(
+    sourceArg,
+    'source-url=/wp-content/uploads/static-site-importer-fixture-matrix/simple-site/source/index.html',
+  );
+  // Candidate defaults to the imported front page served at `/`.
+  assert.ok(visualStep.args.includes('candidate-url=/'));
+});
+
+test('stageFixtureSource copies the raw fixture source into the served source/ subdir', () => {
+  const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-parity-stage-'));
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-parity-stage-test' });
+  writeFixtureMatrixArtifacts({ outputDirectory, matrix });
+
+  const sourceDir = path.join(outputDirectory, 'simple-site', 'source');
+  // The fixture's own files (index.html + style.css) are served from source/,
+  // preserving their relative layout so assets resolve.
+  assert.ok(existsSync(path.join(sourceDir, 'index.html')), 'staged source index.html should exist');
+  assert.ok(existsSync(path.join(sourceDir, 'style.css')), 'staged source style.css should exist');
+  assert.equal(
+    readFileSync(path.join(sourceDir, 'index.html'), 'utf8'),
+    readFileSync(path.join(fixtureRoot, 'simple-site', 'index.html'), 'utf8'),
+  );
+  // The import payload (artifact.json) is still written alongside, unchanged.
+  assert.ok(existsSync(path.join(outputDirectory, 'simple-site', 'artifact.json')), 'artifact.json should still be written');
+});
+
+test('stageFixtureSource direct call returns staged relative paths', () => {
+  const fixtureDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-visual-parity-stage-direct-'));
+  const staged = stageFixtureSource(
+    { id: 'simple-site', directory: path.join(fixtureRoot, 'simple-site') },
+    fixtureDirectory,
+  );
+  assert.ok(staged.includes('index.html'));
+  assert.ok(existsSync(path.join(fixtureDirectory, 'source', 'index.html')));
+});
+
+test('wordpressServedPath strips the /wordpress docroot prefix', () => {
+  assert.equal(
+    wordpressServedPath('/wordpress/wp-content/uploads/foo'),
+    '/wp-content/uploads/foo',
+  );
+  // Already-served paths are returned normalized but unchanged in meaning.
+  assert.equal(wordpressServedPath('/wp-content/uploads/foo'), '/wp-content/uploads/foo');
 });
 
 test('(a) visual-compare mismatch at/under threshold produces no finding', () => {


### PR DESCRIPTION
## What
Makes the SSI fixture-matrix visual-parity proof layer produce a REAL pixelmatch mismatch ratio (source fixture page vs imported WP page) instead of timing out.

## Change
- `lib/fixture-matrix/steps/recipe-builder.mjs`: new `stageFixtureSource()` copies each fixture's raw source (index.html + assets, layout preserved) into the artifacts dir already mounted into the sandbox, so the source is served by the same in-sandbox WordPress origin as the candidate.
- `lib/fixture-matrix/steps/visual-parity-step.mjs`: `source-url` → staged `<id>/source/<entry>`; `candidate-url` stays `/` (correct: per-fixture import sets `page_on_front`, recipe interleaves import+compare). Constants + 4 unit tests (67 pass).
- Depends on wp-codebox #1612 (abort external requests) to avoid the external-font capture hang.

## REAL numbers (live run, 1280-wide, source vs imported)
- 15-saas: **0.945 mismatch** (dimension drift 1380×7248 → 1280×4977)
- 38-medical-clinic: **0.436 mismatch**

## What this reveals (the point of the gate)
Far from 1:1. Content imports structurally correct, but (a) inline SVG icons lose CSS sizing and balloon, and (b) **the imported theme's frontend stylesheet isn't applied** — the page renders as near-unstyled blocks. Capture-only by default (`--visual-parity-gate` to enforce), so this is real actionable fidelity signal, not a harness artifact.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Diagnosis, wiring, and live verification under human review.