### PR TITLE
Matrix exercises product base64 payload encoding (close coverage gap that hid empty style.css)

### DIFF
--- a/WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -15,7 +15,6 @@ import {
 } from '../shared/constants.mjs';
 import {
   normalizeArray,
-  isTextPayloadType,
   isImagePath,
   requiredString,
   shellToken,
@@ -27,20 +26,26 @@ import { visualParityCompareStep, normalizeVisualParityRecipeOptions } from './v
 export function buildFixtureArtifact(fixture, options = {}) {
   const normalized = normalizeFixture(fixture);
   const files = collectFixtureFiles(normalized.directory, options);
+  // Encode EVERY file as `content_base64`, byte-for-byte matching the real
+  // product path. The SSI `import-theme` CLI (static-site-importer.php) reads
+  // each source file and emits `'content_base64' => base64_encode( $content )`
+  // unconditionally — there is no plain-`content` branch in the product. The
+  // matrix previously diverged here, base64-encoding only binary payloads and
+  // sending text (CSS/HTML/JS/JSON/SVG) as plain `content`. That divergence hid
+  // a catastrophic transformer bug: inline CSS was dropped only on the base64
+  // path, so a real import shipped an empty `style.css` (unstyled site) while
+  // the matrix's plain-content artifacts passed green. Mirroring the product's
+  // encoding exactly means the gate can never again exercise a payload shape the
+  // product does not actually produce.
   const artifactFiles = files.map((file) => {
     const payload = fs.readFileSync(file.absolute_path);
-    const artifactFile = {
+    return {
       path: `website/${file.relative_path}`,
       source_path: file.absolute_path,
       type: file.type,
       bytes: file.bytes,
+      content_base64: payload.toString('base64'),
     };
-    if (isTextPayloadType(file.type)) {
-      artifactFile.content = payload.toString('utf8');
-    } else {
-      artifactFile.content_base64 = payload.toString('base64');
-    }
-    return artifactFile;
   });
 
   return {

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -35,6 +35,7 @@ import {
   computeFixtureEditorQuality,
   parseSerializedBlockNames,
   collectVisualParityDiagnostics,
+  buildFixtureArtifact,
   createFixtureMatrix,
   editorBlockValidationStep,
   EDITOR_INVALID_BLOCK_SELECTOR_GROUP,
@@ -63,9 +64,38 @@ test('discovers SSI fixtures and writes Blocks Engine site artifacts', () => {
   assert.equal(matrix.count, 1);
   assert.equal(matrix.fixtures[0].id, 'simple-site');
   assert.equal(artifact.schema, 'blocks-engine/php-transformer/site-artifact/v1');
-  assert.ok(artifact.files.some((file) => file.path === 'website/index.html' && file.content.includes('Simple SSI Fixture')));
+  // Files are base64-encoded exactly like the product's `import-theme` CLI, so
+  // hydrate via `content_base64` to read the payload.
+  const indexFile = artifact.files.find((file) => file.path === 'website/index.html');
+  assert.ok(indexFile);
+  assert.ok(Buffer.from(indexFile.content_base64, 'base64').toString('utf8').includes('Simple SSI Fixture'));
   assert.ok(artifact.files.some((file) => file.path === 'website/style.css'));
   assert.equal(written.result.summary.not_run, 1);
+});
+
+test('matrix artifacts use the product base64 encoding for EVERY payload, including text', () => {
+  // Guards the smoke-test-theater regression: the matrix must build artifacts
+  // with the SAME `content_base64` encoding the real SSI `import-theme` CLI
+  // emits (static-site-importer.php base64-encodes every file unconditionally).
+  // A plain-`content` text payload here means the gate is exercising a path the
+  // product never produces — exactly how an empty-style.css bug stayed green.
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'base64-contract' });
+  const artifact = buildFixtureArtifact(matrix.fixtures[0]);
+
+  assert.ok(artifact.files.length >= 2);
+  for (const file of artifact.files) {
+    // Every file carries base64 content and NO plain `content` field, matching
+    // the product contract byte-for-byte.
+    assert.equal(typeof file.content_base64, 'string', `${file.path} must be base64-encoded`);
+    assert.equal(file.content, undefined, `${file.path} must not use a plain content field`);
+  }
+
+  // The text CSS payload (the exact class that hid the dropped-inline-CSS bug)
+  // round-trips through base64 to its real bytes.
+  const cssFile = artifact.files.find((file) => file.path === 'website/style.css');
+  assert.ok(cssFile);
+  assert.equal(cssFile.type, 'text/css');
+  assert.ok(Buffer.from(cssFile.content_base64, 'base64').toString('utf8').includes('.site-shell'));
 });
 
 test('builds a generic WP Codebox recipe with SSI-owned plugin defaults', () => {


### PR DESCRIPTION
## What
Closes the test-coverage gap that hid the empty-`style.css` bug for an entire iteration cycle. The SSI fixture-matrix built artifacts with plain `content`, but the real `import-theme` CLI base64-encodes **every** file (`content_base64`, no plain branch). Inline CSS was dropped only on the base64 path, so the plain-content matrix passed green while real imports shipped unstyled sites.

## Change
- `lib/fixture-matrix/steps/recipe-builder.mjs` (`buildFixtureArtifact`): base64-encode every file into `content_base64` with no plain `content` field — byte-shape identical to the product CLI. Removed the now-unused `isTextPayloadType` plain-text branch.
- `tools/fixture-matrix.test.mjs`: assertion updated to hydrate via `content_base64`; new test asserting every payload (incl. text CSS — the class that hid the bug) is base64 with no plain field and round-trips correctly.

## Why option (a) not (b)
The matrix's `artifact.json` IS the product contract fed to `validate-artifact`; only the encoding diverged. Replicating the exact encoding makes the test path byte-identical to the product for the dimension that broke, without swapping the gate's driver (the real `import-theme` builds artifacts inside the sandbox and would discard the gate's result semantics).

## Verification
- `node --test tools/*.test.mjs` → 69 pass. `lint-rig-packages` → passed.
- Coordination: pair with the blocks-engine base64-decode fix. Until that lands, an in-sandbox matrix import on the base64 path correctly reproduces the empty-`style.css` (the gate catching the bug); after it merges, end-to-end passes. No shim added.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Gap analysis and the coverage fix under human review.
