### PR TITLE
Expand Woo aggressive fuzz profile commands

### DIFF
--- a/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs
+++ b/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs
@@ -6,50 +6,19 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
 const manifestPath = path.join(packageRoot, 'manifests/aggressive-isolated-fuzz-campaign.json');
+const rigPath = path.join(packageRoot, 'rigs/woocommerce-performance/rig.json');
 const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+const rig = JSON.parse(readFileSync(rigPath, 'utf8'));
 
 const options = parseArgs(process.argv.slice(2));
 const runIdPrefix = options.runIdPrefix || 'woo-firehose-$YYYYMMDD';
 const executionSupported = manifest.readiness?.execution_enabled === true;
 const runnableCommandsEnabled = executionSupported && !options.planOnly;
+const profileWorkloads = rig.fuzz_profiles?.[manifest.profile_id] || [];
 
-const baseRunCommand = [
-  'homeboy', 'fuzz', 'run',
-  '--lab-only',
-  '--rig', 'woocommerce-performance',
-  '--run-id', `${runIdPrefix}-request`,
-  '--tracker-ref', options.trackerRef,
-  '--allow-destructive',
-  '--isolation', 'isolated',
-];
-
-if (options.runner) {
-  baseRunCommand.push('--runner', options.runner);
+if (!Array.isArray(profileWorkloads) || profileWorkloads.length === 0) {
+  throw new Error(`Rig fuzz profile ${manifest.profile_id} must declare at least one workload`);
 }
-if (options.artifactRoot) {
-  baseRunCommand.push('--artifact-root', options.artifactRoot);
-}
-if (options.detachAfterHandoff) {
-  baseRunCommand.push('--detach-after-handoff');
-}
-
-baseRunCommand.push(
-  '--',
-  '--profile', manifest.profile_id,
-  '--fuzz-execution-request-artifact',
-  '--coverage-reconciliation',
-  '--wp-codebox-destructive-fuzz-suite-metadata',
-  '--rest-payload-families',
-  '--chaos-sequence-packs',
-  '--payload-size-depth-families',
-  '--relative-hotspot-taxonomy',
-  '--snapshot-restore',
-  '--hbex-aggressive-isolated-mode',
-  '--hbex-admin-generation',
-  '--hbex-database-generation',
-  '--hbex-browser-generation',
-  '--hbex-editor-generation',
-);
 
 const payload = {
   schema: 'homeboy-rigs/woocommerce-aggressive-firehose-command-plan/v1',
@@ -61,18 +30,19 @@ const payload = {
   runnable_commands_enabled: runnableCommandsEnabled,
   plan_kind: runnableCommandsEnabled ? 'runnable_offloaded_commands' : 'offloaded_command_plan',
   run_id_prefix: runIdPrefix,
+  workload_ids: profileWorkloads,
   blockers: executionSupported ? [] : [
     'manifest.readiness.execution_enabled must be true for offloaded execution',
   ],
-	plan_items: [
-		{
-			purpose: 'validate_disposable_rig',
-			command_argv: withOptionalLabArgs(['homeboy', 'rig', 'check', 'woocommerce-performance'], options),
-		},
+  plan_items: [
     {
-      purpose: 'request_aggressive_isolated_firehose',
-      command_argv: baseRunCommand,
+      purpose: 'validate_disposable_rig',
+      command_argv: withOptionalLabArgs(['homeboy', 'rig', 'check', 'woocommerce-performance'], options),
     },
+    ...profileWorkloads.map((workloadId, index) => ({
+      purpose: `request_aggressive_isolated_firehose:${workloadId}`,
+      command_argv: fuzzRunCommandForWorkload(workloadId, index, options),
+    })),
     {
       purpose: 'collect_reviewer_facing_artifact_refs',
       command_argv: withOptionalLabArgs([
@@ -182,6 +152,49 @@ function parseArgs(argv) {
   }
 
   return parsed;
+}
+
+function fuzzRunCommandForWorkload(workloadId, index, options) {
+  const command = [
+    'homeboy', 'fuzz', 'run',
+    '--lab-only',
+    '--rig', 'woocommerce-performance',
+    '--workload', workloadId,
+    '--run-id', `${runIdPrefix}-${String(index + 1).padStart(2, '0')}-${workloadId}`,
+    '--tracker-ref', options.trackerRef,
+    '--allow-destructive',
+    '--isolation', 'isolated',
+  ];
+
+  if (options.runner) {
+    command.push('--runner', options.runner);
+  }
+  if (options.artifactRoot) {
+    command.push('--artifact-root', options.artifactRoot);
+  }
+  if (options.detachAfterHandoff) {
+    command.push('--detach-after-handoff');
+  }
+
+  command.push(
+    '--',
+    '--profile', manifest.profile_id,
+    '--fuzz-execution-request-artifact',
+    '--coverage-reconciliation',
+    '--wp-codebox-destructive-fuzz-suite-metadata',
+    '--rest-payload-families',
+    '--chaos-sequence-packs',
+    '--payload-size-depth-families',
+    '--relative-hotspot-taxonomy',
+    '--snapshot-restore',
+    '--hbex-aggressive-isolated-mode',
+    '--hbex-admin-generation',
+    '--hbex-database-generation',
+    '--hbex-browser-generation',
+    '--hbex-editor-generation',
+  );
+
+  return command;
 }
 
 function withOptionalLabArgs(command, options) {

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -684,7 +684,10 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
   assert.equal(generatedAggressiveFirehoseCommandPlan.runnable_commands_enabled, true, 'aggressive firehose command plan must default to runnable offloaded output');
   assert.equal(generatedAggressiveFirehoseCommandPlan.plan_kind, 'runnable_offloaded_commands', 'aggressive firehose command plan must default to runnable offloaded commands');
   assert.equal(generatedAggressiveFirehoseCommandPlan.profile_id, campaign.profile_id, 'aggressive firehose command plan profile id drifted');
-  assert.ok(generatedAggressiveFirehoseCommandPlan.commands.length >= 3, 'aggressive firehose command plan must emit runnable commands by default');
+  const aggressiveProfileWorkloads = rig.fuzz_profiles?.[campaign.profile_id] || [];
+  assert.ok(aggressiveProfileWorkloads.length > 0, 'aggressive profile must declare workload ids');
+  assert.equal(generatedAggressiveFirehoseCommandPlan.commands.length, aggressiveProfileWorkloads.length + 2, 'aggressive firehose command plan must emit one request command per workload plus validation/ref collection');
+  assert.deepEqual(generatedAggressiveFirehoseCommandPlan.workload_ids, aggressiveProfileWorkloads, 'aggressive firehose command plan workload ids drifted');
   assert.equal(generatedAggressiveFirehosePlanOnly.runnable_commands_enabled, false, '--plan-only must withhold runnable command arrays');
   assert.deepEqual(generatedAggressiveFirehosePlanOnly.commands, [], '--plan-only aggressive firehose command plan must withhold runnable commands');
   assert.match(generatedAggressiveFirehoseTextPlan, /Offloaded Homeboy\/HBEX command plan/, 'text command plan must advertise offloaded execution');
@@ -694,7 +697,10 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
 	const validationCommand = generatedPlanItems.find((entry) => entry.purpose === 'validate_disposable_rig')?.command_argv || [];
 	assert.deepEqual(validationCommand.slice(0, 3), ['homeboy', 'rig', 'check'], 'aggressive command plan must use Lab-portable rig check for validation');
 	assert.ok(!validationCommand.includes('up'), 'aggressive command plan must not emit local-only rig up');
-	const requestCommand = generatedPlanItems.find((entry) => entry.purpose === 'request_aggressive_isolated_firehose')?.command_argv || [];
+  const requestItems = generatedPlanItems.filter((entry) => entry.purpose?.startsWith('request_aggressive_isolated_firehose:'));
+  assert.equal(requestItems.length, aggressiveProfileWorkloads.length, 'aggressive command plan must include one request item per aggressive workload');
+  assert.deepEqual(new Set(requestItems.map((entry) => entry.command_argv?.[entry.command_argv.indexOf('--workload') + 1])), new Set(aggressiveProfileWorkloads), 'aggressive command plan request workloads drifted');
+	const requestCommand = requestItems[0]?.command_argv || [];
   for (const flag of [
     '--lab-only',
     '--allow-destructive',
@@ -717,6 +723,7 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
     assert.ok(requestCommand.includes(flag), `aggressive command plan request must include ${flag}`);
   }
 	assert.equal(requestCommand[0], 'homeboy', 'aggressive command plan must use Homeboy');
+	assert.ok(requestCommand.includes('--workload'), 'aggressive command plan request must select a concrete Homeboy workload');
 	const extensionArgsIndex = requestCommand.indexOf('--');
 	assert.ok(extensionArgsIndex > 0, 'aggressive command plan must separate Homeboy flags from HBEX extension flags with --');
 	assert.ok(requestCommand.indexOf('--profile') > extensionArgsIndex, 'aggressive command plan profile flag must be passed as an HBEX extension arg');


### PR DESCRIPTION
## Summary
- expand the Woo aggressive firehose profile into concrete `homeboy fuzz run --workload <id>` commands
- keep profile metadata as an HBEX extension argument while satisfying Homeboy core workload selection
- validate that every generated aggressive request command selects one declared workload

## Verification
- `node scripts/lint-rig-packages.mjs`
- `node --test "woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs"`
- `node woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs --runner homeboy-lab --run-id-prefix woo-full-destructive-20260628 --tracker-ref pr:566 --json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Diagnosing the profile-only runtime failure, expanding the command plan, running verification, and drafting the PR.
