### PR TITLE
Run SSI dependency override setup as PHP

### DIFF
--- a/WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -217,12 +217,12 @@ function buildDependencyOverrideSetup(input, importer) {
     ],
     steps: [
       {
-        command: 'wordpress.wp-cli',
-        args: [`command=eval ${wpCliDoubleQuotedToken(dependencyOverrideComposerSetupPhp({
+        command: 'wordpress.run-php',
+        args: [`code=${dependencyOverrideComposerSetupPhp({
           pluginPath: sandboxPluginPath,
           packagePath: sandboxPackagePath,
           packageName,
-        }))}`],
+        })}`],
       },
     ],
     metadata: {
@@ -231,7 +231,7 @@ function buildDependencyOverrideSetup(input, importer) {
         source_path: packagePath,
         sandbox_path: sandboxPackagePath,
         applied_by: 'composer_path_repository_recipe_setup',
-        setup_command: 'wordpress.wp-cli eval',
+        setup_command: 'wordpress.run-php',
       },
     },
   };

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -172,9 +172,9 @@ test('builds WP Codebox recipe setup for SSI Composer dependency overrides', () 
     target: '/tmp/homeboy-rigs-dependency-overrides/blocks-engine-php-transformer',
     mode: 'readonly',
   });
-  assert.equal(recipe.workflow.steps[0].command, 'wordpress.wp-cli');
-  assert.match(recipe.workflow.steps[0].args[0], /^command=eval "/);
-  assert.doesNotMatch(recipe.workflow.steps[0].args[0], /'\\''/);
+  assert.equal(recipe.workflow.steps[0].command, 'wordpress.run-php');
+  assert.match(recipe.workflow.steps[0].args[0], /^code=\s*\n\$pluginPath =/);
+  assert.doesNotMatch(recipe.workflow.steps[0].args[0], /^command=eval/);
   assert.match(recipe.workflow.steps[0].args[0], /composer/);
   assert.match(recipe.workflow.steps[0].args[0], /automattic\/blocks-engine-php-transformer/);
   assert.equal(recipe.workflow.steps[1].args[0], 'command=plugin activate static-site-importer/static-site-importer.php');
@@ -183,7 +183,7 @@ test('builds WP Codebox recipe setup for SSI Composer dependency overrides', () 
     source_path: transformerPath,
     sandbox_path: '/tmp/homeboy-rigs-dependency-overrides/blocks-engine-php-transformer',
     applied_by: 'composer_path_repository_recipe_setup',
-    setup_command: 'wordpress.wp-cli eval',
+    setup_command: 'wordpress.run-php',
   });
 });
 


### PR DESCRIPTION
## Summary

- Run SSI dependency override setup through `wordpress.run-php` instead of `wp eval`.
- Update the recipe-builder regression test to assert the setup payload avoids WP-CLI eval parsing.

## Why

The dependency override setup is a multi-line PHP program that mutates SSI's Composer config and runs Composer. Passing that program through `wordpress.wp-cli command=eval ...` is fragile because the Codebox WP-CLI bridge parses the command into argv before WP-CLI writes an eval temp script. That path produced PHP parse errors before the import ran.

`wordpress.run-php` is the correct Codebox command surface for direct PHP setup code and avoids shell/WP-CLI argument parsing entirely.

## Testing

- `node --check WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs`
- `node --test WordPress/static-site-importer/tools/fixture-matrix.test.mjs`

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Codebox WP-CLI eval parse failure, implementing the command-surface fix, and running targeted verification.
