### PR TITLE
Isolate per-fixture failures in the SSI matrix lane (stop whole-run discard)

### DIFF
--- a/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
+++ b/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
@@ -17,10 +17,14 @@ import {
 
 const DEFAULT_BATCH_SIZE = 10;
 // Each batch provisions its own WP Codebox sandbox, so batches are independent
-// and safe to fan out in parallel. Default to a modest pool so a local run does
-// not stampede the sandbox provider; the hard cap bounds even an explicit
-// override so a fat-fingered `--concurrency 500` can not exhaust the host.
-const DEFAULT_BATCH_CONCURRENCY = 4;
+// and safe to fan out in parallel. A single live sandbox costs ~3.3GB host RSS,
+// but RSS grows superlinearly when several overlap (a measured `--concurrency 4`
+// run peaked near 65GB and OOM-pressured the host). Default to 2 so a plain run
+// still gets parallel speedup while staying within a few GB of headroom; the
+// hard cap bounds even an explicit override so a fat-fingered `--concurrency 500`
+// can not exhaust the host. Operators with RAM to spare can raise `--concurrency`
+// up to the cap.
+const DEFAULT_BATCH_CONCURRENCY = 2;
 const MAX_BATCH_CONCURRENCY = 16;
 const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 
@@ -40,11 +44,22 @@ async function main() {
 
 export default async function runFixtureMatrixBench() {
   const options = { ...optionsFromEnv(), ...parseArgs(process.argv.slice(2)) };
-  const { summary, runtimeError } = await runFixtureMatrix(options);
-  if (runtimeError) {
-    attachChildCommandFailures(runtimeError, summary.runtime?.child_command_failures || []);
-    throw runtimeError;
-  }
+  // Per-fixture / per-batch failures (PHP OOM in collect_artifacts, capture
+  // failures, child timeouts) are already isolated inside `runFixtureMatrix`:
+  // each failing batch is recorded as failed fixtures and folded into the
+  // aggregate while sibling batches still run (see
+  // `runFixtureMatrixBatch`/`mapWithConcurrency`). Re-throwing `runtimeError`
+  // here would make the bench harness treat the entire lane as a hard
+  // assertion_failure and DISCARD the run -- losing the aggregate and every
+  // survivor from the batches that succeeded. Instead, always return the
+  // aggregated metrics so the lane records the partial result; the rig's
+  // `failed_fixture_count <= 0` result-gate then fails the run (because failed
+  // fixtures are counted) WITHOUT discarding it, and `summarizeBenchRun` emits
+  // the operator summary on that gate-FAIL. child_command_failures stay in
+  // metadata so the failing batch remains attributable. Genuine pre-aggregate
+  // setup failures (missing fixtures, composer install) still throw out of
+  // `runFixtureMatrix` and legitimately abort the lane.
+  const { summary } = await runFixtureMatrix(options);
 
   const resultSummary = summary.result_summary || {};
   return {
@@ -68,6 +83,9 @@ export default async function runFixtureMatrixBench() {
       output_directory: summary.output_directory,
       result_summary: summary.result_summary,
       runtime: summary.runtime,
+      // Surface failing batches at the top level (also nested in runtime) so a
+      // gate-FAIL run stays attributable without re-reading the runtime block.
+      ...(summary.child_command_failures?.length ? { child_command_failures: summary.child_command_failures } : {}),
     },
   };
 }
@@ -447,13 +465,6 @@ function runtimeSummary(runtime, runtimeError) {
     ...(runtime.childCommandFailures?.length ? { child_command_failures: runtime.childCommandFailures } : {}),
     error: runtimeError ? runtimeError.message : '',
   };
-}
-
-function attachChildCommandFailures(error, childCommandFailures) {
-  if (!childCommandFailures.length) {
-    return;
-  }
-  error.child_command_failures = childCommandFailures;
 }
 
 function buildWpCodeboxChildCommandFailure({ error, batchNumber, batchSuffix, batchRecipeFile, outputFile, artifactsDir, wpCodeboxBin: bin, artifactRefs }) {

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -904,16 +904,17 @@ module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
     process.env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH = staticSiteImporter;
     process.env.SSI_FIXTURE_MATRIX_RUN = '1';
     process.env.SSI_FIXTURE_MATRIX_BATCH_SIZE = '1';
-    await assert.rejects(
-      () => runFixtureMatrixBench(),
-      (error) => {
-        assert.match(error.message, /^recipe-run failed/);
-        assert.match(error.message, /stderr:\nstderr line 1\nstderr line 2/);
-        assert.equal(error.child_command_failures[0].exit_status, 17);
-        assert.equal(error.child_command_failures[0].artifact_refs.artifacts_directory, process.env.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY);
-        return true;
-      }
-    );
+    // A failing batch must NOT make the bench reject: rejecting makes the harness
+    // discard the whole lane as an assertion_failure. Instead the bench returns
+    // the aggregate with the failed fixture counted (so the
+    // `failed_fixture_count <= 0` result-gate fails the run without discarding it)
+    // and keeps the child-command failure in metadata for attribution.
+    const benchResult = await runFixtureMatrixBench();
+    assert.equal(benchResult.metrics.fixture_count, 1);
+    assert.equal(benchResult.metrics.passed_fixture_count, 0);
+    assert.equal(benchResult.metrics.failed_fixture_count, 1);
+    assert.equal(benchResult.metadata.child_command_failures[0].exit_status, 17);
+    assert.equal(benchResult.metadata.child_command_failures[0].artifact_refs.artifacts_directory, process.env.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY);
   } finally {
     if (previousHelper === undefined) {
       delete process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER;
@@ -1550,6 +1551,68 @@ test('runFixtureMatrix isolates a throwing batch so sibling batches still comple
     assert.equal(summary.result_summary.failed, 1);
   } finally {
     restoreConcurrencyEnv(snapshot);
+  }
+});
+
+test('runFixtureMatrixBench returns a partial result with survivors aggregated when a batch fails', async () => {
+  // The bench-harness entry point is where the whole-run discard used to live:
+  // any failing batch made `runFixtureMatrixBench` throw, so the harness recorded
+  // an assertion_failure and dropped the aggregate (every survivor lost). This
+  // proves the harness boundary now isolates the failure -- the bench returns
+  // normally with the survivors aggregated and the failure counted, so the rig's
+  // `failed_fixture_count <= 0` result-gate fails the run WITHOUT discarding it.
+  const concurrencySnapshot = snapshotConcurrencyEnv();
+  const benchEnvKeys = [
+    'SSI_FIXTURE_MATRIX_FIXTURE_ROOT',
+    'SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY',
+    'SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH',
+    'SSI_FIXTURE_MATRIX_RUN',
+    'SSI_FIXTURE_MATRIX_BATCH_SIZE',
+    'SSI_FIXTURE_MATRIX_CONCURRENCY',
+    'SSI_FIXTURE_MATRIX_VISUAL_PARITY',
+  ];
+  const benchEnvSnapshot = Object.fromEntries(benchEnvKeys.map((key) => [key, process.env[key]]));
+  const workspace = setupConcurrencyWorkspace('ssi-bench-isolation-', 4);
+
+  process.env.HOMEBOY_WP_CODEBOX_RECIPE_HELPER = workspace.helperPath;
+  process.env.SSI_TEST_RECIPE_BATCH_COUNT = '4';
+  process.env.SSI_TEST_RECIPE_UNIT_MS = '5';
+  process.env.SSI_TEST_RECIPE_THROW_BATCH = '2';
+  process.env.SSI_FIXTURE_MATRIX_FIXTURE_ROOT = workspace.fixtureRoot;
+  process.env.SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY = workspace.outputDirectory;
+  process.env.SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH = workspace.staticSiteImporter;
+  process.env.SSI_FIXTURE_MATRIX_RUN = '1';
+  process.env.SSI_FIXTURE_MATRIX_BATCH_SIZE = '1';
+  process.env.SSI_FIXTURE_MATRIX_CONCURRENCY = '4';
+  process.env.SSI_FIXTURE_MATRIX_VISUAL_PARITY = '0';
+
+  try {
+    // Does not reject: the failing batch is recorded, not fatal.
+    const benchResult = await runFixtureMatrixBench();
+
+    // The aggregate spans all four fixtures: the three surviving batches passed
+    // and only the failing batch is counted as failed.
+    assert.equal(benchResult.metrics.fixture_count, 4);
+    assert.equal(benchResult.metrics.passed_fixture_count, 3);
+    assert.equal(benchResult.metrics.failed_fixture_count, 1);
+    assert.equal(benchResult.metrics.not_run_fixture_count, 0);
+
+    // The result-gate (failed_fixture_count <= 0) will fail on this, while the
+    // partial result is still emitted and the failing batch stays attributable.
+    const failures = benchResult.metadata.child_command_failures;
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0].batch_id, 'batch-002');
+    assert.equal(failures[0].exit_status, 19);
+
+    // The aggregate result artifact was written for the lane to record.
+    const resultPayload = JSON.parse(readFileSync(benchResult.artifacts.result.path, 'utf8'));
+    assert.equal(resultPayload.summary.succeeded, 3);
+    assert.equal(resultPayload.summary.failed, 1);
+  } finally {
+    restoreConcurrencyEnv(concurrencySnapshot);
+    for (const key of benchEnvKeys) {
+      restoreEnv(key, benchEnvSnapshot[key]);
+    }
   }
 });
 


### PR DESCRIPTION
## What
A single bad fixture no longer kills the whole SSI fixture-matrix lane. An offloaded run aborted at batch-002 (in-sandbox PHP OOM in collect_artifacts) and the bench discarded the ENTIRE run — no aggregate, no batch-001 survivors.

## Root cause + fix
The batching already isolated failures: `runFixtureMatrixBatch` catches the WP Codebox error, records that batch's fixtures as `failed`, and siblings finish via `mapWithConcurrency`. The bug was purely that the harness entry `runFixtureMatrixBench()` **re-threw** `runtimeError` on any batch failure, so homeboy bench treated the lane as an `assertion_failure` and dropped the aggregate + survivors.
- `runFixtureMatrixBench` no longer throws on batch/runtime errors — it returns the aggregated metrics with `failed_fixture_count` reflecting real failures and surfaces the failing batch in `metadata.child_command_failures`. The `failed_fixture_count <= 0` result-gate then FAILS the run without discarding it. Genuine pre-aggregate setup failures (missing fixtures/composer) still throw. Ordering + gate semantics unchanged.
- `DEFAULT_BATCH_CONCURRENCY` 4 → 2 (cap still 16): one sandbox ~3.3GB RSS but overlapping sandboxes grow superlinearly (~65GB measured at 4); 2 keeps speedup with headroom. Overridable.

## Verification
- `node tools/fixture-matrix.test.mjs` → 75/75, incl. a new test: a 4-fixture lane with batch-2 failing yields `passed:3, failed:1`, result artifact written, failing batch attributed in metadata. Lint passed.
- Pairs with the wp-codebox collect_artifacts memory PR (raises the runtime limit that caused the OOM).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Root-cause diagnosis, fix, and tests under human review.