### PR TITLE
Update destructive fuzz manifests for disposable contracts

### DIFF
--- a/Automattic/jetpack/fuzz/jetpack-cron-sync-actions.json
+++ b/Automattic/jetpack/fuzz/jetpack-cron-sync-actions.json
@@ -33,7 +33,8 @@
         "delete_boundary_artifacts": ["delete_boundary_artifact"],
         "destructive_case_ledgers": ["destructive_case_ledger"],
         "teardown_discard_evidence": ["sandbox_teardown_evidence"],
-        "artifact_bundle_refs": ["artifact_bundle_ref"]
+        "artifact_bundle_refs": ["artifact_bundle_ref"],
+        "rollback_artifacts": ["mutation_isolation_artifact", "delete_boundary_artifact"]
       }
     }
   },

--- a/Automattic/jetpack/fuzz/jetpack-cron-sync-actions.json
+++ b/Automattic/jetpack/fuzz/jetpack-cron-sync-actions.json
@@ -28,7 +28,12 @@
       ],
       "mutation": {
         "safety_boundary": "Runs in isolated WP Codebox fixtures with remote dispatch disabled, original values restored, rollback required, and external HTTP guarded.",
-        "rollback_artifacts": ["cron_sync_actions", "cron_sync_rollback_rows", "queue_option_restore_rows"]
+        "disposable_sandbox_boundary_artifacts": ["disposable_sandbox_boundary"],
+        "mutation_isolation_artifacts": ["cron_sync_actions", "cron_sync_mutation_rows", "queue_option_mutation_rows"],
+        "delete_boundary_artifacts": ["delete_boundary_artifact"],
+        "destructive_case_ledgers": ["destructive_case_ledger"],
+        "teardown_discard_evidence": ["sandbox_teardown_evidence"],
+        "artifact_bundle_refs": ["artifact_bundle_ref"]
       }
     }
   },

--- a/Automattic/jetpack/fuzz/jetpack-module-state-matrix.json
+++ b/Automattic/jetpack/fuzz/jetpack-module-state-matrix.json
@@ -61,7 +61,8 @@
         "delete_boundary_artifacts": ["delete_boundary_artifact"],
         "destructive_case_ledgers": ["destructive_case_ledger"],
         "teardown_discard_evidence": ["sandbox_teardown_evidence"],
-        "artifact_bundle_refs": ["artifact_bundle_ref"]
+        "artifact_bundle_refs": ["artifact_bundle_ref"],
+        "rollback_artifacts": ["mutation_isolation_artifact", "delete_boundary_artifact"]
       }
     },
     "artifact_expectations": {

--- a/Automattic/jetpack/fuzz/jetpack-module-state-matrix.json
+++ b/Automattic/jetpack/fuzz/jetpack-module-state-matrix.json
@@ -56,10 +56,12 @@
       },
       "mutation": {
         "safety_boundary": "Planned only. Execution requires disposable WP Codebox isolation, explicit connected/disconnected fixture inputs, blocked external dispatch, and before/after/restore artifacts for every changed option.",
-        "rollback_artifacts": [
-          "module_state_rollback_plan",
-          "module_option_before_after_restore_rows"
-        ]
+        "disposable_sandbox_boundary_artifacts": ["disposable_sandbox_boundary"],
+        "mutation_isolation_artifacts": ["module_state_mutation_plan", "module_option_before_after_rows"],
+        "delete_boundary_artifacts": ["delete_boundary_artifact"],
+        "destructive_case_ledgers": ["destructive_case_ledger"],
+        "teardown_discard_evidence": ["sandbox_teardown_evidence"],
+        "artifact_bundle_refs": ["artifact_bundle_ref"]
       }
     },
     "artifact_expectations": {

--- a/Automattic/jetpack/fuzz/jetpack-options-matrix.json
+++ b/Automattic/jetpack/fuzz/jetpack-options-matrix.json
@@ -61,7 +61,8 @@
         "delete_boundary_artifacts": ["delete_boundary_artifact"],
         "destructive_case_ledgers": ["destructive_case_ledger"],
         "teardown_discard_evidence": ["sandbox_teardown_evidence"],
-        "artifact_bundle_refs": ["artifact_bundle_ref"]
+        "artifact_bundle_refs": ["artifact_bundle_ref"],
+        "rollback_artifacts": ["mutation_isolation_artifact", "delete_boundary_artifact"]
       }
     },
     "artifact_expectations": {

--- a/Automattic/jetpack/fuzz/jetpack-options-matrix.json
+++ b/Automattic/jetpack/fuzz/jetpack-options-matrix.json
@@ -10,7 +10,7 @@
   "operations": [
     "option-default-read",
     "option-inventory",
-    "option-update-rollback-plan",
+    "option-update-mutation-plan",
     "read-update-safety-classification",
     "connected-state-blocker-classification",
     "serialization-boundary-classification",
@@ -27,39 +27,41 @@
     "mutation_policy": "declare_option_write_plan_until_isolated_connected_fixture_exists",
     "generic_primitive": {
       "status": "blocked",
-      "reason": "Option writes remain planned until disposable runtime isolation, connected-state fixtures, and rollback artifacts are explicitly available."
+      "reason": "Option writes remain planned until disposable runtime isolation, connected-state fixtures, and mutation isolation artifacts are explicitly available."
     },
     "readiness": {
       "level": "declared",
-      "coverage_contract": "Jetpack option inventory, default reads, serialization/autoload classification, connected-state blockers, and option write rollback plans. Mutating writes are not executed without isolated runtime and connected-state fixtures.",
+      "coverage_contract": "Jetpack option inventory, default reads, serialization/autoload classification, connected-state blockers, and option write mutation plans. Mutating writes are not executed without isolated runtime and connected-state fixtures.",
       "upstream_blockers": [
         "isolated runtime fixture must guarantee option writes are disposable",
         "connected-state fixture must provide synthetic Jetpack connection state for connection-sensitive options",
-        "rollback artifact capture must persist before/after/restore rows before option writes are enabled"
+        "mutation isolation artifact capture must persist before/after rows before option writes are enabled"
       ],
       "crud": {
         "create": {
           "level": "declared",
-          "upstream_blocker": "new option writes require disposable runtime isolation and rollback artifacts"
+          "upstream_blocker": "new option writes require disposable runtime isolation and mutation isolation artifacts"
         },
         "read": {
           "level": "executable"
         },
         "update": {
           "level": "declared",
-          "upstream_blocker": "option updates require connected-state fixtures and rollback artifacts"
+          "upstream_blocker": "option updates require connected-state fixtures and mutation isolation artifacts"
         },
         "delete": {
           "level": "declared",
-          "upstream_blocker": "option deletion is out of scope without rollback artifact proof"
+          "upstream_blocker": "option deletion is out of scope without delete-boundary artifact proof"
         }
       },
       "mutation": {
-        "safety_boundary": "Planned only. Execution requires disposable WP Codebox isolation, synthetic Jetpack connected/disconnected fixtures, secret placeholders, and before/after/restore artifacts for every changed option.",
-        "rollback_artifacts": [
-          "option_write_rollback_plan",
-          "option_before_after_restore_rows"
-        ]
+        "safety_boundary": "Planned only. Execution requires disposable WP Codebox isolation, synthetic Jetpack connected/disconnected fixtures, secret placeholders, and mutation isolation artifacts for every changed option.",
+        "disposable_sandbox_boundary_artifacts": ["disposable_sandbox_boundary"],
+        "mutation_isolation_artifacts": ["option_write_mutation_plan", "option_before_after_rows"],
+        "delete_boundary_artifacts": ["delete_boundary_artifact"],
+        "destructive_case_ledgers": ["destructive_case_ledger"],
+        "teardown_discard_evidence": ["sandbox_teardown_evidence"],
+        "artifact_bundle_refs": ["artifact_bundle_ref"]
       }
     },
     "artifact_expectations": {
@@ -67,7 +69,7 @@
         "option_matrix",
         "read_update_safety_rows",
         "connected_state_blockers",
-        "rollback_requirement_rows",
+        "mutation_requirement_rows",
         "serialization_boundary_rows"
       ],
       "optional": [
@@ -98,7 +100,7 @@
       "operations": [
         "option-default-read",
         "option-inventory",
-        "option-update-rollback-plan",
+        "option-update-mutation-plan",
         "read-update-safety-classification",
         "connected-state-blocker-classification",
         "serialization-boundary-classification",
@@ -259,7 +261,7 @@
     "operations": [
       "option-default-read",
       "option-inventory",
-      "option-update-rollback-plan",
+      "option-update-mutation-plan",
       "read-update-safety-classification",
       "connected-state-blocker-classification",
       "serialization-boundary-classification",

--- a/Automattic/jetpack/fuzz/jetpack-sync-queue-coverage.json
+++ b/Automattic/jetpack/fuzz/jetpack-sync-queue-coverage.json
@@ -14,7 +14,7 @@
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report",
     "network_policy": "block_all_synthetic_external_requests",
-    "mutation_policy": "snapshot_queue_options_restore_after_assert",
+    "mutation_policy": "disposable_sandbox_mutation_isolation",
     "artifact_expectations": {
       "required": ["sync_queue", "serialized_action_samples", "queue_rollback_rows", "queue_surface_inventory", "connected_disconnected_blockers", "replay_fixture_manifest", "proof_artifact_index"],
       "optional": ["retry_boundary_rows", "blocked_dispatch_attempts", "queue_drain_skipped_rows"]
@@ -29,7 +29,12 @@
       ],
       "mutation": {
         "safety_boundary": "Runs only against isolated WP Codebox queue options and synthetic action payloads with remote dispatch disabled, original values restored, rollback required, and external HTTP guarded.",
-        "rollback_artifacts": ["sync_queue_coverage", "queue_rollback_rows", "queue_option_restore_rows"]
+        "disposable_sandbox_boundary_artifacts": ["disposable_sandbox_boundary"],
+        "mutation_isolation_artifacts": ["sync_queue_coverage", "mutation_isolation_artifact"],
+        "delete_boundary_artifacts": ["delete_boundary_artifact"],
+        "destructive_case_ledgers": ["destructive_case_ledger"],
+        "teardown_discard_evidence": ["sandbox_teardown_evidence"],
+        "artifact_bundle_refs": ["artifact_bundle_ref"]
       }
     }
   },
@@ -52,9 +57,9 @@
         ],
         "queue_options": ["jpsq_sync_checkout", "jpsq_sync_started", "jpsq_full_sync_started", "jetpack_sync_settings_sync_wait_time", "jetpack_sync_non_blocking", "jetpack_sync_checksum"],
         "queue_surfaces": [
-          { "name": "incremental_sync_queue", "kind": "option_backed_queue", "options": ["jpsq_sync_checkout", "jpsq_sync_started"], "safety_class": "isolated_fixture_mutation", "mutation_policy": "snapshot_restore" },
-          { "name": "full_sync_queue", "kind": "option_backed_queue", "options": ["jpsq_full_sync_started"], "safety_class": "isolated_fixture_mutation", "mutation_policy": "snapshot_restore" },
-          { "name": "sync_settings", "kind": "option_state", "options": ["jetpack_sync_settings_sync_wait_time", "jetpack_sync_non_blocking", "jetpack_sync_checksum"], "safety_class": "isolated_fixture_mutation", "mutation_policy": "snapshot_restore" }
+          { "name": "incremental_sync_queue", "kind": "option_backed_queue", "options": ["jpsq_sync_checkout", "jpsq_sync_started"], "safety_class": "isolated_fixture_mutation", "mutation_policy": "disposable_sandbox_mutation_isolation" },
+          { "name": "full_sync_queue", "kind": "option_backed_queue", "options": ["jpsq_full_sync_started"], "safety_class": "isolated_fixture_mutation", "mutation_policy": "disposable_sandbox_mutation_isolation" },
+          { "name": "sync_settings", "kind": "option_state", "options": ["jetpack_sync_settings_sync_wait_time", "jetpack_sync_non_blocking", "jetpack_sync_checksum"], "safety_class": "isolated_fixture_mutation", "mutation_policy": "disposable_sandbox_mutation_isolation" }
         ],
         "connection_state_blockers": [
           { "state": "disconnected", "classification": "blocked", "reason_code": "connected_required", "applies_to": ["remote_dispatch", "module_state_sync"] },

--- a/Automattic/jetpack/fuzz/jetpack-sync-queue-coverage.json
+++ b/Automattic/jetpack/fuzz/jetpack-sync-queue-coverage.json
@@ -34,7 +34,8 @@
         "delete_boundary_artifacts": ["delete_boundary_artifact"],
         "destructive_case_ledgers": ["destructive_case_ledger"],
         "teardown_discard_evidence": ["sandbox_teardown_evidence"],
-        "artifact_bundle_refs": ["artifact_bundle_ref"]
+        "artifact_bundle_refs": ["artifact_bundle_ref"],
+        "rollback_artifacts": ["mutation_isolation_artifact", "delete_boundary_artifact"]
       }
     }
   },

--- a/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
+++ b/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
@@ -192,7 +192,7 @@ assert.ok(dbRun.module_inventory.expected_modules.includes('stats'), 'Jetpack DB
 
 assertBoundary('jetpack-options-matrix', {
   safetyClass: 'read_only',
-  operations: ['option-default-read', 'option-update-rollback-plan', 'read-update-safety-classification', 'connected-state-blocker-classification', 'serialization-boundary-classification'],
+  operations: ['option-default-read', 'option-update-mutation-plan', 'read-update-safety-classification', 'connected-state-blocker-classification', 'serialization-boundary-classification'],
   inputs: { secret_placeholders_only: true, execute_mutations: false, mutation_mode: 'declared_plan', connected_state_required_for_mutation: true, runtime_isolation_required_for_mutation: true, restore_original_values: true, rollback_required: true },
 });
 assertBoundary('jetpack-module-state-matrix', {

--- a/WordPress/gutenberg/fuzz/gutenberg-rest-route-fuzz.json
+++ b/WordPress/gutenberg/fuzz/gutenberg-rest-route-fuzz.json
@@ -22,10 +22,10 @@
         "Expose an artifact-compatible generic REST route inventory command before replacing the Gutenberg PHP workload."
       ],
       "crud": {
-        "create": { "level": "declared", "upstream_blocker": "safe fixture creation primitive is not available for Gutenberg REST mutations" },
+        "create": { "level": "executable", "via": "mutation_isolation_artifact" },
         "read": { "level": "executable" },
-        "update": { "level": "declared", "upstream_blocker": "safe fixture update primitive is not available for Gutenberg REST mutations" },
-        "delete": { "level": "declared", "upstream_blocker": "safe fixture delete primitive is not available for Gutenberg REST mutations" }
+        "update": { "level": "executable", "via": "mutation_isolation_artifact" },
+        "delete": { "level": "executable", "via": "delete_boundary_artifact" }
       }
     }
   },

--- a/WordPress/gutenberg/manifests/destructive-sequence-packs.json
+++ b/WordPress/gutenberg/manifests/destructive-sequence-packs.json
@@ -1,0 +1,79 @@
+{
+  "schema": "homeboy-rigs/gutenberg-destructive-sequence-packs/v1",
+  "id": "gutenberg-destructive-sequence-packs",
+  "description": "Gutenberg owned destructive sequence packs for editor, entity, navigation, template, pattern, reusable block, insert/edit/save/delete paths in disposable WP Codebox execution.",
+  "status": "contract_backed_executable",
+  "execution_enabled": true,
+  "local_execution_enabled": false,
+  "runner_behavior": "offloaded_codebox_homeboy_hbex_isolated_sandbox",
+  "owner_profile": "gutenberg-fuzzer-profile",
+  "required_upstream_contracts": [
+    "wp-codebox/wordpress-fuzz-runtime-contract/v1",
+    "homeboy/isolation-proof/v1",
+    "homeboy/fuzz-action-model/v1",
+    "homeboy/fuzz-exploration-policy/v1",
+    "homeboy/wordpress-surface-family-contracts/v1",
+    "homeboy/wordpress-fuzz-runtime-workload-operation/v1",
+    "wp-codebox/fuzz-artifact-bundle/v1",
+    "wp-codebox/sandbox-isolation-proof/v1",
+    "wp-codebox/delete-boundary-artifact/v1",
+    "wp-codebox/mutation-isolation-artifact/v1",
+    "homeboy-extensions/generate-database-observations/v1",
+    "homeboy-extensions/generate-admin-observations/v1",
+    "homeboy-extensions/generate-browser-observations/v1",
+    "homeboy-extensions/generate-editor-observations/v1"
+  ],
+  "readiness": {
+    "level": "executable",
+    "execution_enabled": true,
+    "local_execution_enabled": false,
+    "proof_status": "requires_reviewer_facing_artifacts_before_proven",
+    "contract_ids": [
+      "wp-codebox/wordpress-fuzz-runtime-contract/v1",
+      "homeboy/isolation-proof/v1",
+      "homeboy/fuzz-action-model/v1",
+      "homeboy/fuzz-exploration-policy/v1",
+      "homeboy/wordpress-surface-family-contracts/v1",
+      "homeboy/wordpress-fuzz-runtime-workload-operation/v1",
+      "wp-codebox/fuzz-artifact-bundle/v1",
+      "wp-codebox/sandbox-isolation-proof/v1",
+      "wp-codebox/delete-boundary-artifact/v1",
+      "wp-codebox/mutation-isolation-artifact/v1",
+      "homeboy-extensions/generate-database-observations/v1",
+      "homeboy-extensions/generate-admin-observations/v1",
+      "homeboy-extensions/generate-browser-observations/v1",
+      "homeboy-extensions/generate-editor-observations/v1"
+    ],
+    "proof_bundle_requirements": {
+      "status": "required_before_proven",
+      "local_only_refs_allowed": false,
+      "placeholder_refs_allowed": false,
+      "required_refs": ["reviewer-facing Gutenberg destructive sequence resolution artifact ref", "reviewer-facing delete-boundary artifact ref", "reviewer-facing mutation-isolation artifact ref", "reviewer-facing database observation artifact ref", "reviewer-facing admin/browser/editor observation artifact refs", "reviewer-facing fuzz artifact bundle ref"],
+      "required_artifacts": ["destructive_sequence_resolution", "delete_boundary_artifact", "mutation_isolation_artifact", "database_observations", "admin_observations", "browser_observations", "editor_observations", "fuzz_artifact_bundle"]
+    }
+  },
+  "surface_families": [
+    { "id": "templates", "surfaces": ["wp_template", "wp_template_part", "wp_global_styles"], "operations": ["create", "read", "update", "delete"], "readiness": "destructive_isolated_executable" },
+    { "id": "patterns", "surfaces": ["wp_block_pattern", "wp_pattern_directory", "synced_patterns"], "operations": ["create", "read", "update", "delete"], "readiness": "destructive_isolated_executable" },
+    { "id": "reusable-block-entities", "surfaces": ["wp_block", "reusable_blocks", "block_bindings"], "operations": ["create", "read", "update", "delete"], "readiness": "destructive_isolated_executable" },
+    { "id": "navigation", "surfaces": ["wp_navigation", "navigation_menus", "navigation_blocks"], "operations": ["create", "read", "update", "delete"], "readiness": "destructive_isolated_executable" },
+    { "id": "editor-state", "surfaces": ["post_editor", "site_editor", "preferences", "autosaves"], "operations": ["create", "read", "update", "delete"], "readiness": "destructive_isolated_executable" },
+    { "id": "block-insert-edit-save-delete", "surfaces": ["block_editor_canvas", "blocks", "server_rendered_blocks"], "operations": ["insert", "edit", "save", "delete"], "readiness": "destructive_isolated_executable" }
+  ],
+  "sequence_packs": [
+    { "id": "template-lifecycle", "surface_family": "templates", "steps": ["create fixture template and template part", "open site editor", "edit template blocks", "save template entities", "delete fixture template entities inside isolated sandbox"], "required_contract_ids": ["homeboy/wordpress-fuzz-runtime-workload-operation/v1", "wp-codebox/mutation-isolation-artifact/v1", "wp-codebox/delete-boundary-artifact/v1", "homeboy-extensions/generate-editor-observations/v1"], "hotspot_labels": { "sequence": "template-lifecycle", "action": ["template-create", "template-edit", "template-save", "template-delete"], "route": ["wp/v2/templates", "wp/v2/template-parts", "wp/v2/global-styles"], "table": ["wp_posts", "wp_postmeta"], "editor_state": ["site_editor", "template_canvas", "global_styles"] }, "readiness": "destructive_isolated_executable" },
+    { "id": "pattern-lifecycle", "surface_family": "patterns", "steps": ["create fixture pattern", "insert pattern into fixture content", "edit pattern attributes", "save synced pattern state", "delete fixture pattern inside isolated sandbox"], "required_contract_ids": ["homeboy/wordpress-fuzz-runtime-workload-operation/v1", "wp-codebox/mutation-isolation-artifact/v1", "wp-codebox/delete-boundary-artifact/v1", "homeboy-extensions/generate-editor-observations/v1"], "hotspot_labels": { "sequence": "pattern-lifecycle", "action": ["pattern-create", "pattern-insert", "pattern-edit", "pattern-save", "pattern-delete"], "route": ["wp/v2/pattern-directory/patterns", "wp/v2/block-patterns/patterns"], "table": ["wp_posts", "wp_postmeta"], "editor_state": ["pattern_browser", "synced_pattern_state"] }, "readiness": "destructive_isolated_executable" },
+    { "id": "reusable-block-lifecycle", "surface_family": "reusable-block-entities", "steps": ["create reusable block entity", "insert reusable block", "edit referenced block entity", "save post and entity", "delete reusable block inside isolated sandbox"], "required_contract_ids": ["homeboy/wordpress-fuzz-runtime-workload-operation/v1", "wp-codebox/mutation-isolation-artifact/v1", "wp-codebox/delete-boundary-artifact/v1", "homeboy-extensions/generate-editor-observations/v1"], "hotspot_labels": { "sequence": "reusable-block-lifecycle", "action": ["reusable-block-create", "reusable-block-insert", "reusable-block-edit", "reusable-block-save", "reusable-block-delete"], "route": ["wp/v2/blocks", "wp/v2/block-renderer"], "table": ["wp_posts", "wp_postmeta"], "editor_state": ["block_editor", "entity_reference"] }, "readiness": "destructive_isolated_executable" },
+    { "id": "navigation-lifecycle", "surface_family": "navigation", "steps": ["create fixture navigation", "insert navigation block", "edit menu items", "save navigation entity", "delete navigation entity inside isolated sandbox"], "required_contract_ids": ["homeboy/wordpress-fuzz-runtime-workload-operation/v1", "wp-codebox/mutation-isolation-artifact/v1", "wp-codebox/delete-boundary-artifact/v1", "homeboy-extensions/generate-editor-observations/v1"], "hotspot_labels": { "sequence": "navigation-lifecycle", "action": ["navigation-create", "navigation-insert", "navigation-edit", "navigation-save", "navigation-delete"], "route": ["wp/v2/navigation", "wp/v2/menu-items"], "table": ["wp_posts", "wp_postmeta", "wp_terms", "wp_term_relationships"], "editor_state": ["navigation_overlay", "site_editor"] }, "readiness": "destructive_isolated_executable" },
+    { "id": "editor-state-lifecycle", "surface_family": "editor-state", "steps": ["open post editor", "insert draft content", "save preferences and autosave", "update editor entity state", "delete fixture editor state inside isolated sandbox"], "required_contract_ids": ["homeboy/wordpress-fuzz-runtime-workload-operation/v1", "wp-codebox/mutation-isolation-artifact/v1", "wp-codebox/delete-boundary-artifact/v1", "homeboy-extensions/generate-editor-observations/v1"], "hotspot_labels": { "sequence": "editor-state-lifecycle", "action": ["editor-open", "draft-create", "autosave", "preference-update", "editor-state-delete"], "route": ["wp/v2/posts", "wp/v2/autosaves", "wp/v2/users/me"], "table": ["wp_posts", "wp_postmeta", "wp_usermeta"], "editor_state": ["post_editor", "preferences", "autosaves"] }, "readiness": "destructive_isolated_executable" },
+    { "id": "block-insert-edit-save-delete", "surface_family": "block-insert-edit-save-delete", "steps": ["create fixture post", "insert block into editor canvas", "edit block attributes", "save post", "delete inserted block and fixture post inside isolated sandbox"], "required_contract_ids": ["homeboy/wordpress-fuzz-runtime-workload-operation/v1", "wp-codebox/mutation-isolation-artifact/v1", "wp-codebox/delete-boundary-artifact/v1", "homeboy-extensions/generate-editor-observations/v1"], "hotspot_labels": { "sequence": "block-insert-edit-save-delete", "action": ["block-insert", "block-edit", "block-save", "block-delete"], "route": ["wp/v2/posts", "wp/v2/block-renderer"], "table": ["wp_posts", "wp_postmeta"], "editor_state": ["block_editor_canvas", "selection_state", "undo_stack"] }, "readiness": "destructive_isolated_executable" }
+  ],
+  "relative_hotspot_taxonomy": {
+    "labels": ["sequence", "action", "route", "table", "editor_state"],
+    "sequence": ["template-lifecycle", "pattern-lifecycle", "reusable-block-lifecycle", "navigation-lifecycle", "editor-state-lifecycle", "block-insert-edit-save-delete"],
+    "action": ["template-create", "template-save", "pattern-insert", "reusable-block-edit", "navigation-save", "autosave", "block-insert", "block-delete"],
+    "route": ["wp/v2/templates", "wp/v2/template-parts", "wp/v2/global-styles", "wp/v2/blocks", "wp/v2/navigation", "wp/v2/posts", "wp/v2/autosaves", "wp/v2/block-renderer"],
+    "table": ["wp_posts", "wp_postmeta", "wp_usermeta", "wp_terms", "wp_term_relationships"],
+    "editor_state": ["site_editor", "post_editor", "template_canvas", "pattern_browser", "navigation_overlay", "block_editor_canvas", "autosaves", "preferences"]
+  }
+}

--- a/WordPress/gutenberg/tools/validate-fuzz-manifests.mjs
+++ b/WordPress/gutenberg/tools/validate-fuzz-manifests.mjs
@@ -30,6 +30,7 @@ const restRouteCoverage = readJson(packageRoot, 'manifests/rest-route-coverage.j
 const restCases = readJson(packageRoot, 'bench/generated-rest-request-cases.workload.json');
 const dbInventory = readJson(packageRoot, 'bench/db-inventory.workload.json');
 const restQueryProfile = readJson(packageRoot, 'bench/rest-db-query-profile.workload.json');
+const destructiveSequencePacks = readJson(packageRoot, 'manifests/destructive-sequence-packs.json');
 
 const requiredSurfaces = new Set([
   'gutenberg-rest-routes',
@@ -162,6 +163,53 @@ for (const artifact of ['rest_namespace_permission_matrix', 'rest_db_query_profi
   const proofArtifact = apiDbLabCell.proof_artifacts.find((entry) => entry.name === artifact);
   assert.ok(proofArtifact, `API/DB Lab cell missing proof artifact ${artifact}`);
   assert.ok(proofArtifact.required_sections.length > 0, `API/DB Lab cell proof artifact ${artifact} requires sections`);
+}
+
+const requiredDestructiveContracts = new Set([
+  'wp-codebox/wordpress-fuzz-runtime-contract/v1',
+  'homeboy/isolation-proof/v1',
+  'homeboy/fuzz-action-model/v1',
+  'homeboy/fuzz-exploration-policy/v1',
+  'homeboy/wordpress-surface-family-contracts/v1',
+  'homeboy/wordpress-fuzz-runtime-workload-operation/v1',
+  'wp-codebox/fuzz-artifact-bundle/v1',
+  'wp-codebox/sandbox-isolation-proof/v1',
+  'wp-codebox/delete-boundary-artifact/v1',
+  'wp-codebox/mutation-isolation-artifact/v1',
+  'homeboy-extensions/generate-database-observations/v1',
+  'homeboy-extensions/generate-admin-observations/v1',
+  'homeboy-extensions/generate-browser-observations/v1',
+  'homeboy-extensions/generate-editor-observations/v1',
+]);
+
+assert.equal(destructiveSequencePacks.schema, 'homeboy-rigs/gutenberg-destructive-sequence-packs/v1', 'Gutenberg destructive sequence pack schema drifted');
+assert.equal(destructiveSequencePacks.id, 'gutenberg-destructive-sequence-packs', 'Gutenberg destructive sequence pack id drifted');
+assert.equal(destructiveSequencePacks.status, 'contract_backed_executable', 'Gutenberg destructive sequence pack status drifted');
+assert.equal(destructiveSequencePacks.execution_enabled, true, 'Gutenberg destructive sequence packs must be executable');
+assert.equal(destructiveSequencePacks.local_execution_enabled, false, 'Gutenberg destructive sequence packs must not enable local execution');
+assert.equal(destructiveSequencePacks.readiness?.level, 'executable', 'Gutenberg destructive sequence pack readiness drifted');
+assert.equal(destructiveSequencePacks.readiness?.proof_bundle, undefined, 'Gutenberg destructive sequence packs must not claim proof refs before artifacts exist');
+assert.deepEqual(new Set(destructiveSequencePacks.required_upstream_contracts || []), requiredDestructiveContracts, 'Gutenberg destructive sequence upstream contracts drifted');
+assert.deepEqual(new Set(destructiveSequencePacks.readiness?.contract_ids || []), requiredDestructiveContracts, 'Gutenberg destructive sequence readiness contract ids drifted');
+
+const gutenbergFamilies = new Map((destructiveSequencePacks.surface_families || []).map((family) => [family.id, family]));
+assert.deepEqual(new Set(gutenbergFamilies.keys()), new Set(['templates', 'patterns', 'reusable-block-entities', 'navigation', 'editor-state', 'block-insert-edit-save-delete']), 'Gutenberg destructive sequence surface families drifted');
+for (const [familyId, family] of gutenbergFamilies) {
+  assert.equal(family.readiness, 'destructive_isolated_executable', `${familyId} must be executable`);
+  assert.ok(family.operations.includes('delete'), `${familyId} must include delete operations`);
+}
+
+const gutenbergSequences = new Map((destructiveSequencePacks.sequence_packs || []).map((pack) => [pack.id, pack]));
+assert.deepEqual(new Set(gutenbergSequences.keys()), new Set(['template-lifecycle', 'pattern-lifecycle', 'reusable-block-lifecycle', 'navigation-lifecycle', 'editor-state-lifecycle', 'block-insert-edit-save-delete']), 'Gutenberg destructive sequence pack ids drifted');
+assert.deepEqual(new Set(destructiveSequencePacks.relative_hotspot_taxonomy?.labels || []), new Set(['sequence', 'action', 'route', 'table', 'editor_state']), 'Gutenberg destructive hotspot taxonomy labels drifted');
+for (const [sequenceId, sequence] of gutenbergSequences) {
+  assert.equal(sequence.readiness, 'destructive_isolated_executable', `${sequenceId} must be executable`);
+  assert.ok(gutenbergFamilies.has(sequence.surface_family), `${sequenceId} references unknown surface family`);
+  assert.ok(sequence.steps.some((step) => step.includes('delete')), `${sequenceId} must include a delete path`);
+  assert.ok(sequence.required_contract_ids.includes('homeboy/wordpress-fuzz-runtime-workload-operation/v1'), `${sequenceId} must wire Homeboy workload operation contract`);
+  assert.ok(sequence.required_contract_ids.includes('wp-codebox/mutation-isolation-artifact/v1'), `${sequenceId} must wire Codebox mutation-isolation artifacts`);
+  assert.ok(sequence.required_contract_ids.includes('wp-codebox/delete-boundary-artifact/v1'), `${sequenceId} must wire Codebox delete-boundary artifacts`);
+  assert.ok(sequence.required_contract_ids.includes('homeboy-extensions/generate-editor-observations/v1'), `${sequenceId} must wire HBEX editor observation artifacts`);
 }
 
 console.log(`validated ${fuzzManifests.length} Gutenberg fuzz manifests; no fuzz IDs are present in bench_workloads or bench_profiles`);

--- a/WordPress/wordpress-develop/fuzz/rest-api.json
+++ b/WordPress/wordpress-develop/fuzz/rest-api.json
@@ -18,14 +18,19 @@
       "coverage_contract": "WordPress Core REST route inventory, generated safe request cases, and role permission-boundary execution for representative core routes.",
       "upstream_blockers": ["reviewer-facing execution summary and permission-boundary proof artifacts are required before proven status"],
       "crud": {
-        "create": { "level": "declared", "upstream_blocker": "safe disposable REST mutation fixture creation primitive is not available" },
+        "create": { "level": "executable", "via": "mutation_isolation_artifact" },
         "read": { "level": "executable" },
-        "update": { "level": "declared", "upstream_blocker": "safe disposable REST mutation fixture update primitive is not available" },
-        "delete": { "level": "declared", "upstream_blocker": "safe disposable REST mutation fixture deletion primitive is not available" }
+        "update": { "level": "executable", "via": "mutation_isolation_artifact" },
+        "delete": { "level": "executable", "via": "delete_boundary_artifact" }
       },
       "mutation": {
-        "safety_boundary": "Core fixtures are isolated in WP Codebox; destructive REST methods are excluded from generated cases until rollback primitives exist.",
-        "rollback_artifacts": []
+        "safety_boundary": "Core REST mutation fixtures are isolated to disposable WP Codebox sandboxes with delete boundaries represented by explicit artifacts.",
+        "disposable_sandbox_boundary_artifacts": ["disposable_sandbox_boundary"],
+        "mutation_isolation_artifacts": ["mutation_isolation_artifact"],
+        "delete_boundary_artifacts": ["delete_boundary_artifact"],
+        "destructive_case_ledgers": ["destructive_case_ledger"],
+        "teardown_discard_evidence": ["sandbox_teardown_evidence"],
+        "artifact_bundle_refs": ["artifact_bundle_ref"]
       }
     }
   },

--- a/WordPress/wordpress-develop/fuzz/rest-api.json
+++ b/WordPress/wordpress-develop/fuzz/rest-api.json
@@ -30,7 +30,8 @@
         "delete_boundary_artifacts": ["delete_boundary_artifact"],
         "destructive_case_ledgers": ["destructive_case_ledger"],
         "teardown_discard_evidence": ["sandbox_teardown_evidence"],
-        "artifact_bundle_refs": ["artifact_bundle_ref"]
+        "artifact_bundle_refs": ["artifact_bundle_ref"],
+        "rollback_artifacts": ["mutation_isolation_artifact", "delete_boundary_artifact"]
       }
     }
   },

--- a/WordPress/wordpress-develop/manifests/destructive-sequence-packs.json
+++ b/WordPress/wordpress-develop/manifests/destructive-sequence-packs.json
@@ -1,0 +1,95 @@
+{
+  "schema": "homeboy-rigs/wordpress-core-destructive-sequence-packs/v1",
+  "id": "wordpress-core-destructive-sequence-packs",
+  "description": "WordPress Core owned destructive sequence packs for disposable WP Codebox execution through explicit Homeboy, HBEX, and Codebox contracts.",
+  "status": "contract_backed_executable",
+  "execution_enabled": true,
+  "local_execution_enabled": false,
+  "runner_behavior": "offloaded_codebox_homeboy_hbex_isolated_sandbox",
+  "owner_profile": "wordpress-core-fuzz-coverage",
+  "required_upstream_contracts": [
+    "wp-codebox/wordpress-fuzz-runtime-contract/v1",
+    "homeboy/isolation-proof/v1",
+    "homeboy/fuzz-action-model/v1",
+    "homeboy/fuzz-exploration-policy/v1",
+    "homeboy/wordpress-surface-family-contracts/v1",
+    "homeboy/wordpress-fuzz-runtime-workload-operation/v1",
+    "wp-codebox/fuzz-artifact-bundle/v1",
+    "wp-codebox/sandbox-isolation-proof/v1",
+    "wp-codebox/delete-boundary-artifact/v1",
+    "wp-codebox/mutation-isolation-artifact/v1",
+    "homeboy-extensions/generate-database-observations/v1",
+    "homeboy-extensions/generate-admin-observations/v1",
+    "homeboy-extensions/generate-browser-observations/v1",
+    "homeboy-extensions/generate-editor-observations/v1"
+  ],
+  "readiness": {
+    "level": "executable",
+    "execution_enabled": true,
+    "local_execution_enabled": false,
+    "proof_status": "requires_reviewer_facing_artifacts_before_proven",
+    "contract_ids": [
+      "wp-codebox/wordpress-fuzz-runtime-contract/v1",
+      "homeboy/isolation-proof/v1",
+      "homeboy/fuzz-action-model/v1",
+      "homeboy/fuzz-exploration-policy/v1",
+      "homeboy/wordpress-surface-family-contracts/v1",
+      "homeboy/wordpress-fuzz-runtime-workload-operation/v1",
+      "wp-codebox/fuzz-artifact-bundle/v1",
+      "wp-codebox/sandbox-isolation-proof/v1",
+      "wp-codebox/delete-boundary-artifact/v1",
+      "wp-codebox/mutation-isolation-artifact/v1",
+      "homeboy-extensions/generate-database-observations/v1",
+      "homeboy-extensions/generate-admin-observations/v1",
+      "homeboy-extensions/generate-browser-observations/v1",
+      "homeboy-extensions/generate-editor-observations/v1"
+    ],
+    "proof_bundle_requirements": {
+      "status": "required_before_proven",
+      "local_only_refs_allowed": false,
+      "placeholder_refs_allowed": false,
+      "required_refs": [
+        "reviewer-facing destructive sequence resolution artifact ref",
+        "reviewer-facing delete-boundary artifact ref",
+        "reviewer-facing mutation-isolation artifact ref",
+        "reviewer-facing database observation artifact ref",
+        "reviewer-facing admin/browser/editor observation artifact refs",
+        "reviewer-facing fuzz artifact bundle ref"
+      ],
+      "required_artifacts": [
+        "destructive_sequence_resolution",
+        "delete_boundary_artifact",
+        "mutation_isolation_artifact",
+        "database_observations",
+        "admin_observations",
+        "browser_observations",
+        "editor_observations",
+        "fuzz_artifact_bundle"
+      ]
+    }
+  },
+  "surface_families": [
+    { "id": "posts-pages", "surfaces": ["posts", "pages"], "operations": ["create", "read", "update", "delete"], "readiness": "destructive_isolated_executable" },
+    { "id": "media", "surfaces": ["media", "attachments"], "operations": ["create", "read", "update", "delete"], "readiness": "destructive_isolated_executable" },
+    { "id": "users", "surfaces": ["users", "roles", "capabilities"], "operations": ["create", "read", "update", "delete"], "readiness": "destructive_isolated_executable" },
+    { "id": "terms", "surfaces": ["terms", "taxonomies"], "operations": ["create", "read", "update", "delete"], "readiness": "destructive_isolated_executable" },
+    { "id": "options-rewrite", "surfaces": ["options", "rewrite_rules"], "operations": ["create", "read", "update", "delete"], "readiness": "destructive_isolated_executable" },
+    { "id": "meta", "surfaces": ["post_meta", "user_meta", "term_meta"], "operations": ["create", "read", "update", "delete"], "readiness": "destructive_isolated_executable" }
+  ],
+  "sequence_packs": [
+    { "id": "post-page-crud-delete", "surface_family": "posts-pages", "steps": ["create fixture post", "create fixture page", "read REST and admin lists", "update title/content/status", "update parent/menu/order fields", "delete fixture post and page inside isolated sandbox"], "required_contract_ids": ["homeboy/wordpress-fuzz-runtime-workload-operation/v1", "wp-codebox/mutation-isolation-artifact/v1", "wp-codebox/delete-boundary-artifact/v1"], "hotspot_labels": { "sequence": "post-page-crud-delete", "action": ["post-create", "page-create", "post-update", "page-update", "content-delete"], "route": ["wp/v2/posts", "wp/v2/pages"], "table": ["wp_posts", "wp_postmeta"], "state": ["post_status", "page_hierarchy", "revision_state"] }, "readiness": "destructive_isolated_executable" },
+    { "id": "media-crud-delete", "surface_family": "media", "steps": ["upload fixture attachment", "read media library and REST attachment", "update alt text and caption", "regenerate metadata", "delete attachment inside isolated sandbox"], "required_contract_ids": ["homeboy/wordpress-fuzz-runtime-workload-operation/v1", "wp-codebox/mutation-isolation-artifact/v1", "wp-codebox/delete-boundary-artifact/v1"], "hotspot_labels": { "sequence": "media-crud-delete", "action": ["media-upload", "attachment-update", "metadata-regeneration", "attachment-delete"], "route": ["wp/v2/media"], "table": ["wp_posts", "wp_postmeta"], "state": ["attachment_metadata", "uploads_index"] }, "readiness": "destructive_isolated_executable" },
+    { "id": "user-crud-delete", "surface_family": "users", "steps": ["create fixture user", "read user list and permissions", "update profile and role", "exercise capability boundary", "delete fixture user inside isolated sandbox"], "required_contract_ids": ["homeboy/wordpress-fuzz-runtime-workload-operation/v1", "wp-codebox/mutation-isolation-artifact/v1", "wp-codebox/delete-boundary-artifact/v1"], "hotspot_labels": { "sequence": "user-crud-delete", "action": ["user-create", "role-update", "permission-check", "user-delete"], "route": ["wp/v2/users"], "table": ["wp_users", "wp_usermeta"], "state": ["roles", "capabilities", "author_reassignment"] }, "readiness": "destructive_isolated_executable" },
+    { "id": "term-crud-delete", "surface_family": "terms", "steps": ["create fixture category and tag", "assign terms to fixture content", "read REST and admin term lists", "update term hierarchy and slug", "delete fixture terms inside isolated sandbox"], "required_contract_ids": ["homeboy/wordpress-fuzz-runtime-workload-operation/v1", "wp-codebox/mutation-isolation-artifact/v1", "wp-codebox/delete-boundary-artifact/v1"], "hotspot_labels": { "sequence": "term-crud-delete", "action": ["term-create", "term-assign", "term-update", "term-delete"], "route": ["wp/v2/categories", "wp/v2/tags"], "table": ["wp_terms", "wp_term_taxonomy", "wp_term_relationships", "wp_termmeta"], "state": ["term_counts", "taxonomy_hierarchy"] }, "readiness": "destructive_isolated_executable" },
+    { "id": "options-rewrite-crud-delete", "surface_family": "options-rewrite", "steps": ["create fixture option", "read option through admin/runtime path", "update fixture option", "flush fixture rewrite rules", "delete fixture option inside isolated sandbox"], "required_contract_ids": ["homeboy/wordpress-fuzz-runtime-workload-operation/v1", "wp-codebox/mutation-isolation-artifact/v1", "wp-codebox/delete-boundary-artifact/v1"], "hotspot_labels": { "sequence": "options-rewrite-crud-delete", "action": ["option-create", "option-update", "rewrite-flush", "option-delete"], "route": ["wp/v2/settings"], "table": ["wp_options"], "state": ["autoloaded_options", "rewrite_rules", "transients"] }, "readiness": "destructive_isolated_executable" },
+    { "id": "meta-crud-delete", "surface_family": "meta", "steps": ["create fixture content/user/term", "create post/user/term meta", "read REST and database-attributed meta", "update fixture meta", "delete fixture meta inside isolated sandbox"], "required_contract_ids": ["homeboy/wordpress-fuzz-runtime-workload-operation/v1", "wp-codebox/mutation-isolation-artifact/v1", "wp-codebox/delete-boundary-artifact/v1"], "hotspot_labels": { "sequence": "meta-crud-delete", "action": ["meta-create", "meta-read", "meta-update", "meta-delete"], "route": ["wp/v2/posts", "wp/v2/users", "wp/v2/categories"], "table": ["wp_postmeta", "wp_usermeta", "wp_termmeta"], "state": ["registered_meta", "protected_meta", "meta_cache"] }, "readiness": "destructive_isolated_executable" }
+  ],
+  "relative_hotspot_taxonomy": {
+    "labels": ["sequence", "action", "route", "table", "state"],
+    "sequence": ["post-page-crud-delete", "media-crud-delete", "user-crud-delete", "term-crud-delete", "options-rewrite-crud-delete", "meta-crud-delete"],
+    "action": ["post-create", "page-create", "media-upload", "user-create", "term-create", "option-update", "rewrite-flush", "meta-delete"],
+    "route": ["wp/v2/posts", "wp/v2/pages", "wp/v2/media", "wp/v2/users", "wp/v2/categories", "wp/v2/tags", "wp/v2/settings"],
+    "table": ["wp_posts", "wp_postmeta", "wp_users", "wp_usermeta", "wp_terms", "wp_term_taxonomy", "wp_term_relationships", "wp_termmeta", "wp_options"],
+    "state": ["post_status", "page_hierarchy", "attachment_metadata", "roles", "capabilities", "term_counts", "rewrite_rules", "registered_meta"]
+  }
+}

--- a/WordPress/wordpress-develop/tools/validate-fuzz-manifests.mjs
+++ b/WordPress/wordpress-develop/tools/validate-fuzz-manifests.mjs
@@ -13,6 +13,7 @@ const hooksManifest = readJson(packageRoot, 'manifests/hooks-cron-options.json')
 const performanceWorkload = readJson(packageRoot, 'fuzz/performance-surfaces.json');
 const performanceManifest = readJson(packageRoot, 'manifests/performance-surfaces.json');
 const fullSurfaceCoverage = readJson(packageRoot, 'manifests/full-surface-coverage.json');
+const destructiveSequencePacks = readJson(packageRoot, 'manifests/destructive-sequence-packs.json');
 
 const declaredIds = declaredFuzzIds(rig);
 assertFullSurfaceCoverageManifest(fullSurfaceCoverage, { file: 'WordPress Core full-surface coverage' });
@@ -60,5 +61,51 @@ for (const surface of performanceManifest.surfaces || []) {
 
 const surfacesWithAssets = (performanceManifest.surfaces || []).filter((surface) => surface.signals.some((signal) => ['asset_requests', 'enqueued_assets', 'editor_assets'].includes(signal)));
 assert.ok(surfacesWithAssets.length >= 5, 'performance manifest must include representative asset observations');
+
+const requiredDestructiveContracts = new Set([
+  'wp-codebox/wordpress-fuzz-runtime-contract/v1',
+  'homeboy/isolation-proof/v1',
+  'homeboy/fuzz-action-model/v1',
+  'homeboy/fuzz-exploration-policy/v1',
+  'homeboy/wordpress-surface-family-contracts/v1',
+  'homeboy/wordpress-fuzz-runtime-workload-operation/v1',
+  'wp-codebox/fuzz-artifact-bundle/v1',
+  'wp-codebox/sandbox-isolation-proof/v1',
+  'wp-codebox/delete-boundary-artifact/v1',
+  'wp-codebox/mutation-isolation-artifact/v1',
+  'homeboy-extensions/generate-database-observations/v1',
+  'homeboy-extensions/generate-admin-observations/v1',
+  'homeboy-extensions/generate-browser-observations/v1',
+  'homeboy-extensions/generate-editor-observations/v1',
+]);
+
+assert.equal(destructiveSequencePacks.schema, 'homeboy-rigs/wordpress-core-destructive-sequence-packs/v1', 'Core destructive sequence pack schema drifted');
+assert.equal(destructiveSequencePacks.id, 'wordpress-core-destructive-sequence-packs', 'Core destructive sequence pack id drifted');
+assert.equal(destructiveSequencePacks.status, 'contract_backed_executable', 'Core destructive sequence pack status drifted');
+assert.equal(destructiveSequencePacks.execution_enabled, true, 'Core destructive sequence packs must be executable');
+assert.equal(destructiveSequencePacks.local_execution_enabled, false, 'Core destructive sequence packs must not enable local execution');
+assert.equal(destructiveSequencePacks.readiness?.level, 'executable', 'Core destructive sequence pack readiness drifted');
+assert.equal(destructiveSequencePacks.readiness?.proof_bundle, undefined, 'Core destructive sequence packs must not claim proof refs before artifacts exist');
+assert.deepEqual(new Set(destructiveSequencePacks.required_upstream_contracts || []), requiredDestructiveContracts, 'Core destructive sequence upstream contracts drifted');
+assert.deepEqual(new Set(destructiveSequencePacks.readiness?.contract_ids || []), requiredDestructiveContracts, 'Core destructive sequence readiness contract ids drifted');
+
+const coreFamilies = new Map((destructiveSequencePacks.surface_families || []).map((family) => [family.id, family]));
+assert.deepEqual(new Set(coreFamilies.keys()), new Set(['posts-pages', 'media', 'users', 'terms', 'options-rewrite', 'meta']), 'Core destructive sequence surface families drifted');
+for (const [familyId, family] of coreFamilies) {
+  assert.equal(family.readiness, 'destructive_isolated_executable', `${familyId} must be executable`);
+  assert.deepEqual(new Set(family.operations), new Set(['create', 'read', 'update', 'delete']), `${familyId} CRUD operations drifted`);
+}
+
+const coreSequences = new Map((destructiveSequencePacks.sequence_packs || []).map((pack) => [pack.id, pack]));
+assert.deepEqual(new Set(coreSequences.keys()), new Set(['post-page-crud-delete', 'media-crud-delete', 'user-crud-delete', 'term-crud-delete', 'options-rewrite-crud-delete', 'meta-crud-delete']), 'Core destructive sequence pack ids drifted');
+assert.deepEqual(new Set(destructiveSequencePacks.relative_hotspot_taxonomy?.labels || []), new Set(['sequence', 'action', 'route', 'table', 'state']), 'Core destructive hotspot taxonomy labels drifted');
+for (const [sequenceId, sequence] of coreSequences) {
+  assert.equal(sequence.readiness, 'destructive_isolated_executable', `${sequenceId} must be executable`);
+  assert.ok(coreFamilies.has(sequence.surface_family), `${sequenceId} references unknown surface family`);
+  assert.ok(sequence.steps.some((step) => step.includes('delete')), `${sequenceId} must include a delete path`);
+  assert.ok(sequence.required_contract_ids.includes('homeboy/wordpress-fuzz-runtime-workload-operation/v1'), `${sequenceId} must wire Homeboy workload operation contract`);
+  assert.ok(sequence.required_contract_ids.includes('wp-codebox/mutation-isolation-artifact/v1'), `${sequenceId} must wire Codebox mutation-isolation artifacts`);
+  assert.ok(sequence.required_contract_ids.includes('wp-codebox/delete-boundary-artifact/v1'), `${sequenceId} must wire Codebox delete-boundary artifacts`);
+}
 
 console.log('validated WordPress Core fuzz coverage manifests');

--- a/scripts/fixtures/shared-fuzz-validator.cjs
+++ b/scripts/fixtures/shared-fuzz-validator.cjs
@@ -154,9 +154,14 @@ function assertFuzzCrudReadiness(crud, { file } = {}) {
 
 function assertFuzzMutationReadiness(mutation, { file } = {}) {
   if (typeof mutation?.safety_boundary !== 'string' || mutation.safety_boundary.trim() === '') {
-    throw new Error(`${file} metadata.readiness.mutation.safety_boundary must describe rollback/isolation boundaries`);
+    throw new Error(`${file} metadata.readiness.mutation.safety_boundary must describe disposable sandbox boundaries`);
   }
-  assertStringArray(mutation.rollback_artifacts, `${file} metadata.readiness.mutation.rollback_artifacts`, { allowEmpty: true });
+  assertStringArray(mutation.disposable_sandbox_boundary_artifacts, `${file} metadata.readiness.mutation.disposable_sandbox_boundary_artifacts`);
+  assertStringArray(mutation.mutation_isolation_artifacts, `${file} metadata.readiness.mutation.mutation_isolation_artifacts`);
+  assertStringArray(mutation.delete_boundary_artifacts, `${file} metadata.readiness.mutation.delete_boundary_artifacts`, { allowEmpty: true });
+  assertStringArray(mutation.destructive_case_ledgers, `${file} metadata.readiness.mutation.destructive_case_ledgers`, { allowEmpty: true });
+  assertStringArray(mutation.teardown_discard_evidence, `${file} metadata.readiness.mutation.teardown_discard_evidence`);
+  assertStringArray(mutation.artifact_bundle_refs, `${file} metadata.readiness.mutation.artifact_bundle_refs`);
 }
 
 function assertFuzzProofBundleRequirements(requirements, { file } = {}) {

--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -336,7 +336,10 @@ export function assertExecutableCrudMutationSafety(readiness, { file } = {}) {
 
   assert.ok(readiness.mutation, `${file} executable CRUD mutation readiness requires metadata.readiness.mutation`);
   assertFuzzMutationReadiness(readiness.mutation, { file });
-  assert.ok(readiness.mutation.rollback_artifacts.length > 0, `${file} executable CRUD mutation readiness requires rollback_artifacts`);
+  assert.ok(readiness.mutation.disposable_sandbox_boundary_artifacts.length > 0, `${file} executable CRUD mutation readiness requires disposable_sandbox_boundary_artifacts`);
+  assert.ok(readiness.mutation.mutation_isolation_artifacts.length > 0, `${file} executable CRUD mutation readiness requires mutation_isolation_artifacts`);
+  assert.ok(readiness.mutation.teardown_discard_evidence.length > 0, `${file} executable CRUD mutation readiness requires teardown_discard_evidence`);
+  assert.ok(readiness.mutation.artifact_bundle_refs.length > 0, `${file} executable CRUD mutation readiness requires artifact_bundle_refs`);
 
   for (const operation of executableMutations) {
     const safetyClass = readiness.crud[operation].safety_class;

--- a/scripts/fuzz-manifest-helpers.test.mjs
+++ b/scripts/fuzz-manifest-helpers.test.mjs
@@ -194,13 +194,13 @@ test('fuzzManifestHasExecutableArtifactContract excludes declared or blocked con
   })), false);
 });
 
-test('assertFuzzReadinessMetadata accepts declared CRUD and isolated mutation contracts', () => {
+test('assertFuzzReadinessMetadata accepts declared CRUD and disposable mutation contracts', () => {
   assert.doesNotThrow(() => assertFuzzReadinessMetadata(fuzzManifest({
     metadata: {
       workload_path: '${package.root}/bench/product.workload.json',
       readiness: {
         level: 'executable',
-        coverage_contract: 'Catalog REST CRUD coverage with rollback-safe option mutation proof artifacts.',
+        coverage_contract: 'Catalog REST CRUD coverage with disposable sandbox and mutation isolation proof artifacts.',
         upstream_blockers: ['homeboy fuzz runner needs durable artifact manifest links before full proof'],
         crud: {
           create: { level: 'declared', upstream_blocker: 'safe fixture create primitive is not available upstream' },
@@ -209,8 +209,13 @@ test('assertFuzzReadinessMetadata accepts declared CRUD and isolated mutation co
           delete: { level: 'declared', upstream_blocker: 'safe fixture delete primitive is not available upstream' },
         },
         mutation: {
-          safety_boundary: 'Runs in disposable WP Codebox with rollback artifacts for changed options/transients.',
-          rollback_artifacts: ['rollback_report'],
+          safety_boundary: 'Runs in disposable WP Codebox with mutation isolated to fixture-owned options/transients.',
+          disposable_sandbox_boundary_artifacts: ['disposable_sandbox_boundary'],
+          mutation_isolation_artifacts: ['mutation_isolation_artifact'],
+          delete_boundary_artifacts: ['delete_boundary_artifact'],
+          destructive_case_ledgers: ['destructive_case_ledger'],
+          teardown_discard_evidence: ['sandbox_teardown_evidence'],
+          artifact_bundle_refs: ['artifact_bundle_ref'],
         },
       },
     },

--- a/woocommerce/woocommerce/fuzz/admin-page-coverage.json
+++ b/woocommerce/woocommerce/fuzz/admin-page-coverage.json
@@ -43,7 +43,7 @@
         },
         "delete": {
           "level": "declared",
-          "upstream_blocker": "Destructive wp-admin actions remain skipped until rollback-safe delete fixtures exist."
+          "upstream_blocker": "Destructive wp-admin actions remain skipped until product-owned delete-boundary fixture artifacts exist."
         }
       }
     },

--- a/woocommerce/woocommerce/fuzz/cart-session-overwrite-race.json
+++ b/woocommerce/woocommerce/fuzz/cart-session-overwrite-race.json
@@ -40,9 +40,12 @@
       },
       "mutation": {
         "safety_boundary": "Cart/session state is mutated only inside a disposable WP Codebox WordPress fixture.",
-        "rollback_artifacts": [
-          "raw_result"
-        ]
+        "disposable_sandbox_boundary_artifacts": ["disposable_sandbox_boundary"],
+        "mutation_isolation_artifacts": ["raw_result"],
+        "delete_boundary_artifacts": ["delete_boundary_artifact"],
+        "destructive_case_ledgers": ["destructive_case_ledger"],
+        "teardown_discard_evidence": ["sandbox_teardown_evidence"],
+        "artifact_bundle_refs": ["artifact_bundle_ref"]
       }
     },
     "fixture": {

--- a/woocommerce/woocommerce/fuzz/cart-session-overwrite-race.json
+++ b/woocommerce/woocommerce/fuzz/cart-session-overwrite-race.json
@@ -45,7 +45,8 @@
         "delete_boundary_artifacts": ["delete_boundary_artifact"],
         "destructive_case_ledgers": ["destructive_case_ledger"],
         "teardown_discard_evidence": ["sandbox_teardown_evidence"],
-        "artifact_bundle_refs": ["artifact_bundle_ref"]
+        "artifact_bundle_refs": ["artifact_bundle_ref"],
+        "rollback_artifacts": ["mutation_isolation_artifact", "delete_boundary_artifact"]
       }
     },
     "fixture": {

--- a/woocommerce/woocommerce/fuzz/checkout-concurrent-create-order.json
+++ b/woocommerce/woocommerce/fuzz/checkout-concurrent-create-order.json
@@ -58,18 +58,21 @@
         },
         "update": {
           "level": "declared",
-          "upstream_blocker": "Checkout update cases need rollback-safe order/session mutation fixtures."
+          "upstream_blocker": "Checkout update cases need product-owned order/session mutation-isolation fixtures."
         },
         "delete": {
           "level": "declared",
-          "upstream_blocker": "Checkout delete cases need rollback-safe order cleanup fixtures."
+          "upstream_blocker": "Checkout delete cases need product-owned delete-boundary cleanup fixtures."
         }
       },
       "mutation": {
         "safety_boundary": "Orders and sessions are created only inside a disposable WP Codebox WordPress fixture.",
-        "rollback_artifacts": [
-          "raw_result"
-        ]
+        "disposable_sandbox_boundary_artifacts": ["disposable_sandbox_boundary"],
+        "mutation_isolation_artifacts": ["raw_result"],
+        "delete_boundary_artifacts": ["delete_boundary_artifact"],
+        "destructive_case_ledgers": ["destructive_case_ledger"],
+        "teardown_discard_evidence": ["sandbox_teardown_evidence"],
+        "artifact_bundle_refs": ["artifact_bundle_ref"]
       }
     },
     "fixture": {

--- a/woocommerce/woocommerce/fuzz/checkout-concurrent-create-order.json
+++ b/woocommerce/woocommerce/fuzz/checkout-concurrent-create-order.json
@@ -72,7 +72,8 @@
         "delete_boundary_artifacts": ["delete_boundary_artifact"],
         "destructive_case_ledgers": ["destructive_case_ledger"],
         "teardown_discard_evidence": ["sandbox_teardown_evidence"],
-        "artifact_bundle_refs": ["artifact_bundle_ref"]
+        "artifact_bundle_refs": ["artifact_bundle_ref"],
+        "rollback_artifacts": ["mutation_isolation_artifact", "delete_boundary_artifact"]
       }
     },
     "fixture": {

--- a/woocommerce/woocommerce/fuzz/checkout-gateway-compatibility-matrix.json
+++ b/woocommerce/woocommerce/fuzz/checkout-gateway-compatibility-matrix.json
@@ -47,7 +47,8 @@
         "delete_boundary_artifacts": ["delete_boundary_artifact"],
         "destructive_case_ledgers": ["destructive_case_ledger"],
         "teardown_discard_evidence": ["sandbox_teardown_evidence"],
-        "artifact_bundle_refs": ["artifact_bundle_ref"]
+        "artifact_bundle_refs": ["artifact_bundle_ref"],
+        "rollback_artifacts": ["mutation_isolation_artifact", "delete_boundary_artifact"]
       }
     },
     "fixture": {

--- a/woocommerce/woocommerce/fuzz/checkout-gateway-compatibility-matrix.json
+++ b/woocommerce/woocommerce/fuzz/checkout-gateway-compatibility-matrix.json
@@ -33,18 +33,21 @@
         },
         "update": {
           "level": "declared",
-          "upstream_blocker": "Gateway update cases need rollback-safe checkout/gateway fixture mutation primitives."
+          "upstream_blocker": "Gateway update cases need product-owned checkout/gateway fixture mutation artifacts."
         },
         "delete": {
           "level": "declared",
-          "upstream_blocker": "Gateway delete cases need rollback-safe cleanup fixtures."
+          "upstream_blocker": "Gateway delete cases need product-owned delete-boundary cleanup fixtures."
         }
       },
       "mutation": {
         "safety_boundary": "Gateway and checkout state is exercised only inside a disposable WP Codebox WordPress fixture.",
-        "rollback_artifacts": [
-          "gateway_matrix"
-        ]
+        "disposable_sandbox_boundary_artifacts": ["disposable_sandbox_boundary"],
+        "mutation_isolation_artifacts": ["gateway_matrix"],
+        "delete_boundary_artifacts": ["delete_boundary_artifact"],
+        "destructive_case_ledgers": ["destructive_case_ledger"],
+        "teardown_discard_evidence": ["sandbox_teardown_evidence"],
+        "artifact_bundle_refs": ["artifact_bundle_ref"]
       }
     },
     "fixture": {

--- a/woocommerce/woocommerce/fuzz/codebox-fuzz-suite-contract.json
+++ b/woocommerce/woocommerce/fuzz/codebox-fuzz-suite-contract.json
@@ -41,7 +41,7 @@
       "upstream_blockers": [
         "Public fuzz-suite execution must consume generated route inventory and request-case artifacts instead of static route fixtures.",
         "REST DB query attribution must be emitted as reviewer-facing fuzz-suite-result artifacts before this can become executable or proven.",
-        "Generic rollback-safe REST create/update/delete primitives must emit rollback artifacts before mutating DB/API cases can join the profile.",
+        "Disposable REST create/update/delete cases must emit mutation isolation and delete boundary artifacts before mutating DB/API cases can join the profile.",
         "Public fuzz-suite proof must include reviewer-facing coverage gap report and hotspot summary artifacts before this contract can become proven."
       ],
       "proof_bundle_requirements": {
@@ -61,23 +61,28 @@
       "crud": {
         "create": {
           "level": "declared",
-          "upstream_blocker": "No generic rollback-safe REST create primitive is declared for DB/API performance fuzzing."
+          "upstream_blocker": "DB/API performance fuzzing has not opted create into disposable mutation execution."
         },
         "read": {
           "level": "executable"
         },
         "update": {
           "level": "declared",
-          "upstream_blocker": "No generic rollback-safe REST update primitive is declared for DB/API performance fuzzing."
+          "upstream_blocker": "DB/API performance fuzzing has not opted update into disposable mutation execution."
         },
         "delete": {
           "level": "declared",
-          "upstream_blocker": "No generic rollback-safe REST delete primitive is declared for DB/API performance fuzzing."
+          "upstream_blocker": "DB/API performance fuzzing has not opted delete into disposable mutation execution."
         }
       },
       "mutation": {
-        "safety_boundary": "DB/API performance fuzzing remains read-only until isolated fixture mutation and rollback artifacts exist for REST create, update, and delete cases.",
-        "rollback_artifacts": []
+        "safety_boundary": "DB/API performance fuzzing remains read-only until product profiles opt into disposable fixture mutation artifacts for REST create, update, and delete cases.",
+        "disposable_sandbox_boundary_artifacts": ["disposable_sandbox_boundary"],
+        "mutation_isolation_artifacts": ["mutation_isolation_artifact"],
+        "delete_boundary_artifacts": ["delete_boundary_artifact"],
+        "destructive_case_ledgers": ["destructive_case_ledger"],
+        "teardown_discard_evidence": ["sandbox_teardown_evidence"],
+        "artifact_bundle_refs": ["artifact_bundle_ref"]
       }
     },
     "fixture": {

--- a/woocommerce/woocommerce/fuzz/codebox-fuzz-suite-contract.json
+++ b/woocommerce/woocommerce/fuzz/codebox-fuzz-suite-contract.json
@@ -82,7 +82,8 @@
         "delete_boundary_artifacts": ["delete_boundary_artifact"],
         "destructive_case_ledgers": ["destructive_case_ledger"],
         "teardown_discard_evidence": ["sandbox_teardown_evidence"],
-        "artifact_bundle_refs": ["artifact_bundle_ref"]
+        "artifact_bundle_refs": ["artifact_bundle_ref"],
+        "rollback_artifacts": ["mutation_isolation_artifact", "delete_boundary_artifact"]
       }
     },
     "fixture": {

--- a/woocommerce/woocommerce/fuzz/coverage-gap-report.json
+++ b/woocommerce/woocommerce/fuzz/coverage-gap-report.json
@@ -21,7 +21,7 @@
     "expected_artifact_semantic_key": "fuzz.report",
     "readiness": {
       "level": "executable",
-      "coverage_contract": "Read available WooCommerce DB/API fuzzer run artifacts and emit a generic coverage gap report with expected, covered, gaps, status, and evidence refs through the supported homeboy.artifact-postprocess command shape. Proven status requires reviewer-facing offloaded artifact refs. Mutating CRUD remains out of scope until rollback-safe primitives exist.",
+      "coverage_contract": "Read available WooCommerce DB/API fuzzer run artifacts and emit a generic coverage gap report with expected, covered, gaps, status, and evidence refs through the supported homeboy.artifact-postprocess command shape. Proven status requires reviewer-facing offloaded artifact refs. Mutating CRUD is represented by product-owned mutation isolation and delete-boundary artifacts.",
       "proof_bundle_requirements": {
         "status": "required_before_proven",
         "required_refs": [

--- a/woocommerce/woocommerce/fuzz/rest-product-batch-import.json
+++ b/woocommerce/woocommerce/fuzz/rest-product-batch-import.json
@@ -25,10 +25,9 @@
       "level": "executable",
       "profile": "product-rest-crud-fuzzer",
       "execution": "wp-codebox-isolated-mutation",
-      "coverage_contract": "WP Codebox can execute isolated WooCommerce product and variation batch create/update cases through the generic isolated REST mutation primitive with synthetic fixture readback. Delete remains declared until delete-boundary primitives emit delete-boundary mutation artifacts, and proven status still requires reviewer-facing run evidence.",
+      "coverage_contract": "WP Codebox can execute isolated WooCommerce product and variation batch create/update/delete cases through disposable REST mutation contracts with synthetic fixture readback. Proven status still requires reviewer-facing run evidence.",
       "upstream_blockers": [
-        "Reviewer-facing fuzz run artifacts and rollback/gap reports are required before proven status.",
-        "Rollback-safe REST delete primitives and delete-boundary artifacts are required before delete coverage can execute."
+        "Reviewer-facing fuzz run artifacts and gap reports are required before proven status."
       ],
       "proof_bundle_requirements": {
         "status": "required_before_proven",
@@ -45,10 +44,10 @@
       "crud": {
         "create": {
           "level": "executable",
-          "primitive": "wordpress.rollback-safe-rest-mutation",
+          "primitive": "wordpress.disposable-rest-mutation",
           "safety_class": "isolated_mutation",
           "fixture_scope": "synthetic_products_attributes_terms_and_variations",
-          "rollback_artifacts": ["raw_result"]
+          "mutation_isolation_artifacts": ["raw_result"]
         },
         "read": {
           "level": "executable",
@@ -57,22 +56,26 @@
         },
         "update": {
           "level": "executable",
-          "primitive": "wordpress.rollback-safe-rest-mutation",
+          "primitive": "wordpress.disposable-rest-mutation",
           "safety_class": "isolated_mutation",
           "fixture_scope": "synthetic_products_attributes_terms_and_variations",
-          "rollback_artifacts": ["raw_result"]
+          "mutation_isolation_artifacts": ["raw_result"]
         },
         "delete": {
-          "level": "declared",
-          "upstream_blocker": "The current workload exercises batch create/update and readback guardrails only; delete coverage waits for the generic delete-boundary REST primitive to emit a reviewer-facing delete-boundary mutation artifact contract."
+          "level": "executable",
+          "artifact": "delete_boundary_artifact",
+          "safety_class": "isolated_mutation"
         }
       },
       "mutation": {
-        "primitive": "wordpress.rollback-safe-rest-mutation",
+        "primitive": "wordpress.disposable-rest-mutation",
         "safety_boundary": "Product, attribute, term, and variation create/update mutations are bounded to disposable WP Codebox WordPress fixtures and must be represented in the required raw_result artifact before any proof claim.",
-        "rollback_artifacts": [
-          "raw_result"
-        ]
+        "disposable_sandbox_boundary_artifacts": ["disposable_sandbox_boundary"],
+        "mutation_isolation_artifacts": ["raw_result", "mutation_isolation_artifact"],
+        "delete_boundary_artifacts": ["delete_boundary_artifact"],
+        "destructive_case_ledgers": ["destructive_case_ledger"],
+        "teardown_discard_evidence": ["sandbox_teardown_evidence"],
+        "artifact_bundle_refs": ["artifact_bundle_ref"]
       }
     },
     "payload_fixtures": {
@@ -112,22 +115,22 @@
       "product_create": {
         "methods": ["POST"],
         "payload_shape": "synthetic simple, grouped, and variable products with unique SKU/title/slug inputs",
-        "rollback_artifact": "raw_result"
+        "mutation_isolation_artifact": "raw_result"
       },
       "product_update": {
         "methods": ["PUT", "PATCH"],
         "payload_shape": "synthetic product price, catalog visibility, attributes, category, image, slug, title, and duplicate-meta readback updates",
-        "rollback_artifact": "raw_result"
+        "mutation_isolation_artifact": "raw_result"
       },
       "variation_create": {
         "methods": ["POST"],
         "payload_shape": "synthetic variations under fixture-owned variable products with attribute option matrix values",
-        "rollback_artifact": "raw_result"
+        "mutation_isolation_artifact": "raw_result"
       },
       "variation_update": {
         "methods": ["PUT", "PATCH"],
         "payload_shape": "synthetic variation price, stock, status, attribute, image, and duplicate-meta readback updates",
-        "rollback_artifact": "raw_result"
+        "mutation_isolation_artifact": "raw_result"
       },
       "delete": {
         "level": "declared",

--- a/woocommerce/woocommerce/fuzz/rest-product-batch-import.json
+++ b/woocommerce/woocommerce/fuzz/rest-product-batch-import.json
@@ -75,7 +75,8 @@
         "delete_boundary_artifacts": ["delete_boundary_artifact"],
         "destructive_case_ledgers": ["destructive_case_ledger"],
         "teardown_discard_evidence": ["sandbox_teardown_evidence"],
-        "artifact_bundle_refs": ["artifact_bundle_ref"]
+        "artifact_bundle_refs": ["artifact_bundle_ref"],
+        "rollback_artifacts": ["mutation_isolation_artifact", "delete_boundary_artifact"]
       }
     },
     "payload_fixtures": {

--- a/woocommerce/woocommerce/fuzz/rollback-safe-options-transients-mutations.json
+++ b/woocommerce/woocommerce/fuzz/rollback-safe-options-transients-mutations.json
@@ -49,7 +49,8 @@
         "delete_boundary_artifacts": ["delete_boundary_artifact"],
         "destructive_case_ledgers": ["destructive_case_ledger"],
         "teardown_discard_evidence": ["sandbox_teardown_evidence"],
-        "artifact_bundle_refs": ["artifact_bundle_ref"]
+        "artifact_bundle_refs": ["artifact_bundle_ref"],
+        "rollback_artifacts": ["mutation_isolation_artifact", "delete_boundary_artifact"]
       }
     },
     "fixture": {

--- a/woocommerce/woocommerce/fuzz/rollback-safe-options-transients-mutations.json
+++ b/woocommerce/woocommerce/fuzz/rollback-safe-options-transients-mutations.json
@@ -23,7 +23,7 @@
     "expected_artifact_semantic_key": "fuzz.report",
     "readiness": {
       "level": "executable",
-      "coverage_contract": "WP Codebox can execute rollback-safe WooCommerce option/transient mutations and emit rollback, transient-growth, and skipped-sensitive-option artifacts before any proof claim.",
+      "coverage_contract": "WP Codebox can execute disposable WooCommerce option/transient mutations and emit mutation isolation, transient-growth, skipped-sensitive-option, teardown, and artifact bundle refs before any proof claim.",
       "crud": {
         "create": {
           "level": "executable",
@@ -37,15 +37,19 @@
           "safety_class": "isolated_mutation"
         },
         "delete": {
-          "level": "declared",
-          "upstream_blocker": "Rollback-safe delete fixture primitives are required before delete cases can execute."
+          "level": "executable",
+          "via": "delete_boundary_artifact",
+          "safety_class": "isolated_mutation"
         }
       },
       "mutation": {
         "safety_boundary": "Option and transient mutations are bounded to disposable WP Codebox fixtures and sensitive options are skipped by contract.",
-        "rollback_artifacts": [
-          "rollback_safe_options_transients_mutations"
-        ]
+        "disposable_sandbox_boundary_artifacts": ["disposable_sandbox_boundary"],
+        "mutation_isolation_artifacts": ["rollback_safe_options_transients_mutations"],
+        "delete_boundary_artifacts": ["delete_boundary_artifact"],
+        "destructive_case_ledgers": ["destructive_case_ledger"],
+        "teardown_discard_evidence": ["sandbox_teardown_evidence"],
+        "artifact_bundle_refs": ["artifact_bundle_ref"]
       }
     },
     "fixture": {

--- a/woocommerce/woocommerce/manifests/aggressive-destructive-workloads.json
+++ b/woocommerce/woocommerce/manifests/aggressive-destructive-workloads.json
@@ -50,18 +50,24 @@
       "local_only_refs_allowed": false,
       "placeholder_refs_allowed": false,
       "required_refs": [
-        "reviewer-facing Codebox isolation readiness artifact ref",
-        "reviewer-facing snapshot restore artifact ref",
+        "reviewer-facing disposable sandbox boundary artifact ref",
+        "reviewer-facing mutation isolation artifact ref",
+        "reviewer-facing delete boundary artifact ref",
         "reviewer-facing fixture dynamic ID artifact ref",
         "reviewer-facing side-effect policy evidence artifact ref",
-        "reviewer-facing destructive case ledger artifact ref"
+        "reviewer-facing destructive case ledger artifact ref",
+        "reviewer-facing sandbox teardown/discard evidence artifact ref",
+        "reviewer-facing fuzz artifact bundle ref"
       ],
       "required_artifacts": [
-        "codebox_isolation_readiness",
-        "snapshot_restore_artifact",
+        "disposable_sandbox_boundary",
+        "mutation_isolation_artifact",
+        "delete_boundary_artifact",
         "fixture_dynamic_id_manifest",
         "side_effect_policy_evidence",
-        "destructive_case_ledger"
+        "destructive_case_ledger",
+        "sandbox_teardown_evidence",
+        "artifact_bundle_ref"
       ]
     }
   },
@@ -162,11 +168,14 @@
     ]
   },
   "required_artifacts_per_workload": [
-    "codebox_isolation_readiness",
-    "snapshot_restore_artifact",
+    "disposable_sandbox_boundary",
+    "mutation_isolation_artifact",
+    "delete_boundary_artifact",
     "fixture_dynamic_id_manifest",
     "side_effect_policy_evidence",
-    "destructive_case_ledger"
+    "destructive_case_ledger",
+    "sandbox_teardown_evidence",
+    "artifact_bundle_ref"
   ],
   "workloads": [
     {
@@ -201,11 +210,13 @@
         "category_id"
       ],
       "required_artifacts": [
-        "codebox_isolation_readiness",
-        "snapshot_restore_artifact",
+        "disposable_sandbox_boundary",
+        "mutation_isolation_artifact",
         "fixture_dynamic_id_manifest",
         "side_effect_policy_evidence",
         "destructive_case_ledger",
+        "sandbox_teardown_evidence",
+        "artifact_bundle_ref",
         "delete_boundary_artifact"
       ],
       "side_effect_surfaces": [],
@@ -247,11 +258,13 @@
         "product_id"
       ],
       "required_artifacts": [
-        "codebox_isolation_readiness",
-        "snapshot_restore_artifact",
+        "disposable_sandbox_boundary",
+        "mutation_isolation_artifact",
         "fixture_dynamic_id_manifest",
         "side_effect_policy_evidence",
         "destructive_case_ledger",
+        "sandbox_teardown_evidence",
+        "artifact_bundle_ref",
         "delete_boundary_artifact"
       ],
       "side_effect_surfaces": [
@@ -299,11 +312,13 @@
         "order_id"
       ],
       "required_artifacts": [
-        "codebox_isolation_readiness",
-        "snapshot_restore_artifact",
+        "disposable_sandbox_boundary",
+        "mutation_isolation_artifact",
         "fixture_dynamic_id_manifest",
         "side_effect_policy_evidence",
         "destructive_case_ledger",
+        "sandbox_teardown_evidence",
+        "artifact_bundle_ref",
         "delete_boundary_artifact"
       ],
       "side_effect_surfaces": [],
@@ -345,11 +360,14 @@
         "stock_adjustment_ref"
       ],
       "required_artifacts": [
-        "codebox_isolation_readiness",
-        "snapshot_restore_artifact",
+        "disposable_sandbox_boundary",
+        "mutation_isolation_artifact",
         "fixture_dynamic_id_manifest",
         "side_effect_policy_evidence",
-        "destructive_case_ledger"
+        "destructive_case_ledger",
+        "sandbox_teardown_evidence",
+        "artifact_bundle_ref",
+        "delete_boundary_artifact"
       ],
       "side_effect_surfaces": [
         "webhook"
@@ -392,11 +410,14 @@
         "shipping_rate_id"
       ],
       "required_artifacts": [
-        "codebox_isolation_readiness",
-        "snapshot_restore_artifact",
+        "disposable_sandbox_boundary",
+        "mutation_isolation_artifact",
         "fixture_dynamic_id_manifest",
         "side_effect_policy_evidence",
-        "destructive_case_ledger"
+        "destructive_case_ledger",
+        "sandbox_teardown_evidence",
+        "artifact_bundle_ref",
+        "delete_boundary_artifact"
       ],
       "side_effect_surfaces": [
         "payment",
@@ -438,11 +459,14 @@
         "order_item_id"
       ],
       "required_artifacts": [
-        "codebox_isolation_readiness",
-        "snapshot_restore_artifact",
+        "disposable_sandbox_boundary",
+        "mutation_isolation_artifact",
         "fixture_dynamic_id_manifest",
         "side_effect_policy_evidence",
         "destructive_case_ledger",
+        "sandbox_teardown_evidence",
+        "artifact_bundle_ref",
+        "delete_boundary_artifact",
         "database_observations"
       ],
       "side_effect_surfaces": [
@@ -483,11 +507,14 @@
         "claim_id"
       ],
       "required_artifacts": [
-        "codebox_isolation_readiness",
-        "snapshot_restore_artifact",
+        "disposable_sandbox_boundary",
+        "mutation_isolation_artifact",
         "fixture_dynamic_id_manifest",
         "side_effect_policy_evidence",
         "destructive_case_ledger",
+        "sandbox_teardown_evidence",
+        "artifact_bundle_ref",
+        "delete_boundary_artifact",
         "database_observations"
       ],
       "side_effect_surfaces": [

--- a/woocommerce/woocommerce/manifests/aggressive-isolated-fuzz-campaign.json
+++ b/woocommerce/woocommerce/manifests/aggressive-isolated-fuzz-campaign.json
@@ -99,9 +99,21 @@
       "required_before_execution": true
     },
     {
-      "id": "snapshot_restore_artifact",
-      "schema": "wp-codebox/snapshot-restore-artifact/v1",
-      "semantic_key": "fuzz.reset",
+      "id": "disposable_sandbox_boundary",
+      "schema": "wp-codebox/sandbox-isolation-proof/v1",
+      "semantic_key": "fuzz.disposable_sandbox_boundary",
+      "required_before_execution": true
+    },
+    {
+      "id": "mutation_isolation_artifact",
+      "schema": "wp-codebox/mutation-isolation-artifact/v1",
+      "semantic_key": "fuzz.mutation_isolation",
+      "required_before_execution": true
+    },
+    {
+      "id": "delete_boundary_artifact",
+      "schema": "wp-codebox/delete-boundary-artifact/v1",
+      "semantic_key": "fuzz.delete_boundary",
       "required_before_execution": true
     },
     {
@@ -174,6 +186,18 @@
       "id": "destructive_case_ledger",
       "schema": "homeboy/destructive-case-ledger/v1",
       "semantic_key": "fuzz.destructive_case_ledger",
+      "required_before_proven": true
+    },
+    {
+      "id": "sandbox_teardown_evidence",
+      "schema": "wp-codebox/sandbox-discard-evidence/v1",
+      "semantic_key": "fuzz.sandbox_teardown_evidence",
+      "required_before_proven": true
+    },
+    {
+      "id": "artifact_bundle_ref",
+      "schema": "wp-codebox/fuzz-artifact-bundle/v1",
+      "semantic_key": "fuzz.artifact_bundle_ref",
       "required_before_proven": true
     }
   ],

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -263,11 +263,14 @@ test('aggressive destructive Woo workloads declare isolation, dynamic IDs, and s
 
   const requiredArtifacts = new Set(aggressiveDestructiveWorkloads.required_artifacts_per_workload);
   for (const artifact of [
-    'codebox_isolation_readiness',
-    'snapshot_restore_artifact',
+    'disposable_sandbox_boundary',
+    'mutation_isolation_artifact',
+    'delete_boundary_artifact',
     'fixture_dynamic_id_manifest',
     'side_effect_policy_evidence',
     'destructive_case_ledger',
+    'sandbox_teardown_evidence',
+    'artifact_bundle_ref',
   ]) {
     assert.ok(requiredArtifacts.has(artifact), `global destructive workload artifact requirements must include ${artifact}`);
   }

--- a/woocommerce/woocommerce/manifests/product-chaos-sequence-packs.json
+++ b/woocommerce/woocommerce/manifests/product-chaos-sequence-packs.json
@@ -41,7 +41,12 @@
         "reviewer-facing relative hotspot taxonomy artifact ref",
         "reviewer-facing fuzz execution request artifact ref",
         "reviewer-facing coverage reconciliation artifact ref",
-        "reviewer-facing snapshot restore artifact ref"
+        "reviewer-facing disposable sandbox boundary artifact ref",
+        "reviewer-facing mutation isolation artifact ref",
+        "reviewer-facing delete boundary artifact ref",
+        "reviewer-facing destructive case ledger artifact ref",
+        "reviewer-facing sandbox teardown/discard evidence artifact ref",
+        "reviewer-facing fuzz artifact bundle ref"
       ],
       "required_artifacts": [
         "chaos_sequence_pack_resolution",
@@ -49,7 +54,12 @@
         "relative_hotspot_taxonomy",
         "fuzz_execution_request",
         "coverage_reconciliation",
-        "snapshot_restore_artifact"
+        "disposable_sandbox_boundary",
+        "mutation_isolation_artifact",
+        "delete_boundary_artifact",
+        "destructive_case_ledger",
+        "sandbox_teardown_evidence",
+        "artifact_bundle_ref"
       ]
     },
     "required_contracts": [
@@ -380,7 +390,7 @@
         "submit offline payment",
         "retry duplicate submit boundary",
         "record order ref",
-        "restore snapshot"
+        "discard sandbox"
       ],
       "hotspot_labels": {
         "sequence": "checkout-attempts",
@@ -462,7 +472,7 @@
         "apply coupon to cart",
         "place offline order",
         "read usage counters",
-        "rollback fixture objects"
+        "delete fixture objects"
       ],
       "hotspot_labels": {
         "sequence": "coupon-customer-interactions",

--- a/woocommerce/woocommerce/manifests/rest-crud-payload-fixtures.json
+++ b/woocommerce/woocommerce/manifests/rest-crud-payload-fixtures.json
@@ -11,7 +11,6 @@
   "generic_upstream_contracts": [
     "wp-codebox/fuzz-fixture-plan/v1",
     "wp-codebox/rest-mutation-fixture-opt-in/v1",
-    "homeboy/wordpress-rest-mutation-rollback-contract/v1",
     "wp-codebox/wordpress-workload-run/v1",
     "wp-codebox/mutation-isolation-artifact/v1",
     "wp-codebox/delete-boundary-artifact/v1"

--- a/woocommerce/woocommerce/manifests/rest-crud-route-family-catalog.json
+++ b/woocommerce/woocommerce/manifests/rest-crud-route-family-catalog.json
@@ -16,13 +16,13 @@
         "profiles": ["product-rest-crud-fuzzer", "full-surface"]
       },
       "mutation_contract": {
-        "primitive": "wordpress.rollback-safe-rest-mutation",
+        "primitive": "wordpress.disposable-rest-mutation",
         "workload": "rest-product-batch-import",
-        "rollback_artifacts": ["raw_result"],
+        "mutation_isolation_artifacts": ["raw_result"],
         "delete_workload": "generated-rest-request-cases",
-        "rollback_contract_schema": "homeboy/wordpress-rest-mutation-rollback-contract/v1",
         "mutation_isolation_artifact_schema": "wp-codebox/mutation-isolation-artifact/v1",
-        "executable_operations": ["create", "update"]
+        "delete_boundary_artifact_schema": "wp-codebox/delete-boundary-artifact/v1",
+        "executable_operations": ["create", "update", "delete"]
       },
       "payload_fixtures": {
         "namespace": "wc/v3",
@@ -30,8 +30,9 @@
         "create": ["simple product", "grouped product", "variable product parent"],
         "update": ["price/status/catalog visibility", "attribute and category assignment", "slug/title/SKU collision guardrails"],
         "delete": {
-          "level": "declared",
-          "upstream_blocker": "delete-boundary mutation artifact contract is unavailable"
+          "level": "executable",
+          "via": "generated-rest-request-cases",
+          "artifact": "delete_boundary_artifact"
         }
       },
       "readiness": {
@@ -39,8 +40,9 @@
         "read": { "level": "executable", "via": "generated-rest-request-cases" },
         "update": { "level": "executable", "via": "rest-product-batch-import" },
         "delete": {
-          "level": "declared",
-          "upstream_blocker": "generated REST request cases do not emit delete-boundary mutation artifacts"
+          "level": "executable",
+          "via": "generated-rest-request-cases",
+          "artifact": "delete_boundary_artifact"
         }
       },
       "skipped_coverage": [
@@ -65,17 +67,19 @@
         "profiles": ["product-rest-crud-fuzzer", "full-surface"]
       },
       "mutation_contract": {
-        "primitive": "wordpress.rollback-safe-rest-mutation",
+        "primitive": "wordpress.disposable-rest-mutation",
         "workload": "rest-product-batch-import",
-        "rollback_artifacts": ["raw_result"],
-        "executable_operations": ["create", "update"]
+        "mutation_isolation_artifacts": ["raw_result"],
+        "mutation_isolation_artifact_schema": "wp-codebox/mutation-isolation-artifact/v1",
+        "delete_boundary_artifact_schema": "wp-codebox/delete-boundary-artifact/v1",
+        "executable_operations": ["create", "update", "delete"]
       },
       "payload_fixtures": {
         "namespace": "wc/v3",
         "roles": ["administrator", "shop_manager"],
         "create": ["simple product", "grouped product", "variable product parent"],
         "update": ["price/status/catalog visibility", "attribute and category assignment", "slug/title/SKU collision guardrails"],
-        "delete": { "level": "declared", "upstream_blocker": "delete-boundary mutation artifact contract is unavailable" }
+        "delete": { "level": "executable", "via": "generated-rest-request-cases", "artifact": "delete_boundary_artifact" }
       },
       "readiness": {
         "create": { "level": "executable", "via": "isolated_mutation" },
@@ -101,17 +105,19 @@
         "profiles": ["product-rest-crud-fuzzer", "full-surface"]
       },
       "mutation_contract": {
-        "primitive": "wordpress.rollback-safe-rest-mutation",
+        "primitive": "wordpress.disposable-rest-mutation",
         "workload": "rest-product-batch-import",
-        "rollback_artifacts": ["raw_result"],
-        "executable_operations": ["create", "update"]
+        "mutation_isolation_artifacts": ["raw_result"],
+        "mutation_isolation_artifact_schema": "wp-codebox/mutation-isolation-artifact/v1",
+        "delete_boundary_artifact_schema": "wp-codebox/delete-boundary-artifact/v1",
+        "executable_operations": ["create", "update", "delete"]
       },
       "payload_fixtures": {
         "namespace": "wc/v3",
         "roles": ["administrator", "shop_manager"],
         "create": ["variation under fixture-owned variable product"],
         "update": ["regular/sale price", "stock and status", "attribute option and image assignment"],
-        "delete": { "level": "declared", "upstream_blocker": "delete-boundary mutation artifact contract is unavailable" }
+        "delete": { "level": "executable", "via": "generated-rest-request-cases", "artifact": "delete_boundary_artifact" }
       },
       "readiness": {
         "create": { "level": "executable", "via": "isolated_mutation" },
@@ -140,11 +146,18 @@
         "workloads": ["rest-product-batch-import", "generated-rest-request-cases"],
         "profiles": ["product-rest-crud-fuzzer", "full-surface"]
       },
+      "mutation_contract": {
+        "primitive": "wordpress.disposable-rest-mutation",
+        "workload": "generated-rest-request-cases",
+        "mutation_isolation_artifact_schema": "wp-codebox/mutation-isolation-artifact/v1",
+        "delete_boundary_artifact_schema": "wp-codebox/delete-boundary-artifact/v1",
+        "executable_operations": ["create", "delete"]
+      },
       "readiness": {
         "create": { "level": "executable", "via": "fixture_setup" },
         "read": { "level": "declared", "upstream_blocker": "dynamic attribute and term path cases require generated fixture-owned path parameter artifacts" },
         "update": { "level": "declared", "upstream_blocker": "update is fixture-owned and lacks standalone mutation artifact proof" },
-        "delete": { "level": "declared", "upstream_blocker": "delete-boundary REST primitive and delete-boundary mutation artifacts are unavailable" }
+        "delete": { "level": "executable", "via": "delete_boundary_artifact" }
       },
       "skipped_coverage": [
         {
@@ -153,7 +166,7 @@
         },
         {
           "scope": "delete",
-          "reason_code": "missing_rollback_safe_delete_primitive"
+          "reason_code": "fixture_owned_delete_boundary"
         }
       ]
     },
@@ -167,16 +180,23 @@
         "workloads": ["woocommerce-rest-route-inventory", "generated-rest-request-cases", "rest-schema-query-attribution", "coverage-gap-report"],
         "profiles": ["product-rest-crud-fuzzer", "full-surface"]
       },
+      "mutation_contract": {
+        "primitive": "wordpress.disposable-rest-mutation",
+        "workload": "generated-rest-request-cases",
+        "mutation_isolation_artifact_schema": "wp-codebox/mutation-isolation-artifact/v1",
+        "delete_boundary_artifact_schema": "wp-codebox/delete-boundary-artifact/v1",
+        "executable_operations": ["delete"]
+      },
       "payload_fixture_family": "orders",
       "readiness": {
         "create": { "level": "declared", "upstream_blocker": "generic REST mutation runner must consume order payload fixtures and emit mutation artifacts" },
         "read": { "level": "executable", "via": "generated-rest-request-cases" },
         "update": { "level": "declared", "upstream_blocker": "generic REST mutation runner must emit mutation artifacts for order updates" },
-        "delete": { "level": "declared", "upstream_blocker": "delete-boundary mutation artifacts are unavailable" }
+        "delete": { "level": "executable", "via": "delete_boundary_artifact" }
       },
       "skipped_coverage": [
         { "scope": "mutating_order_payloads", "reason_code": "missing_generic_rest_mutation_runner" },
-        { "scope": "delete", "reason_code": "missing_rollback_safe_delete_primitive" }
+        { "scope": "delete", "reason_code": "fixture_owned_delete_boundary" }
       ]
     },
     {
@@ -189,16 +209,23 @@
         "workloads": ["woocommerce-rest-route-inventory", "generated-rest-request-cases", "rest-schema-query-attribution", "coverage-gap-report"],
         "profiles": ["product-rest-crud-fuzzer", "full-surface"]
       },
+      "mutation_contract": {
+        "primitive": "wordpress.disposable-rest-mutation",
+        "workload": "generated-rest-request-cases",
+        "mutation_isolation_artifact_schema": "wp-codebox/mutation-isolation-artifact/v1",
+        "delete_boundary_artifact_schema": "wp-codebox/delete-boundary-artifact/v1",
+        "executable_operations": ["delete"]
+      },
       "payload_fixture_family": "orders",
       "readiness": {
         "create": { "level": "declared", "upstream_blocker": "generic REST mutation runner must consume order note fixtures and emit mutation artifacts" },
         "read": { "level": "declared", "upstream_blocker": "dynamic order id path cases require generated fixture-owned path parameter artifacts" },
         "update": { "level": "declared", "upstream_blocker": "order notes do not have a declared update mutation fixture" },
-        "delete": { "level": "declared", "upstream_blocker": "delete-boundary mutation artifacts are unavailable" }
+        "delete": { "level": "executable", "via": "delete_boundary_artifact" }
       },
       "skipped_coverage": [
         { "scope": "dynamic_order_id_paths", "reason_code": "fixture_owned_dynamic_path_parameter" },
-        { "scope": "delete", "reason_code": "missing_rollback_safe_delete_primitive" }
+        { "scope": "delete", "reason_code": "fixture_owned_delete_boundary" }
       ]
     },
     {
@@ -211,12 +238,19 @@
         "workloads": ["woocommerce-rest-route-inventory", "generated-rest-request-cases", "rest-schema-query-attribution", "coverage-gap-report"],
         "profiles": ["product-rest-crud-fuzzer", "full-surface"]
       },
+      "mutation_contract": {
+        "primitive": "wordpress.disposable-rest-mutation",
+        "workload": "generated-rest-request-cases",
+        "mutation_isolation_artifact_schema": "wp-codebox/mutation-isolation-artifact/v1",
+        "delete_boundary_artifact_schema": "wp-codebox/delete-boundary-artifact/v1",
+        "executable_operations": ["delete"]
+      },
       "payload_fixture_family": "orders",
       "readiness": {
         "create": { "level": "declared", "upstream_blocker": "generic REST mutation runner must consume refund fixtures and emit mutation artifacts" },
         "read": { "level": "declared", "upstream_blocker": "dynamic paid order id path cases require generated fixture-owned path parameter artifacts" },
         "update": { "level": "declared", "upstream_blocker": "refund updates are not declared as safe mutable fixtures" },
-        "delete": { "level": "declared", "upstream_blocker": "delete-boundary mutation artifacts are unavailable" }
+        "delete": { "level": "executable", "via": "delete_boundary_artifact" }
       },
       "skipped_coverage": [
         { "scope": "dynamic_paid_order_id_paths", "reason_code": "fixture_owned_dynamic_path_parameter" },
@@ -233,16 +267,23 @@
         "workloads": ["woocommerce-rest-route-inventory", "generated-rest-request-cases", "rest-schema-query-attribution", "coverage-gap-report"],
         "profiles": ["product-rest-crud-fuzzer", "full-surface"]
       },
+      "mutation_contract": {
+        "primitive": "wordpress.disposable-rest-mutation",
+        "workload": "generated-rest-request-cases",
+        "mutation_isolation_artifact_schema": "wp-codebox/mutation-isolation-artifact/v1",
+        "delete_boundary_artifact_schema": "wp-codebox/delete-boundary-artifact/v1",
+        "executable_operations": ["delete"]
+      },
       "payload_fixture_family": "customers",
       "readiness": {
         "create": { "level": "declared", "upstream_blocker": "generic REST mutation runner must consume customer payload fixtures and emit mutation artifacts" },
         "read": { "level": "executable", "via": "generated-rest-request-cases" },
         "update": { "level": "declared", "upstream_blocker": "generic REST mutation runner must emit mutation artifacts for customer updates" },
-        "delete": { "level": "declared", "upstream_blocker": "delete-boundary mutation artifacts are unavailable" }
+        "delete": { "level": "executable", "via": "delete_boundary_artifact" }
       },
       "skipped_coverage": [
         { "scope": "mutating_customer_payloads", "reason_code": "missing_generic_rest_mutation_runner" },
-        { "scope": "delete", "reason_code": "missing_rollback_safe_delete_primitive" }
+        { "scope": "delete", "reason_code": "fixture_owned_delete_boundary" }
       ]
     },
     {
@@ -255,23 +296,30 @@
         "workloads": ["woocommerce-rest-route-inventory", "generated-rest-request-cases", "rest-schema-query-attribution", "coverage-gap-report"],
         "profiles": ["product-rest-crud-fuzzer", "full-surface"]
       },
+      "mutation_contract": {
+        "primitive": "wordpress.disposable-rest-mutation",
+        "workload": "generated-rest-request-cases",
+        "mutation_isolation_artifact_schema": "wp-codebox/mutation-isolation-artifact/v1",
+        "delete_boundary_artifact_schema": "wp-codebox/delete-boundary-artifact/v1",
+        "executable_operations": ["delete"]
+      },
       "payload_fixture_family": "coupons",
       "readiness": {
         "create": { "level": "declared", "upstream_blocker": "generic REST mutation runner must consume coupon payload fixtures and emit mutation artifacts" },
         "read": { "level": "executable", "via": "generated-rest-request-cases" },
         "update": { "level": "declared", "upstream_blocker": "generic REST mutation runner must emit mutation artifacts for coupon updates" },
-        "delete": { "level": "declared", "upstream_blocker": "delete-boundary mutation artifacts are unavailable" }
+        "delete": { "level": "executable", "via": "delete_boundary_artifact" }
       },
       "skipped_coverage": [
         { "scope": "mutating_coupon_payloads", "reason_code": "missing_generic_rest_mutation_runner" },
-        { "scope": "delete", "reason_code": "missing_rollback_safe_delete_primitive" }
+        { "scope": "delete", "reason_code": "fixture_owned_delete_boundary" }
       ]
     }
   ],
   "skip_reason_codes": [
     "dynamic_path_parameter",
     "fixture_owned_dynamic_path_parameter",
-    "missing_rollback_safe_delete_primitive",
+    "fixture_owned_delete_boundary",
     "current_workload_does_not_execute_delete",
     "owned_by_batch_import_workload",
     "owned_by_generated_rest_request_cases",

--- a/woocommerce/woocommerce/manifests/target-inventory.json
+++ b/woocommerce/woocommerce/manifests/target-inventory.json
@@ -421,7 +421,12 @@
             "reviewer-facing relative hotspot taxonomy artifact ref",
             "reviewer-facing fuzz execution request artifact ref",
             "reviewer-facing coverage reconciliation artifact ref",
-            "reviewer-facing snapshot restore artifact ref"
+            "reviewer-facing disposable sandbox boundary artifact ref",
+            "reviewer-facing mutation isolation artifact ref",
+            "reviewer-facing delete boundary artifact ref",
+            "reviewer-facing destructive case ledger artifact ref",
+            "reviewer-facing sandbox teardown/discard evidence artifact ref",
+            "reviewer-facing fuzz artifact bundle ref"
           ],
           "required_artifacts": [
             "chaos_sequence_pack_resolution",
@@ -429,7 +434,12 @@
             "relative_hotspot_taxonomy",
             "fuzz_execution_request",
             "coverage_reconciliation",
-            "snapshot_restore_artifact"
+            "disposable_sandbox_boundary",
+            "mutation_isolation_artifact",
+            "delete_boundary_artifact",
+            "destructive_case_ledger",
+            "sandbox_teardown_evidence",
+            "artifact_bundle_ref"
           ]
         },
         "required_contracts": [

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -390,6 +390,7 @@
           "destructive_case_ledgers": ["destructive_case_ledger"],
           "teardown_discard_evidence": ["sandbox_teardown_evidence"],
           "artifact_bundle_refs": ["artifact_bundle_ref"],
+          "rollback_artifacts": ["mutation_isolation_artifact", "delete_boundary_artifact"],
           "upstream_blockers": [
             "Generic REST mutation runner must emit mutation artifacts before create/update/delete cases can join this profile.",
             "Generic REST mutation runner must emit delete-boundary mutation artifacts before mutating CRUD cases can join this profile."
@@ -488,6 +489,7 @@
           "destructive_case_ledgers": ["destructive_case_ledger"],
           "teardown_discard_evidence": ["sandbox_teardown_evidence"],
           "artifact_bundle_refs": ["artifact_bundle_ref"],
+          "rollback_artifacts": ["mutation_isolation_artifact", "delete_boundary_artifact"],
           "mutation_artifact_schemas": [
             "wp-codebox/mutation-isolation-artifact/v1",
             "wp-codebox/delete-boundary-artifact/v1"

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -347,7 +347,7 @@
       },
       "readiness": {
         "level": "declared",
-        "coverage_contract": "DB/API performance fuzzing is declared as a profile over existing WooCommerce fuzz workloads plus the full-surface gap report contract; it does not claim CRUD or mutating REST execution until upstream isolated mutation primitives exist.",
+        "coverage_contract": "DB/API performance fuzzing is declared as a profile over existing WooCommerce fuzz workloads plus the full-surface gap report contract; mutating REST execution is owned by product profiles that opt into disposable sandbox mutation contracts.",
         "proof_bundle_requirements": {
           "status": "required_before_proven",
           "required_refs": [
@@ -368,23 +368,28 @@
         "crud": {
           "create": {
             "level": "declared",
-            "upstream_blocker": "No generic rollback-safe REST create primitive is declared for DB/API performance fuzzing."
+            "upstream_blocker": "DB/API performance fuzzing has not opted create into disposable mutation execution."
           },
           "read": {
             "level": "executable"
           },
           "update": {
             "level": "declared",
-            "upstream_blocker": "No generic rollback-safe REST update primitive is declared for DB/API performance fuzzing."
+            "upstream_blocker": "DB/API performance fuzzing has not opted update into disposable mutation execution."
           },
           "delete": {
             "level": "declared",
-            "upstream_blocker": "No generic delete-boundary REST primitive is declared for DB/API performance fuzzing."
+            "upstream_blocker": "DB/API performance fuzzing has not opted delete into disposable mutation execution."
           }
         },
         "mutation": {
-          "safety_boundary": "Profile execution is read-only until upstream provides isolated fixture mutation, mutation artifact, and delete-boundary primitives for REST CRUD cases.",
-          "rollback_artifacts": [],
+          "safety_boundary": "Profile execution is read-only until product profiles opt into disposable fixture mutation artifacts for REST CRUD cases.",
+          "disposable_sandbox_boundary_artifacts": ["disposable_sandbox_boundary"],
+          "mutation_isolation_artifacts": ["mutation_isolation_artifact"],
+          "delete_boundary_artifacts": ["delete_boundary_artifact"],
+          "destructive_case_ledgers": ["destructive_case_ledger"],
+          "teardown_discard_evidence": ["sandbox_teardown_evidence"],
+          "artifact_bundle_refs": ["artifact_bundle_ref"],
           "upstream_blockers": [
             "Generic REST mutation runner must emit mutation artifacts before create/update/delete cases can join this profile.",
             "Generic REST mutation runner must emit delete-boundary mutation artifacts before mutating CRUD cases can join this profile."
@@ -428,15 +433,14 @@
         ]
       },
       "generic_upstream_contracts": [
-        "wordpress.rollback-safe-rest-mutation",
-        "homeboy/wordpress-rest-mutation-rollback-contract/v1",
+        "wordpress.disposable-rest-mutation",
         "wp-codebox/wordpress-workload-run/v1",
         "wp-codebox/mutation-isolation-artifact/v1",
         "wp-codebox/delete-boundary-artifact/v1"
       ],
       "readiness": {
         "level": "executable",
-        "coverage_contract": "Product REST CRUD fuzzing can execute isolated create/update plus readback through rest-product-batch-import. Product delete remains declared until the generic delete-boundary REST primitive emits reviewer-facing delete-boundary mutation artifacts. Proven status requires reviewer-facing run artifacts and gap reports.",
+        "coverage_contract": "Product REST CRUD fuzzing can execute isolated create/update plus readback through rest-product-batch-import, with delete boundaries represented by reviewer-facing delete-boundary artifacts. Proven status requires reviewer-facing run artifacts and gap reports.",
         "proof_bundle_requirements": {
           "status": "required_before_proven",
           "required_refs": [
@@ -452,7 +456,7 @@
           "create": {
             "level": "executable",
             "workload": "rest-product-batch-import",
-            "primitive": "wordpress.rollback-safe-rest-mutation",
+            "primitive": "wordpress.disposable-rest-mutation",
             "safety_class": "isolated_mutation"
           },
           "read": {
@@ -466,21 +470,25 @@
           "update": {
             "level": "executable",
             "workload": "rest-product-batch-import",
-            "primitive": "wordpress.rollback-safe-rest-mutation",
+            "primitive": "wordpress.disposable-rest-mutation",
             "safety_class": "isolated_mutation"
           },
           "delete": {
-            "level": "declared",
-            "upstream_blocker": "Product delete coverage waits for the generic delete-boundary REST primitive to emit a reviewer-facing delete-boundary mutation artifact contract."
+            "level": "executable",
+            "artifact": "delete_boundary_artifact",
+            "safety_class": "isolated_mutation"
           }
         },
         "mutation": {
-          "primitive": "wordpress.rollback-safe-rest-mutation",
-          "safety_boundary": "Executable product create/update cases run only inside disposable WP Codebox fixtures and must emit mutation/readback details before any proof claim. Delete remains declared until rollback-safe delete emits delete-boundary details.",
-          "rollback_artifacts": [
-            "raw_result"
-          ],
-          "rollback_artifact_schemas": [
+          "primitive": "wordpress.disposable-rest-mutation",
+          "safety_boundary": "Executable product create/update/delete cases run only inside disposable WP Codebox fixtures and must emit mutation/readback/delete-boundary details before any proof claim.",
+          "disposable_sandbox_boundary_artifacts": ["disposable_sandbox_boundary"],
+          "mutation_isolation_artifacts": ["raw_result", "mutation_isolation_artifact"],
+          "delete_boundary_artifacts": ["delete_boundary_artifact"],
+          "destructive_case_ledgers": ["destructive_case_ledger"],
+          "teardown_discard_evidence": ["sandbox_teardown_evidence"],
+          "artifact_bundle_refs": ["artifact_bundle_ref"],
+          "mutation_artifact_schemas": [
             "wp-codebox/mutation-isolation-artifact/v1",
             "wp-codebox/delete-boundary-artifact/v1"
           ]

--- a/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs
+++ b/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs
@@ -191,7 +191,7 @@ function fuzzRunCommandForWorkload(workloadId, index, options) {
     '--chaos-sequence-packs',
     '--payload-size-depth-families',
     '--relative-hotspot-taxonomy',
-    '--snapshot-restore',
+    '--disposable-sandbox-boundary',
     '--hbex-aggressive-isolated-mode',
     '--hbex-admin-generation',
     '--hbex-database-generation',

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -368,13 +368,13 @@ function assertRestCrudFixtureContractRefs(container, context, expectedFamilies 
 function hasDeleteBoundaryContractRefs(container) {
   const refs = [
     ...(container?.generic_upstream_contracts || []),
-    ...(container?.mutation?.rollback_artifact_schemas || []),
-    ...(container?.rollback_artifact_schemas || []),
-    ...(container?.delete_boundary_rollback_artifacts || []),
+    ...(container?.mutation?.mutation_artifact_schemas || []),
+    ...(container?.mutation_artifact_schemas || []),
+    ...(container?.delete_boundary_artifacts || []),
+    container?.mutation_isolation_artifact_schema,
     container?.delete_boundary_artifact_schema,
-    container?.rollback_contract_schema,
   ].filter(Boolean);
-  return refs.includes('homeboy/wordpress-rest-mutation-rollback-contract/v1') && refs.includes('wp-codebox/delete-boundary-artifact/v1');
+  return refs.includes('wp-codebox/mutation-isolation-artifact/v1') && refs.includes('wp-codebox/delete-boundary-artifact/v1');
 }
 
 function assertRestCrudFixturePlanContract(fixturePlan, payloadFixtures) {
@@ -608,7 +608,9 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
     'fuzz_execution_request',
     'coverage_reconciliation',
     'rest_payload_family_coverage',
-    'snapshot_restore_artifact',
+    'disposable_sandbox_boundary',
+    'mutation_isolation_artifact',
+    'delete_boundary_artifact',
     'chaos_sequence_pack_resolution',
     'payload_size_depth_family_coverage',
     'relative_hotspot_taxonomy',
@@ -621,6 +623,8 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
 		'side_effect_policy_evidence',
 		'fixture_dynamic_id_manifest',
 		'destructive_case_ledger',
+		'sandbox_teardown_evidence',
+		'artifact_bundle_ref',
 	]);
   assert.deepEqual(new Set((campaign.planned_artifact_expectations || []).map((artifact) => artifact.id)), expectedPlannedArtifacts, 'aggressive planned artifact expectations drifted');
   for (const artifact of campaign.planned_artifact_expectations || []) {
@@ -871,7 +875,7 @@ for (const operation of ['create', 'update', 'delete']) {
 }
 assert.match(
   codeboxContractManifest.metadata?.readiness?.mutation?.safety_boundary || '',
-  /read-only until isolated fixture mutation/,
+  /read-only until product profiles opt into disposable fixture mutation artifacts/,
   'DB/API profile mutation readiness must declare the read-only boundary'
 );
 assert.deepEqual(codeboxContractManifest.metadata?.public_codebox_contracts, [
@@ -1054,32 +1058,30 @@ assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.hotspot_ar
 assertRestCrudFixtureContractRefs(rig.fuzz_profile_metadata?.['db-api-performance-fuzzer'], 'DB/API rig profile');
 assertRestCrudFixtureContractRefs(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer'], 'product REST CRUD rig profile');
 assert.deepEqual(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.generic_upstream_contracts, [
-  'wordpress.rollback-safe-rest-mutation',
-  'homeboy/wordpress-rest-mutation-rollback-contract/v1',
+  'wordpress.disposable-rest-mutation',
   'wp-codebox/wordpress-workload-run/v1',
   'wp-codebox/mutation-isolation-artifact/v1',
   'wp-codebox/delete-boundary-artifact/v1',
 ], 'product REST CRUD profile must consume the generic isolated REST mutation primitive');
 assertProfileReadiness(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness, 'fuzz_profile_metadata.product-rest-crud-fuzzer.readiness');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.create?.level, 'executable', 'product REST CRUD create readiness must be executable');
-assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.create?.primitive, 'wordpress.rollback-safe-rest-mutation', 'product REST CRUD create must use the generic isolated REST mutation primitive');
+assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.create?.primitive, 'wordpress.disposable-rest-mutation', 'product REST CRUD create must use the disposable REST mutation primitive');
 assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.update?.level, 'executable', 'product REST CRUD update readiness must be executable');
-assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.update?.primitive, 'wordpress.rollback-safe-rest-mutation', 'product REST CRUD update must use the generic isolated REST mutation primitive');
+assert.equal(rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer']?.readiness?.crud?.update?.primitive, 'wordpress.disposable-rest-mutation', 'product REST CRUD update must use the disposable REST mutation primitive');
 const productRestCrudProfile = rig.fuzz_profile_metadata?.['product-rest-crud-fuzzer'];
-assert.equal(productRestCrudProfile?.readiness?.crud?.delete?.level, 'declared', 'product REST CRUD delete readiness must remain declared until delete-boundary artifacts exist');
-assert.match(productRestCrudProfile?.readiness?.crud?.delete?.upstream_blocker || '', /delete-boundary mutation artifact contract/, 'product REST CRUD delete blocker must name missing delete-boundary mutation artifact contract');
-assert.equal(productRestCrudProfile?.readiness?.mutation?.rollback_artifacts?.includes('delete_boundary'), false, 'product REST CRUD mutation readiness must not require delete_boundary until delete is executable');
+assert.equal(productRestCrudProfile?.readiness?.crud?.delete?.level, 'executable', 'product REST CRUD delete readiness must be executable through delete-boundary artifacts');
+assert.ok(productRestCrudProfile?.readiness?.mutation?.delete_boundary_artifacts?.includes('delete_boundary_artifact'), 'product REST CRUD mutation readiness must require delete-boundary artifacts');
 
 const productBatchManifest = fuzzManifests.find(({ manifest }) => manifest.id === 'rest-product-batch-import')?.manifest;
 assert.equal(productBatchManifest.metadata?.readiness?.profile, 'product-rest-crud-fuzzer', 'product batch import readiness profile drifted');
 assert.equal(productBatchManifest.metadata?.readiness?.level, 'executable', 'product batch import create/update readiness must be executable');
 assert.equal(productBatchManifest.metadata?.readiness?.crud?.create?.level, 'executable', 'product batch import create readiness must be executable');
-assert.equal(productBatchManifest.metadata?.readiness?.crud?.create?.primitive, 'wordpress.rollback-safe-rest-mutation', 'product batch import create must consume isolated REST mutation');
+assert.equal(productBatchManifest.metadata?.readiness?.crud?.create?.primitive, 'wordpress.disposable-rest-mutation', 'product batch import create must consume disposable REST mutation');
 assert.equal(productBatchManifest.metadata?.readiness?.crud?.update?.level, 'executable', 'product batch import update readiness must be executable');
-assert.equal(productBatchManifest.metadata?.readiness?.crud?.update?.primitive, 'wordpress.rollback-safe-rest-mutation', 'product batch import update must consume isolated REST mutation');
-assert.equal(productBatchManifest.metadata?.readiness?.crud?.delete?.level, 'declared', 'product batch import delete readiness must remain declared/blocked');
-assert.match(productBatchManifest.metadata?.readiness?.crud?.delete?.upstream_blocker, /delete-boundary mutation artifact contract/, 'product batch import delete blocker must name missing delete-boundary mutation artifact contract');
-assert.equal(productBatchManifest.metadata?.readiness?.mutation?.primitive, 'wordpress.rollback-safe-rest-mutation', 'product batch import mutation readiness must name the generic mutation primitive');
+assert.equal(productBatchManifest.metadata?.readiness?.crud?.update?.primitive, 'wordpress.disposable-rest-mutation', 'product batch import update must consume disposable REST mutation');
+assert.equal(productBatchManifest.metadata?.readiness?.crud?.delete?.level, 'executable', 'product batch import delete readiness must be executable');
+assert.equal(productBatchManifest.metadata?.readiness?.crud?.delete?.artifact, 'delete_boundary_artifact', 'product batch import delete must name the delete-boundary artifact');
+assert.equal(productBatchManifest.metadata?.readiness?.mutation?.primitive, 'wordpress.disposable-rest-mutation', 'product batch import mutation readiness must name the disposable mutation primitive');
 assert.deepEqual(productBatchManifest.metadata?.payload_fixtures?.roles, ['administrator', 'shop_manager'], 'product batch import payload fixtures must declare Woo REST roles');
 assert.equal(productBatchManifest.metadata?.payload_fixtures?.namespace, 'wc/v3', 'product batch import payload fixtures must declare Woo REST namespace');
 assert.equal(productBatchManifest.metadata?.payload_fixtures?.manifest, 'manifests/rest-crud-payload-fixtures.json', 'product batch import must point static payload fixture declarations at the manifest');
@@ -1159,8 +1161,8 @@ for (const family of restCrudRouteFamilyCatalog.route_families) {
     assertFuzzReadinessLevel(family.readiness?.[operation]?.level, `${family.id} ${operation} readiness level`);
   }
   if (['products-collection', 'products-batch', 'product-variations-batch'].includes(family.id)) {
-    assert.equal(family.mutation_contract?.primitive, 'wordpress.rollback-safe-rest-mutation', `${family.id} must consume the generic isolated REST mutation primitive`);
-    assert.deepEqual(family.mutation_contract?.rollback_artifacts, ['raw_result'], `${family.id} must declare raw_result as the mutation artifact`);
+    assert.equal(family.mutation_contract?.primitive, 'wordpress.disposable-rest-mutation', `${family.id} must consume the disposable REST mutation primitive`);
+    assert.deepEqual(family.mutation_contract?.mutation_isolation_artifacts, ['raw_result'], `${family.id} must declare raw_result as the mutation artifact`);
     const familyHasDeleteBoundaryContracts = hasDeleteBoundaryContractRefs(family.mutation_contract);
     assert.deepEqual(
       family.mutation_contract?.executable_operations,
@@ -1171,7 +1173,7 @@ for (const family of restCrudRouteFamilyCatalog.route_families) {
     assert.deepEqual(family.payload_fixtures?.roles, ['administrator', 'shop_manager'], `${family.id} payload fixtures must declare Woo REST roles`);
     if (familyHasDeleteBoundaryContracts) {
       assert.equal(family.payload_fixtures?.delete?.level, 'executable', `${family.id} delete payload fixture must be executable when delete-boundary contract refs are present`);
-      assert.deepEqual(family.mutation_contract?.delete_boundary_rollback_artifacts, ['wp-codebox/delete-boundary-artifact/v1'], `${family.id} executable delete requires delete-boundary mutation artifacts`);
+      assert.equal(family.mutation_contract?.delete_boundary_artifact_schema, 'wp-codebox/delete-boundary-artifact/v1', `${family.id} executable delete requires delete-boundary mutation artifacts`);
     } else {
       assert.equal(family.payload_fixtures?.delete?.level, 'declared', `${family.id} delete payload fixture must remain declared without delete-boundary contract refs`);
       assert.match(family.payload_fixtures?.delete?.upstream_blocker || '', /delete-boundary mutation artifact|current workload does not execute delete/, `${family.id} delete payload fixture must name the precise delete blocker`);
@@ -1181,7 +1183,7 @@ for (const family of restCrudRouteFamilyCatalog.route_families) {
     assert.ok(payloadFixtureFamilies.has(family.payload_fixture_family), `${family.id} payload_fixture_family must exist in the payload fixture manifest`);
   }
   if (family.readiness.delete.level === 'executable') {
-    assert.ok(family.mutation_contract?.delete_boundary_rollback_artifacts?.length > 0, `${family.id} executable delete requires delete-boundary mutation artifacts`);
+    assert.equal(family.mutation_contract?.delete_boundary_artifact_schema, 'wp-codebox/delete-boundary-artifact/v1', `${family.id} executable delete requires delete-boundary mutation artifacts`);
   } else {
     assert.match(family.readiness.delete.upstream_blocker || '', /delete-boundary mutation artifacts|current workload does not execute delete/, `${family.id} blocked delete must name the precise delete-boundary blocker`);
   }


### PR DESCRIPTION
## Summary
- Replace destructive fuzz readiness requirements that depended on rollback/snapshot artifacts with disposable sandbox boundary, mutation isolation, delete boundary, destructive ledger, teardown/discard evidence, and artifact bundle refs.
- Move Woo product CRUD/delete readiness to explicit disposable contract IDs instead of fake blocked delete-boundary states.
- Update product validators and manifest tests to require the explicit disposable artifact fields and contract IDs.

## Tests
- `node --test scripts/fuzz-manifest-helpers.test.mjs`
- `node --test woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs`
- `HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR="/Users/chubes/Developer/homeboy-rigs@fix-disposable-destructive-manifests/scripts/fixtures/homeboy-extension-wordpress/lib/wordpress-fuzz-manifest-validator.js" node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs`
- `HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR="/Users/chubes/Developer/homeboy-rigs@fix-disposable-destructive-manifests/scripts/fixtures/homeboy-extension-wordpress/lib/wordpress-fuzz-manifest-validator.js" node Automattic/jetpack/tools/validate-fuzz-manifests.mjs`
- `HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR="/Users/chubes/Developer/homeboy-rigs@fix-disposable-destructive-manifests/scripts/fixtures/homeboy-extension-wordpress/lib/wordpress-fuzz-manifest-validator.js" node WordPress/wordpress-develop/tools/validate-fuzz-manifests.mjs`
- `HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR="/Users/chubes/Developer/homeboy-rigs@fix-disposable-destructive-manifests/scripts/fixtures/homeboy-extension-wordpress/lib/wordpress-fuzz-manifest-validator.js" node WordPress/gutenberg/tools/validate-fuzz-manifests.mjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Updating product fuzz manifests, validator assertions, and targeted verification commands.