### PR TITLE
Fix SSI Codebox eval setup quoting

### DIFF
--- a/WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -218,7 +218,7 @@ function buildDependencyOverrideSetup(input, importer) {
     steps: [
       {
         command: 'wordpress.wp-cli',
-        args: [`command=eval ${shellToken(dependencyOverrideComposerSetupPhp({
+        args: [`command=eval ${wpCliDoubleQuotedToken(dependencyOverrideComposerSetupPhp({
           pluginPath: sandboxPluginPath,
           packagePath: sandboxPackagePath,
           packageName,
@@ -300,6 +300,11 @@ if ($exitCode !== 0) {
 
 function phpString(value) {
   return `'${String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+function wpCliDoubleQuotedToken(value) {
+  const text = String(value || '');
+  return `"${text.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 }
 
 // Convert an in-sandbox WordPress filesystem path into its web-served path by

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -173,7 +173,8 @@ test('builds WP Codebox recipe setup for SSI Composer dependency overrides', () 
     mode: 'readonly',
   });
   assert.equal(recipe.workflow.steps[0].command, 'wordpress.wp-cli');
-  assert.match(recipe.workflow.steps[0].args[0], /^command=eval /);
+  assert.match(recipe.workflow.steps[0].args[0], /^command=eval "/);
+  assert.doesNotMatch(recipe.workflow.steps[0].args[0], /'\\''/);
   assert.match(recipe.workflow.steps[0].args[0], /composer/);
   assert.match(recipe.workflow.steps[0].args[0], /automattic\/blocks-engine-php-transformer/);
   assert.equal(recipe.workflow.steps[1].args[0], 'command=plugin activate static-site-importer/static-site-importer.php');


### PR DESCRIPTION
## Summary

- Fix SSI dependency override setup recipes to emit Codebox-safe `wp eval` quoting.
- Add a regression assertion that the generated eval payload does not use POSIX single-quote escape sequences.

## Why

The dependency override recipe path generated `command=eval '...php...'` using `shellToken()`. WP Codebox's `wordpress.wp-cli` parser does not implement POSIX ` '\'' ` single-quote escape semantics, so PHP code containing single-quoted strings survived as invalid syntax and crashed before import:

```text
PHP Parse error: syntax error, unexpected string content "", expecting "-" or identifier or variable or number in /tmp/wp-codebox-wp-cli-3.php
```

Double-quoted token escaping matches the parser behavior and preserves the PHP payload as one `wp eval` argument.

## Testing

- `node --check WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs`
- `node --test WordPress/static-site-importer/tools/fixture-matrix.test.mjs`

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Codebox recipe parse failure, implementing the quoting fix, and running targeted verification.
