### PR TITLE
Add Woo destructive fuzz workloads

### DIFF
--- a/woocommerce/woocommerce/manifests/aggressive-destructive-workloads.json
+++ b/woocommerce/woocommerce/manifests/aggressive-destructive-workloads.json
@@ -1,0 +1,196 @@
+{
+  "schema": "homeboy-rigs/woocommerce-aggressive-destructive-workloads/v1",
+  "id": "woocommerce-aggressive-destructive-workloads",
+  "profile_id": "aggressive-isolated-firehose",
+  "description": "WooCommerce-owned aggressive destructive workload declarations for offloaded WP Codebox isolation. These declarations provide Woo surface knowledge and fixture policy only; Homeboy, HBEX, and WP Codebox supply the generic execution, isolation, and artifact contracts.",
+  "execution_scope": "offloaded_codebox_homeboy_hbex_isolated_sandbox",
+  "local_execution_enabled": false,
+  "destructive_full_coverage_proven": false,
+  "source_manifests": {
+    "campaign": "manifests/aggressive-isolated-fuzz-campaign.json",
+    "route_family_catalog": "manifests/rest-crud-route-family-catalog.json",
+    "payload_fixtures": "manifests/rest-crud-payload-fixtures.json",
+    "fixture_plan": "manifests/rest-crud-fixture-plan.json",
+    "fixture_opt_ins": "manifests/rest-crud-fixture-opt-ins.json",
+    "sequence_packs": "manifests/product-chaos-sequence-packs.json"
+  },
+  "generic_contracts": [
+    "homeboy/destructive-isolated-mode/v1",
+    "homeboy/fuzz-execution-request-artifact/v1",
+    "homeboy/fuzz-coverage-reconciliation/v1",
+    "wp-codebox/destructive-fuzz-suite-metadata/v1",
+    "wp-codebox/snapshot-restore-artifact/v1",
+    "wp-codebox/mutation-isolation-artifact/v1",
+    "homeboy/wordpress-rest-mutation-rollback-contract/v1",
+    "wp-codebox/delete-boundary-artifact/v1",
+    "homeboy-rigs/external-side-effect-policy/v1"
+  ],
+  "readiness": {
+    "level": "executable_in_isolated_sandbox",
+    "execution_enabled": true,
+    "local_execution_enabled": false,
+    "proof_status": "requires_reviewer_facing_artifacts",
+    "coverage_contract": "Aggressive destructive workloads may run only through offloaded WP Codebox isolation with explicit destructive mode, fixture-owned dynamic IDs, rollback plans, rollback verification, and side-effect policy artifacts. No destructive case is proven by this manifest alone.",
+    "proof_bundle_requirements": {
+      "status": "required_before_proven",
+      "local_only_refs_allowed": false,
+      "placeholder_refs_allowed": false,
+      "required_refs": [
+        "reviewer-facing Codebox isolation readiness artifact ref",
+        "reviewer-facing snapshot restore artifact ref",
+        "reviewer-facing fixture dynamic ID artifact ref",
+        "reviewer-facing rollback plan artifact ref",
+        "reviewer-facing rollback verification artifact ref",
+        "reviewer-facing side-effect policy evidence artifact ref",
+        "reviewer-facing destructive case ledger artifact ref"
+      ],
+      "required_artifacts": [
+        "codebox_isolation_readiness",
+        "snapshot_restore_artifact",
+        "fixture_dynamic_id_manifest",
+        "rollback_plan",
+        "rollback_verification",
+        "side_effect_policy_evidence",
+        "destructive_case_ledger"
+      ]
+    }
+  },
+  "dynamic_id_policy": {
+    "scope": "fixture_owned_only",
+    "id_source": "runtime_fixture_artifacts",
+    "placeholder_ids_allowed": false,
+    "foreign_ids_allowed": false,
+    "required_artifact": "fixture_dynamic_id_manifest",
+    "required_fields": ["fixture_namespace", "created_ids", "route_parameter_bindings", "owner_case_id", "rollback_ref"]
+  },
+  "side_effect_policy": {
+    "live_external_effects_allowed": false,
+    "required_artifact": "side_effect_policy_evidence",
+    "surfaces": [
+      {
+        "id": "payment",
+        "policy": "isolated_mock_only_or_safe_skip",
+        "blocked_live_effects": ["payment authorization", "payment capture", "payment refund", "saved credential mutation"],
+        "allowed_evidence": ["safe_skip_artifact", "isolated_mock_execution_artifact"]
+      },
+      {
+        "id": "tax",
+        "policy": "safe_skip_or_isolated_builtin_rates_only",
+        "blocked_live_effects": ["external tax provider request", "credential-bearing tax account mutation"],
+        "allowed_evidence": ["safe_skip_artifact", "isolated_mock_execution_artifact"]
+      },
+      {
+        "id": "shipping",
+        "policy": "safe_skip_or_isolated_mock_rates_only",
+        "blocked_live_effects": ["carrier rate request", "label purchase", "tracking webhook mutation"],
+        "allowed_evidence": ["safe_skip_artifact", "isolated_mock_execution_artifact"]
+      },
+      {
+        "id": "webhook",
+        "policy": "safe_skip_or_loopback_only",
+        "blocked_live_effects": ["remote webhook delivery", "third-party callback registration"],
+        "allowed_evidence": ["safe_skip_artifact", "isolated_mock_execution_artifact"]
+      },
+      {
+        "id": "marketplace",
+        "policy": "safe_skip_only",
+        "blocked_live_effects": ["marketplace install", "extension purchase", "remote marketplace API mutation"],
+        "allowed_evidence": ["safe_skip_artifact"]
+      },
+      {
+        "id": "credential_bearing_settings",
+        "policy": "safe_skip_only",
+        "blocked_live_effects": ["API key write", "secret token write", "OAuth connection mutation", "account disconnect"],
+        "allowed_evidence": ["safe_skip_artifact"]
+      }
+    ]
+  },
+  "required_artifacts_per_workload": [
+    "codebox_isolation_readiness",
+    "snapshot_restore_artifact",
+    "fixture_dynamic_id_manifest",
+    "rollback_plan",
+    "rollback_verification",
+    "side_effect_policy_evidence",
+    "destructive_case_ledger"
+  ],
+  "workloads": [
+    {
+      "id": "product-variation-destructive-lifecycle",
+      "surfaces": ["products", "variations", "attributes", "terms"],
+      "fixture_family": "catalog-products-and-variations",
+      "route_families": ["products-collection", "products-batch", "product-variations-batch", "product-attributes-and-terms"],
+      "operations": ["create product", "create variation", "update price", "update stock", "update attributes", "delete variation", "delete product"],
+      "fixture_dynamic_ids": ["product_id", "variation_id", "attribute_id", "term_id", "category_id"],
+      "rollback_scope": ["wp_posts", "wp_postmeta", "terms", "term_taxonomy", "term_relationships", "wp_wc_product_meta_lookup"],
+      "required_artifacts": ["codebox_isolation_readiness", "snapshot_restore_artifact", "fixture_dynamic_id_manifest", "rollback_plan", "rollback_verification", "side_effect_policy_evidence", "destructive_case_ledger", "delete_boundary_artifact"],
+      "side_effect_surfaces": []
+    },
+    {
+      "id": "order-refund-destructive-lifecycle",
+      "surfaces": ["orders", "refunds", "order_notes"],
+      "fixture_family": "orders-coupons-customers",
+      "route_families": ["orders-collection", "orders-notes", "orders-refunds"],
+      "operations": ["create order", "status transition", "add note", "create refund candidate", "delete order"],
+      "fixture_dynamic_ids": ["order_id", "order_item_id", "refund_id", "order_note_id", "customer_id", "product_id"],
+      "rollback_scope": ["wp_wc_orders", "wp_wc_order_addresses", "wp_wc_order_operational_data", "wp_woocommerce_order_items", "wp_woocommerce_order_itemmeta", "wp_wc_order_stats", "wp_comments", "wp_commentmeta"],
+      "required_artifacts": ["codebox_isolation_readiness", "snapshot_restore_artifact", "fixture_dynamic_id_manifest", "rollback_plan", "rollback_verification", "side_effect_policy_evidence", "destructive_case_ledger", "delete_boundary_artifact"],
+      "side_effect_surfaces": ["payment", "tax"]
+    },
+    {
+      "id": "coupon-customer-destructive-lifecycle",
+      "surfaces": ["coupons", "customers", "usage_limits"],
+      "fixture_family": "orders-coupons-customers",
+      "route_families": ["coupons-collection", "customers-collection"],
+      "operations": ["create coupon", "create customer", "update billing", "apply coupon", "read usage counters", "delete coupon", "delete customer"],
+      "fixture_dynamic_ids": ["coupon_id", "coupon_code", "customer_id", "user_id", "cart_token", "order_id"],
+      "rollback_scope": ["wp_users", "wp_usermeta", "wp_posts", "wp_postmeta", "wp_wc_orders", "wp_wc_order_coupon_lookup"],
+      "required_artifacts": ["codebox_isolation_readiness", "snapshot_restore_artifact", "fixture_dynamic_id_manifest", "rollback_plan", "rollback_verification", "side_effect_policy_evidence", "destructive_case_ledger", "delete_boundary_artifact"],
+      "side_effect_surfaces": []
+    },
+    {
+      "id": "stock-inventory-destructive-lifecycle",
+      "surfaces": ["stock", "inventory", "lookup_tables", "low_stock_notifications"],
+      "fixture_family": "catalog-products-and-variations",
+      "route_families": ["products-collection", "products-batch", "product-variations-batch"],
+      "operations": ["set stock quantity", "toggle manage stock", "backorder transition", "reduce stock through checkout", "restore stock"],
+      "fixture_dynamic_ids": ["product_id", "variation_id", "order_id", "order_item_id", "stock_adjustment_ref"],
+      "rollback_scope": ["wp_postmeta", "wp_wc_product_meta_lookup", "wp_wc_order_product_lookup", "wp_actionscheduler_actions"],
+      "required_artifacts": ["codebox_isolation_readiness", "snapshot_restore_artifact", "fixture_dynamic_id_manifest", "rollback_plan", "rollback_verification", "side_effect_policy_evidence", "destructive_case_ledger"],
+      "side_effect_surfaces": ["webhook"]
+    },
+    {
+      "id": "cart-checkout-session-destructive-lifecycle",
+      "surfaces": ["cart", "checkout", "sessions", "shipping_packages"],
+      "fixture_family": "cart-checkout-store-api",
+      "route_families": ["store-api-cart", "store-api-checkout"],
+      "operations": ["create session", "add item", "update quantity", "apply coupon", "select shipping", "submit checkout", "reset session"],
+      "fixture_dynamic_ids": ["session_key", "cart_item_key", "cart_token", "nonce", "order_id", "shipping_rate_id"],
+      "rollback_scope": ["wp_woocommerce_sessions", "wp_wc_orders", "wp_wc_order_addresses", "wp_woocommerce_order_items", "wp_actionscheduler_actions"],
+      "required_artifacts": ["codebox_isolation_readiness", "snapshot_restore_artifact", "fixture_dynamic_id_manifest", "rollback_plan", "rollback_verification", "side_effect_policy_evidence", "destructive_case_ledger"],
+      "side_effect_surfaces": ["payment", "tax", "shipping"]
+    },
+    {
+      "id": "hpos-order-table-destructive-lifecycle",
+      "surfaces": ["hpos", "order_tables", "order_lookup_tables"],
+      "fixture_family": "orders-coupons-customers",
+      "route_families": ["orders-collection", "orders-refunds"],
+      "operations": ["create HPOS order", "mutate addresses", "mutate operational data", "create refund", "verify table cleanup"],
+      "fixture_dynamic_ids": ["order_id", "refund_id", "order_address_id", "operational_data_ref", "order_item_id"],
+      "rollback_scope": ["wp_wc_orders", "wp_wc_order_addresses", "wp_wc_order_operational_data", "wp_wc_orders_meta", "wp_wc_order_stats", "wp_wc_order_product_lookup", "wp_wc_order_coupon_lookup"],
+      "required_artifacts": ["codebox_isolation_readiness", "snapshot_restore_artifact", "fixture_dynamic_id_manifest", "rollback_plan", "rollback_verification", "side_effect_policy_evidence", "destructive_case_ledger", "database_observations"],
+      "side_effect_surfaces": ["payment", "tax"]
+    },
+    {
+      "id": "action-scheduler-destructive-lifecycle",
+      "surfaces": ["action_scheduler", "scheduled_jobs", "webhook_delivery_jobs"],
+      "fixture_family": "settings-reports-admin",
+      "route_families": [],
+      "operations": ["enqueue fixture action", "mutate action status", "run due fixture action", "cleanup action logs", "verify no leaked pending actions"],
+      "fixture_dynamic_ids": ["action_id", "group_id", "hook_name", "log_entry_id", "claim_id"],
+      "rollback_scope": ["wp_actionscheduler_actions", "wp_actionscheduler_claims", "wp_actionscheduler_groups", "wp_actionscheduler_logs"],
+      "required_artifacts": ["codebox_isolation_readiness", "snapshot_restore_artifact", "fixture_dynamic_id_manifest", "rollback_plan", "rollback_verification", "side_effect_policy_evidence", "destructive_case_ledger", "database_observations"],
+      "side_effect_surfaces": ["webhook", "marketplace", "credential_bearing_settings"]
+    }
+  ]
+}

--- a/woocommerce/woocommerce/manifests/aggressive-isolated-fuzz-campaign.json
+++ b/woocommerce/woocommerce/manifests/aggressive-isolated-fuzz-campaign.json
@@ -12,6 +12,7 @@
     "fixture_plan": "manifests/rest-crud-fixture-plan.json",
     "rest_mutation_fixture_opt_ins": "manifests/rest-crud-fixture-opt-ins.json",
     "product_chaos_sequence_packs": "manifests/product-chaos-sequence-packs.json",
+    "aggressive_destructive_workloads": "manifests/aggressive-destructive-workloads.json",
     "admin_actions": "manifests/admin-action-inventory.json",
     "block_inventory_rendering": "manifests/block-inventory-rendering-fuzz.json"
   },
@@ -180,6 +181,30 @@
       "schema": "homeboy/woocommerce-performance-hotspots-summary/v1",
       "semantic_key": "fuzz.relative_hotspots",
       "required_before_proven": true
+    },
+    {
+      "id": "side_effect_policy_evidence",
+      "schema": "homeboy-rigs/external-side-effect-policy/v1",
+      "semantic_key": "fuzz.side_effect_policy_evidence",
+      "required_before_proven": true
+    },
+    {
+      "id": "fixture_dynamic_id_manifest",
+      "schema": "wp-codebox/fixture-dynamic-id-manifest/v1",
+      "semantic_key": "fuzz.fixture_dynamic_ids",
+      "required_before_proven": true
+    },
+    {
+      "id": "rollback_verification",
+      "schema": "wp-codebox/rollback-verification/v1",
+      "semantic_key": "fuzz.rollback_verification",
+      "required_before_proven": true
+    },
+    {
+      "id": "destructive_case_ledger",
+      "schema": "homeboy/destructive-case-ledger/v1",
+      "semantic_key": "fuzz.destructive_case_ledger",
+      "required_before_proven": true
     }
   ],
   "fixture_families": [
@@ -262,11 +287,11 @@
     }
   ],
   "planned_case_groups": {
-    "sequence": ["product-lifecycle", "variation-lifecycle", "cart-mutation", "checkout-attempts", "order-mutation", "coupon-customer-interactions", "settings-report-admin-pages", "store-rest-cross-surface"],
+    "sequence": ["product-lifecycle", "variation-lifecycle", "cart-mutation", "checkout-attempts", "order-mutation", "coupon-customer-interactions", "stock-inventory-mutation", "hpos-order-table-mutation", "action-scheduler-mutation", "settings-report-admin-pages", "store-rest-cross-surface"],
     "route": ["wc/v3/products", "wc/v3/products/batch", "wc/v3/products/<product_id>/variations/batch", "wc/v3/orders", "wc/v3/coupons", "wc/v3/customers", "wc/store/v1/cart", "wc/store/v1/checkout"],
     "action": ["add-to-cart", "apply-coupon", "place-order", "order-status-transition", "admin-menu-get", "wc-ajax-frontend-action"],
     "query": ["catalog lookup", "cart/session lookup", "checkout totals", "order lookup", "analytics report", "coupon validation"],
-    "table": ["wp_posts", "wp_postmeta", "wp_wc_orders", "wp_wc_order_addresses", "wp_woocommerce_order_items", "wp_wc_product_meta_lookup", "wp_actionscheduler_actions"],
+    "table": ["wp_posts", "wp_postmeta", "wp_wc_orders", "wp_wc_order_addresses", "wp_wc_order_operational_data", "wp_wc_orders_meta", "wp_woocommerce_order_items", "wp_woocommerce_order_itemmeta", "wp_wc_product_meta_lookup", "wp_woocommerce_sessions", "wp_actionscheduler_actions", "wp_actionscheduler_claims", "wp_actionscheduler_groups", "wp_actionscheduler_logs"],
     "page": ["shop", "product", "cart", "checkout", "orders admin", "products admin", "analytics admin", "settings admin"],
     "block": ["woocommerce/product-collection", "woocommerce/cart", "woocommerce/checkout", "woocommerce/product-button", "woocommerce/product-price", "woocommerce/filter-wrapper"]
   },
@@ -298,9 +323,13 @@
         "reviewer-facing browser observation artifact ref",
         "reviewer-facing editor observation artifact ref",
         "reviewer-facing per-case timing artifact ref",
-        "reviewer-facing relative hotspots artifact ref"
+        "reviewer-facing relative hotspots artifact ref",
+        "reviewer-facing fixture dynamic ID manifest artifact ref",
+        "reviewer-facing rollback verification artifact ref",
+        "reviewer-facing side-effect policy evidence artifact ref",
+        "reviewer-facing destructive case ledger artifact ref"
       ],
-      "required_artifacts": ["destructive_isolated_mode_artifact", "fuzz_execution_request", "coverage_reconciliation", "destructive_fuzz_suite_metadata", "snapshot_restore_artifact", "rest_payload_family_coverage", "chaos_sequence_pack_resolution", "payload_size_depth_family_coverage", "relative_hotspot_taxonomy", "hbex_aggressive_isolated_mode_artifact", "admin_observations", "database_observations", "browser_observations", "editor_observations", "per_case_timing", "relative_hotspots"]
+      "required_artifacts": ["destructive_isolated_mode_artifact", "fuzz_execution_request", "coverage_reconciliation", "destructive_fuzz_suite_metadata", "snapshot_restore_artifact", "rest_payload_family_coverage", "chaos_sequence_pack_resolution", "payload_size_depth_family_coverage", "relative_hotspot_taxonomy", "hbex_aggressive_isolated_mode_artifact", "admin_observations", "database_observations", "browser_observations", "editor_observations", "per_case_timing", "relative_hotspots", "fixture_dynamic_id_manifest", "rollback_verification", "side_effect_policy_evidence", "destructive_case_ledger"]
     },
     "required_contracts": [
       "homeboy/destructive-isolated-mode/v1",

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -26,6 +26,8 @@ const generatedRestCases = JSON.parse(readFileSync(path.join(packageRoot, 'fuzz/
 const codeboxFuzzSuiteWorkload = JSON.parse(readFileSync(path.join(packageRoot, 'fuzz/codebox-fuzz-suite-contract.json'), 'utf8'));
 const codeboxFuzzSuiteManifest = JSON.parse(readFileSync(path.join(packageRoot, 'manifests/codebox-fuzz-suite-contract.json'), 'utf8'));
 const dbApiFuzzCampaign = JSON.parse(readFileSync(path.join(packageRoot, 'manifests/db-api-fuzz-campaign.json'), 'utf8'));
+const aggressiveIsolatedCampaign = JSON.parse(readFileSync(path.join(packageRoot, 'manifests/aggressive-isolated-fuzz-campaign.json'), 'utf8'));
+const aggressiveDestructiveWorkloads = JSON.parse(readFileSync(path.join(packageRoot, 'manifests/aggressive-destructive-workloads.json'), 'utf8'));
 const performanceHotspots = JSON.parse(readFileSync(path.join(packageRoot, 'fuzz/performance-hotspots-artifact-summary.json'), 'utf8'));
 const restDbQueryProfileWorkload = JSON.parse(readFileSync(path.join(packageRoot, 'bench/rest-db-query-profile.workload.json'), 'utf8'));
 const coverageGapReport = JSON.parse(readFileSync(path.join(packageRoot, 'fuzz/coverage-gap-report.json'), 'utf8'));
@@ -217,4 +219,108 @@ test('DB/API campaign consumes the declared Codebox fixture contract without pro
   assert.equal(codeboxFuzzSuiteWorkload.metadata.fixture.suite_manifest, '${package.root}/manifests/codebox-fuzz-suite-contract.json');
   assert.equal(codeboxFuzzSuiteManifest.target.metadata.proof_bundle, undefined);
   assert.equal(codeboxFuzzSuiteManifest.target.metadata.proof_bundle_requirements.status, 'required_before_proven');
+});
+
+test('aggressive destructive Woo workloads declare isolation, rollback, dynamic IDs, and side-effect policy gates', () => {
+  assert.equal(
+    aggressiveIsolatedCampaign.fixture_sources.aggressive_destructive_workloads,
+    'manifests/aggressive-destructive-workloads.json'
+  );
+  assert.equal(aggressiveDestructiveWorkloads.execution_scope, 'offloaded_codebox_homeboy_hbex_isolated_sandbox');
+  assert.equal(aggressiveDestructiveWorkloads.local_execution_enabled, false);
+  assert.equal(aggressiveDestructiveWorkloads.destructive_full_coverage_proven, false);
+  assert.equal(aggressiveDestructiveWorkloads.readiness.proof_bundle_requirements.status, 'required_before_proven');
+  assert.equal(aggressiveDestructiveWorkloads.dynamic_id_policy.scope, 'fixture_owned_only');
+  assert.equal(aggressiveDestructiveWorkloads.dynamic_id_policy.placeholder_ids_allowed, false);
+  assert.equal(aggressiveDestructiveWorkloads.dynamic_id_policy.foreign_ids_allowed, false);
+
+  const requiredWorkloadIds = new Set([
+    'product-variation-destructive-lifecycle',
+    'order-refund-destructive-lifecycle',
+    'coupon-customer-destructive-lifecycle',
+    'stock-inventory-destructive-lifecycle',
+    'cart-checkout-session-destructive-lifecycle',
+    'hpos-order-table-destructive-lifecycle',
+    'action-scheduler-destructive-lifecycle',
+  ]);
+  assert.deepEqual(new Set(aggressiveDestructiveWorkloads.workloads.map((workload) => workload.id)), requiredWorkloadIds);
+
+  const requiredArtifacts = new Set(aggressiveDestructiveWorkloads.required_artifacts_per_workload);
+  for (const artifact of [
+    'codebox_isolation_readiness',
+    'snapshot_restore_artifact',
+    'fixture_dynamic_id_manifest',
+    'rollback_plan',
+    'rollback_verification',
+    'side_effect_policy_evidence',
+    'destructive_case_ledger',
+  ]) {
+    assert.ok(requiredArtifacts.has(artifact), `global destructive workload artifact requirements must include ${artifact}`);
+  }
+
+  for (const workload of aggressiveDestructiveWorkloads.workloads) {
+    assert.ok(workload.fixture_family, `${workload.id} must bind to a fixture family`);
+    assert.ok(workload.fixture_dynamic_ids.length > 0, `${workload.id} must use fixture-owned dynamic IDs`);
+    assert.ok(workload.rollback_scope.length > 0, `${workload.id} must declare rollback scope`);
+    for (const artifact of requiredArtifacts) {
+      assert.ok(workload.required_artifacts.includes(artifact), `${workload.id} must require ${artifact}`);
+    }
+  }
+});
+
+test('aggressive destructive Woo workloads cover required destructive surface families', () => {
+  const workloadSurfaces = new Map(
+    aggressiveDestructiveWorkloads.workloads.map((workload) => [workload.id, new Set(workload.surfaces)])
+  );
+
+  assert.ok(workloadSurfaces.get('product-variation-destructive-lifecycle').has('variations'));
+  assert.ok(workloadSurfaces.get('order-refund-destructive-lifecycle').has('refunds'));
+  assert.ok(workloadSurfaces.get('coupon-customer-destructive-lifecycle').has('customers'));
+  assert.ok(workloadSurfaces.get('stock-inventory-destructive-lifecycle').has('inventory'));
+  assert.ok(workloadSurfaces.get('cart-checkout-session-destructive-lifecycle').has('sessions'));
+  assert.ok(workloadSurfaces.get('hpos-order-table-destructive-lifecycle').has('hpos'));
+  assert.ok(workloadSurfaces.get('action-scheduler-destructive-lifecycle').has('action_scheduler'));
+
+  const hposRollbackScope = new Set(
+    aggressiveDestructiveWorkloads.workloads.find((workload) => workload.id === 'hpos-order-table-destructive-lifecycle').rollback_scope
+  );
+  assert.ok(hposRollbackScope.has('wp_wc_orders'));
+  assert.ok(hposRollbackScope.has('wp_wc_order_addresses'));
+  assert.ok(hposRollbackScope.has('wp_wc_order_operational_data'));
+
+  const actionSchedulerRollbackScope = new Set(
+    aggressiveDestructiveWorkloads.workloads.find((workload) => workload.id === 'action-scheduler-destructive-lifecycle').rollback_scope
+  );
+  assert.ok(actionSchedulerRollbackScope.has('wp_actionscheduler_actions'));
+  assert.ok(actionSchedulerRollbackScope.has('wp_actionscheduler_claims'));
+  assert.ok(actionSchedulerRollbackScope.has('wp_actionscheduler_logs'));
+});
+
+test('external side-effect policy blocks live effects and requires skip or isolated mock evidence', () => {
+  assert.equal(aggressiveDestructiveWorkloads.side_effect_policy.live_external_effects_allowed, false);
+  assert.equal(aggressiveDestructiveWorkloads.side_effect_policy.required_artifact, 'side_effect_policy_evidence');
+
+  const policies = new Map(
+    aggressiveDestructiveWorkloads.side_effect_policy.surfaces.map((surface) => [surface.id, surface])
+  );
+  for (const policyId of ['payment', 'tax', 'shipping', 'webhook', 'marketplace', 'credential_bearing_settings']) {
+    const policy = policies.get(policyId);
+    assert.ok(policy, `${policyId} side-effect policy must be declared`);
+    assert.ok(policy.blocked_live_effects.length > 0, `${policyId} policy must list blocked live effects`);
+    assert.ok(policy.allowed_evidence.includes('safe_skip_artifact'), `${policyId} policy must allow safe skip evidence`);
+  }
+
+  assert.ok(policies.get('payment').allowed_evidence.includes('isolated_mock_execution_artifact'));
+  assert.deepEqual(policies.get('marketplace').allowed_evidence, ['safe_skip_artifact']);
+  assert.deepEqual(policies.get('credential_bearing_settings').allowed_evidence, ['safe_skip_artifact']);
+
+  for (const workload of aggressiveDestructiveWorkloads.workloads) {
+    for (const policyId of workload.side_effect_surfaces) {
+      assert.ok(policies.has(policyId), `${workload.id} references unknown side-effect policy ${policyId}`);
+      assert.ok(
+        workload.required_artifacts.includes(aggressiveDestructiveWorkloads.side_effect_policy.required_artifact),
+        `${workload.id} must require side-effect evidence when referencing ${policyId}`
+      );
+    }
+  }
 });

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -632,9 +632,13 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
     'database_observations',
     'admin_observations',
     'browser_observations',
-    'editor_observations',
-    'relative_hotspots',
-  ]);
+		'editor_observations',
+		'relative_hotspots',
+		'side_effect_policy_evidence',
+		'fixture_dynamic_id_manifest',
+		'rollback_verification',
+		'destructive_case_ledger',
+	]);
   assert.deepEqual(new Set((campaign.planned_artifact_expectations || []).map((artifact) => artifact.id)), expectedPlannedArtifacts, 'aggressive planned artifact expectations drifted');
   for (const artifact of campaign.planned_artifact_expectations || []) {
     assert.equal(typeof artifact.schema, 'string', `aggressive planned artifact ${artifact.id} requires schema`);
@@ -663,10 +667,14 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
   assert.equal(campaign.readiness?.proof_bundle, undefined, 'aggressive executable campaign must not carry proof refs before reviewer-facing artifacts exist');
   assertFuzzProofBundleRequirements(campaign.readiness?.proof_bundle_requirements, { file: 'aggressive-isolated-fuzz-campaign readiness' });
   assert.deepEqual(new Set(campaign.readiness?.proof_bundle_requirements?.required_artifacts || []), new Set([
-    ...(campaign.required_upstream_capabilities || []).map((capability) => capability.artifact),
-    'per_case_timing',
-    'relative_hotspots',
-  ]), 'aggressive proof artifacts must match upstream and planned capability artifacts');
+		...(campaign.required_upstream_capabilities || []).map((capability) => capability.artifact),
+		'per_case_timing',
+		'relative_hotspots',
+		'fixture_dynamic_id_manifest',
+		'rollback_verification',
+		'side_effect_policy_evidence',
+		'destructive_case_ledger',
+	]), 'aggressive proof artifacts must match upstream and planned capability artifacts');
   assert.equal(campaign.readiness?.upstream_blockers, undefined, 'aggressive campaign must not carry terminal upstream blockers');
   assert.deepEqual(new Set(campaign.readiness?.required_contracts || []), requiredContracts, 'aggressive campaign readiness required contracts drifted');
 


### PR DESCRIPTION
## Summary
- add aggressive destructive Woo workload declarations for CRUD, checkout/session, order/refund, customer/coupon, stock/inventory, HPOS/table, and scheduler surfaces
- wire the destructive workload manifest into the existing aggressive isolated campaign
- require isolation, rollback, dynamic identifiers, and external side-effect policy coverage in manifest tests

## Verification
- node --test "woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs"
- node -e 'for (const f of ["woocommerce/woocommerce/manifests/aggressive-isolated-fuzz-campaign.json", "woocommerce/woocommerce/manifests/aggressive-destructive-workloads.json"]) JSON.parse(require("node:fs").readFileSync(f, "utf8")); console.log("Woo destructive manifest JSON parse passed")'

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Preparing destructive workload declarations, validating manifest coverage, running verification, and drafting the PR.