### PR TITLE
Fix WooCommerce performance rig runtime dependency paths

### DIFF
--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -119,23 +119,23 @@ test('fuzz workload metadata does not fall back to benchmark transcripts', () =>
   }
 });
 
-test('Woo Composer prep declares generic dependency materialization for vendor output', () => {
+test('Woo Composer prep declares dependency materialization for plugin vendor output', () => {
   const dependencySteps = performanceRig.requirements?.dependency_materialization || [];
   const composerStep = dependencySteps.find((step) => step.id === 'woocommerce-php-package-dependencies');
 
   assert.ok(composerStep, 'expected WooCommerce PHP dependency materialization step');
-  assert.equal(composerStep.provider, 'wordpress-php-package-dependencies');
+  assert.match(composerStep.command, /prepare-runtime-dependency\.sh" composer/);
   assert.equal(composerStep.component, 'woocommerce');
-  assert.equal(composerStep.cwd, '${components.woocommerce.path}');
+  assert.equal(composerStep.cwd, '${components.woocommerce.path}/plugins/woocommerce');
   assert.deepEqual(composerStep.cache_key_inputs, [
-    '${components.woocommerce.path}/composer.json',
-    '${components.woocommerce.path}/composer.lock',
+    '${components.woocommerce.path}/plugins/woocommerce/composer.json',
+    '${components.woocommerce.path}/plugins/woocommerce/composer.lock',
   ]);
   assert.deepEqual(
     new Set(composerStep.expected_outputs.map((output) => `${output.kind}:${output.path}`)),
     new Set([
-      'dir:${components.woocommerce.path}/vendor',
-      'file:${components.woocommerce.path}/vendor/autoload_packages.php',
+      'dir:${components.woocommerce.path}/plugins/woocommerce/vendor',
+      'file:${components.woocommerce.path}/plugins/woocommerce/vendor/autoload_packages.php',
     ])
   );
 
@@ -147,6 +147,7 @@ test('Woo Composer prep declares generic dependency materialization for vendor o
   assert.equal(composerRequirements.length, 2);
   for (const requirement of composerRequirements) {
     assert.match(requirement.prepare_command, /prepare-runtime-dependency\.sh" composer/);
+    assert.match(requirement.file, /plugins\/woocommerce\/vendor\/autoload_packages\.php$/);
     assert.doesNotMatch(requirement.remediation, /homeboy rig up/);
     assert.match(requirement.remediation, /woocommerce-php-package-dependencies/);
   }

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -67,27 +67,27 @@
     "dependency_materialization": [
       {
         "id": "woocommerce-php-package-dependencies",
-        "provider": "wordpress-php-package-dependencies",
+        "command": "bash \"${package.root}/tools/prepare-runtime-dependency.sh\" composer \"${components.woocommerce.path}/plugins/woocommerce\"",
         "component": "woocommerce",
-        "cwd": "${components.woocommerce.path}",
+        "cwd": "${components.woocommerce.path}/plugins/woocommerce",
         "inputs": {
-          "recipe": "wordpress-php-package-dependencies",
-          "manifest": "${components.woocommerce.path}/composer.json",
-          "lockfile": "${components.woocommerce.path}/composer.lock"
+          "recipe": "wordpress-plugin-php-package-dependencies",
+          "manifest": "${components.woocommerce.path}/plugins/woocommerce/composer.json",
+          "lockfile": "${components.woocommerce.path}/plugins/woocommerce/composer.lock"
         },
         "expected_outputs": [
           {
-            "path": "${components.woocommerce.path}/vendor",
+            "path": "${components.woocommerce.path}/plugins/woocommerce/vendor",
             "kind": "dir"
           },
           {
-            "path": "${components.woocommerce.path}/vendor/autoload_packages.php",
+            "path": "${components.woocommerce.path}/plugins/woocommerce/vendor/autoload_packages.php",
             "kind": "file"
           }
         ],
         "cache_key_inputs": [
-          "${components.woocommerce.path}/composer.json",
-          "${components.woocommerce.path}/composer.lock"
+          "${components.woocommerce.path}/plugins/woocommerce/composer.json",
+          "${components.woocommerce.path}/plugins/woocommerce/composer.lock"
         ],
         "safety": "network_access"
       }
@@ -549,37 +549,37 @@
       {
         "kind": "requirement",
         "label": "WooCommerce runner checkout exists",
-        "file": "${components.woocommerce.path}/woocommerce.php",
-        "remediation": "Pass homeboy bench --path /path/to/plugins/woocommerce or update components.woocommerce.path before running woocommerce-performance."
+        "file": "${components.woocommerce.path}/plugins/woocommerce/woocommerce.php",
+        "remediation": "Pass homeboy bench --path /path/to/woocommerce-monorepo or update components.woocommerce.path before running woocommerce-performance."
       },
       {
         "kind": "requirement",
         "label": "WooCommerce cart class exists",
-        "file": "${components.woocommerce.path}/includes/class-wc-cart.php",
-        "remediation": "Verify the selected component path is the WooCommerce monorepo plugin directory, not an empty or partial clone."
+        "file": "${components.woocommerce.path}/plugins/woocommerce/includes/class-wc-cart.php",
+        "remediation": "Verify the selected component path is the WooCommerce monorepo checkout, not an empty or partial clone."
       },
       {
         "kind": "requirement",
         "label": "WooCommerce shipping class exists",
-        "file": "${components.woocommerce.path}/includes/class-wc-shipping.php",
-        "remediation": "Verify the selected component path is the WooCommerce monorepo plugin directory, not an empty or partial clone."
+        "file": "${components.woocommerce.path}/plugins/woocommerce/includes/class-wc-shipping.php",
+        "remediation": "Verify the selected component path is the WooCommerce monorepo checkout, not an empty or partial clone."
       },
       {
         "kind": "requirement",
         "label": "WooCommerce Composer package autoloader exists or can be prepared",
-        "file": "${components.woocommerce.path}/vendor/autoload_packages.php",
-        "prepare_command": "bash \"${package.root}/tools/prepare-runtime-dependency.sh\" composer \"${components.woocommerce.path}\"",
+        "file": "${components.woocommerce.path}/plugins/woocommerce/vendor/autoload_packages.php",
+        "prepare_command": "bash \"${package.root}/tools/prepare-runtime-dependency.sh\" composer \"${components.woocommerce.path}/plugins/woocommerce\"",
         "prepare_phases": [
           "up",
           "bench_prepare"
         ],
-        "remediation": "Materialize dependency step woocommerce-php-package-dependencies with provider wordpress-php-package-dependencies."
+        "remediation": "Materialize dependency step woocommerce-php-package-dependencies for the plugins/woocommerce runtime path."
       },
       {
         "kind": "requirement",
         "label": "WooCommerce generated feature config exists or can be prepared",
-        "file": "${components.woocommerce.path}/includes/react-admin/feature-config.php",
-        "prepare_command": "bash \"${package.root}/tools/prepare-runtime-dependency.sh\" feature-config \"${components.woocommerce.path}\"",
+        "file": "${components.woocommerce.path}/plugins/woocommerce/includes/react-admin/feature-config.php",
+        "prepare_command": "bash \"${package.root}/tools/prepare-runtime-dependency.sh\" feature-config \"${components.woocommerce.path}/plugins/woocommerce\"",
         "prepare_phases": [
           "up",
           "bench_prepare"
@@ -589,8 +589,8 @@
       {
         "kind": "requirement",
         "label": "WooCommerce admin script asset registry exists or can be built",
-        "file": "${components.woocommerce.path}/assets/client/admin/wp-admin-scripts/command-palette.asset.php",
-        "prepare_command": "bash \"${package.root}/tools/prepare-runtime-dependency.sh\" admin-assets \"${components.woocommerce.path}\"",
+        "file": "${components.woocommerce.path}/plugins/woocommerce/assets/client/admin/wp-admin-scripts/command-palette.asset.php",
+        "prepare_command": "bash \"${package.root}/tools/prepare-runtime-dependency.sh\" admin-assets \"${components.woocommerce.path}/plugins/woocommerce\"",
         "prepare_phases": [
           "up",
           "bench_prepare"
@@ -610,18 +610,18 @@
       {
         "kind": "requirement",
         "label": "WooCommerce Composer package autoloader exists or can be prepared",
-        "file": "${components.woocommerce.path}/vendor/autoload_packages.php",
-        "prepare_command": "bash \"${package.root}/tools/prepare-runtime-dependency.sh\" composer \"${components.woocommerce.path}\"",
+        "file": "${components.woocommerce.path}/plugins/woocommerce/vendor/autoload_packages.php",
+        "prepare_command": "bash \"${package.root}/tools/prepare-runtime-dependency.sh\" composer \"${components.woocommerce.path}/plugins/woocommerce\"",
         "prepare_phases": [
           "fuzz_prepare"
         ],
-        "remediation": "Materialize dependency step woocommerce-php-package-dependencies with provider wordpress-php-package-dependencies."
+        "remediation": "Materialize dependency step woocommerce-php-package-dependencies for the plugins/woocommerce runtime path."
       },
       {
         "kind": "requirement",
         "label": "WooCommerce generated feature config exists or can be prepared",
-        "file": "${components.woocommerce.path}/includes/react-admin/feature-config.php",
-        "prepare_command": "bash \"${package.root}/tools/prepare-runtime-dependency.sh\" feature-config \"${components.woocommerce.path}\"",
+        "file": "${components.woocommerce.path}/plugins/woocommerce/includes/react-admin/feature-config.php",
+        "prepare_command": "bash \"${package.root}/tools/prepare-runtime-dependency.sh\" feature-config \"${components.woocommerce.path}/plugins/woocommerce\"",
         "prepare_phases": [
           "fuzz_prepare"
         ],

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -95,9 +95,9 @@ assert.deepEqual(actualFuzzIds, expectedFuzzIds, 'WooCommerce fuzz manifest ids 
 assert.deepEqual(declaredIds, expectedFuzzIds, 'rig fuzz_workloads.wordpress ids drifted');
 
 const runtimePrepFiles = new Set([
-  '${components.woocommerce.path}/vendor/autoload_packages.php',
-  '${components.woocommerce.path}/includes/react-admin/feature-config.php',
-  '${components.woocommerce.path}/assets/client/admin/wp-admin-scripts/command-palette.asset.php',
+  '${components.woocommerce.path}/plugins/woocommerce/vendor/autoload_packages.php',
+  '${components.woocommerce.path}/plugins/woocommerce/includes/react-admin/feature-config.php',
+  '${components.woocommerce.path}/plugins/woocommerce/assets/client/admin/wp-admin-scripts/command-palette.asset.php',
 ]);
 const runtimePrepCheckSteps = (rig.pipeline?.check || []).filter((step) => runtimePrepFiles.has(step.file));
 


### PR DESCRIPTION
## Summary
- materialize WooCommerce PHP package dependencies through the rig-owned prep command at plugins/woocommerce
- align WooCommerce performance rig dependency outputs and prepare checks with the Lab materialized monorepo checkout layout
- update remediation copy to point at the plugin runtime path

## Testing
- homeboy rig lint /Users/chubes/Developer/homeboy-rigs@cook-woocommerce-dependency-materialization/woocommerce/woocommerce --id woocommerce-performance

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigation, code edits, test/validation execution, and PR drafting.