### PR TITLE
Fix Woo aggressive fuzz command args

### DIFF
--- a/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs
+++ b/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs
@@ -17,11 +17,25 @@ const baseRunCommand = [
   'homeboy', 'fuzz', 'run',
   '--lab-only',
   '--rig', 'woocommerce-performance',
-  '--profile', manifest.profile_id,
   '--run-id', `${runIdPrefix}-request`,
   '--tracker-ref', options.trackerRef,
   '--allow-destructive',
   '--isolation', 'isolated',
+];
+
+if (options.runner) {
+  baseRunCommand.push('--runner', options.runner);
+}
+if (options.artifactRoot) {
+  baseRunCommand.push('--artifact-root', options.artifactRoot);
+}
+if (options.detachAfterHandoff) {
+  baseRunCommand.push('--detach-after-handoff');
+}
+
+baseRunCommand.push(
+  '--',
+  '--profile', manifest.profile_id,
   '--fuzz-execution-request-artifact',
   '--coverage-reconciliation',
   '--wp-codebox-destructive-fuzz-suite-metadata',
@@ -35,17 +49,7 @@ const baseRunCommand = [
   '--hbex-database-generation',
   '--hbex-browser-generation',
   '--hbex-editor-generation',
-];
-
-if (options.runner) {
-  baseRunCommand.push('--runner', options.runner);
-}
-if (options.artifactRoot) {
-  baseRunCommand.push('--artifact-root', options.artifactRoot);
-}
-if (options.detachAfterHandoff) {
-  baseRunCommand.push('--detach-after-handoff');
-}
+);
 
 const payload = {
   schema: 'homeboy-rigs/woocommerce-aggressive-firehose-command-plan/v1',

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -713,8 +713,12 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
   ]) {
     assert.ok(requestCommand.includes(flag), `aggressive command plan request must include ${flag}`);
   }
-  assert.equal(requestCommand[0], 'homeboy', 'aggressive command plan must use Homeboy');
-  assert.ok(!requestCommand.includes('--execute-local'), 'aggressive command plan must not include local execution');
+	assert.equal(requestCommand[0], 'homeboy', 'aggressive command plan must use Homeboy');
+	const extensionArgsIndex = requestCommand.indexOf('--');
+	assert.ok(extensionArgsIndex > 0, 'aggressive command plan must separate Homeboy flags from HBEX extension flags with --');
+	assert.ok(requestCommand.indexOf('--profile') > extensionArgsIndex, 'aggressive command plan profile flag must be passed as an HBEX extension arg');
+	assert.ok(requestCommand.indexOf('--runner') < extensionArgsIndex || !requestCommand.includes('--runner'), 'aggressive command plan runner flag must stay on the Homeboy side of --');
+	assert.ok(!requestCommand.includes('--execute-local'), 'aggressive command plan must not include local execution');
   assert.ok(!requestCommand.includes('--allow-local-fallback'), 'aggressive command plan must not allow local fallback');
   assertNoLocalOnlyRefs(campaign, 'aggressive-isolated-fuzz-campaign');
   assertNoProofPlaceholders(campaign, 'aggressive-isolated-fuzz-campaign');


### PR DESCRIPTION
## Summary
- move HBEX-specific aggressive firehose flags after the Homeboy `--` extension-arg separator
- keep Homeboy core flags such as `--runner`, `--run-id`, `--allow-destructive`, and `--isolation` before the separator
- validate the command-plan boundary so generated runnable commands are accepted by Homeboy core

## Verification
- `node scripts/lint-rig-packages.mjs`
- `node --test "woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs"`
- `node woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs --runner homeboy-lab --run-id-prefix woo-full-destructive-20260628 --tracker-ref pr:566 --json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the generated command failure, patching the command-plan boundary, running verification, and drafting the PR.
