### PR TITLE
Declare WooCommerce dependency materialization

### DIFF
--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -119,7 +119,26 @@ test('fuzz workload metadata does not fall back to benchmark transcripts', () =>
   }
 });
 
-test('Woo Composer prep delegates to Homeboy dependency install primitive', () => {
+test('Woo Composer prep declares generic dependency materialization for vendor output', () => {
+  const dependencySteps = performanceRig.requirements?.dependency_materialization || [];
+  const composerStep = dependencySteps.find((step) => step.id === 'woocommerce-php-package-dependencies');
+
+  assert.ok(composerStep, 'expected WooCommerce PHP dependency materialization step');
+  assert.equal(composerStep.provider, 'wordpress-php-package-dependencies');
+  assert.equal(composerStep.component, 'woocommerce');
+  assert.equal(composerStep.cwd, '${components.woocommerce.path}');
+  assert.deepEqual(composerStep.cache_key_inputs, [
+    '${components.woocommerce.path}/composer.json',
+    '${components.woocommerce.path}/composer.lock',
+  ]);
+  assert.deepEqual(
+    new Set(composerStep.expected_outputs.map((output) => `${output.kind}:${output.path}`)),
+    new Set([
+      'dir:${components.woocommerce.path}/vendor',
+      'file:${components.woocommerce.path}/vendor/autoload_packages.php',
+    ])
+  );
+
   const composerRequirements = [
     ...performanceRig.pipeline.check,
     ...performanceRig.pipeline.fuzz_prepare,
@@ -128,6 +147,8 @@ test('Woo Composer prep delegates to Homeboy dependency install primitive', () =
   assert.equal(composerRequirements.length, 2);
   for (const requirement of composerRequirements) {
     assert.match(requirement.prepare_command, /prepare-runtime-dependency\.sh" composer/);
+    assert.doesNotMatch(requirement.remediation, /homeboy rig up/);
+    assert.match(requirement.remediation, /woocommerce-php-package-dependencies/);
   }
 
   assert.match(runtimePrepScript, /homeboy deps install --path "\$woocommerce_plugin_source"/);

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -63,6 +63,36 @@
       "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; the WooCommerce component checkout is user-owned."
     }
   },
+  "requirements": {
+    "dependency_materialization": [
+      {
+        "id": "woocommerce-php-package-dependencies",
+        "provider": "wordpress-php-package-dependencies",
+        "component": "woocommerce",
+        "cwd": "${components.woocommerce.path}",
+        "inputs": {
+          "recipe": "wordpress-php-package-dependencies",
+          "manifest": "${components.woocommerce.path}/composer.json",
+          "lockfile": "${components.woocommerce.path}/composer.lock"
+        },
+        "expected_outputs": [
+          {
+            "path": "${components.woocommerce.path}/vendor",
+            "kind": "dir"
+          },
+          {
+            "path": "${components.woocommerce.path}/vendor/autoload_packages.php",
+            "kind": "file"
+          }
+        ],
+        "cache_key_inputs": [
+          "${components.woocommerce.path}/composer.json",
+          "${components.woocommerce.path}/composer.lock"
+        ],
+        "safety": "network_access"
+      }
+    ]
+  },
   "bench": {
     "default_component": "woocommerce",
     "warmup_iterations": 0
@@ -543,7 +573,7 @@
           "up",
           "bench_prepare"
         ],
-        "remediation": "Install Composer on the runner, then run: homeboy rig up woocommerce-performance"
+        "remediation": "Materialize dependency step woocommerce-php-package-dependencies with provider wordpress-php-package-dependencies."
       },
       {
         "kind": "requirement",
@@ -585,7 +615,7 @@
         "prepare_phases": [
           "fuzz_prepare"
         ],
-        "remediation": "Install Composer on the runner, then run: homeboy rig up woocommerce-performance"
+        "remediation": "Materialize dependency step woocommerce-php-package-dependencies with provider wordpress-php-package-dependencies."
       },
       {
         "kind": "requirement",


### PR DESCRIPTION
## Summary
- Declare WooCommerce PHP dependency materialization using the HBEX WordPress dependency recipe provider.
- Require deterministic vendor outputs, including vendor/autoload_packages.php, with composer manifest and lockfile cache inputs.
- Update Woo manifest tests to assert the declared dependency step and ensure the Composer autoloader path is not only remediated through homeboy rig up.

## Tests
- node --test woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
- node scripts/lint-rig-packages.mjs
- node --test scripts/lint-rig-packages.test.mjs

## Notes
- Full node --test was attempted but remains blocked by unrelated Studio helper fixture discovery for scripts/fixtures/homeboy-extension-wordpress/lib/wordpress-helper-consumer.js.
- No local fuzz or benchmark run was executed.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the Homeboy/HBEX dependency materialization contract, editing the Woo rig manifest, adding tests, and running verification.