### PR TITLE
Make static-style parity the primary gate; demote pixelmatch to opt-in

### DIFF
--- a/WordPress/static-site-importer/lib/fixture-matrix/steps/visual-parity-step.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/steps/visual-parity-step.mjs
@@ -2,6 +2,17 @@
 //
 // Extracted verbatim from the former `lib/fixture-matrix.mjs` monolith as part
 // of the matrix modularization (Refs #242).
+//
+// PRIMARY PARITY SIGNAL: the deterministic, render-free static style parity gate
+// (blocks-engine php-transformer `composer static-parity`) is the primary parity
+// signal — same inputs yield a byte-identical 0..1 score plus a per-element /
+// per-property diff, with no rasterization, no dimension-sensitivity, and no OOM.
+// This full-page pixelmatch step is DEMOTED to optional visual EVIDENCE: it is
+// non-gating by default (see findings.mjs `resolveLossAcceptance`) and now also
+// captures a bounded viewport by default rather than a full-page screenshot,
+// because unbounded full-page capture OOM'd on tall (~6000px) pages. Full-page
+// capture remains available per-fixture via an explicit `full_page`/`fullPage`
+// opt-in.
 
 import {
   DEFAULT_VISUAL_PARITY_PIXEL_THRESHOLD,
@@ -11,7 +22,7 @@ import {
   DEFAULT_VISUAL_PARITY_WAIT_FOR,
   VISUAL_PARITY_SOURCE_SUBDIR,
 } from '../shared/constants.mjs';
-import { objectValue, finiteNumber } from '../shared/utils.mjs';
+import { objectValue, finiteNumber, isTruthySignal } from '../shared/utils.mjs';
 
 // Compose the existing `wordpress.visual-compare` recipe command into a
 // per-fixture visual-parity step. This is the same command the reusable
@@ -76,7 +87,10 @@ export function normalizeVisualParityRecipeOptions(input = {}) {
       width: finiteNumber(viewport.width, DEFAULT_VISUAL_PARITY_VIEWPORT.width),
       height: finiteNumber(viewport.height, DEFAULT_VISUAL_PARITY_VIEWPORT.height),
     },
-    fullPage: input.visualParityFullPage !== false && input.visual_parity_full_page !== false && input.fullPage !== false,
+    // Demoted to optional evidence: full-page capture is opt-in (default false)
+    // so the OOM-prone unbounded screenshot is never the default. Any truthy
+    // `full_page`/`fullPage`/`visual_parity_full_page` re-enables it per fixture.
+    fullPage: isTruthySignal(input.visualParityFullPage ?? input.visual_parity_full_page ?? input.fullPage),
     waitFor: input.visualParityWaitFor || input.visual_parity_wait_for || input.waitFor || DEFAULT_VISUAL_PARITY_WAIT_FOR,
   };
 }

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -2247,6 +2247,22 @@ test('visualParityCompareStep composes the existing wordpress.visual-compare com
   assert.ok(step.args.includes('candidate-label=shop-candidate'));
 });
 
+test('visualParityCompareStep demotes full-page capture to an opt-in (default bounded viewport)', () => {
+  // Default: full-page is OFF (the OOM-prone unbounded screenshot is no longer
+  // the default; the deterministic static parity gate is the primary signal).
+  const defaultStep = visualParityCompareStep({ fixture: { id: 'tall' } });
+  assert.ok(defaultStep.args.includes('full-page=false'));
+
+  // Opt-in per fixture re-enables full-page evidence.
+  for (const optIn of [
+    { fixture: { id: 'tall' }, fullPage: true },
+    { fixture: { id: 'tall' }, visual_parity_full_page: true },
+    { fixture: { id: 'tall' }, visualParityFullPage: true },
+  ]) {
+    assert.ok(visualParityCompareStep(optIn).args.includes('full-page=true'));
+  }
+});
+
 test('default visual-parity source-url targets the staged source/ subdir on the served uploads path', () => {
   const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'visual-parity-source-url-test' });
   const recipe = buildFixtureMatrixRecipe({


### PR DESCRIPTION
## What
Makes the deterministic static-style parity signal the PRIMARY gate in the SSI fixture matrix and demotes flaky full-page pixelmatch to opt-in. Pairs with the blocks-engine static-style-parity-gate PR.

## Change
- `lib/fixture-matrix/steps/visual-parity-step.mjs`: full-page pixelmatch `full-page` default -> false (fixes the tall-page screenshot OOM root cause; was already non-gating by default). Pixelmatch retained as opt-in evidence. Render-free static parity (`composer static-parity`, gate-ready via `--fail-under`) is now the documented primary signal.
- Added a test for the demoted default + per-fixture opt-in.

## Verification
- `node --test fixture-matrix.test.mjs`: 74/74 pass; `node --check` clean.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Gate wiring + tests under human review.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Design, implementation, and determinism/reliability verification under human review.