### PR TITLE
Fix Woo firehose isolation proof handoff

### DIFF
--- a/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs
+++ b/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs
@@ -31,6 +31,24 @@ const payload = {
   plan_kind: executionSupported ? (runnableCommandsEnabled ? 'runnable_offloaded_commands' : 'offloaded_command_plan') : 'declared_offloaded_command_plan',
   run_id_prefix: runIdPrefix,
   workload_ids: profileWorkloads,
+  upstream_contract_artifact_sources: [
+    {
+      contract: 'homeboy/isolation-proof/v1',
+      source: 'homeboy fuzz run Lab/offloaded runner metadata',
+      persisted_artifact_kind: 'fuzz_result_envelope',
+      persisted_fields: [
+        'results.planner.isolation_proof_source',
+        'results.isolation.proof_source',
+      ],
+      required_command_flags: ['--lab-only', '--allow-destructive', '--isolation', 'isolated', '--require-result-envelope'],
+    },
+    {
+      contract: 'wp-codebox/sandbox-isolation-proof/v1',
+      source: 'WP Codebox fuzz artifact bundle emitted by the offloaded runtime',
+      persisted_artifact_kind: 'fuzz_artifacts',
+      semantic_key: 'fuzz.disposable_sandbox_boundary',
+    },
+  ],
   blockers: executionSupported ? [] : [
     'manifest.readiness.execution_enabled is false because REST CRUD fixture-plan mutations are disabled',
   ],
@@ -53,6 +71,8 @@ const payload = {
           '--status', 'completed',
           '--tracker-ref', options.trackerRef,
           '--artifact-kind', 'fuzz.execution_request',
+          '--artifact-kind', 'fuzz_result_envelope',
+          '--artifact-kind', 'fuzz_artifacts',
           '--artifact-kind', 'fuzz.coverage_reconciliation',
           '--artifact-kind', 'fuzz.payload_family_coverage',
           '--artifact-kind', 'fuzz.chaos_sequence_packs',
@@ -168,7 +188,7 @@ function fuzzRunCommandForWorkload(workloadId, index, options) {
     '--tracker-ref', options.trackerRef,
     '--allow-destructive',
     '--isolation', 'isolated',
-    '--isolation-proof', '${artifact.root}/isolation-proof.json',
+    '--require-result-envelope',
   ];
 
   if (options.runner) {

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -664,6 +664,16 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
   assert.equal(generatedAggressiveFirehoseCommandPlan.plan_kind, 'runnable_offloaded_commands', 'aggressive firehose command plan kind drifted');
   assert.ok(generatedAggressiveFirehoseCommandPlan.commands.length > 0, 'aggressive firehose command plan must emit runnable offloaded commands');
   assert.deepEqual(generatedAggressiveFirehoseCommandPlan.blockers, [], 'aggressive firehose command plan must not carry stale blockers');
+  const upstreamArtifactSources = generatedAggressiveFirehoseCommandPlan.upstream_contract_artifact_sources || [];
+  const homeboyIsolationSource = upstreamArtifactSources.find((source) => source.contract === 'homeboy/isolation-proof/v1');
+  const codeboxIsolationSource = upstreamArtifactSources.find((source) => source.contract === 'wp-codebox/sandbox-isolation-proof/v1');
+  assert.ok(homeboyIsolationSource, 'aggressive firehose command plan must declare the Homeboy isolation proof artifact source');
+  assert.equal(homeboyIsolationSource.source, 'homeboy fuzz run Lab/offloaded runner metadata', 'Homeboy isolation proof must come from upstream run metadata');
+  assert.equal(homeboyIsolationSource.persisted_artifact_kind, 'fuzz_result_envelope', 'Homeboy isolation proof must be referenced through the persisted fuzz result envelope');
+  assert.ok(homeboyIsolationSource.persisted_fields.includes('results.isolation.proof_source'), 'Homeboy isolation proof source must name the persisted isolation field');
+  assert.ok(codeboxIsolationSource, 'aggressive firehose command plan must declare the WP Codebox sandbox proof artifact source');
+  assert.equal(codeboxIsolationSource.persisted_artifact_kind, 'fuzz_artifacts', 'WP Codebox sandbox proof must be referenced through persisted fuzz artifacts');
+  assert.equal(codeboxIsolationSource.semantic_key, 'fuzz.disposable_sandbox_boundary', 'WP Codebox sandbox proof must use the disposable boundary semantic key');
   assert.equal(generatedAggressiveFirehoseCommandPlan.profile_id, campaign.profile_id, 'aggressive firehose command plan profile id drifted');
   const aggressiveProfileWorkloads = rig.fuzz_profiles?.[campaign.profile_id] || [];
   assert.ok(aggressiveProfileWorkloads.length > 0, 'aggressive profile must declare workload ids');
@@ -681,8 +691,13 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
   assert.equal(requestItems.length, aggressiveProfileWorkloads.length, 'aggressive command plan must include request items for each workload');
   for (const item of requestItems) {
     assert.ok(item.command_argv.includes('--allow-destructive'), `${item.purpose} must opt into destructive fuzzing`);
-    assert.ok(item.command_argv.includes('--isolation-proof'), `${item.purpose} must provide explicit Homeboy isolation proof`);
+    assert.ok(item.command_argv.includes('--lab-only'), `${item.purpose} must require offloaded Lab execution for isolation proof`);
+    assert.ok(item.command_argv.includes('--require-result-envelope'), `${item.purpose} must require the persisted upstream result envelope`);
+    assert.ok(!item.command_argv.includes('--isolation-proof'), `${item.purpose} must not point at a manual isolation proof file`);
   }
+  const artifactRefCollector = generatedPlanItems.find((entry) => entry.purpose === 'collect_reviewer_facing_artifact_refs')?.command_argv || [];
+  assert.ok(artifactRefCollector.includes('fuzz_result_envelope'), 'artifact ref collection must include the Homeboy fuzz result envelope');
+  assert.ok(artifactRefCollector.includes('fuzz_artifacts'), 'artifact ref collection must include WP Codebox fuzz artifacts');
   assertNoLocalOnlyRefs(campaign, 'aggressive-isolated-fuzz-campaign');
   assertNoProofPlaceholders(campaign, 'aggressive-isolated-fuzz-campaign');
 }


### PR DESCRIPTION
## Summary
- Replace the Woo aggressive firehose manual isolation proof file placeholder with Homeboy Lab/offloaded run metadata and result-envelope artifact refs.
- Include WP Codebox fuzz artifact refs in the generated reviewer-facing collection command.
- Strengthen validation so generated requests require the upstream result envelope and reject manual isolation proof paths.

## Tests
- `node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs`
- `node --test woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs`
- `node --test shared/wp-codebox/contract.test.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the Woo firehose handoff, updating the command plan and validator, running targeted tests, and drafting this PR description.