### PR TITLE
Expose SSI Codebox replay path

### DIFF
--- a/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
+++ b/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
@@ -129,6 +129,11 @@ export async function runFixtureMatrix(options) {
   });
   const recipeFile = path.join(outputDirectory, 'wp-codebox-static-site-fixture-matrix-recipe.json');
   fs.writeFileSync(recipeFile, `${JSON.stringify(recipe, null, 2)}\n`);
+  const replay = wpCodeboxReplayCommand({
+    recipeFile,
+    artifactsDir: replayArtifactsDirectory(outputDirectory),
+    wpCodeboxBin: options.wpCodeboxBin,
+  });
 
   let runtime = null;
   let runtimeError = null;
@@ -191,6 +196,7 @@ export async function runFixtureMatrix(options) {
     dependency_overrides: dependencyOverrides,
     output_directory: outputDirectory,
     recipe_file: recipeFile,
+    replay,
     artifact_refs: written.artifact_refs,
     ...(runtime?.childCommandFailures?.length ? { child_command_failures: runtime.childCommandFailures } : {}),
     result_file: path.join(outputDirectory, 'static-site-fixture-matrix-result.json'),
@@ -500,6 +506,32 @@ function wpCodeboxRecipeRunCommand({ recipeFile, artifactsDir, outputFile, wpCod
   return { argv };
 }
 
+function wpCodeboxReplayCommand({ recipeFile, artifactsDir, wpCodeboxBin: bin }) {
+  const base = safeWpCodeboxCommand(bin);
+  const argv = [
+    base.command,
+    ...(base.args || []),
+    'recipe-run',
+    '--recipe', recipeFile,
+    '--artifacts', artifactsDir,
+    '--json',
+  ];
+  return {
+    artifacts_directory: artifactsDir,
+    argv,
+    command: argv.map(shellArg).join(' '),
+  };
+}
+
+function safeWpCodeboxCommand(bin) {
+  return { command: bin || process.env.HOMEBOY_WP_CODEBOX_BIN || 'wp-codebox', args: [] };
+}
+
+function replayArtifactsDirectory(outputDirectory) {
+  const resolved = path.resolve(outputDirectory);
+  return path.join(path.dirname(resolved), `${path.basename(resolved)}-wp-codebox-replay-artifacts`);
+}
+
 function batchArtifactRefs({ outputDirectory, batchSuffix, batchRecipeFile, outputFile }) {
   return {
     artifacts_directory: outputDirectory,
@@ -537,6 +569,10 @@ function parseArgs(args) {
     }
     if (arg === '--run') {
       options.run = true;
+      continue;
+    }
+    if (arg.startsWith('--no-')) {
+      options[camelCase(arg.slice(5))] = false;
       continue;
     }
     if (arg.startsWith('--')) {
@@ -704,8 +740,13 @@ function camelCase(value) {
   return value.replace(/-([a-z])/g, (_match, letter) => letter.toUpperCase());
 }
 
+function shellArg(value) {
+  const text = String(value);
+  return /^[A-Za-z0-9_/:=.,+@%-]+$/.test(text) ? text : `'${text.replace(/'/g, `'\\''`)}'`;
+}
+
 function printHelp() {
-  process.stdout.write(`Usage: static-site-fixture-matrix [fixture-root] [options]\n\nOptions:\n  --fixture-root <path>              Static-site fixture root. Defaults to this package's fixtures directory.\n  --output-directory <path>          Artifact output directory.\n  --static-site-importer-path <path> Static Site Importer checkout/plugin directory.\n  --static-site-importer-slug <slug> Plugin slug. Defaults to static-site-importer.\n  --static-site-importer-plugin <p>  Plugin activation file. Defaults to static-site-importer/static-site-importer.php.\n  --artifact-root <path>             Generated artifact root to normalize into fixtures.\n  --blocks-engine-php-transformer-path <path>\n                                     Blocks Engine repo root or php-transformer package path for Composer.\n  --entrypoint <file>                Fixture entrypoint. Defaults to index.html.\n  --max-depth <n>                    Fixture discovery depth. Defaults to 2.\n  --wordpress-version <version>      WP Codebox WordPress version. Defaults to latest.\n  --batch-size <n>                   Fixtures per WP Codebox run when --run is used. Defaults to 10.\n  --concurrency <n>                  Batches (WP Codebox sandboxes) to run in parallel. Defaults to ${DEFAULT_BATCH_CONCURRENCY}, hard-capped at ${MAX_BATCH_CONCURRENCY}.\n  --run                             Execute WP Codebox recipes. Omit locally to only materialize artifacts.\n`);
+  process.stdout.write(`Usage: static-site-fixture-matrix [fixture-root] [options]\n\nOptions:\n  --fixture-root <path>              Static-site fixture root. Defaults to this package's fixtures directory.\n  --output-directory <path>          Artifact output directory.\n  --static-site-importer-path <path> Static Site Importer checkout/plugin directory.\n  --static-site-importer-slug <slug> Plugin slug. Defaults to static-site-importer.\n  --static-site-importer-plugin <p>  Plugin activation file. Defaults to static-site-importer/static-site-importer.php.\n  --artifact-root <path>             Generated artifact root to normalize into fixtures.\n  --blocks-engine-php-transformer-path <path>\n                                     Blocks Engine repo root or php-transformer package path for Composer.\n  --entrypoint <file>                Fixture entrypoint. Defaults to index.html.\n  --max-depth <n>                    Fixture discovery depth. Defaults to 2.\n  --wordpress-version <version>      WP Codebox WordPress version. Defaults to latest.\n  --batch-size <n>                   Fixtures per WP Codebox run when --run is used. Defaults to 10.\n  --concurrency <n>                  Batches (WP Codebox sandboxes) to run in parallel. Defaults to ${DEFAULT_BATCH_CONCURRENCY}, hard-capped at ${MAX_BATCH_CONCURRENCY}.\n  --no-editor-validation            Skip browser editor block validation.\n  --no-visual-parity                Skip wordpress.visual-compare recipe steps. Same as SSI_FIXTURE_MATRIX_VISUAL_PARITY=0.\n  --run                             Execute WP Codebox recipes. Omit locally to only materialize artifacts.\n`);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -933,6 +934,49 @@ module.exports = { wpCodeboxBin, wpCodeboxCommand, runWpCodeboxRecipe };
     restoreEnv('SSI_FIXTURE_MATRIX_RUN', previousRun);
     restoreEnv('SSI_FIXTURE_MATRIX_BATCH_SIZE', previousBatchSize);
   }
+});
+
+test('CLI --no-visual-parity disables visual steps and records a safe WP Codebox replay command', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-focused-codebox-replay-'));
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  const cliFixtureRoot = path.join(root, 'fixtures');
+  const outputDirectory = path.join(root, 'artifacts');
+  mkdirSync(staticSiteImporter, { recursive: true });
+  mkdirSync(path.join(cliFixtureRoot, 'fixture-a'), { recursive: true });
+  writeFileSync(path.join(cliFixtureRoot, 'fixture-a', 'index.html'), '<h1>Focused replay fixture</h1>');
+
+  const result = spawnSync(process.execPath, [
+    path.join(packageRoot, 'bench', 'static-site-fixture-matrix.bench.mjs'),
+    '--fixture-root', cliFixtureRoot,
+    '--output-directory', outputDirectory,
+    '--static-site-importer-path', staticSiteImporter,
+    '--max-depth', '1',
+    '--no-visual-parity',
+  ], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOMEBOY_WP_CODEBOX_RECIPE_HELPER: '',
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /"replay"/);
+
+  const recipeFile = path.join(outputDirectory, 'wp-codebox-static-site-fixture-matrix-recipe.json');
+  const recipe = JSON.parse(readFileSync(recipeFile, 'utf8'));
+  const summary = JSON.parse(readFileSync(path.join(outputDirectory, 'cli-run.json'), 'utf8'));
+  assert.equal(recipe.workflow.steps.some((step) => step.command === 'wordpress.visual-compare'), false);
+  assert.equal(summary.replay.artifacts_directory, path.join(root, 'artifacts-wp-codebox-replay-artifacts'));
+  assert.equal(summary.replay.artifacts_directory.startsWith(`${outputDirectory}${path.sep}`), false);
+  assert.deepEqual(summary.replay.argv, [
+    'wp-codebox',
+    'recipe-run',
+    '--recipe', recipeFile,
+    '--artifacts', summary.replay.artifacts_directory,
+    '--json',
+  ]);
+  assert.match(summary.replay.command, /wp-codebox recipe-run --recipe .* --artifacts .* --json/);
 });
 
 function fakeGitRunner(stateByPath) {


### PR DESCRIPTION
## Summary
- Add `--no-visual-parity` for focused Static Site Importer fixture-matrix debugging.
- Preserve `SSI_FIXTURE_MATRIX_VISUAL_PARITY=0` behavior.
- Record a safe direct WP Codebox replay command in the generated summary, using an artifact directory outside the mounted output tree.

Fixes #590.

## Testing
- `node --test WordPress/static-site-importer/tools/fixture-matrix.test.mjs`
- `git diff --check`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** implementation, focused test coverage, verification workflow
