### PR TITLE
Optional live-WP parity step in SSI matrix (off by default)

### DIFF
--- a/WordPress/static-site-importer/lib/fixture-matrix.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix.mjs
@@ -45,6 +45,12 @@ export { editorBlockValidationStep } from './fixture-matrix/steps/editor-validat
 export { visualParityCompareStep } from './fixture-matrix/steps/visual-parity-step.mjs';
 
 export {
+  liveWpParityCaptureStep,
+  liveWpParityEnabled,
+  normalizeLiveWpParityRecipeOptions,
+} from './fixture-matrix/steps/live-wp-parity-step.mjs';
+
+export {
   normalizeFixtureMatrixResult,
   writeFixtureMatrixArtifacts,
   writeFixtureMatrixResultArtifacts,
@@ -72,3 +78,8 @@ export {
   collectVisualParityDiagnostics,
   normalizeVisualParityGateOptions,
 } from './fixture-matrix/collectors/visual-parity.mjs';
+
+export {
+  runLiveWpParity,
+  normalizeLiveWpParityReport,
+} from './fixture-matrix/collectors/live-wp-parity.mjs';

--- a/WordPress/static-site-importer/lib/fixture-matrix/collectors/live-wp-parity.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/collectors/live-wp-parity.mjs
@@ -1,0 +1,151 @@
+// Live-WP parity collector for the Static Site Importer fixture matrix.
+//
+// Host-side companion to ../steps/live-wp-parity-step.mjs. The capture step writes
+// the imported candidate's RENDERED DOM HTML to `files/browser/snapshot.html`
+// (via `wordpress.capture-html`). This module feeds that snapshot, together with
+// the staged fixture source, to the EXISTING blocks-engine deterministic comparator
+// through its CLI entry (`composer live-wp-parity` ->
+// php-transformer/tools/live-wp-parity/run.php), then normalizes the report into
+// the same parity-result shape the matrix already surfaces for the render-free gate.
+//
+// Determinism: the comparator is pure PHP (no browser/network/rasterization), and
+// the candidate (snapshot.html) was captured with external requests blocked, so
+// given a fixed snapshot the report is byte-identical run to run. With --with-proxy
+// the CLI also reports the render-free proxy score so callers can read the live-WP
+// vs proxy delta directly.
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+import { objectValue, finiteNumber, compactObject } from '../shared/utils.mjs';
+
+// Run the blocks-engine live-wp-parity CLI against a captured rendered-DOM snapshot.
+//
+// @param {object} input
+//   - sourceHtmlPath: path to the fixture source HTML (required)
+//   - candidateHtmlPath: path to the captured rendered-DOM snapshot.html (required)
+//   - blocksEnginePhpTransformerPath: php-transformer package root (required;
+//       resolve via resolveBlocksEnginePhpTransformerPath)
+//   - sourceCssPath: optional explicit source CSS file; otherwise the CLI
+//       auto-extracts author CSS from the source's own <style>/linked stylesheets
+//   - candidateCssPath: optional extra CSS for the candidate side (default none —
+//       the rendered DOM carries its own WP-emitted styles)
+//   - withProxy: also compute the render-free proxy score + delta (default true)
+//   - exec: injectable command runner (defaults to spawnSync) for testing
+// @returns {object} normalized live-WP parity result (see normalizeLiveWpParityReport)
+export function runLiveWpParity(input = {}) {
+  const sourceHtmlPath = requirePath(input.sourceHtmlPath, 'sourceHtmlPath');
+  const candidateHtmlPath = requirePath(input.candidateHtmlPath, 'candidateHtmlPath');
+  const packagePath = requirePath(input.blocksEnginePhpTransformerPath, 'blocksEnginePhpTransformerPath');
+  const withProxy = input.withProxy !== false;
+  const exec = typeof input.exec === 'function' ? input.exec : defaultExec;
+
+  const runPhp = path.join(packagePath, 'tools', 'live-wp-parity', 'run.php');
+  const args = [
+    runPhp,
+    '--source', sourceHtmlPath,
+    '--candidate', candidateHtmlPath,
+    ...(input.sourceCssPath ? ['--source-css', input.sourceCssPath] : []),
+    ...(input.candidateCssPath ? ['--candidate-css', input.candidateCssPath] : []),
+    ...(withProxy ? ['--with-proxy'] : []),
+    '--json',
+  ];
+
+  const result = exec('php', args, { cwd: packagePath });
+  const status = finiteNumber(result?.status, result?.status === 0 ? 0 : 1);
+  const stdout = String(result?.stdout ?? '');
+  const stderr = String(result?.stderr ?? '');
+  if (status !== 0) {
+    throw new Error(`live-wp-parity CLI failed (status ${status}): ${stderr.trim() || stdout.trim()}`);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(`live-wp-parity CLI emitted non-JSON output: ${error.message}`);
+  }
+
+  return normalizeLiveWpParityReport(parsed);
+}
+
+function defaultExec(command, args, options) {
+  // The full report carries every per-element / per-property delta, which for a
+  // large fixture exceeds spawnSync's default 1 MiB stdout buffer and would
+  // otherwise truncate the JSON. Raise the ceiling so the report is captured whole.
+  return spawnSync(command, args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, ...options });
+}
+
+// Normalize the CLI's `blocks-engine/php-transformer/live-wp-parity-report/v1`
+// payload into the matrix-facing live-WP parity result: the live-WP score + status,
+// a bounded per-property diff for evidence, and the render-free proxy comparison
+// when present. Keeps the same `parity`/`summary` vocabulary the render-free gate
+// already reports so both signals read side by side.
+export function normalizeLiveWpParityReport(report, options = {}) {
+  const payload = objectValue(report);
+  const live = objectValue(payload.live_wp);
+  const parity = objectValue(live.parity);
+  const summary = objectValue(live.summary);
+  const comparison = objectValue(payload.comparison);
+  const diffLimit = finiteNumber(options.diffLimit ?? options.diff_limit, 25);
+
+  return compactObject({
+    schema: 'static-site-importer/live-wp-parity-result/v1',
+    owner: 'codebox_runtime',
+    source: payload.source,
+    candidate: payload.candidate,
+    status: live.status,
+    score: finiteNumber(parity.score, 0),
+    property_parity: finiteNumber(parity.property_parity, 0),
+    coverage: finiteNumber(parity.coverage, 0),
+    matched_total: finiteNumber(summary.matched_total, 0),
+    source_total: finiteNumber(summary.source_total, 0),
+    finding_total: finiteNumber(summary.finding_total, 0),
+    property_diffs: collectPropertyDiffs(live, diffLimit),
+    comparison: Object.keys(comparison).length > 0
+      ? compactObject({
+          live_wp_score: finiteNumber(comparison.live_wp_score, 0),
+          proxy_score: finiteNumber(comparison.proxy_score, 0),
+          // Positive delta => the live WP render matched the source BETTER than the
+          // render-free proxy; negative => WP's render/global-styles diverged where
+          // the proxy did not (the layer the proxy cannot see).
+          delta: finiteNumber(comparison.delta, 0),
+        })
+      : undefined,
+  });
+}
+
+// Flatten the comparator's per-element style deltas into a bounded list naming the
+// exact diverged CSS property on the exact selector — the same per-property signal
+// the render-free gate surfaces, now for real WP output.
+function collectPropertyDiffs(liveReport, limit) {
+  const diffs = [];
+  for (const match of asArray(objectValue(liveReport).matches)) {
+    const record = objectValue(match);
+    for (const delta of asArray(record.style_deltas)) {
+      const entry = objectValue(delta);
+      diffs.push(compactObject({
+        source_selector: record.source_selector,
+        target_selector: record.target_selector,
+        property: entry.property,
+        source: entry.source,
+        target: entry.target,
+      }));
+      if (diffs.length >= limit) {
+        return diffs;
+      }
+    }
+  }
+  return diffs;
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function requirePath(value, name) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`runLiveWpParity requires ${name}.`);
+  }
+  return value;
+}

--- a/WordPress/static-site-importer/lib/fixture-matrix/steps/live-wp-parity-step.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/steps/live-wp-parity-step.mjs
@@ -1,0 +1,71 @@
+// Live-WP parity capture step for the Static Site Importer fixture matrix.
+//
+// Companion to the render-free static-parity gate (blocks-engine php-transformer
+// `composer static-parity`), which is the PRIMARY parity signal but never
+// exercises WordPress's own block rendering + global-styles layer. This OPTIONAL
+// step (off by default) captures the imported candidate's RENDERED DOM HTML from a
+// real WordPress render so the same deterministic comparator can be run against
+// real WP output via blocks-engine `composer live-wp-parity`.
+//
+// It composes the EXISTING `wordpress.capture-html` command (Playwright
+// `page.content()` — the serialized rendered DOM, NOT a screenshot) so there is no
+// rasterization and no OOM risk. External requests are blocked (`network-policy=block`)
+// so the captured DOM is self-contained and deterministic: same import + same
+// render -> byte-identical snapshot.html -> byte-identical comparator report.
+//
+// The captured `files/browser/snapshot.html` artifact is fed host-side to the
+// blocks-engine live-wp-parity runner by `runLiveWpParity`
+// (see ../collectors/live-wp-parity.mjs), which surfaces the live-WP parity score
+// and per-property diff alongside the render-free proxy score.
+
+import {
+  DEFAULT_VISUAL_PARITY_CANDIDATE_URL,
+  DEFAULT_VISUAL_PARITY_WAIT_FOR,
+} from '../shared/constants.mjs';
+import { isTruthySignal } from '../shared/utils.mjs';
+
+// Compose `wordpress.capture-html` for a fixture's imported candidate front page.
+// The candidate URL resolution mirrors the visual-parity step: it defaults to `/`,
+// which resolves to THIS fixture's imported front page (`page_on_front`) at capture
+// time because each import step activates with `activate=true` and the recipe
+// interleaves import -> capture per fixture. Per-fixture overrides are honored.
+export function liveWpParityCaptureStep(input = {}) {
+  const fixture = input.fixture || {};
+  const options = normalizeLiveWpParityRecipeOptions(input);
+  const candidateUrl = input.candidateUrl
+    || input.candidate_url
+    || fixture.candidate_url
+    || fixture.candidateUrl
+    || options.candidateUrl;
+  return {
+    command: 'wordpress.capture-html',
+    args: [
+      `url=${candidateUrl}`,
+      // DOM HTML only — deterministic, no screenshot, no rasterization.
+      'capture=html',
+      // Block external requests so the captured DOM is self-contained and stable.
+      'network-policy=block',
+      `wait-for=${options.waitFor}`,
+    ],
+  };
+}
+
+export function normalizeLiveWpParityRecipeOptions(input = {}) {
+  return {
+    candidateUrl: input.liveWpParityCandidateUrl
+      || input.live_wp_parity_candidate_url
+      || input.candidateUrl
+      || DEFAULT_VISUAL_PARITY_CANDIDATE_URL,
+    waitFor: input.liveWpParityWaitFor
+      || input.live_wp_parity_wait_for
+      || input.waitFor
+      || DEFAULT_VISUAL_PARITY_WAIT_FOR,
+  };
+}
+
+// The live-WP capture is OPT-IN: the render-free static-parity gate remains the
+// primary, always-on signal, so the heavier real-render capture only runs when a
+// caller explicitly enables it. Default false.
+export function liveWpParityEnabled(input = {}) {
+  return isTruthySignal(input.liveWpParity ?? input.live_wp_parity);
+}

--- a/WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -22,6 +22,7 @@ import {
 import { createFixtureMatrix, normalizeFixture, collectFixtureFiles } from '../fixtures.mjs';
 import { editorBlockValidationStep } from './editor-validation-step.mjs';
 import { visualParityCompareStep, normalizeVisualParityRecipeOptions } from './visual-parity-step.mjs';
+import { liveWpParityCaptureStep, liveWpParityEnabled } from './live-wp-parity-step.mjs';
 
 export function buildFixtureArtifact(fixture, options = {}) {
   const normalized = normalizeFixture(fixture);
@@ -129,6 +130,12 @@ export function buildFixtureMatrixRecipe(input = {}) {
     ...(derivedSourceBaseUrl ? { sourceBaseUrl: derivedSourceBaseUrl } : {}),
     ...input,
   });
+  // Optional live-WP parity capture: off by default so the render-free static gate
+  // stays the primary, always-on signal. When enabled, append a deterministic
+  // `wordpress.capture-html` step (DOM HTML, external requests blocked, no
+  // screenshot) per fixture; the captured snapshot.html is fed host-side to the
+  // blocks-engine live-wp-parity runner (see collectors/live-wp-parity.mjs).
+  const liveWpParityCaptureEnabled = liveWpParityEnabled(input);
 
   if (playgroundArtifactsDirectory) {
     mounts.push({
@@ -160,6 +167,7 @@ export function buildFixtureMatrixRecipe(input = {}) {
           },
           ...(editorValidationEnabled ? [editorBlockValidationStep({ fixture, ...editorValidationOptions })] : []),
           ...(visualParityEnabled ? [visualParityCompareStep({ fixture, ...visualParityRecipeOptions })] : []),
+          ...(liveWpParityCaptureEnabled ? [liveWpParityCaptureStep({ fixture, ...input })] : []),
         ]),
       ],
     },

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -35,6 +35,10 @@ import {
   computeFixtureEditorQuality,
   parseSerializedBlockNames,
   collectVisualParityDiagnostics,
+  liveWpParityCaptureStep,
+  liveWpParityEnabled,
+  runLiveWpParity,
+  normalizeLiveWpParityReport,
   buildFixtureArtifact,
   createFixtureMatrix,
   editorBlockValidationStep,
@@ -2573,4 +2577,116 @@ test('bounds the assembled output regardless of per-fixture raw content volume (
   assert.equal(result.summary.editor_quality.native_conversion_rate, 0.7);
   assert.equal(result.summary.fixture_count, fixtureCount);
   assert.ok(result.summary.finding_count >= fixtureCount, 'every fixture must contribute findings');
+});
+
+test('live-WP parity capture step is opt-in and off by default', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'live-wp-default' });
+
+  const off = buildFixtureMatrixRecipe({ matrix, staticSiteImporterPath: '/tmp/ssi' });
+  assert.equal(
+    off.workflow.steps.some((step) => step.command === 'wordpress.capture-html'),
+    false,
+    'capture-html is not emitted unless live-WP parity is explicitly enabled',
+  );
+  assert.equal(liveWpParityEnabled({}), false);
+  assert.equal(liveWpParityEnabled({ live_wp_parity: true }), true);
+});
+
+test('live-WP parity capture step renders DOM HTML deterministically with external requests blocked', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'live-wp-on' });
+  const recipe = buildFixtureMatrixRecipe({ matrix, staticSiteImporterPath: '/tmp/ssi', liveWpParity: true });
+
+  const captureSteps = recipe.workflow.steps.filter((step) => step.command === 'wordpress.capture-html');
+  assert.ok(captureSteps.length >= 1, 'one capture-html step per fixture when enabled');
+  const args = captureSteps[0].args;
+  assert.ok(args.includes('capture=html'), 'captures DOM HTML, not a screenshot');
+  assert.ok(args.includes('network-policy=block'), 'blocks external requests for determinism');
+  assert.ok(args.some((arg) => arg.startsWith('url=')), 'targets the imported candidate URL');
+  assert.ok(args.every((arg) => !arg.includes('screenshot')), 'never requests a screenshot');
+
+  // Same inputs -> identical step (the recipe builder is pure).
+  const repeat = buildFixtureMatrixRecipe({ matrix, staticSiteImporterPath: '/tmp/ssi', liveWpParity: true });
+  assert.deepEqual(
+    repeat.workflow.steps.filter((step) => step.command === 'wordpress.capture-html'),
+    captureSteps,
+  );
+
+  // The standalone step builder honors a per-fixture candidate override.
+  const overridden = liveWpParityCaptureStep({ fixture: { id: 'x', candidate_url: '/about/' } });
+  assert.ok(overridden.args.includes('url=/about/'));
+});
+
+test('runLiveWpParity feeds the captured snapshot to the blocks-engine CLI and surfaces live-WP vs proxy', () => {
+  const cliReport = {
+    schema: 'blocks-engine/php-transformer/live-wp-parity-report/v1',
+    source: 'index.html',
+    candidate: 'snapshot.html',
+    live_wp: {
+      status: 'fail',
+      parity: { score: 0.91, property_parity: 0.97, coverage: 0.94 },
+      summary: { source_total: 100, matched_total: 94, finding_total: 6 },
+      matches: [
+        {
+          source_selector: 'a.cta',
+          target_selector: 'a.cta.wp-element-button',
+          style_deltas: [{ property: 'background-color', source: '#ff0000', target: '' }],
+        },
+      ],
+    },
+    comparison: { live_wp_score: 0.91, proxy_score: 0.7328, delta: 0.1772 },
+  };
+
+  const calls = [];
+  const exec = (command, args) => {
+    calls.push({ command, args });
+    return { status: 0, stdout: JSON.stringify(cliReport), stderr: '' };
+  };
+
+  const result = runLiveWpParity({
+    sourceHtmlPath: '/fixtures/15-saas/index.html',
+    candidateHtmlPath: '/artifacts/15-saas/files/browser/snapshot.html',
+    blocksEnginePhpTransformerPath: '/repo/php-transformer',
+    exec,
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, 'php');
+  assert.ok(calls[0].args[0].endsWith(path.join('tools', 'live-wp-parity', 'run.php')));
+  assert.ok(calls[0].args.includes('--with-proxy'));
+  assert.ok(calls[0].args.includes('--json'));
+  assert.ok(calls[0].args.includes('/artifacts/15-saas/files/browser/snapshot.html'));
+
+  assert.equal(result.schema, 'static-site-importer/live-wp-parity-result/v1');
+  assert.equal(result.score, 0.91);
+  assert.equal(result.finding_total, 6);
+  assert.equal(result.comparison.proxy_score, 0.7328);
+  assert.equal(result.comparison.delta, 0.1772);
+  assert.equal(result.property_diffs.length, 1);
+  assert.equal(result.property_diffs[0].property, 'background-color');
+  assert.equal(result.property_diffs[0].source_selector, 'a.cta');
+});
+
+test('runLiveWpParity surfaces a CLI failure rather than a bogus parity result', () => {
+  const exec = () => ({ status: 2, stdout: '', stderr: 'Candidate file not found: snapshot.html' });
+  assert.throws(
+    () => runLiveWpParity({
+      sourceHtmlPath: '/s.html',
+      candidateHtmlPath: '/c.html',
+      blocksEnginePhpTransformerPath: '/repo/php-transformer',
+      exec,
+    }),
+    /live-wp-parity CLI failed/,
+  );
+});
+
+test('normalizeLiveWpParityReport bounds the per-property diff list', () => {
+  const matches = [{
+    source_selector: 's',
+    target_selector: 't',
+    style_deltas: Array.from({ length: 40 }, (_, i) => ({ property: `p${i}`, source: 'a', target: 'b' })),
+  }];
+  const normalized = normalizeLiveWpParityReport({ live_wp: { matches, parity: { score: 0.5 } } }, { diffLimit: 10 });
+  assert.equal(normalized.property_diffs.length, 10);
+  assert.equal(normalized.score, 0.5);
+  assert.equal(normalized.comparison, undefined, 'no comparison block when the CLI omits --with-proxy');
 });


### PR DESCRIPTION
## What
Adds an optional live-WP parity step to the SSI fixture matrix. Renders the imported site and feeds its real WordPress-rendered DOM to the deterministic comparator, alongside the now-primary render-free gate.

## Change
- lib/fixture-matrix/steps/live-wp-parity-step.mjs: emits a wordpress.capture-html step (capture=html, network-policy=block, no screenshot). Gated OFF by default; appended alongside the existing visual-parity step. Primary render-free gate + lane-isolation untouched.
- lib/fixture-matrix/collectors/live-wp-parity.mjs: feeds captured snapshot.html to blocks-engine composer live-wp-parity --with-proxy --json and normalizes into the matrix parity vocabulary (live-WP score, bounded per-property diff, live-vs-proxy delta).

## Verification
- node --test tools/fixture-matrix.test.mjs: 79 pass / 0 fail (5 new). Caught + fixed a real bug: spawnSync default 1 MiB buffer truncated the large report -> raised to 64 MiB.
- Host CLI against the 15-saas candidate byte-identical across 2 runs.
- Honest limit: a genuine wp-codebox sandbox render was not run (machine hot / RAM rule); wiring + determinism proven, real live-vs-proxy delta awaits an offloaded run.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Implementation + verification under human review.