### PR TITLE
Fix stale message-folding assertions in fixture-matrix test (main green)

### DIFF
--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -881,11 +881,13 @@ module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
     });
     const failure = summary.runtime.child_command_failures[0];
 
-    // #560: the child's real stderr (+ stdout tail) is folded into the thrown
-    // error message so the cause propagates instead of a bare command line.
+    // The child's raw failure cause propagates as the runtime error message. The
+    // child's real stderr + stdout tails are surfaced for attribution on the
+    // structured child-command failure below (`stderr_tail`/`stdout_tail`).
+    // Folding those tails into the Error *message* (#560) now lives in the
+    // production WP Codebox recipe helper (quarantined out of shared/wp-codebox
+    // in PR #573), which this test mocks, so the rig path keeps the bare cause.
     assert.match(runtimeError.message, /^recipe-run failed/);
-    assert.match(runtimeError.message, /stderr:\nstderr line 1\nstderr line 2/);
-    assert.match(runtimeError.message, /stdout \(tail\):\nstdout line 1\nstdout line 2/);
     assert.equal(summary.runtime.exit_code, 17);
     assert.equal(failure.schema, 'homeboy/child-command-failure/v1');
     assert.equal(failure.exit_status, 17);


### PR DESCRIPTION
## What
Fixes a pre-existing failing test on `main` (a broken window): `fixture matrix records generic child command failures for failed WP Codebox batches` in `tools/fixture-matrix.test.mjs`.

## Root cause (verified — stale test, not a regression)
PR #573 ("Quarantine WP Codebox helper behavior in rigs", f049ff3) moved the stderr/stdout message-folding (`enrichRecipeError`) out of the rig's `shared/wp-codebox/recipe.mjs` (now a pure passthrough) into the production `homeboy-extension-wordpress` helper. It deleted `recipe.test.mjs` but missed the SSI fixture-matrix test's message-folding assertions, which still expected the folded `stderr:\n...` in `runtimeError.message`. The actual message is now the bare `recipe-run failed`. (Not #577 lane-isolation — that path was untouched. Not a surfacing regression — the child's stderr/stdout are still attributed via the structured `failure.stderr_tail`/`stdout_tail`/`exit_status`, which still assert green.)

## Fix
`tools/fixture-matrix.test.mjs`: keep `assert.match(runtimeError.message, /^recipe-run failed/)` (raw cause still propagates); remove the two folding assertions that now belong to the helper's own coverage; document where folding lives. Intent preserved — structured tails still prove a failed batch is attributed.

## Verification
- `node --test tools/fixture-matrix.test.mjs` → 83/83 pass. Lint + `node --check` clean.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** Claude Code (Claude Opus 4.8, 1M context)
- **Used for:** Forensic root-cause + the stale-assertion fix under human review.
