### PR TITLE
Remove local rig assumptions

### DIFF
--- a/Automattic/studio/docs/studio-canonical-loop-proof.md
+++ b/Automattic/studio/docs/studio-canonical-loop-proof.md
@@ -18,16 +18,16 @@ The first real runtime proof is `studio-native-live-runtime-open.mjs`: it opens 
 
 ```bash
 node Automattic/studio/proofs/studio-canonical-loop-proof.mjs --check
-node Automattic/studio/proofs/studio-canonical-loop-proof.mjs \
-  --out /tmp/studio-canonical-loop-proof
+HOMEBOY_INVOCATION_ARTIFACT_DIR=/path/to/artifacts \
+  node Automattic/studio/proofs/studio-canonical-loop-proof.mjs
 node scripts/lint-rig-packages.mjs Automattic/studio
 ```
 
 ## Run The Contract Harness
 
 ```bash
-node Automattic/studio/proofs/studio-canonical-loop-proof.mjs \
-  --out /tmp/studio-canonical-loop-proof
+HOMEBOY_INVOCATION_ARTIFACT_DIR=/path/to/artifacts \
+  node Automattic/studio/proofs/studio-canonical-loop-proof.mjs
 ```
 
 ## Run The Local WordPress Harness
@@ -35,21 +35,21 @@ node Automattic/studio/proofs/studio-canonical-loop-proof.mjs \
 Run this from a Studio site directory that has Static Site Importer active:
 
 ```bash
-node /path/to/homeboy-rigs/Automattic/studio/proofs/studio-canonical-loop-proof.mjs \
-  --mode local-wp \
-  --out /tmp/studio-canonical-loop-local-wp-proof
+HOMEBOY_INVOCATION_ARTIFACT_DIR=/path/to/artifacts \
+  node /path/to/homeboy-rigs/Automattic/studio/proofs/studio-canonical-loop-proof.mjs \
+    --mode local-wp
 ```
 
 `local-wp` mode writes the same artifacts as stub mode, but the initial materialization and reimport materialization are performed through `static_site_importer_ability_import_website_artifact()` via `studio wp eval-file`.
 
 ## Run The Live Runtime Open Proof
 
-Run this against the purpose-built local Studio Native runtime:
+Run this against an explicit Studio Native runtime URL:
 
 ```bash
-node Automattic/studio/proofs/studio-native-live-runtime-open.mjs \
-  --url http://studio-native-local-runtime.local/ \
-  --out /tmp/studio-native-live-runtime-open
+STUDIO_NATIVE_RUNTIME_URL=https://your-studio-native-runtime.example \
+HOMEBOY_INVOCATION_ARTIFACT_DIR=/path/to/artifacts \
+  node Automattic/studio/proofs/studio-native-live-runtime-open.mjs
 ```
 
 This proof opens the site, opens the WordPress REST index, reaches `/wp-json/studio-native/v1/status` even when auth-protected, and fails unless the real routes for chat, run events, Codebox artifact handoff, Codebox artifact session, contained-site open/create, and WP Codebox browser endpoints are present.

--- a/Automattic/studio/proofs/studio-canonical-loop-proof.mjs
+++ b/Automattic/studio/proofs/studio-canonical-loop-proof.mjs
@@ -218,7 +218,10 @@ async function main() {
   const checkOnly = hasArg('--check');
   const mode = argValue('--mode') || 'stub';
   const hostRequestPath = argValue('--host-request') || defaultHostRequestPath;
-  const outDir = path.resolve(argValue('--out') || path.join(os.tmpdir(), `studio-canonical-loop-proof-${process.pid}`));
+  const artifactRoot = process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR
+    || process.env.HOMEBOY_TRACE_ARTIFACT_DIR
+    || process.env.HOMEBOY_BENCH_ARTIFACT_DIR;
+  const outDir = path.resolve(argValue('--out') || path.join(artifactRoot || os.tmpdir(), `studio-canonical-loop-proof-${process.pid}`));
 
   if (!['stub', 'local-wp'].includes(mode)) {
     throw new Error('Supported modes are stub and local-wp. Full live mode requires a Studio Native runtime with the Codebox handoff route installed.');

--- a/Automattic/studio/proofs/studio-native-live-runtime-open.mjs
+++ b/Automattic/studio/proofs/studio-native-live-runtime-open.mjs
@@ -14,11 +14,23 @@ function now() {
 }
 
 function normalizeBaseUrl(value) {
-  const url = new URL(value || 'http://studio-native-local-runtime.local/');
+  if (!value) {
+    throw new Error('Studio Native runtime URL is required. Pass --url or set STUDIO_NATIVE_RUNTIME_URL.');
+  }
+
+  const url = new URL(value);
   url.pathname = url.pathname.replace(/\/+$/, '/');
   url.search = '';
   url.hash = '';
   return url;
+}
+
+function defaultOutDir(name) {
+  const artifactRoot = process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR
+    || process.env.HOMEBOY_TRACE_ARTIFACT_DIR
+    || process.env.HOMEBOY_BENCH_ARTIFACT_DIR;
+
+  return path.join(artifactRoot || os.tmpdir(), `${name}-${process.pid}`);
 }
 
 async function fetchText(url) {
@@ -46,7 +58,7 @@ function assert(condition, message) {
 
 async function main() {
   const baseUrl = normalizeBaseUrl(argValue('--url') || process.env.STUDIO_NATIVE_RUNTIME_URL);
-  const outDir = path.resolve(argValue('--out') || path.join(os.tmpdir(), `studio-native-live-runtime-open-${process.pid}`));
+  const outDir = path.resolve(argValue('--out') || defaultOutDir('studio-native-live-runtime-open'));
   await mkdir(outDir, { recursive: true });
 
   const homepage = await fetchText(baseUrl);

--- a/Automattic/studio/rigs/studio-canonical-loop-proof/rig.json
+++ b/Automattic/studio/rigs/studio-canonical-loop-proof/rig.json
@@ -49,7 +49,7 @@
       {
         "kind": "check",
         "label": "canonical loop contract harness passes",
-        "command": "node ${package.root}/proofs/studio-canonical-loop-proof.mjs --out /tmp/studio-canonical-loop-proof-rig-check",
+        "command": "node ${package.root}/proofs/studio-canonical-loop-proof.mjs",
         "expect_exit": 0
       }
     ]

--- a/Automattic/studio/rigs/studio-native-live-runtime-open/rig.json
+++ b/Automattic/studio/rigs/studio-native-live-runtime-open/rig.json
@@ -17,7 +17,7 @@
       {
         "kind": "check",
         "label": "studio native live runtime opens",
-        "command": "node ${package.root}/proofs/studio-native-live-runtime-open.mjs --url ${env.STUDIO_NATIVE_RUNTIME_URL} --out /tmp/studio-native-live-runtime-open-rig-check",
+        "command": "node ${package.root}/proofs/studio-native-live-runtime-open.mjs --url ${env.STUDIO_NATIVE_RUNTIME_URL}",
         "expect_exit": 0
       }
     ]

--- a/README.md
+++ b/README.md
@@ -427,9 +427,9 @@ Express Checkout Element browser waterfall trace against a local WooCommerce
 Stripe checkout plus a packaged WooCommerce dependency.
 
 ```bash
-homeboy rig install $HOME/Developer/homeboy-rigs@<branch>/woocommerce/woocommerce-gateway-stripe
+homeboy rig install /path/to/homeboy-rigs/woocommerce/woocommerce-gateway-stripe
 homeboy rig check woocommerce-stripe-ece-product-page
-homeboy trace --rig woocommerce-stripe-ece-product-page woocommerce-gateway-stripe ece-product-page-waterfall --output /tmp/wc-stripe-ece-waterfall.json
+homeboy trace --rig woocommerce-stripe-ece-product-page woocommerce-gateway-stripe ece-product-page-waterfall
 ```
 
 Additional trace scenarios cover post-load interactions for scrolling to the ECE

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -126,6 +126,10 @@ function lintRigPortability(file, fuzzWorkloadsByPackageRoot) {
     failures.push(`${rel}: isolated-block-editor must use the component path or shared node_modules setting instead of /var/lib/datamachine`);
   }
 
+  if (/Automattic\/studio\/rigs\/studio-(?:canonical-loop-proof|native-live-runtime-open)\/rig\.json/.test(rel) && /--out\s+\/tmp\//.test(contents)) {
+    failures.push(`${rel}: proof rig checks must let proof scripts use Homeboy artifact env output directories instead of hard-coded /tmp outputs`);
+  }
+
   if (localDeveloperCheckoutPattern.test(contents)) {
     failures.push(`${rel}: use portable component path settings instead of committed ~/Developer or $HOME/Developer checkout paths`);
   }
@@ -463,6 +467,14 @@ function lintPortableSource(file) {
 
   if (contents.includes(tsrmlsPatchMarker)) {
     failures.push(`${rel}: TSRMLS fallback defines are owned by WordPress/wordpress-playground#3512; do not patch Playground source in rigs`);
+  }
+
+  if (rel === 'Automattic/studio/proofs/studio-native-live-runtime-open.mjs' && contents.includes('studio-native-local-runtime.local')) {
+    failures.push(`${rel}: live runtime proof must require an explicit runtime URL instead of falling back to local DNS`);
+  }
+
+  if (rel === 'woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs' && /Developer\/woocommerce\/plugins\/woocommerce/.test(contents)) {
+    failures.push(`${rel}: Woo Stripe ECE workload must use the declared WooCommerce component/env path instead of a local Developer fallback`);
   }
 }
 

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -253,6 +253,59 @@ test('accepts explicitly allowed shared path self-targets', () => {
   assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
 });
 
+test('rejects Studio proof rig checks with hard-coded tmp outputs', () => {
+  const directory = createRigPackage({
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+  });
+  const rigRoot = join(directory, 'Automattic', 'studio', 'rigs', 'studio-native-live-runtime-open');
+  mkdirSync(rigRoot, { recursive: true });
+  writeJson(join(rigRoot, 'rig.json'), {
+    id: 'studio-native-live-runtime-open',
+    pipeline: {
+      check: [{ kind: 'check', command: 'node proofs/studio-native-live-runtime-open.mjs --out /tmp/studio-native-proof' }],
+    },
+  });
+
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /proof rig checks must let proof scripts use Homeboy artifact env output directories/);
+});
+
+test('rejects Studio Native live proof local DNS fallback', () => {
+  const directory = createRigPackage({
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+  });
+  const proofRoot = join(directory, 'Automattic', 'studio', 'proofs');
+  mkdirSync(proofRoot, { recursive: true });
+  writeFileSync(join(proofRoot, 'studio-native-live-runtime-open.mjs'), "const url = 'http://studio-native-local-runtime.local/';\n");
+
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /must require an explicit runtime URL instead of falling back to local DNS/);
+});
+
+test('rejects Woo Stripe ECE local WooCommerce Developer fallback', () => {
+  const directory = createRigPackage({
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+  });
+  const benchRoot = join(directory, 'woocommerce', 'woocommerce-gateway-stripe', 'bench');
+  mkdirSync(benchRoot, { recursive: true });
+  writeFileSync(join(benchRoot, 'ece-product-page-waterfall.trace.mjs'), "const path = 'Developer/woocommerce/plugins/woocommerce';\n");
+
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Woo Stripe ECE workload must use the declared WooCommerce component\/env path/);
+});
+
 test('rejects rigs with resources, empty down lifecycle, and no cleanup policy', () => {
   const directory = createRigPackage({
     rig: {

--- a/woocommerce/woocommerce-gateway-stripe/README.md
+++ b/woocommerce/woocommerce-gateway-stripe/README.md
@@ -65,27 +65,18 @@ Secondary noisy metrics:
 The rig owns its benchmark fixture at `bench/fixture-bootstrap.php`; the target
 Stripe checkout does not need benchmark fixture files.
 
-For `homeboy rig check`, update `components.woocommerce-gateway-stripe.path` in
-`rigs/woocommerce-stripe-ece-product-page/rig.json` when the target Stripe
-checkout is a worktree instead of `~/Developer/woocommerce-gateway-stripe`:
+For `homeboy rig check`, provide the declared component path env when the target
+Stripe checkout is a worktree:
 
-```json
-"components": {
-  "woocommerce-gateway-stripe": {
-    "path": "/path/to/woocommerce-gateway-stripe-worktree"
-  }
-}
+```bash
+export HOMEBOY_RIG_COMPONENT_PATH__WOOCOMMERCE_STRIPE_ECE_PRODUCT_PAGE__WOOCOMMERCE_GATEWAY_STRIPE=/path/to/woocommerce-gateway-stripe-worktree
 ```
 
 The rig also needs a WooCommerce plugin directory. Prefer a packaged WooCommerce
 plugin build when tracing Stripe browser behavior:
 
-```json
-"components": {
-  "woocommerce": {
-    "path": "/path/to/woocommerce"
-  }
-}
+```bash
+export HOMEBOY_RIG_COMPONENT_PATH__WOOCOMMERCE_STRIPE_ECE_PRODUCT_PAGE__WOOCOMMERCE=/path/to/woocommerce/plugins/woocommerce
 ```
 
 The Stripe plugin mounted into WP Codebox must carry fresh product-page ECE
@@ -115,7 +106,7 @@ export HOMEBOY_WP_CODEBOX_BIN=/path/to/wp-codebox/packages/cli/dist/index.js
 ## Install
 
 ```bash
-homeboy rig install $HOME/Developer/homeboy-rigs@<branch>/woocommerce/woocommerce-gateway-stripe
+homeboy rig install /path/to/homeboy-rigs/woocommerce/woocommerce-gateway-stripe
 homeboy rig check woocommerce-stripe-ece-product-page
 ```
 

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -24,7 +24,8 @@ const scenarioId = process.env.HOMEBOY_TRACE_SCENARIO || DEFAULT_ECE_SCENARIO_ID
 const scenario = eceProductPageScenario(scenarioId);
 const resultsFile = process.env.HOMEBOY_TRACE_RESULTS_FILE;
 const artifactDir = process.env.HOMEBOY_TRACE_ARTIFACT_DIR || path.join(tmpdir(), 'wc-stripe-ece-waterfall-artifacts');
-const woocommercePath = process.env.HOMEBOY_WC_STRIPE_WOOCOMMERCE_PATH || path.join(process.env.HOME || '', 'Developer/woocommerce/plugins/woocommerce');
+const woocommercePath = process.env.HOMEBOY_WC_STRIPE_WOOCOMMERCE_PATH
+  || process.env.HOMEBOY_RIG_COMPONENT_PATH__WOOCOMMERCE_STRIPE_ECE_PRODUCT_PAGE__WOOCOMMERCE;
 const wpVersion = process.env.HOMEBOY_WC_STRIPE_WP_VERSION || '7.0';
 const eceLocations = process.env.HOMEBOY_WC_STRIPE_ECE_LOCATIONS || 'product';
 const acceptedPaymentMethods = setting('woocommerce_stripe_accepted_payment_methods', process.env.HOMEBOY_WC_STRIPE_ACCEPTED_PAYMENT_METHODS || 'card,link');
@@ -57,8 +58,11 @@ if (!traceHelperDir) {
 if (!existsSync(fixtureBootstrapPath)) {
   throw new Error(`Missing rig-owned Stripe fixture bootstrap at ${fixtureBootstrapPath}`);
 }
+if (!woocommercePath) {
+  throw new Error('WooCommerce dependency plugin path is required. Set HOMEBOY_WC_STRIPE_WOOCOMMERCE_PATH or HOMEBOY_RIG_COMPONENT_PATH__WOOCOMMERCE_STRIPE_ECE_PRODUCT_PAGE__WOOCOMMERCE.');
+}
 if (!existsSync(path.join(woocommercePath, 'woocommerce.php'))) {
-  throw new Error(`Missing WooCommerce dependency plugin at ${woocommercePath}. Set HOMEBOY_WC_STRIPE_WOOCOMMERCE_PATH to a packaged WooCommerce plugin directory.`);
+  throw new Error(`Missing WooCommerce dependency plugin at ${woocommercePath}. Set HOMEBOY_WC_STRIPE_WOOCOMMERCE_PATH or HOMEBOY_RIG_COMPONENT_PATH__WOOCOMMERCE_STRIPE_ECE_PRODUCT_PAGE__WOOCOMMERCE to a packaged WooCommerce plugin directory.`);
 }
 
 const fixtureBootstrapSource = (await readFile(fixtureBootstrapPath, 'utf8'))


### PR DESCRIPTION
## Summary
- Require explicit Studio Native runtime URLs instead of falling back to local DNS.
- Prefer Homeboy artifact directories for Studio proof outputs instead of hardcoded /tmp paths.
- Remove Woo Stripe ECE fallback to a local ~/Developer WooCommerce checkout.
- Add static lint coverage for these regressions.

## Testing
- node --test scripts/lint-rig-packages.test.mjs
- node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs
- node scripts/lint-rig-packages.mjs Automattic/studio
- node scripts/lint-rig-packages.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Investigation, implementation, focused test selection, and PR preparation.