### PR TITLE
Wire Woo firehose campaign inputs

### DIFF
--- a/woocommerce/woocommerce/manifests/aggressive-isolated-fuzz-campaign.json
+++ b/woocommerce/woocommerce/manifests/aggressive-isolated-fuzz-campaign.json
@@ -16,6 +16,83 @@
     "admin_actions": "manifests/admin-action-inventory.json",
     "block_inventory_rendering": "manifests/block-inventory-rendering-fuzz.json"
   },
+  "campaign_input_groups": {
+    "sequence_packs": {
+      "manifest": "manifests/product-chaos-sequence-packs.json",
+      "required_artifacts": [
+        "chaos_sequence_pack_resolution",
+        "payload_size_depth_family_coverage",
+        "relative_hotspot_taxonomy"
+      ]
+    },
+    "rest_fixture_families": {
+      "manifests": [
+        "manifests/rest-crud-route-family-catalog.json",
+        "manifests/rest-crud-payload-fixtures.json",
+        "manifests/rest-crud-fixture-plan.json",
+        "manifests/rest-crud-fixture-opt-ins.json"
+      ],
+      "required_artifacts": [
+        "fixture_dynamic_id_manifest",
+        "mutation_isolation_artifact",
+        "delete_boundary_artifact"
+      ]
+    },
+    "admin_action_surfaces": {
+      "manifest": "manifests/admin-action-inventory.json",
+      "required_artifacts": [
+        "admin_observations",
+        "side_effect_policy_evidence"
+      ]
+    },
+    "browser_action_corpus_hooks": {
+      "scenario_paths": [
+        "browser-scenarios/shop.json",
+        "browser-scenarios/product.json",
+        "browser-scenarios/cart.json",
+        "browser-scenarios/checkout.json",
+        "browser-scenarios/products_admin.json",
+        "browser-scenarios/orders_admin.json",
+        "browser-scenarios/analytics_admin.json"
+      ],
+      "required_artifacts": [
+        "browser_observations",
+        "coverage_reconciliation"
+      ]
+    },
+    "observation_groups": {
+      "groups": [
+        "db",
+        "write",
+        "cache",
+        "query",
+        "block",
+        "page",
+        "admin",
+        "workflow"
+      ],
+      "required_artifacts": [
+        "database_observations",
+        "admin_observations",
+        "browser_observations",
+        "editor_observations"
+      ]
+    },
+    "side_effect_policy": {
+      "manifest": "manifests/aggressive-destructive-workloads.json#side_effect_policy",
+      "required_artifacts": [
+        "side_effect_policy_evidence"
+      ]
+    },
+    "hotspot_convergence": {
+      "manifest": "manifests/db-api-hotspot-artifact-io.json",
+      "required_artifacts": [
+        "relative_hotspots",
+        "coverage_reconciliation",
+        "per_case_timing"
+      ]
+    }
+  },
   "command_plan_generator": "tools/aggressive-firehose-command-plan.mjs",
   "required_upstream_capabilities": [
     {
@@ -431,6 +508,25 @@
       "analytics report",
       "coupon validation"
     ],
+    "db": [
+      "hpos order tables",
+      "product lookup tables",
+      "session tables",
+      "action scheduler tables"
+    ],
+    "write": [
+      "product fixture writes",
+      "order fixture writes",
+      "coupon fixture writes",
+      "customer fixture writes",
+      "safe settings writes"
+    ],
+    "cache": [
+      "transient reads and writes",
+      "object cache invalidation",
+      "session cache mutation",
+      "lookup table refresh"
+    ],
     "table": [
       "wp_posts",
       "wp_postmeta",
@@ -457,6 +553,12 @@
       "analytics admin",
       "settings admin"
     ],
+    "admin": [
+      "orders admin actions",
+      "products admin actions",
+      "analytics admin filters",
+      "settings admin safe mutations"
+    ],
     "block": [
       "woocommerce/product-collection",
       "woocommerce/cart",
@@ -464,6 +566,13 @@
       "woocommerce/product-button",
       "woocommerce/product-price",
       "woocommerce/filter-wrapper"
+    ],
+    "workflow": [
+      "catalog to cart",
+      "cart to checkout",
+      "checkout to order",
+      "order to admin fulfillment",
+      "settings to storefront behavior"
     ]
   },
   "relative_hotspot_labels": [
@@ -471,9 +580,14 @@
     "route",
     "action",
     "query",
+    "db",
+    "write",
+    "cache",
     "table",
     "page",
-    "block"
+    "admin",
+    "block",
+    "workflow"
   ],
   "readiness": {
     "level": "executable",

--- a/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs
+++ b/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs
@@ -15,6 +15,8 @@ const runIdPrefix = options.runIdPrefix || 'woo-firehose-$YYYYMMDD';
 const executionSupported = manifest.readiness?.execution_enabled === true;
 const runnableCommandsEnabled = executionSupported && !options.planOnly;
 const profileWorkloads = rig.fuzz_profiles?.[manifest.profile_id] || [];
+const plannedArtifactSemanticKeys = (manifest.planned_artifact_expectations || []).map((artifact) => artifact.semantic_key);
+const campaignInputs = buildCampaignInputs(manifest);
 
 if (!Array.isArray(profileWorkloads) || profileWorkloads.length === 0) {
   throw new Error(`Rig fuzz profile ${manifest.profile_id} must declare at least one workload`);
@@ -43,6 +45,8 @@ const payload = {
       ...profileWorkloads.map((workloadId, index) => ({
         purpose: `request_aggressive_isolated_firehose:${workloadId}`,
         command_argv: fuzzRunCommandForWorkload(workloadId, index, options),
+        campaign_inputs: campaignInputs,
+        artifact_expectations: manifest.planned_artifact_expectations,
       })),
       {
         purpose: 'collect_reviewer_facing_artifact_refs',
@@ -52,19 +56,7 @@ const payload = {
           '--kind', 'fuzz',
           '--status', 'completed',
           '--tracker-ref', options.trackerRef,
-          '--artifact-kind', 'fuzz.execution_request',
-          '--artifact-kind', 'fuzz.coverage_reconciliation',
-          '--artifact-kind', 'fuzz.payload_family_coverage',
-          '--artifact-kind', 'fuzz.chaos_sequence_packs',
-          '--artifact-kind', 'fuzz.payload_size_depth_families',
-          '--artifact-kind', 'fuzz.relative_hotspot_taxonomy',
-          '--artifact-kind', 'fuzz.reset',
-          '--artifact-kind', 'fuzz.case_timing',
-          '--artifact-kind', 'wordpress.database_observations',
-          '--artifact-kind', 'wordpress.admin_observations',
-          '--artifact-kind', 'wordpress.browser_observations',
-          '--artifact-kind', 'wordpress.editor_observations',
-          '--artifact-kind', 'fuzz.relative_hotspots',
+          ...plannedArtifactSemanticKeys.flatMap((semanticKey) => ['--artifact-kind', semanticKey]),
         ], options),
       },
     ] : []),
@@ -200,6 +192,17 @@ function fuzzRunCommandForWorkload(workloadId, index, options) {
   );
 
   return command;
+}
+
+function buildCampaignInputs(campaign) {
+  return {
+    campaign_manifest: 'manifests/aggressive-isolated-fuzz-campaign.json',
+    target_inventory_manifest: campaign.target_inventory_manifest,
+    full_surface_manifest: campaign.full_surface_manifest,
+    product_surface_taxonomy_ref: campaign.product_surface_taxonomy_ref,
+    fixture_sources: campaign.fixture_sources || {},
+    groups: campaign.campaign_input_groups || {},
+  };
 }
 
 function withOptionalLabArgs(command, options) {

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -637,6 +637,50 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
     assert.ok(artifact.required_before_execution === true || artifact.required_before_proven === true, `aggressive planned artifact ${artifact.id} must block execution or proof`);
   }
 
+  const expectedCampaignInputGroups = new Set([
+    'sequence_packs',
+    'rest_fixture_families',
+    'admin_action_surfaces',
+    'browser_action_corpus_hooks',
+    'observation_groups',
+    'side_effect_policy',
+    'hotspot_convergence',
+  ]);
+  assert.deepEqual(new Set(Object.keys(campaign.campaign_input_groups || {})), expectedCampaignInputGroups, 'aggressive campaign input groups drifted');
+  assert.equal(campaign.campaign_input_groups.sequence_packs.manifest, 'manifests/product-chaos-sequence-packs.json', 'aggressive campaign must consume sequence packs');
+  assert.ok(campaign.campaign_input_groups.rest_fixture_families.manifests.includes('manifests/rest-crud-payload-fixtures.json'), 'aggressive campaign must consume REST fixture family fixtures');
+  assert.ok(campaign.campaign_input_groups.rest_fixture_families.manifests.includes('manifests/rest-crud-fixture-plan.json'), 'aggressive campaign must consume REST fixture plan inputs');
+  assert.equal(campaign.campaign_input_groups.admin_action_surfaces.manifest, 'manifests/admin-action-inventory.json', 'aggressive campaign must consume admin action surfaces');
+  assert.deepEqual(new Set(campaign.campaign_input_groups.browser_action_corpus_hooks.scenario_paths), new Set([
+    'browser-scenarios/shop.json',
+    'browser-scenarios/product.json',
+    'browser-scenarios/cart.json',
+    'browser-scenarios/checkout.json',
+    'browser-scenarios/products_admin.json',
+    'browser-scenarios/orders_admin.json',
+    'browser-scenarios/analytics_admin.json',
+  ]), 'aggressive campaign browser action corpus hooks drifted');
+  assert.deepEqual(new Set(campaign.campaign_input_groups.observation_groups.groups), new Set([
+    'db',
+    'write',
+    'cache',
+    'query',
+    'block',
+    'page',
+    'admin',
+    'workflow',
+  ]), 'aggressive campaign observation groups drifted');
+  assert.equal(campaign.campaign_input_groups.side_effect_policy.manifest, 'manifests/aggressive-destructive-workloads.json#side_effect_policy', 'aggressive campaign must consume side-effect policy evidence contract');
+  assert.equal(campaign.campaign_input_groups.hotspot_convergence.manifest, 'manifests/db-api-hotspot-artifact-io.json', 'aggressive campaign must consume hotspot artifact IO contract');
+
+  const plannedArtifactIds = new Set((campaign.planned_artifact_expectations || []).map((artifact) => artifact.id));
+  for (const [groupName, group] of Object.entries(campaign.campaign_input_groups || {})) {
+    assert.ok(Array.isArray(group.required_artifacts) && group.required_artifacts.length > 0, `aggressive campaign input group ${groupName} requires artifact expectations`);
+    for (const artifact of group.required_artifacts) {
+      assert.ok(plannedArtifactIds.has(artifact), `aggressive campaign input group ${groupName} requires undeclared artifact expectation ${artifact}`);
+    }
+  }
+
   const taxonomySurfaces = new Set(Object.keys(productSurfaceTaxonomy));
   assert.deepEqual(new Set((campaign.fixture_families || []).map((family) => family.surface)), taxonomySurfaces, 'aggressive fixture families must cover the product surface taxonomy');
   for (const family of campaign.fixture_families || []) {
@@ -645,7 +689,7 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
     assert.ok(Array.isArray(family.planned_operations) && family.planned_operations.length > 0, `${family.id} requires planned operations`);
   }
 
-  assert.deepEqual(new Set(Object.keys(campaign.planned_case_groups || {})), new Set(['sequence', 'route', 'action', 'query', 'table', 'page', 'block']), 'aggressive planned case groups drifted');
+  assert.deepEqual(new Set(Object.keys(campaign.planned_case_groups || {})), new Set(['sequence', 'route', 'action', 'query', 'db', 'write', 'cache', 'table', 'page', 'admin', 'block', 'workflow']), 'aggressive planned case groups drifted');
   for (const [group, labels] of Object.entries(campaign.planned_case_groups || {})) {
     assert.ok(Array.isArray(labels) && labels.length > 0, `aggressive case group ${group} requires labels`);
   }
@@ -682,6 +726,21 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
   for (const item of requestItems) {
     assert.ok(item.command_argv.includes('--allow-destructive'), `${item.purpose} must opt into destructive fuzzing`);
     assert.ok(item.command_argv.includes('--isolation-proof'), `${item.purpose} must provide explicit Homeboy isolation proof`);
+    assert.equal(item.campaign_inputs?.campaign_manifest, 'manifests/aggressive-isolated-fuzz-campaign.json', `${item.purpose} must link the campaign manifest`);
+    assert.equal(item.campaign_inputs?.target_inventory_manifest, 'manifests/target-inventory.json', `${item.purpose} must link the target inventory manifest`);
+    assert.equal(item.campaign_inputs?.groups?.sequence_packs?.manifest, 'manifests/product-chaos-sequence-packs.json', `${item.purpose} must pass sequence pack inputs`);
+    assert.ok(item.campaign_inputs?.groups?.rest_fixture_families?.manifests?.includes('manifests/rest-crud-payload-fixtures.json'), `${item.purpose} must pass REST fixture family inputs`);
+    assert.equal(item.campaign_inputs?.groups?.admin_action_surfaces?.manifest, 'manifests/admin-action-inventory.json', `${item.purpose} must pass admin action surfaces`);
+    assert.ok(item.campaign_inputs?.groups?.browser_action_corpus_hooks?.scenario_paths?.includes('browser-scenarios/checkout.json'), `${item.purpose} must pass browser action corpus hooks`);
+    assert.ok(item.campaign_inputs?.groups?.side_effect_policy?.required_artifacts?.includes('side_effect_policy_evidence'), `${item.purpose} must require side-effect policy evidence`);
+    assert.ok(item.campaign_inputs?.groups?.hotspot_convergence?.required_artifacts?.includes('relative_hotspots'), `${item.purpose} must require hotspot/convergence artifacts`);
+    assert.deepEqual(new Set(item.campaign_inputs?.groups?.observation_groups?.groups || []), new Set(['db', 'write', 'cache', 'query', 'block', 'page', 'admin', 'workflow']), `${item.purpose} observation groups drifted`);
+    assert.deepEqual(new Set((item.artifact_expectations || []).map((artifact) => artifact.id)), expectedPlannedArtifacts, `${item.purpose} artifact expectations must mirror campaign expectations`);
+  }
+  const collectRefsCommand = generatedPlanItems.find((entry) => entry.purpose === 'collect_reviewer_facing_artifact_refs')?.command_argv || [];
+  const plannedSemanticKeys = new Set((campaign.planned_artifact_expectations || []).map((artifact) => artifact.semantic_key));
+  for (const semanticKey of plannedSemanticKeys) {
+    assert.ok(collectRefsCommand.includes(semanticKey), `aggressive artifact ref collection must request ${semanticKey}`);
   }
   assertNoLocalOnlyRefs(campaign, 'aggressive-isolated-fuzz-campaign');
   assertNoProofPlaceholders(campaign, 'aggressive-isolated-fuzz-campaign');


### PR DESCRIPTION
## Summary
- Add Woo aggressive firehose campaign input groups for sequence packs, REST fixture families, admin action surfaces, browser action corpus hooks, observation groups, side-effect policy, and hotspot/convergence artifacts.
- Carry those Woo-owned inputs and artifact expectations in the generated command-plan payload while keeping runnable commands on existing Homeboy/HBEX contract flags.
- Extend Woo manifest validation to assert the command plan and workload manifest include the required inputs and reviewer-facing artifact expectations.

## Tests
- `node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs`
- `node --test woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs scripts/lint-rig-packages.test.mjs scripts/fuzz-manifest-helpers.test.mjs woocommerce/woocommerce/tools/db-api-fuzzer-artifacts.test.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing Woo-specific manifest/command-plan wiring, updating validator coverage, and running targeted validation.