### PR TITLE
Use rig check in Woo aggressive fuzz plan

### DIFF
--- a/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs
+++ b/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs
@@ -17,11 +17,25 @@ const baseRunCommand = [
   'homeboy', 'fuzz', 'run',
   '--lab-only',
   '--rig', 'woocommerce-performance',
-  '--profile', manifest.profile_id,
   '--run-id', `${runIdPrefix}-request`,
   '--tracker-ref', options.trackerRef,
   '--allow-destructive',
   '--isolation', 'isolated',
+];
+
+if (options.runner) {
+  baseRunCommand.push('--runner', options.runner);
+}
+if (options.artifactRoot) {
+  baseRunCommand.push('--artifact-root', options.artifactRoot);
+}
+if (options.detachAfterHandoff) {
+  baseRunCommand.push('--detach-after-handoff');
+}
+
+baseRunCommand.push(
+  '--',
+  '--profile', manifest.profile_id,
   '--fuzz-execution-request-artifact',
   '--coverage-reconciliation',
   '--wp-codebox-destructive-fuzz-suite-metadata',
@@ -35,17 +49,7 @@ const baseRunCommand = [
   '--hbex-database-generation',
   '--hbex-browser-generation',
   '--hbex-editor-generation',
-];
-
-if (options.runner) {
-  baseRunCommand.push('--runner', options.runner);
-}
-if (options.artifactRoot) {
-  baseRunCommand.push('--artifact-root', options.artifactRoot);
-}
-if (options.detachAfterHandoff) {
-  baseRunCommand.push('--detach-after-handoff');
-}
+);
 
 const payload = {
   schema: 'homeboy-rigs/woocommerce-aggressive-firehose-command-plan/v1',

--- a/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs
+++ b/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs
@@ -64,11 +64,11 @@ const payload = {
   blockers: executionSupported ? [] : [
     'manifest.readiness.execution_enabled must be true for offloaded execution',
   ],
-  plan_items: [
-    {
-      purpose: 'prepare_disposable_rig',
-      command_argv: withOptionalLabArgs(['homeboy', 'rig', 'up', 'woocommerce-performance'], options),
-    },
+	plan_items: [
+		{
+			purpose: 'validate_disposable_rig',
+			command_argv: withOptionalLabArgs(['homeboy', 'rig', 'check', 'woocommerce-performance'], options),
+		},
     {
       purpose: 'request_aggressive_isolated_firehose',
       command_argv: baseRunCommand,

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -690,8 +690,11 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
   assert.match(generatedAggressiveFirehoseTextPlan, /Offloaded Homeboy\/HBEX command plan/, 'text command plan must advertise offloaded execution');
   assert.match(generatedAggressiveFirehoseTextPlan, /^homeboy /m, 'default text command plan must print runnable homeboy commands');
   const generatedPlanItems = generatedAggressiveFirehoseCommandPlan.plan_items || [];
-  assert.ok(generatedPlanItems.length >= 3, 'aggressive firehose command plan must include prepare, request, and ref collection plan items');
-  const requestCommand = generatedPlanItems.find((entry) => entry.purpose === 'request_aggressive_isolated_firehose')?.command_argv || [];
+	assert.ok(generatedPlanItems.length >= 3, 'aggressive firehose command plan must include validation, request, and ref collection plan items');
+	const validationCommand = generatedPlanItems.find((entry) => entry.purpose === 'validate_disposable_rig')?.command_argv || [];
+	assert.deepEqual(validationCommand.slice(0, 3), ['homeboy', 'rig', 'check'], 'aggressive command plan must use Lab-portable rig check for validation');
+	assert.ok(!validationCommand.includes('up'), 'aggressive command plan must not emit local-only rig up');
+	const requestCommand = generatedPlanItems.find((entry) => entry.purpose === 'request_aggressive_isolated_firehose')?.command_argv || [];
   for (const flag of [
     '--lab-only',
     '--allow-destructive',

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -713,8 +713,12 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
   ]) {
     assert.ok(requestCommand.includes(flag), `aggressive command plan request must include ${flag}`);
   }
-  assert.equal(requestCommand[0], 'homeboy', 'aggressive command plan must use Homeboy');
-  assert.ok(!requestCommand.includes('--execute-local'), 'aggressive command plan must not include local execution');
+	assert.equal(requestCommand[0], 'homeboy', 'aggressive command plan must use Homeboy');
+	const extensionArgsIndex = requestCommand.indexOf('--');
+	assert.ok(extensionArgsIndex > 0, 'aggressive command plan must separate Homeboy flags from HBEX extension flags with --');
+	assert.ok(requestCommand.indexOf('--profile') > extensionArgsIndex, 'aggressive command plan profile flag must be passed as an HBEX extension arg');
+	assert.ok(requestCommand.indexOf('--runner') < extensionArgsIndex || !requestCommand.includes('--runner'), 'aggressive command plan runner flag must stay on the Homeboy side of --');
+	assert.ok(!requestCommand.includes('--execute-local'), 'aggressive command plan must not include local execution');
   assert.ok(!requestCommand.includes('--allow-local-fallback'), 'aggressive command plan must not allow local fallback');
   assertNoLocalOnlyRefs(campaign, 'aggressive-isolated-fuzz-campaign');
   assertNoProofPlaceholders(campaign, 'aggressive-isolated-fuzz-campaign');


### PR DESCRIPTION
## Summary
- replace the Woo aggressive firehose command-plan `rig up` step with Lab-portable `rig check`
- keep disposable runtime setup inside `homeboy fuzz run`, where Lab offload can safely materialize the rig/workspace
- validate that generated command plans do not emit local-only `rig up`

## Verification
- `node scripts/lint-rig-packages.mjs`
- `node --test "woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs"`
- `node woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs --runner homeboy-lab --run-id-prefix woo-full-destructive-20260628 --tracker-ref pr:566 --json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the non-portable generated `rig up` step, patching the command plan, running verification, and drafting the PR.
