### PR TITLE
Bootstrap stdio for SSI override setup

### DIFF
--- a/WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -239,6 +239,12 @@ function buildDependencyOverrideSetup(input, importer) {
 
 function dependencyOverrideComposerSetupPhp({ pluginPath, packagePath, packageName }) {
   return `
+if (!defined('STDERR')) {
+    define('STDERR', fopen('php://stderr', 'wb'));
+}
+if (!defined('STDOUT')) {
+    define('STDOUT', fopen('php://stdout', 'wb'));
+}
 $pluginPath = ${phpString(pluginPath)};
 $packagePath = ${phpString(packagePath)};
 $packageName = ${phpString(packageName)};

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -173,7 +173,8 @@ test('builds WP Codebox recipe setup for SSI Composer dependency overrides', () 
     mode: 'readonly',
   });
   assert.equal(recipe.workflow.steps[0].command, 'wordpress.run-php');
-  assert.match(recipe.workflow.steps[0].args[0], /^code=\s*\n\$pluginPath =/);
+  assert.match(recipe.workflow.steps[0].args[0], /^code=\s*\nif \(!defined\('STDERR'\)\)/);
+  assert.match(recipe.workflow.steps[0].args[0], /\$pluginPath =/);
   assert.doesNotMatch(recipe.workflow.steps[0].args[0], /^command=eval/);
   assert.match(recipe.workflow.steps[0].args[0], /composer/);
   assert.match(recipe.workflow.steps[0].args[0], /automattic\/blocks-engine-php-transformer/);


### PR DESCRIPTION
## Summary

- Bootstrap `STDERR` and `STDOUT` in the SSI dependency override setup PHP.
- Update the recipe-builder regression test to assert the setup payload initializes stdio before emitting diagnostics.

## Why

`wordpress.run-php` does not define CLI constants like `STDERR`. The Composer override setup writes actionable failure messages to stderr, so the first error path crashed with:

```text
Fatal error: Uncaught Error: Undefined constant "STDERR"
```

The setup payload now defines `STDERR`/`STDOUT` from `php://stderr` and `php://stdout` when the runtime has not already provided them.

## Testing

- `node --check WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs`
- `node --test WordPress/static-site-importer/tools/fixture-matrix.test.mjs`

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Codebox run-php stdio failure, implementing the bootstrap, and running targeted verification.
