### PR TITLE
Use Codebox dependency overlays for SSI overrides

### DIFF
--- a/WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs
+++ b/WordPress/static-site-importer/lib/fixture-matrix/steps/recipe-builder.mjs
@@ -104,7 +104,6 @@ export function buildFixtureMatrixRecipe(input = {}) {
   const importer = normalizeStaticSiteImporterPlugin(input);
   const dependencyOverrideSetup = buildDependencyOverrideSetup(input, importer);
   const mounts = normalizeArray(input.mounts);
-  mounts.push(...dependencyOverrideSetup.mounts);
   const extraPlugins = [importer.extraPlugin, ...normalizeArray(input.extraPlugins || input.extra_plugins)];
   const editorValidationEnabled = input.editorValidation !== false && input.editor_validation !== false;
   // Real-content validation options forwarded to the editor-validate-blocks step.
@@ -156,13 +155,15 @@ export function buildFixtureMatrixRecipe(input = {}) {
     inputs: {
       mounts,
       extra_plugins: extraPlugins,
+      ...(dependencyOverrideSetup.dependencyOverlays.length
+        ? { dependency_overlays: dependencyOverrideSetup.dependencyOverlays }
+        : {}),
     },
     ...(Object.keys(dependencyOverrideSetup.metadata).length
       ? { metadata: { dependency_overrides: dependencyOverrideSetup.metadata } }
       : {}),
     workflow: {
       steps: [
-        ...dependencyOverrideSetup.steps,
         importer.activationStep,
         ...matrix.fixtures.flatMap((fixture) => [
           {
@@ -188,7 +189,7 @@ function buildDependencyOverrideSetup(input, importer) {
   const blocksEnginePhpTransformer = overrides.blocks_engine_php_transformer || overrides.blocksEnginePhpTransformer;
   const rawPackagePath = blocksEnginePhpTransformer?.path || '';
   if (!rawPackagePath) {
-    return { mounts: [], steps: [], metadata: {} };
+    return { dependencyOverlays: [], metadata: {} };
   }
 
   const packagePath = path.resolve(rawPackagePath);
@@ -205,33 +206,21 @@ function buildDependencyOverrideSetup(input, importer) {
     throw new Error(`SSI dependency override path must contain ${packageName}: ${packagePath}`);
   }
 
-  const sandboxPackagePath = '/tmp/homeboy-rigs-dependency-overrides/blocks-engine-php-transformer';
-  const sandboxPluginPath = `/wordpress/wp-content/plugins/${importer.slug}`;
   return {
-    mounts: [
+    dependencyOverlays: [
       {
+        kind: 'composer-package',
+        package: packageName,
+        consumer: importer.slug,
         source: packagePath,
-        target: sandboxPackagePath,
-        mode: 'readonly',
-      },
-    ],
-    steps: [
-      {
-        command: 'wordpress.run-php',
-        args: [`code=${dependencyOverrideComposerSetupPhp({
-          pluginPath: sandboxPluginPath,
-          packagePath: sandboxPackagePath,
-          packageName,
-        })}`],
       },
     ],
     metadata: {
       blocks_engine_php_transformer: {
         package: packageName,
         source_path: packagePath,
-        sandbox_path: sandboxPackagePath,
-        applied_by: 'composer_path_repository_recipe_setup',
-        setup_command: 'wordpress.run-php',
+        applied_by: 'wp_codebox_dependency_overlay',
+        consumer: importer.slug,
       },
     },
   };

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -167,24 +167,19 @@ test('builds WP Codebox recipe setup for SSI Composer dependency overrides', () 
     },
   });
 
-  assert.deepEqual(recipe.inputs.mounts[0], {
+  assert.deepEqual(recipe.inputs.dependency_overlays[0], {
+    kind: 'composer-package',
+    package: 'automattic/blocks-engine-php-transformer',
+    consumer: 'static-site-importer',
     source: transformerPath,
-    target: '/tmp/homeboy-rigs-dependency-overrides/blocks-engine-php-transformer',
-    mode: 'readonly',
   });
-  assert.equal(recipe.workflow.steps[0].command, 'wordpress.run-php');
-  assert.match(recipe.workflow.steps[0].args[0], /^code=\s*\nif \(!defined\('STDERR'\)\)/);
-  assert.match(recipe.workflow.steps[0].args[0], /\$pluginPath =/);
-  assert.doesNotMatch(recipe.workflow.steps[0].args[0], /^command=eval/);
-  assert.match(recipe.workflow.steps[0].args[0], /composer/);
-  assert.match(recipe.workflow.steps[0].args[0], /automattic\/blocks-engine-php-transformer/);
-  assert.equal(recipe.workflow.steps[1].args[0], 'command=plugin activate static-site-importer/static-site-importer.php');
+  assert.equal(recipe.inputs.mounts.length, 0);
+  assert.equal(recipe.workflow.steps[0].args[0], 'command=plugin activate static-site-importer/static-site-importer.php');
   assert.deepEqual(recipe.metadata.dependency_overrides.blocks_engine_php_transformer, {
     package: 'automattic/blocks-engine-php-transformer',
     source_path: transformerPath,
-    sandbox_path: '/tmp/homeboy-rigs-dependency-overrides/blocks-engine-php-transformer',
-    applied_by: 'composer_path_repository_recipe_setup',
-    setup_command: 'wordpress.run-php',
+    applied_by: 'wp_codebox_dependency_overlay',
+    consumer: 'static-site-importer',
   });
 });
 


### PR DESCRIPTION
## Summary
- Replace SSI fixture-matrix custom Composer setup steps with WP Codebox dependency_overlays.
- Keep Blocks Engine PHP transformer overrides mounted through the existing composer-package overlay contract.
- Update recipe-generation coverage to assert no sandbox Composer setup command is emitted.

## Verification
- node --test WordPress/static-site-importer/tools/fixture-matrix.test.mjs
- Regenerated focused Liquid Bonsai recipe with --no-visual-parity.
- Replayed focused recipe through WP Codebox successfully; editor validation reported 19/19 valid blocks.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosis, implementation, verification, and PR description drafting.