### PR TITLE
Clarify rig lifecycle cleanup intent

### DIFF
--- a/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
+++ b/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
@@ -26,6 +26,12 @@
       "${components.jetpack.path}"
     ]
   },
+  "lifecycle": {
+    "cleanup": {
+      "intent": "external",
+      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; the Jetpack component checkout is user-owned."
+    }
+  },
   "bench": {
     "default_component": "jetpack",
     "warmup_iterations": 0

--- a/Automattic/studio/rigs/studio-combined/rig.json
+++ b/Automattic/studio/rigs/studio-combined/rig.json
@@ -18,6 +18,13 @@
     }
   },
 
+  "lifecycle": {
+    "cleanup": {
+      "intent": "pipeline",
+      "reason": "pipeline.down stops the Studio daemon and tarball server; component checkouts remain user-owned resources."
+    }
+  },
+
   "services": {
     "tarball-server": {
       "kind": "http-static",

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -35,6 +35,7 @@ const studioModelRigGenerator = join(root, 'scripts/generate-studio-agent-model-
 const personalPathPrefix = '/Users/' + 'chubes/';
 const localDeveloperCheckoutPattern = /(?:~|\$HOME)\/Developer\//;
 const tsrmlsPatchMarker = 'PHP-WASM-COMBINED-FIXES ' + 'TSRMLS fallback';
+const cleanupIntents = new Set(['none', 'external', 'manual', 'pipeline']);
 
 if (!existsSync(root)) {
   console.error(`Lint root does not exist: ${root}`);
@@ -134,10 +135,44 @@ function lintRigPortability(file, fuzzWorkloadsByPackageRoot) {
   }
 
   lintSharedPaths(rel, rig);
+  lintLifecycleCleanup(rel, rig);
 
   lintFuzzWorkloads(rel, file, rig, fuzzWorkloadsByPackageRoot);
   lintFuzzProfiles(rel, rig);
   lintBenchProfiles(rel, file, rig, fuzzWorkloadsByPackageRoot);
+}
+
+function hasDeclaredResources(resources) {
+  if (!resources || typeof resources !== 'object' || Array.isArray(resources)) {
+    return false;
+  }
+
+  return Object.values(resources).some((value) => Array.isArray(value) ? value.length > 0 : Boolean(value));
+}
+
+function lifecycleCleanupPolicy(rig) {
+  const cleanup = rig.lifecycle?.cleanup;
+  return cleanup && typeof cleanup === 'object' && !Array.isArray(cleanup) ? cleanup : null;
+}
+
+function lintLifecycleCleanup(rel, rig) {
+  const cleanup = lifecycleCleanupPolicy(rig);
+
+  if (cleanup) {
+    if (!cleanupIntents.has(cleanup.intent)) {
+      failures.push(`${rel}: lifecycle.cleanup.intent must be one of ${[...cleanupIntents].join(', ')}`);
+    }
+
+    if (typeof cleanup.reason !== 'string' || cleanup.reason.trim() === '') {
+      failures.push(`${rel}: lifecycle.cleanup.reason must explain the cleanup boundary`);
+    }
+  }
+
+  if (!hasDeclaredResources(rig.resources) || !Array.isArray(rig.pipeline?.down) || rig.pipeline.down.length > 0 || cleanup) {
+    return;
+  }
+
+  warnings.push(`${rel}: rigs with declared resources and empty pipeline.down should declare lifecycle.cleanup intent`);
 }
 
 function lintSharedPaths(rel, rig) {

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -253,6 +253,75 @@ test('accepts explicitly allowed shared path self-targets', () => {
   assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
 });
 
+test('warns when rigs declare resources with empty down lifecycle and no cleanup policy', () => {
+  const directory = createRigPackage({
+    rig: {
+      resources: {
+        ports: [8080],
+      },
+      pipeline: {
+        down: [],
+      },
+    },
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+  });
+
+  const result = runLint(directory);
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.match(result.stderr, /declared resources and empty pipeline\.down should declare lifecycle\.cleanup intent/);
+});
+
+test('accepts explicit cleanup policy for rigs with resources and empty down lifecycle', () => {
+  const directory = createRigPackage({
+    rig: {
+      lifecycle: {
+        cleanup: {
+          intent: 'external',
+          reason: 'The runner owns the declared resource boundary.',
+        },
+      },
+      resources: {
+        exclusive: ['generic:${env.HOMEBOY_SETTINGS_GENERIC_NAMESPACE}'],
+      },
+      pipeline: {
+        down: [],
+      },
+    },
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+  });
+
+  const result = runLint(directory);
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.doesNotMatch(result.stderr, /declared resources and empty pipeline\.down/);
+});
+
+test('rejects invalid explicit cleanup policy', () => {
+  const directory = createRigPackage({
+    rig: {
+      lifecycle: {
+        cleanup: {
+          intent: 'implicit',
+        },
+      },
+    },
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+  });
+
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /lifecycle\.cleanup\.intent must be one of none, external, manual, pipeline/);
+  assert.match(result.stderr, /lifecycle\.cleanup\.reason must explain the cleanup boundary/);
+});
+
 test('rejects committed local Developer checkout paths in stacks', () => {
   const directory = createRigPackage({
     fuzzWorkloads: {

--- a/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
+++ b/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
@@ -19,6 +19,12 @@
       "${components.woocommerce-gateway-stripe.path}"
     ]
   },
+  "lifecycle": {
+    "cleanup": {
+      "intent": "external",
+      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+    }
+  },
   "trace": {
     "default_component": "woocommerce-gateway-stripe"
   },

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -57,6 +57,12 @@
       "${components.woocommerce.path}"
     ]
   },
+  "lifecycle": {
+    "cleanup": {
+      "intent": "external",
+      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; the WooCommerce component checkout is user-owned."
+    }
+  },
   "bench": {
     "default_component": "woocommerce",
     "warmup_iterations": 0


### PR DESCRIPTION
## Summary
- Add linter coverage for rigs that declare resources while leaving pipeline.down empty without explicit cleanup intent.
- Add explicit lifecycle.cleanup metadata to Studio combined, WooCommerce performance, Stripe ECE product page, and Jetpack API route inventory rigs.
- Keep empty-down lifecycle ambiguity as a warning for remaining rigs rather than a broad schema rewrite.

## Tests
- node --test scripts/lint-rig-packages.test.mjs
- node --test shared/wp-codebox/contract.test.mjs
- node scripts/lint-rig-packages.mjs .

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the linter/test updates, adding lifecycle cleanup metadata, and running verification.