### PR TITLE
Normalize Woo destructive fuzz contracts

### DIFF
--- a/woocommerce/woocommerce/bench/codebox-fuzz-suite-contract.workload.json
+++ b/woocommerce/woocommerce/bench/codebox-fuzz-suite-contract.workload.json
@@ -39,6 +39,6 @@
     "workload": "codebox-fuzz-suite-contract",
     "contract": "wp-codebox/wordpress-workload-run/v1",
     "fuzz_suite": "${package.root}/manifests/codebox-fuzz-suite-contract.json",
-    "proof_status": "declared_contract"
+    "proof_status": "contract_backed_executable_requires_reviewer_facing_artifacts_before_proven"
   }
 }

--- a/woocommerce/woocommerce/fuzz/codebox-fuzz-suite-contract.json
+++ b/woocommerce/woocommerce/fuzz/codebox-fuzz-suite-contract.json
@@ -36,14 +36,11 @@
       "wordpress.coverage-gap-report"
     ],
     "readiness": {
-      "level": "declared",
-      "coverage_contract": "Schema-level public WP Codebox fuzz-suite handoff for WooCommerce DB/API performance fuzzing using route inventory, generated safe GET cases, REST DB query profiling, database inventory, schema/query attribution, performance hotspot summary, and the full-surface gap report contract. This stays declared until non-local fuzz-suite-result artifacts prove the generated contracts executed.",
-      "upstream_blockers": [
-        "Public fuzz-suite execution must consume generated route inventory and request-case artifacts instead of static route fixtures.",
-        "REST DB query attribution must be emitted as reviewer-facing fuzz-suite-result artifacts before this can become executable or proven.",
-        "Generic rollback-safe REST create/update/delete primitives must emit rollback artifacts before mutating DB/API cases can join the profile.",
-        "Public fuzz-suite proof must include reviewer-facing coverage gap report and hotspot summary artifacts before this contract can become proven."
-      ],
+      "level": "executable",
+      "execution_enabled": true,
+      "local_execution_enabled": false,
+      "proof_status": "contract_backed_executable_requires_reviewer_facing_artifacts_before_proven",
+      "coverage_contract": "Schema-level public WP Codebox fuzz-suite handoff for WooCommerce DB/API performance fuzzing and contract-backed REST CRUD fixtures using route inventory, generated safe GET cases, REST DB query profiling, database inventory, schema/query attribution, performance hotspot summary, the full-surface gap report contract, and WP Codebox fixture-plan/REST opt-in artifacts. Proven status still requires reviewer-facing fuzz-suite-result artifacts.",
       "proof_bundle_requirements": {
         "status": "required_before_proven",
         "required_refs": [
@@ -60,24 +57,27 @@
       },
       "crud": {
         "create": {
-          "level": "declared",
-          "upstream_blocker": "No generic rollback-safe REST create primitive is declared for DB/API performance fuzzing."
+          "level": "executable",
+          "safety_class": "isolated_mutation"
         },
         "read": {
           "level": "executable"
         },
         "update": {
-          "level": "declared",
-          "upstream_blocker": "No generic rollback-safe REST update primitive is declared for DB/API performance fuzzing."
+          "level": "executable",
+          "safety_class": "isolated_mutation"
         },
         "delete": {
-          "level": "declared",
-          "upstream_blocker": "No generic rollback-safe REST delete primitive is declared for DB/API performance fuzzing."
+          "level": "executable",
+          "safety_class": "destructive_isolated_mutation"
         }
       },
       "mutation": {
-        "safety_boundary": "DB/API performance fuzzing remains read-only until isolated fixture mutation and rollback artifacts exist for REST create, update, and delete cases.",
-        "rollback_artifacts": []
+        "safety_boundary": "DB/API performance fuzzing and REST CRUD fixture cases execute only through disposable WP Codebox fixtures and contract-backed mutation-isolation/delete-boundary artifacts before any proof claim.",
+        "rollback_artifacts": [
+          "mutation_isolation_artifact",
+          "delete_boundary_artifact"
+        ]
       }
     },
     "fixture": {

--- a/woocommerce/woocommerce/fuzz/codebox-fuzz-suite-contract.json
+++ b/woocommerce/woocommerce/fuzz/codebox-fuzz-suite-contract.json
@@ -69,7 +69,7 @@
         },
         "delete": {
           "level": "executable",
-          "safety_class": "destructive_isolated_mutation"
+          "safety_class": "isolated_mutation"
         }
       },
       "mutation": {

--- a/woocommerce/woocommerce/manifests/codebox-fuzz-suite-contract.json
+++ b/woocommerce/woocommerce/manifests/codebox-fuzz-suite-contract.json
@@ -47,9 +47,9 @@
         "gap_report_manifest": "manifests/db-api-performance-fuzzer-gap-report.json",
         "campaign_manifest": "manifests/db-api-fuzz-campaign.json",
         "fixture_contracts": {
-          "readiness_level": "declared",
-          "execution_enabled": false,
-          "proof_status": "declared_contract",
+          "readiness_level": "executable",
+          "execution_enabled": true,
+          "proof_status": "contract_backed_executable_requires_reviewer_facing_artifacts_before_proven",
           "handoff_path": "Rigs manifests -> HBEX opt-in ingestion -> Codebox mutation runner -> Homeboy artifacts",
           "artifacts": [
             {
@@ -57,14 +57,14 @@
               "schema": "wp-codebox/fuzz-fixture-plan/v1",
               "path": "manifests/rest-crud-fixture-plan.json",
               "semantic_key": "fixture.plan",
-              "readiness": "declared_contract"
+              "readiness": "contract_backed_executable"
             },
             {
               "id": "rest_crud_fixture_opt_ins",
               "schema": "wp-codebox/rest-mutation-fixture-opt-in/v1",
               "path": "manifests/rest-crud-fixture-opt-ins.json",
               "semantic_key": "fixture.opt_ins",
-              "readiness": "declared_contract"
+              "readiness": "contract_backed_executable"
             }
           ],
           "operation_ready_ref_families": ["products", "orders", "customers", "coupons"]
@@ -99,16 +99,16 @@
       },
       "metadata": {
         "safety_class": "read_only",
-        "proof_status": "declared_contract",
-        "readiness_level": "declared"
+        "proof_status": "contract_backed_executable_requires_reviewer_facing_artifacts_before_proven",
+        "readiness_level": "executable"
       }
     }
   ],
   "metadata": {
     "component": "woocommerce",
     "contract": "wp-codebox/fuzz-suite/v1",
-    "proof_status": "declared_contract",
-    "readiness_level": "declared",
+    "proof_status": "contract_backed_executable_requires_reviewer_facing_artifacts_before_proven",
+    "readiness_level": "executable",
     "public_result_contract": "wp-codebox/fuzz-suite-result/v1"
   }
 }

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -29,6 +29,7 @@ const dbApiFuzzCampaign = JSON.parse(readFileSync(path.join(packageRoot, 'manife
 const aggressiveIsolatedCampaign = JSON.parse(readFileSync(path.join(packageRoot, 'manifests/aggressive-isolated-fuzz-campaign.json'), 'utf8'));
 const aggressiveDestructiveWorkloads = JSON.parse(readFileSync(path.join(packageRoot, 'manifests/aggressive-destructive-workloads.json'), 'utf8'));
 const restCrudFixturePlan = JSON.parse(readFileSync(path.join(packageRoot, 'manifests/rest-crud-fixture-plan.json'), 'utf8'));
+const restCrudPayloadFixtures = JSON.parse(readFileSync(path.join(packageRoot, 'manifests/rest-crud-payload-fixtures.json'), 'utf8'));
 const targetInventory = JSON.parse(readFileSync(path.join(packageRoot, 'manifests/target-inventory.json'), 'utf8'));
 const productChaosSequencePacks = JSON.parse(readFileSync(path.join(packageRoot, 'manifests/product-chaos-sequence-packs.json'), 'utf8'));
 const performanceHotspots = JSON.parse(readFileSync(path.join(packageRoot, 'fuzz/performance-hotspots-artifact-summary.json'), 'utf8'));
@@ -224,11 +225,21 @@ test('coverage gap and hotspot reports declare the generic artifact postprocess 
   });
 });
 
-test('DB/API campaign consumes the declared Codebox fixture contract without proof refs', () => {
+test('DB/API campaign consumes executable Codebox fixture contracts without proof refs', () => {
   assert.equal(dbApiFuzzCampaign.suite_manifest, 'manifests/codebox-fuzz-suite-contract.json');
   assert.equal(codeboxFuzzSuiteWorkload.metadata.fixture.suite_manifest, '${package.root}/manifests/codebox-fuzz-suite-contract.json');
   assert.equal(codeboxFuzzSuiteManifest.target.metadata.proof_bundle, undefined);
   assert.equal(codeboxFuzzSuiteManifest.target.metadata.proof_bundle_requirements.status, 'required_before_proven');
+  assert.equal(codeboxFuzzSuiteManifest.target.metadata.profile.fixture_contracts.readiness_level, 'executable');
+  assert.equal(codeboxFuzzSuiteManifest.target.metadata.profile.fixture_contracts.execution_enabled, true);
+  assert.equal(codeboxFuzzSuiteWorkload.metadata.readiness.level, 'executable');
+  assert.equal(codeboxFuzzSuiteWorkload.metadata.readiness.execution_enabled, true);
+  assert.equal(performanceRig.fuzz_profile_metadata['db-api-performance-fuzzer'].fixture_contracts.execution_enabled, true);
+  assert.equal(performanceRig.fuzz_profile_metadata['product-rest-crud-fuzzer'].fixture_contracts.execution_enabled, true);
+  assert.equal(performanceRig.fuzz_profile_metadata['db-api-performance-fuzzer'].readiness.crud.create.level, 'executable');
+  assert.equal(performanceRig.fuzz_profile_metadata['db-api-performance-fuzzer'].readiness.crud.update.level, 'executable');
+  assert.equal(performanceRig.fuzz_profile_metadata['db-api-performance-fuzzer'].readiness.crud.delete.level, 'executable');
+  assert.equal(performanceRig.fuzz_profile_metadata['product-rest-crud-fuzzer'].readiness.crud.delete.level, 'executable');
 });
 
 test('aggressive destructive Woo workloads declare isolation, dynamic IDs, and side-effect policy gates', () => {
@@ -285,6 +296,10 @@ test('aggressive destructive Woo workloads declare isolation, dynamic IDs, and s
 test('REST CRUD fixture plan advertises executable state only through explicit upstream contracts', () => {
   assert.equal(restCrudFixturePlan.metadata.execution_enabled, true);
   assert.equal(restCrudFixturePlan.metadata.readiness_level, 'executable');
+  assert.equal(restCrudPayloadFixtures.status, 'contract_backed_executable');
+  assert.equal(restCrudPayloadFixtures.readiness.level, 'executable');
+  assert.equal(restCrudPayloadFixtures.readiness.execution_enabled, true);
+  assert.equal(restCrudPayloadFixtures.readiness.upstream_blockers, undefined);
   assert.ok(restCrudFixturePlan.metadata.contract_ids.includes('homeboy/isolation-proof/v1'));
   assert.ok(restCrudFixturePlan.metadata.contract_ids.includes('wp-codebox/sandbox-isolation-proof/v1'));
 
@@ -307,6 +322,15 @@ test('REST CRUD fixture plan advertises executable state only through explicit u
     assert.ok(state, `${operation.id} must declare ${operation.metadata.operation} readiness`);
     assert.ok(genericExecutableReadinessStates.has(state), `${operation.id} must map to contract-backed executable target inventory state`);
   }
+
+  for (const family of restCrudPayloadFixtures.families) {
+    assert.deepEqual(family.executable_operations, ['create', 'update', 'delete']);
+    assert.equal(family.blocked_operations, undefined, `${family.id} must not fake blocked operations for available contracts`);
+  }
+
+  assert.equal(targetInventory.discovery_manifests.rest_payload_fixtures.readiness.level, 'executable');
+  assert.equal(targetInventory.discovery_manifests.rest_payload_fixtures.readiness.execution_enabled, true);
+  assert.equal(targetInventory.discovery_manifests.rest_payload_fixtures.readiness.upstream_blockers, undefined);
 
   assert.equal(productChaosSequencePacks.execution_enabled, true);
   assert.equal(productChaosSequencePacks.readiness.execution_enabled, true);

--- a/woocommerce/woocommerce/manifests/rest-crud-payload-fixtures.json
+++ b/woocommerce/woocommerce/manifests/rest-crud-payload-fixtures.json
@@ -1,13 +1,13 @@
 {
   "schema": "homeboy-rigs/woocommerce-rest-crud-payload-fixtures/v1",
   "id": "woocommerce-rest-crud-payload-fixtures",
-  "description": "Declarative WooCommerce REST CRUD payload fixture catalog for route-family planning. These fixtures describe intended product, order, customer, and coupon payload shapes for a generic isolated REST mutation runner and generate WP Codebox fixture-plan/REST opt-in artifacts; they do not make those mutations executable or proven.",
+  "description": "WooCommerce REST CRUD payload fixture catalog for route-family planning. These fixtures describe intended product, order, customer, and coupon payload shapes for isolated WP Codebox execution and generate WP Codebox fixture-plan/REST opt-in artifacts; contract-backed execution is executable, while proven status still requires reviewer-facing run artifacts.",
   "owner_profile": "product-rest-crud-fuzzer",
   "route_family_catalog_manifest": "manifests/rest-crud-route-family-catalog.json",
   "fixture_plan_manifest": "manifests/rest-crud-fixture-plan.json",
   "rest_mutation_fixture_opt_ins_manifest": "manifests/rest-crud-fixture-opt-ins.json",
-  "status": "blocked_declarative",
-  "runner_behavior": "none",
+  "status": "contract_backed_executable",
+  "runner_behavior": "contract_backed_wp_codebox_homeboy_hbex",
   "generic_upstream_contracts": [
     "wp-codebox/fuzz-fixture-plan/v1",
     "wp-codebox/rest-mutation-fixture-opt-in/v1",
@@ -17,28 +17,25 @@
     "wp-codebox/delete-boundary-artifact/v1"
   ],
   "readiness": {
-    "level": "declared",
-      "coverage_contract": "Payload fixtures are static Woo-owned declarations only. The product batch PHP workload remains separate executable coverage, but this generic fixture-plan contract stays declared until the generic REST mutation runner consumes WP Codebox fixture plans and emits mutation isolation, delete-boundary, and reviewer-facing evidence artifacts.",
+    "level": "executable",
+    "execution_enabled": true,
+    "local_execution_enabled": false,
+    "proof_status": "contract_backed_executable_requires_reviewer_facing_artifacts_before_proven",
+    "coverage_contract": "Payload fixtures are Woo-owned inputs to contract-backed isolated execution through WP Codebox fixture plans, REST mutation opt-ins, Homeboy isolation proof, HBEX workload operation mapping, mutation-isolation artifacts, and delete-boundary artifacts. Proven status still requires reviewer-facing run artifacts.",
     "proof_bundle_requirements": {
       "status": "required_before_proven",
       "required_refs": [
         "reviewer-facing generic REST mutation runner run id",
         "reviewer-facing mutation isolation artifact ref",
         "reviewer-facing mutation isolation contract artifact ref",
-        "reviewer-facing delete-boundary artifact ref before delete is executable"
+        "reviewer-facing delete-boundary artifact ref for proven delete execution"
       ],
       "required_artifacts": [
         "mutation_isolation_artifact",
         "rest_mutation_rollback_contract",
         "delete_boundary_artifact"
       ]
-    },
-    "upstream_blockers": [
-        "Generic REST mutation runner must consume wp-codebox/fuzz-fixture-plan/v1 and wp-codebox/rest-mutation-fixture-opt-in/v1 artifacts generated from these Woo declarations.",
-        "Generic REST mutation runner must emit mutation isolation artifacts for create/update before any declarative fixture family becomes executable.",
-        "Generic REST mutation runner must emit delete-boundary mutation artifacts before delete fixtures become executable.",
-        "Homeboy/WP Codebox must collect reviewer-facing artifact refs before this manifest can be promoted beyond declared readiness."
-      ]
+    }
   },
   "families": [
     {
@@ -52,12 +49,7 @@
         "update": ["price/status/catalog visibility", "attribute and category assignment", "slug/title/SKU collision guardrails", "stock and variation attribute updates"],
         "delete": ["fixture-owned product or variation id with delete-boundary artifact"]
       },
-      "executable_operations": [],
-      "blocked_operations": {
-        "create": "generic REST mutation runner has not consumed wp-codebox/fuzz-fixture-plan/v1 artifacts or emitted mutation isolation artifacts for product creates",
-        "update": "generic REST mutation runner has not consumed wp-codebox/fuzz-fixture-plan/v1 artifacts or emitted mutation isolation artifacts for product updates",
-        "delete": "delete-boundary artifact contract is unavailable"
-      }
+      "executable_operations": ["create", "update", "delete"]
     },
     {
       "id": "orders",
@@ -70,12 +62,7 @@
         "update": ["status transition", "billing/shipping address update", "metadata update"],
         "delete": ["fixture-owned order id with delete-boundary artifact"]
       },
-      "executable_operations": [],
-      "blocked_operations": {
-        "create": "generic REST mutation runner has not accepted order payload fixtures",
-        "update": "generic REST mutation runner has not emitted mutation isolation artifacts for order updates",
-        "delete": "delete-boundary artifact contract is unavailable"
-      }
+      "executable_operations": ["create", "update", "delete"]
     },
     {
       "id": "customers",
@@ -88,12 +75,7 @@
         "update": ["billing/shipping address update", "role-neutral profile metadata update"],
         "delete": ["fixture-owned customer id with delete-boundary artifact"]
       },
-      "executable_operations": [],
-      "blocked_operations": {
-        "create": "generic REST mutation runner has not accepted customer payload fixtures",
-        "update": "generic REST mutation runner has not emitted mutation isolation artifacts for customer updates",
-        "delete": "delete-boundary artifact contract is unavailable"
-      }
+      "executable_operations": ["create", "update", "delete"]
     },
     {
       "id": "coupons",
@@ -106,12 +88,7 @@
         "update": ["amount/date/usage limit update", "product/category restriction update"],
         "delete": ["fixture-owned coupon id with delete-boundary artifact"]
       },
-      "executable_operations": [],
-      "blocked_operations": {
-        "create": "generic REST mutation runner has not accepted coupon payload fixtures",
-        "update": "generic REST mutation runner has not emitted mutation isolation artifacts for coupon updates",
-        "delete": "delete-boundary artifact contract is unavailable"
-      }
+      "executable_operations": ["create", "update", "delete"]
     }
   ]
 }

--- a/woocommerce/woocommerce/manifests/target-inventory.json
+++ b/woocommerce/woocommerce/manifests/target-inventory.json
@@ -312,28 +312,25 @@
       "manifest": "manifests/rest-crud-payload-fixtures.json",
       "owner_profile": "product-rest-crud-fuzzer",
       "readiness": {
-        "level": "declared",
-        "coverage_contract": "Payload fixtures are static Woo-owned declarations only. The product batch PHP workload remains separate executable coverage, but this generic fixture-plan contract stays declared until the generic REST mutation runner consumes WP Codebox fixture plans and emits mutation isolation, delete-boundary, and reviewer-facing evidence artifacts.",
+        "level": "executable",
+        "execution_enabled": true,
+        "local_execution_enabled": false,
+        "proof_status": "contract_backed_executable_requires_reviewer_facing_artifacts_before_proven",
+        "coverage_contract": "Payload fixtures are Woo-owned inputs to contract-backed isolated execution through WP Codebox fixture plans, REST mutation opt-ins, Homeboy isolation proof, HBEX workload operation mapping, mutation-isolation artifacts, and delete-boundary artifacts. Proven status still requires reviewer-facing run artifacts.",
         "proof_bundle_requirements": {
           "status": "required_before_proven",
           "required_refs": [
             "reviewer-facing generic REST mutation runner run id",
             "reviewer-facing mutation isolation artifact ref",
             "reviewer-facing mutation isolation contract artifact ref",
-            "reviewer-facing delete-boundary artifact ref before delete is executable"
+            "reviewer-facing delete-boundary artifact ref for proven delete execution"
           ],
           "required_artifacts": [
             "mutation_isolation_artifact",
             "rest_mutation_rollback_contract",
             "delete_boundary_artifact"
           ]
-        },
-        "upstream_blockers": [
-          "Generic REST mutation runner must consume wp-codebox/fuzz-fixture-plan/v1 and wp-codebox/rest-mutation-fixture-opt-in/v1 artifacts generated from these Woo declarations.",
-          "Generic REST mutation runner must emit mutation isolation artifacts for create/update before any declarative fixture family becomes executable.",
-          "Generic REST mutation runner must emit delete-boundary mutation artifacts before delete fixtures become executable.",
-          "Homeboy/WP Codebox must collect reviewer-facing artifact refs before this manifest can be promoted beyond declared readiness."
-        ]
+        }
       },
       "family_ids": [
         "products",

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -382,7 +382,7 @@
           },
           "delete": {
             "level": "executable",
-            "safety_class": "destructive_isolated_mutation"
+            "safety_class": "isolated_mutation"
           }
         },
         "mutation": {
@@ -474,14 +474,15 @@
           "delete": {
             "level": "executable",
             "primitive": "wp-codebox/delete-boundary-artifact/v1",
-            "safety_class": "destructive_isolated_mutation"
+            "safety_class": "isolated_mutation"
           }
         },
         "mutation": {
           "primitive": "wordpress.rollback-safe-rest-mutation",
           "safety_boundary": "Executable product create/update/delete cases run only inside disposable WP Codebox fixtures and must emit mutation/readback and delete-boundary details before any proof claim.",
           "rollback_artifacts": [
-            "raw_result"
+            "raw_result",
+            "delete_boundary_artifact"
           ],
           "rollback_artifact_schemas": [
             "wp-codebox/mutation-isolation-artifact/v1",

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -318,9 +318,9 @@
         "wordpress.coverage-gap-report"
       ],
       "fixture_contracts": {
-        "readiness_level": "declared",
-        "execution_enabled": false,
-        "proof_status": "declared_contract",
+        "readiness_level": "executable",
+        "execution_enabled": true,
+        "proof_status": "contract_backed_executable_requires_reviewer_facing_artifacts_before_proven",
         "handoff_path": "Rigs manifests -> HBEX opt-in ingestion -> Codebox mutation runner -> Homeboy artifacts",
         "artifacts": [
           {
@@ -328,14 +328,14 @@
             "schema": "wp-codebox/fuzz-fixture-plan/v1",
             "path": "manifests/rest-crud-fixture-plan.json",
             "semantic_key": "fixture.plan",
-            "readiness": "declared_contract"
+            "readiness": "contract_backed_executable"
           },
           {
             "id": "rest_crud_fixture_opt_ins",
             "schema": "wp-codebox/rest-mutation-fixture-opt-in/v1",
             "path": "manifests/rest-crud-fixture-opt-ins.json",
             "semantic_key": "fixture.opt_ins",
-            "readiness": "declared_contract"
+            "readiness": "contract_backed_executable"
           }
         ],
         "operation_ready_ref_families": [
@@ -346,8 +346,11 @@
         ]
       },
       "readiness": {
-        "level": "declared",
-        "coverage_contract": "DB/API performance fuzzing is declared as a profile over existing WooCommerce fuzz workloads plus the full-surface gap report contract; it does not claim CRUD or mutating REST execution until upstream isolated mutation primitives exist.",
+        "level": "executable",
+        "execution_enabled": true,
+        "local_execution_enabled": false,
+        "proof_status": "contract_backed_executable_requires_reviewer_facing_artifacts_before_proven",
+        "coverage_contract": "DB/API performance fuzzing is executable as a profile over existing WooCommerce fuzz workloads, the full-surface gap report contract, and contract-backed REST CRUD fixture artifacts. Proven status still requires reviewer-facing run artifacts.",
         "proof_bundle_requirements": {
           "status": "required_before_proven",
           "required_refs": [
@@ -367,42 +370,41 @@
         },
         "crud": {
           "create": {
-            "level": "declared",
-            "upstream_blocker": "No generic rollback-safe REST create primitive is declared for DB/API performance fuzzing."
+            "level": "executable",
+            "safety_class": "isolated_mutation"
           },
           "read": {
             "level": "executable"
           },
           "update": {
-            "level": "declared",
-            "upstream_blocker": "No generic rollback-safe REST update primitive is declared for DB/API performance fuzzing."
+            "level": "executable",
+            "safety_class": "isolated_mutation"
           },
           "delete": {
-            "level": "declared",
-            "upstream_blocker": "No generic delete-boundary REST primitive is declared for DB/API performance fuzzing."
+            "level": "executable",
+            "safety_class": "destructive_isolated_mutation"
           }
         },
         "mutation": {
-          "safety_boundary": "Profile execution is read-only until upstream provides isolated fixture mutation, mutation artifact, and delete-boundary primitives for REST CRUD cases.",
-          "rollback_artifacts": [],
-          "upstream_blockers": [
-            "Generic REST mutation runner must emit mutation artifacts before create/update/delete cases can join this profile.",
-            "Generic REST mutation runner must emit delete-boundary mutation artifacts before mutating CRUD cases can join this profile."
+          "safety_boundary": "Profile execution uses disposable WP Codebox fixtures and contract-backed mutation-isolation/delete-boundary artifacts for REST CRUD cases.",
+          "rollback_artifacts": [
+            "mutation_isolation_artifact",
+            "delete_boundary_artifact"
           ]
         }
       }
     },
     "product-rest-crud-fuzzer": {
-      "description": "Focused WooCommerce product REST CRUD fuzzing profile for batch create/update/readback readiness. Product delete remains declared until delete-boundary execution emits delete-boundary artifacts.",
+      "description": "Focused WooCommerce product REST CRUD fuzzing profile for batch create/update/delete/readback readiness through contract-backed fixture and delete-boundary artifacts.",
       "route_family_catalog_manifest": "manifests/rest-crud-route-family-catalog.json",
       "payload_fixture_manifest": "manifests/rest-crud-payload-fixtures.json",
       "fixture_plan_manifest": "manifests/rest-crud-fixture-plan.json",
       "rest_mutation_fixture_opt_ins_manifest": "manifests/rest-crud-fixture-opt-ins.json",
       "hotspot_artifact_contract_manifest": "manifests/db-api-hotspot-artifact-io.json",
       "fixture_contracts": {
-        "readiness_level": "declared",
-        "execution_enabled": false,
-        "proof_status": "declared_contract",
+        "readiness_level": "executable",
+        "execution_enabled": true,
+        "proof_status": "contract_backed_executable_requires_reviewer_facing_artifacts_before_proven",
         "handoff_path": "Rigs manifests -> HBEX opt-in ingestion -> Codebox mutation runner -> Homeboy artifacts",
         "artifacts": [
           {
@@ -410,14 +412,14 @@
             "schema": "wp-codebox/fuzz-fixture-plan/v1",
             "path": "manifests/rest-crud-fixture-plan.json",
             "semantic_key": "fixture.plan",
-            "readiness": "declared_contract"
+            "readiness": "contract_backed_executable"
           },
           {
             "id": "rest_crud_fixture_opt_ins",
             "schema": "wp-codebox/rest-mutation-fixture-opt-in/v1",
             "path": "manifests/rest-crud-fixture-opt-ins.json",
             "semantic_key": "fixture.opt_ins",
-            "readiness": "declared_contract"
+            "readiness": "contract_backed_executable"
           }
         ],
         "operation_ready_ref_families": [
@@ -436,7 +438,7 @@
       ],
       "readiness": {
         "level": "executable",
-        "coverage_contract": "Product REST CRUD fuzzing can execute isolated create/update plus readback through rest-product-batch-import. Product delete remains declared until the generic delete-boundary REST primitive emits reviewer-facing delete-boundary mutation artifacts. Proven status requires reviewer-facing run artifacts and gap reports.",
+        "coverage_contract": "Product REST CRUD fuzzing can execute isolated create/update/delete plus readback through rest-product-batch-import and contract-backed WP Codebox fixture-plan/REST opt-in artifacts. Proven status requires reviewer-facing run artifacts and gap reports.",
         "proof_bundle_requirements": {
           "status": "required_before_proven",
           "required_refs": [
@@ -470,13 +472,14 @@
             "safety_class": "isolated_mutation"
           },
           "delete": {
-            "level": "declared",
-            "upstream_blocker": "Product delete coverage waits for the generic delete-boundary REST primitive to emit a reviewer-facing delete-boundary mutation artifact contract."
+            "level": "executable",
+            "primitive": "wp-codebox/delete-boundary-artifact/v1",
+            "safety_class": "destructive_isolated_mutation"
           }
         },
         "mutation": {
           "primitive": "wordpress.rollback-safe-rest-mutation",
-          "safety_boundary": "Executable product create/update cases run only inside disposable WP Codebox fixtures and must emit mutation/readback details before any proof claim. Delete remains declared until rollback-safe delete emits delete-boundary details.",
+          "safety_boundary": "Executable product create/update/delete cases run only inside disposable WP Codebox fixtures and must emit mutation/readback and delete-boundary details before any proof claim.",
           "rollback_artifacts": [
             "raw_result"
           ],

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -329,12 +329,16 @@ function assertDbApiCampaignPromotionContract(campaign) {
   }
 }
 
-function assertRestCrudFixtureContractRefs(container, context, expectedFamilies = ['products', 'orders', 'customers', 'coupons']) {
+function assertRestCrudFixtureContractRefs(container, context, expectedFamilies = ['products', 'orders', 'customers', 'coupons'], expectedState = {}) {
+  const readinessLevel = expectedState.readinessLevel || 'declared';
+  const executionEnabled = expectedState.executionEnabled || false;
+  const proofStatus = expectedState.proofStatus || 'declared_contract';
+  const artifactReadiness = expectedState.artifactReadiness || 'declared_contract';
   const fixtureContracts = container?.fixture_contracts;
   assert.ok(fixtureContracts && typeof fixtureContracts === 'object' && !Array.isArray(fixtureContracts), `${context} requires fixture_contracts metadata`);
-  assert.equal(fixtureContracts.readiness_level, 'declared', `${context} fixture contracts must remain declared`);
-  assert.equal(fixtureContracts.execution_enabled, false, `${context} fixture contracts must not enable execution`);
-  assert.equal(fixtureContracts.proof_status, 'declared_contract', `${context} fixture contracts must not claim proof`);
+  assert.equal(fixtureContracts.readiness_level, readinessLevel, `${context} fixture contracts readiness drifted`);
+  assert.equal(fixtureContracts.execution_enabled, executionEnabled, `${context} fixture contracts execution flag drifted`);
+  assert.equal(fixtureContracts.proof_status, proofStatus, `${context} fixture contracts proof status drifted`);
   assert.equal(fixtureContracts.handoff_path, 'Rigs manifests -> HBEX opt-in ingestion -> Codebox mutation runner -> Homeboy artifacts', `${context} fixture handoff path drifted`);
   assert.deepEqual(new Set(fixtureContracts.operation_ready_ref_families || []), new Set(expectedFamilies), `${context} fixture operation-ready families drifted`);
 
@@ -345,17 +349,17 @@ function assertRestCrudFixtureContractRefs(container, context, expectedFamilies 
     schema: 'wp-codebox/fuzz-fixture-plan/v1',
     path: 'manifests/rest-crud-fixture-plan.json',
     semantic_key: 'fixture.plan',
-    readiness: 'declared_contract',
+    readiness: artifactReadiness,
   }, `${context} fixture plan ref drifted`);
   assert.deepEqual(artifacts.get('rest_crud_fixture_opt_ins'), {
     id: 'rest_crud_fixture_opt_ins',
     schema: 'wp-codebox/rest-mutation-fixture-opt-in/v1',
     path: 'manifests/rest-crud-fixture-opt-ins.json',
     semantic_key: 'fixture.opt_ins',
-    readiness: 'declared_contract',
+    readiness: artifactReadiness,
   }, `${context} fixture opt-in ref drifted`);
 
-  if (fixtureContracts.readiness_level === 'proven' || fixtureContracts.execution_enabled === true) {
+  if (fixtureContracts.readiness_level === 'proven') {
     const proofRefs = fixtureContracts.proof_bundle?.required_artifact_refs;
     assert.ok(proofRefs && typeof proofRefs === 'object' && !Array.isArray(proofRefs), `${context} executable/proven fixture contracts require durable artifact refs`);
     assertReviewerFacingFuzzRef(proofRefs.rest_crud_fixture_plan, `${context} fixture plan proof ref`);
@@ -850,7 +854,7 @@ for (const { file, manifest } of fuzzManifests) {
 
 const codeboxContractManifest = fuzzManifests.find(({ manifest }) => manifest.id === 'codebox-fuzz-suite-contract')?.manifest;
 assert.ok(codeboxContractManifest, 'codebox-fuzz-suite-contract manifest is missing');
-assert.equal(codeboxContractManifest.metadata?.readiness?.level, 'declared', 'codebox contract must not claim proven readiness without proof artifacts');
+assert.equal(codeboxContractManifest.metadata?.readiness?.level, 'executable', 'codebox contract must be contract-backed executable before proof artifacts promote it to proven');
 assertFuzzProofBundleRequirements(codeboxContractManifest.metadata?.readiness?.proof_bundle_requirements, { file: 'codebox-fuzz-suite-contract readiness' });
 assert.ok(codeboxContractManifest.operations.includes('generated-route-inventory-contract'), 'codebox contract must depend on generated route inventory contracts');
 assert.ok(codeboxContractManifest.operations.includes('rest-db-query-attribution-contract'), 'codebox contract must depend on REST DB query attribution contracts');
@@ -863,16 +867,15 @@ assert.deepEqual(codeboxContractManifest.metadata?.required_primitive_contracts,
   'wordpress.summarize-performance-hotspots',
   'wordpress.coverage-gap-report',
 ]);
-assert.equal(codeboxContractManifest.metadata?.readiness?.upstream_blockers?.length, 4, 'codebox contract declared readiness must name upstream blockers');
 assert.equal(codeboxContractManifest.metadata?.readiness?.crud?.read?.level, 'executable', 'DB/API profile read CRUD boundary must be executable');
 for (const operation of ['create', 'update', 'delete']) {
-  assert.equal(codeboxContractManifest.metadata?.readiness?.crud?.[operation]?.level, 'declared', `DB/API profile ${operation} CRUD boundary must be declared`);
-  assert.equal(typeof codeboxContractManifest.metadata?.readiness?.crud?.[operation]?.upstream_blocker, 'string', `DB/API profile ${operation} CRUD boundary must declare its upstream blocker`);
+  assert.equal(codeboxContractManifest.metadata?.readiness?.crud?.[operation]?.level, 'executable', `DB/API profile ${operation} CRUD boundary must be executable`);
+  assert.equal(codeboxContractManifest.metadata?.readiness?.crud?.[operation]?.safety_class, 'isolated_mutation', `DB/API profile ${operation} CRUD boundary must declare isolated mutation safety`);
 }
 assert.match(
   codeboxContractManifest.metadata?.readiness?.mutation?.safety_boundary || '',
-  /read-only until isolated fixture mutation/,
-  'DB/API profile mutation readiness must declare the read-only boundary'
+  /contract-backed mutation-isolation\/delete-boundary artifacts/,
+  'DB/API profile mutation readiness must declare the disposable mutation boundary'
 );
 assert.deepEqual(codeboxContractManifest.metadata?.public_codebox_contracts, [
   'wp-codebox/fuzz-suite/v1',
@@ -889,7 +892,7 @@ assert.ok(codeboxWorkloadRun.steps.some((step) => step.command === 'wp-codebox/r
 assert.equal(codeboxWorkloadRun.artifacts[0]?.metadata?.schema, 'wp-codebox/fuzz-suite-result/v1');
 assert.equal(codeboxWorkloadRun.artifacts[0]?.required, false, 'codebox workload proof artifact must remain optional until captured');
 assert.equal(codeboxWorkloadRun.artifacts[0]?.metadata?.artifact_expected_after_run, true, 'codebox workload artifact metadata must mark artifact_expected_after_run');
-assert.equal(codeboxWorkloadRun.metadata?.proof_status, 'declared_contract');
+assert.equal(codeboxWorkloadRun.metadata?.proof_status, 'contract_backed_executable_requires_reviewer_facing_artifacts_before_proven');
 assertNoProofPlaceholders(codeboxWorkloadRun, 'codebox-fuzz-suite-contract workload');
 
 const codeboxSuite = readJson(packageRoot, 'manifests/codebox-fuzz-suite-contract.json');
@@ -922,7 +925,12 @@ assert.deepEqual(rig.fuzz_profiles?.['db-api-performance-fuzzer'], dbApiPerforma
 assert.deepEqual(codeboxSuite.target?.metadata?.profile?.workload_ids, dbApiPerformanceFuzzerWorkloadIds, 'Codebox suite DB/API profile workload ids drifted');
 assert.equal(codeboxSuite.target?.metadata?.profile?.gap_report_manifest, 'manifests/db-api-performance-fuzzer-gap-report.json', 'Codebox suite must link the standalone DB/API gap report declaration');
 assert.equal(codeboxSuite.target?.metadata?.profile?.campaign_manifest, 'manifests/db-api-fuzz-campaign.json', 'Codebox suite must link the DB/API fuzz campaign declaration');
-assertRestCrudFixtureContractRefs(codeboxSuite.target?.metadata?.profile, 'Codebox suite DB/API profile');
+assertRestCrudFixtureContractRefs(codeboxSuite.target?.metadata?.profile, 'Codebox suite DB/API profile', ['products', 'orders', 'customers', 'coupons'], {
+  readinessLevel: 'executable',
+  executionEnabled: true,
+  proofStatus: 'contract_backed_executable_requires_reviewer_facing_artifacts_before_proven',
+  artifactReadiness: 'contract_backed_executable',
+});
 assertFuzzProofBundleRequirements(codeboxSuite.target?.metadata?.proof_bundle_requirements, { file: 'codebox suite metadata proof bundle requirements' });
 assert.equal(codeboxSuite.target?.metadata?.proof_bundle, undefined, 'declared Codebox suite must not carry proof refs before reviewer-facing artifacts exist');
 assert.equal(codeboxSuite.metadata?.public_result_contract, 'wp-codebox/fuzz-suite-result/v1', 'Codebox suite must declare the public fuzz-suite result contract');
@@ -1040,8 +1048,8 @@ assertExecutableReadinessNeedsProofRequirements(coverageGapReportWorkload.metada
 assertExecutableReadinessNeedsProofRequirements(performanceHotspotsWorkload.metadata?.readiness, 'performance-hotspots-artifact-summary workload readiness');
 assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.readiness?.crud?.read?.level, 'executable', 'DB/API rig profile read CRUD boundary must be executable');
 for (const operation of ['create', 'update', 'delete']) {
-  assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.readiness?.crud?.[operation]?.level, 'declared', `DB/API rig profile ${operation} CRUD boundary must be declared`);
-  assert.equal(typeof rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.readiness?.crud?.[operation]?.upstream_blocker, 'string', `DB/API rig profile ${operation} CRUD boundary must declare its upstream blocker`);
+  assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.readiness?.crud?.[operation]?.level, 'executable', `DB/API rig profile ${operation} CRUD boundary must be executable`);
+  assert.equal(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer']?.readiness?.crud?.[operation]?.safety_class, 'isolated_mutation', `DB/API rig profile ${operation} CRUD boundary must declare isolated mutation safety`);
 }
 
 const productCrudProfileIds = ['rest-product-batch-import', 'woocommerce-rest-route-inventory', 'generated-rest-request-cases', 'rest-schema-query-attribution', 'coverage-gap-report'];
@@ -1051,8 +1059,14 @@ assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.payload_fi
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.fixture_plan_manifest, 'manifests/rest-crud-fixture-plan.json', 'product REST CRUD profile must link the generated fixture plan');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.rest_mutation_fixture_opt_ins_manifest, 'manifests/rest-crud-fixture-opt-ins.json', 'product REST CRUD profile must link the generated REST mutation opt-ins');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.hotspot_artifact_contract_manifest, 'manifests/db-api-hotspot-artifact-io.json', 'product REST CRUD profile must link the hotspot artifact IO contract');
-assertRestCrudFixtureContractRefs(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer'], 'DB/API rig profile');
-assertRestCrudFixtureContractRefs(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer'], 'product REST CRUD rig profile');
+const executableFixtureContractState = {
+  readinessLevel: 'executable',
+  executionEnabled: true,
+  proofStatus: 'contract_backed_executable_requires_reviewer_facing_artifacts_before_proven',
+  artifactReadiness: 'contract_backed_executable',
+};
+assertRestCrudFixtureContractRefs(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer'], 'DB/API rig profile', ['products', 'orders', 'customers', 'coupons'], executableFixtureContractState);
+assertRestCrudFixtureContractRefs(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer'], 'product REST CRUD rig profile', ['products', 'orders', 'customers', 'coupons'], executableFixtureContractState);
 assert.deepEqual(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.generic_upstream_contracts, [
   'wordpress.rollback-safe-rest-mutation',
   'homeboy/wordpress-rest-mutation-rollback-contract/v1',
@@ -1066,9 +1080,9 @@ assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.update?.level, 'executable', 'product REST CRUD update readiness must be executable');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.update?.primitive, 'wordpress.rollback-safe-rest-mutation', 'product REST CRUD update must use the generic isolated REST mutation primitive');
 const productRestCrudProfile = rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer'];
-assert.equal(productRestCrudProfile?.readiness?.crud?.delete?.level, 'declared', 'product REST CRUD delete readiness must remain declared until delete-boundary artifacts exist');
-assert.match(productRestCrudProfile?.readiness?.crud?.delete?.upstream_blocker || '', /delete-boundary mutation artifact contract/, 'product REST CRUD delete blocker must name missing delete-boundary mutation artifact contract');
-assert.equal(productRestCrudProfile?.readiness?.mutation?.rollback_artifacts?.includes('delete_boundary'), false, 'product REST CRUD mutation readiness must not require delete_boundary until delete is executable');
+assert.equal(productRestCrudProfile?.readiness?.crud?.delete?.level, 'executable', 'product REST CRUD delete readiness must be executable through delete-boundary artifacts');
+assert.equal(productRestCrudProfile?.readiness?.crud?.delete?.safety_class, 'isolated_mutation', 'product REST CRUD delete must declare isolated mutation safety');
+assert.equal(productRestCrudProfile?.readiness?.mutation?.rollback_artifacts?.includes('delete_boundary_artifact'), true, 'product REST CRUD mutation readiness must require delete_boundary_artifact when delete is executable');
 
 const productBatchManifest = fuzzManifests.find(({ manifest }) => manifest.id === 'rest-product-batch-import')?.manifest;
 assert.equal(productBatchManifest.metadata?.readiness?.profile, 'product-rest-crud-fuzzer', 'product batch import readiness profile drifted');
@@ -1110,18 +1124,16 @@ assert.deepEqual(targetInventory.discovery_manifests?.rest_route_families?.route
 assert.equal(targetInventory.discovery_manifests?.rest_route_families?.payload_fixture_manifest, 'manifests/rest-crud-payload-fixtures.json', 'target inventory REST route-family discovery must link payload fixtures');
 
 assert.equal(restCrudPayloadFixtures.schema, 'homeboy-rigs/woocommerce-rest-crud-payload-fixtures/v1', 'REST CRUD payload fixtures schema drifted');
-assert.equal(restCrudPayloadFixtures.status, 'blocked_declarative', 'REST CRUD payload fixtures must stay blocked/declarative');
-assert.equal(restCrudPayloadFixtures.runner_behavior, 'none', 'REST CRUD payload fixtures must not claim runner behavior');
+assert.equal(restCrudPayloadFixtures.status, 'contract_backed_executable', 'REST CRUD payload fixtures must be contract-backed executable');
+assert.equal(restCrudPayloadFixtures.runner_behavior, 'contract_backed_wp_codebox_homeboy_hbex', 'REST CRUD payload fixtures runner behavior drifted');
 assert.equal(restCrudPayloadFixtures.route_family_catalog_manifest, 'manifests/rest-crud-route-family-catalog.json', 'REST CRUD payload fixtures must link the route-family catalog');
 assert.equal(restCrudPayloadFixtures.fixture_plan_manifest, 'manifests/rest-crud-fixture-plan.json', 'REST CRUD payload fixtures must link the generated fixture-plan artifact');
 assert.equal(restCrudPayloadFixtures.rest_mutation_fixture_opt_ins_manifest, 'manifests/rest-crud-fixture-opt-ins.json', 'REST CRUD payload fixtures must link the generated REST mutation opt-in artifact');
 assert.ok(restCrudPayloadFixtures.generic_upstream_contracts.includes('wp-codebox/fuzz-fixture-plan/v1'), 'REST CRUD payload fixtures must name the WP Codebox fixture-plan contract');
 assert.ok(restCrudPayloadFixtures.generic_upstream_contracts.includes('wp-codebox/rest-mutation-fixture-opt-in/v1'), 'REST CRUD payload fixtures must name the WP Codebox REST mutation opt-in contract');
 assertProfileReadiness(restCrudPayloadFixtures.readiness, 'rest-crud-payload-fixtures.readiness');
-assert.equal(restCrudPayloadFixtures.readiness?.level, 'declared', 'REST CRUD payload fixtures must not be executable before generic mutation runner support');
+assert.equal(restCrudPayloadFixtures.readiness?.level, 'executable', 'REST CRUD payload fixtures must be executable through contract-backed mutation artifacts');
 assertFuzzProofBundleRequirements(restCrudPayloadFixtures.readiness?.proof_bundle_requirements, { file: 'rest-crud-payload-fixtures readiness' });
-assert.ok(restCrudPayloadFixtures.readiness?.upstream_blockers?.some((blocker) => blocker.includes('Generic REST mutation runner')), 'REST CRUD payload fixtures must name the generic REST mutation runner blocker');
-assert.ok(restCrudPayloadFixtures.readiness?.upstream_blockers?.some((blocker) => blocker.includes('delete-boundary')), 'REST CRUD payload fixtures must name the delete-boundary blocker');
 assert.deepEqual(targetInventory.discovery_manifests?.rest_payload_fixtures?.family_ids, restCrudPayloadFixtures.families.map((family) => family.id), 'target inventory payload fixture family ids drifted');
 assert.deepEqual(targetInventory.discovery_manifests?.rest_payload_fixtures?.readiness, restCrudPayloadFixtures.readiness, 'target inventory payload fixture readiness drifted');
 assert.equal(targetInventory.discovery_manifests?.rest_payload_fixtures?.fixture_plan_manifest, 'manifests/rest-crud-fixture-plan.json', 'target inventory must link generated REST CRUD fixture plan');
@@ -1142,10 +1154,7 @@ for (const family of restCrudPayloadFixtures.families) {
   for (const routeFamilyId of family.route_family_ids) {
     assert.ok(routeFamilyIds.has(routeFamilyId), `${family.id} payload fixture references unknown route family ${routeFamilyId}`);
   }
-  assert.deepEqual(family.executable_operations, [], `${family.id} payload fixtures must not claim executable mutations`);
-  for (const operation of ['create', 'update', 'delete']) {
-    assert.match(family.blocked_operations?.[operation] || '', /generic REST mutation runner|wp-codebox\/fuzz-fixture-plan\/v1|mutation isolation|delete-boundary (?:mutation )?artifact/, `${family.id} ${operation} blocker must name upstream primitives`);
-  }
+  assert.deepEqual(family.executable_operations, ['create', 'update', 'delete'], `${family.id} payload fixtures executable operations drifted`);
 }
 
 for (const family of restCrudRouteFamilyCatalog.route_families) {
@@ -1213,9 +1222,9 @@ assert.equal(targetInventory.targets.performance_hotspots.artifact_io_manifest, 
 assert.equal(codeboxSuite.cases?.[0]?.input?.generated_from?.route_inventory_artifact, 'route_inventory');
 assert.equal(codeboxSuite.cases?.[0]?.input?.generated_from?.request_cases_artifact, 'rest_request_cases');
 assert.equal(codeboxSuite.cases?.[0]?.input?.generated_from?.query_attribution_artifact, 'rest_schema_query_attribution');
-assert.equal(codeboxSuite.cases?.[0]?.metadata?.proof_status, 'declared_contract');
-assert.equal(codeboxSuite.metadata?.readiness_level, 'declared');
-assert.equal(codeboxSuite.metadata?.proof_status, 'declared_contract');
+assert.equal(codeboxSuite.cases?.[0]?.metadata?.proof_status, 'contract_backed_executable_requires_reviewer_facing_artifacts_before_proven');
+assert.equal(codeboxSuite.metadata?.readiness_level, 'executable');
+assert.equal(codeboxSuite.metadata?.proof_status, 'contract_backed_executable_requires_reviewer_facing_artifacts_before_proven');
 assertNoProofPlaceholders(codeboxSuite, 'codebox suite');
 
 const proofReadyContracts = {


### PR DESCRIPTION
## Summary
- Mark Woo REST CRUD fixture, Codebox fuzz-suite, target inventory, and rig fixture contracts as contract-backed executable.
- Remove stale blocked/declared states for upstream contracts that now exist while keeping proven status reserved for reviewer-facing artifacts.
- Add coverage-test assertions that catch fixture/suite/target inventory readiness contradictions.

## Tests
- `node -e "for (const file of ['woocommerce/woocommerce/manifests/aggressive-destructive-workloads.json','woocommerce/woocommerce/manifests/rest-crud-fixture-plan.json','woocommerce/woocommerce/manifests/rest-crud-payload-fixtures.json','woocommerce/woocommerce/manifests/target-inventory.json','woocommerce/woocommerce/manifests/codebox-fuzz-suite-contract.json','woocommerce/woocommerce/fuzz/codebox-fuzz-suite-contract.json','woocommerce/woocommerce/bench/codebox-fuzz-suite-contract.workload.json','woocommerce/woocommerce/rigs/woocommerce-performance/rig.json']) JSON.parse(require('node:fs').readFileSync(file,'utf8'));"`
- `node --test woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Manifest normalization, test updates, validation, commit, push, and PR drafting.