### PR TITLE
Fix SSI fixture matrix no-run summary

### DIFF
--- a/WordPress/static-site-importer/lib/fixture-matrix/findings.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/findings.mjs
@@ -45,7 +45,7 @@ export function findingsForFixtureResult(result, context = {}) {
   if (result.status === 'failed' && findings.length === 0) {
     findings.push(normalizeDiagnosticFinding({ kind: 'fixture_failed', message: result.error || 'Static-site fixture validation failed without a structured diagnostic.' }, result, 0));
   }
-  if (context.matrix?.fixtures?.some((fixture) => fixture.id === result.fixture_id) && result.status === 'not_run') {
+  if (context.executionRequested !== false && context.matrix?.fixtures?.some((fixture) => fixture.id === result.fixture_id) && result.status === 'not_run') {
     findings.push(normalizeDiagnosticFinding({ kind: 'fixture_not_run', message: 'Static-site fixture was discovered but did not produce a validation result.' }, result, 0));
   }
   return findings;

--- a/WordPress/static-site-importer/lib/fixture-matrix/result.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/result.mjs
@@ -51,13 +51,16 @@ import { buildFixtureArtifact, stageFixtureSource } from './steps/recipe-builder
 
 export function normalizeFixtureMatrixResult(input = {}) {
   const matrix = input.matrix || createFixtureMatrix(input);
+  const generationStatus = input.generationStatus || input.generation_status || 'succeeded';
+  const executionStatus = normalizeExecutionStatus(input);
+  const executionRequested = executionStatus !== 'not_requested';
   const results = normalizeArray(input.results || input.fixture_results || input.fixtureResults).map(normalizeFixtureResult);
   const resultByFixture = new Map(results.map((result) => [result.fixture_id, result]));
   const fixtureResults = matrix.fixtures.map((fixture) => attachFixtureTaxonomy(
     resultByFixture.get(fixture.id) || normalizeFixtureResult({ fixture_id: fixture.id, fixture_path: fixture.fixture_path, status: 'not_run' }),
     fixture,
   ));
-  const baseFindings = dedupeFindings(fixtureResults.flatMap((result) => findingsForFixtureResult(result, { matrix })));
+  const baseFindings = dedupeFindings(fixtureResults.flatMap((result) => findingsForFixtureResult(result, { matrix, executionRequested })));
   // Editor-quality metrics are computed from generic block-composition data plus
   // the #537 editor-invalid findings. Scoring always runs; gating is opt-in.
   const nativeRateGate = normalizeNativeRateGateOptions(input.editorQuality || input.editor_quality || input);
@@ -70,7 +73,7 @@ export function normalizeFixtureMatrixResult(input = {}) {
   const grouped = groupFindings(actionableFindings);
   const acceptableActionableFindings = actionableFindings.filter((finding) => finding.loss_acceptance === 'acceptable');
   const unacceptableActionableFindings = actionableFindings.filter((finding) => finding.loss_acceptance !== 'acceptable');
-  const gatedFixtureResults = fixtureResults.map((result) => attachFixtureEditorQuality(applyFixtureQualityGate(result, findings), editorQualityByFixture.get(result.fixture_id)));
+  const gatedFixtureResults = fixtureResults.map((result) => attachFixtureEditorQuality(applyFixtureQualityGate(result, findings, { executionRequested }), editorQualityByFixture.get(result.fixture_id)));
   const lossClassCounts = countBy(findings, (finding) => finding.loss_class || 'unsupported_loss');
   const acceptanceCounts = countBy(findings, (finding) => finding.loss_acceptance || 'unacceptable');
   const classRollups = fixtureClassRollups(gatedFixtureResults, findings);
@@ -81,6 +84,8 @@ export function normalizeFixtureMatrixResult(input = {}) {
     matrix_id: matrix.id,
     fixture_root: matrix.fixture_root,
     summary: {
+      generation_status: generationStatus,
+      execution_status: executionStatus,
       fixture_count: matrix.fixtures.length,
       succeeded: gatedFixtureResults.filter((result) => result.status === 'passed').length,
       failed: gatedFixtureResults.filter((result) => result.status === 'failed').length,
@@ -112,7 +117,32 @@ export function normalizeFixtureMatrixResult(input = {}) {
   };
 }
 
-function applyFixtureQualityGate(result, findings) {
+function normalizeExecutionStatus(input = {}) {
+  const explicit = input.executionStatus || input.execution_status;
+  if (explicit) {
+    return String(explicit);
+  }
+  if (input.executionRequested === false || input.execution_requested === false || input.run === false) {
+    return 'not_requested';
+  }
+  return 'requested';
+}
+
+function applyFixtureQualityGate(result, findings, options = {}) {
+  if (options.executionRequested === false && result.status === 'not_run') {
+    return {
+      ...result,
+      raw_status: result.status,
+      success: false,
+      quality_gate: {
+        status: 'not_run',
+        acceptable_finding_count: 0,
+        unacceptable_finding_count: 0,
+        loss_classes: {},
+      },
+    };
+  }
+
   const fixtureFindings = findings.filter((finding) => finding.fixture_id === result.fixture_id);
   const unacceptableFindings = fixtureFindings.filter((finding) => finding.loss_acceptance === 'unacceptable');
   const status = unacceptableFindings.length > 0 ? 'failed' : 'passed';
@@ -203,7 +233,7 @@ export function normalizeFixtureResult(input) {
 export function writeFixtureMatrixArtifacts(input = {}) {
   const outputDirectory = requiredString(input.outputDirectory || input.output_directory, 'outputDirectory');
   const matrix = input.matrix || createFixtureMatrix(input);
-  const result = input.result || normalizeFixtureMatrixResult({ ...input, matrix });
+  const result = input.result || normalizeFixtureMatrixResult({ ...input, matrix, execution_status: input.execution_status || input.executionStatus || 'not_requested' });
 
   fs.mkdirSync(outputDirectory, { recursive: true });
   for (const fixture of matrix.fixtures) {

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -75,7 +75,29 @@ test('discovers SSI fixtures and writes Blocks Engine site artifacts', () => {
   assert.ok(indexFile);
   assert.ok(Buffer.from(indexFile.content_base64, 'base64').toString('utf8').includes('Simple SSI Fixture'));
   assert.ok(artifact.files.some((file) => file.path === 'website/style.css'));
+  assert.equal(written.result.summary.generation_status, 'succeeded');
+  assert.equal(written.result.summary.execution_status, 'not_requested');
+  assert.equal(written.result.summary.succeeded, 0);
+  assert.equal(written.result.summary.failed, 0);
   assert.equal(written.result.summary.not_run, 1);
+  assert.equal(written.result.summary.finding_count, 0);
+  assert.equal(written.result.summary.unacceptable_finding_count, 0);
+  assert.equal(written.result.summary.unacceptable_loss_classes.fixture_not_run, undefined);
+  assert.equal(written.result.findings.some((finding) => finding.loss_class === 'fixture_not_run'), false);
+});
+
+test('execution-requested fixture matrices still fail missing validation results', () => {
+  const matrix = createFixtureMatrix({ fixture_root: fixtureRoot, id: 'missing-run-result-test' });
+  const result = normalizeFixtureMatrixResult({ matrix, execution_status: 'requested' });
+
+  assert.equal(result.summary.generation_status, 'succeeded');
+  assert.equal(result.summary.execution_status, 'requested');
+  assert.equal(result.summary.succeeded, 0);
+  assert.equal(result.summary.failed, 1);
+  assert.equal(result.summary.not_run, 1);
+  assert.equal(result.summary.unacceptable_finding_count, 1);
+  assert.equal(result.summary.unacceptable_loss_classes.fixture_not_run, 1);
+  assert.equal(result.findings.some((finding) => finding.loss_class === 'fixture_not_run'), true);
 });
 
 test('matrix artifacts use the product base64 encoding for EVERY payload, including text', () => {


### PR DESCRIPTION
## Summary
- Separate SSI fixture matrix generation and execution status in result summaries.
- Treat recipe/artifact-only generation as execution_status=not_requested without fixture_not_run quality findings.
- Preserve fixture_not_run failures when execution is requested and validation results are missing.

Fixes #594.

## Tests
- node --test "WordPress/static-site-importer/tools/fixture-matrix.test.mjs"
- node "WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs" --fixture-root "WordPress/static-site-importer/fixtures" --output-directory "/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/ssi-fixture-matrix-no-run-summary" --static-site-importer-path "/Users/chubes/Developer/static-site-importer" --no-visual-parity

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the fixture matrix result/finding flow, implementing the no-run summary fix, adding targeted tests, and running verification.