### PR TITLE
Enforce explicit rig cleanup intent

### DIFF
--- a/Automattic/jetpack/rigs/jetpack-browser-coverage/rig.json
+++ b/Automattic/jetpack/rigs/jetpack-browser-coverage/rig.json
@@ -17,6 +17,12 @@
       "${components.jetpack.path}"
     ]
   },
+  "lifecycle": {
+    "cleanup": {
+      "intent": "external",
+      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+    }
+  },
   "trace": {
     "default_component": "jetpack"
   },

--- a/Automattic/studio/rigs/studio-figma-to-wordpress-import/rig.json
+++ b/Automattic/studio/rigs/studio-figma-to-wordpress-import/rig.json
@@ -13,6 +13,12 @@
       "${components.blocks-engine.path}"
     ]
   },
+  "lifecycle": {
+    "cleanup": {
+      "intent": "manual",
+      "reason": "The rig runs a repo-local fixture matrix against a user-owned Blocks Engine checkout and does not create separate runtime resources."
+    }
+  },
   "pipeline": {
     "check": [
       {

--- a/WordPress/gutenberg/rigs/gutenberg-api-route-inventory/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-api-route-inventory/rig.json
@@ -22,6 +22,12 @@
       "${components.gutenberg.path}"
     ]
   },
+  "lifecycle": {
+    "cleanup": {
+      "intent": "external",
+      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+    }
+  },
   "bench": {
     "default_component": "gutenberg",
     "warmup_iterations": 0

--- a/WordPress/gutenberg/rigs/gutenberg-browser-coverage/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-browser-coverage/rig.json
@@ -15,6 +15,12 @@
       "${components.gutenberg.path}"
     ]
   },
+  "lifecycle": {
+    "cleanup": {
+      "intent": "external",
+      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+    }
+  },
   "trace": {
     "default_component": "gutenberg"
   },

--- a/WordPress/gutenberg/rigs/gutenberg-notes-unsaved-attachment/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-notes-unsaved-attachment/rig.json
@@ -15,6 +15,12 @@
       "${components.gutenberg.path}"
     ]
   },
+  "lifecycle": {
+    "cleanup": {
+      "intent": "external",
+      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+    }
+  },
   "trace": {
     "default_component": "gutenberg"
   },

--- a/WordPress/gutenberg/rigs/gutenberg-pattern-preview-assets/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-pattern-preview-assets/rig.json
@@ -15,6 +15,12 @@
       "${components.gutenberg.path}"
     ]
   },
+  "lifecycle": {
+    "cleanup": {
+      "intent": "external",
+      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+    }
+  },
   "trace": {
     "default_component": "gutenberg"
   },

--- a/WordPress/wordpress-develop/rigs/wordpress-core-fuzz-coverage/rig.json
+++ b/WordPress/wordpress-develop/rigs/wordpress-core-fuzz-coverage/rig.json
@@ -22,6 +22,12 @@
       "${components.wordpress-develop.path}"
     ]
   },
+  "lifecycle": {
+    "cleanup": {
+      "intent": "external",
+      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+    }
+  },
   "fuzz": {
     "default_component": "wordpress-develop",
     "schema": "homeboy/fuzz-workload/v1",

--- a/WordPress/wordpress-playground/rigs/playground-cli-diagnostics/rig.json
+++ b/WordPress/wordpress-playground/rigs/playground-cli-diagnostics/rig.json
@@ -18,6 +18,12 @@
       "${components.wordpress-playground.path}"
     ]
   },
+  "lifecycle": {
+    "cleanup": {
+      "intent": "manual",
+      "reason": "The rig may install dependencies into the user-owned Playground checkout; removing that checkout state is an operator decision."
+    }
+  },
   "bench_workloads": {
     "nodejs": [
       "${package.root}/bench/playground-cli-runphp-errors.bench.mjs"

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -172,7 +172,7 @@ function lintLifecycleCleanup(rel, rig) {
     return;
   }
 
-  warnings.push(`${rel}: rigs with declared resources and empty pipeline.down should declare lifecycle.cleanup intent`);
+  failures.push(`${rel}: rigs with declared resources and empty pipeline.down must declare lifecycle.cleanup intent`);
 }
 
 function lintSharedPaths(rel, rig) {

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -253,7 +253,7 @@ test('accepts explicitly allowed shared path self-targets', () => {
   assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
 });
 
-test('warns when rigs declare resources with empty down lifecycle and no cleanup policy', () => {
+test('rejects rigs with resources, empty down lifecycle, and no cleanup policy', () => {
   const directory = createRigPackage({
     rig: {
       resources: {
@@ -270,8 +270,8 @@ test('warns when rigs declare resources with empty down lifecycle and no cleanup
 
   const result = runLint(directory);
 
-  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
-  assert.match(result.stderr, /declared resources and empty pipeline\.down should declare lifecycle\.cleanup intent/);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /declared resources and empty pipeline\.down must declare lifecycle\.cleanup intent/);
 });
 
 test('accepts explicit cleanup policy for rigs with resources and empty down lifecycle', () => {

--- a/woocommerce/woocommerce/rigs/woocommerce-browser-coverage/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-browser-coverage/rig.json
@@ -15,6 +15,12 @@
       "${components.woocommerce.path}"
     ]
   },
+  "lifecycle": {
+    "cleanup": {
+      "intent": "external",
+      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+    }
+  },
   "trace": {
     "default_component": "woocommerce"
   },

--- a/woocommerce/woocommerce/rigs/woocommerce-cart-session-race-browser/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-cart-session-race-browser/rig.json
@@ -18,6 +18,12 @@
       "${components.woocommerce.path}"
     ]
   },
+  "lifecycle": {
+    "cleanup": {
+      "intent": "external",
+      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+    }
+  },
   "trace": {
     "default_component": "woocommerce"
   },


### PR DESCRIPTION
## Summary
- Add explicit lifecycle.cleanup intent to the remaining rigs that declared resources with empty pipeline.down.
- Promote the lifecycle cleanup linter from warning to failure so new resource-owning rigs must declare cleanup ownership.
- Update the lint test to assert the behavior instead of accepting prose-only warnings.

## Tests
- node --test scripts/lint-rig-packages.test.mjs scripts/fuzz-manifest-helpers.test.mjs scripts/fuzz-coverage-matrix.test.mjs shared/wordpress-helper-loader.test.mjs shared/nodejs-workload-utils-loader.test.mjs shared/wp-codebox/contract.test.mjs shared/webperf/deferred-init-webperf.test.mjs
- node scripts/lint-rig-packages.mjs .

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafting and verifying the lifecycle cleanup metadata and linter/test updates.