### PR TITLE
Remove local checkout fallbacks from rig workloads

### DIFF
--- a/Automattic/studio/bench/playground-web-startup.trace.mjs
+++ b/Automattic/studio/bench/playground-web-startup.trace.mjs
@@ -1,6 +1,6 @@
 import { createWriteStream } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
@@ -11,7 +11,10 @@ const HELPER_DIR = process.env.HOMEBOY_TRACE_HELPER_DIR;
 if (!HELPER_DIR) {
 	throw new Error('HOMEBOY_TRACE_HELPER_DIR is required');
 }
-const PLAYGROUND_PATH = process.env.PLAYGROUND_WEB_TRACE_PLAYGROUND_PATH || path.join(homedir(), 'Developer/wordpress-playground');
+const PLAYGROUND_PATH = process.env.PLAYGROUND_WEB_TRACE_PLAYGROUND_PATH || process.env.HOMEBOY_COMPONENT_PATH;
+if (!PLAYGROUND_PATH) {
+	throw new Error('PLAYGROUND_WEB_TRACE_PLAYGROUND_PATH or HOMEBOY_COMPONENT_PATH is required and must point to the wordpress-playground component checkout.');
+}
 const BASE_URL = process.env.PLAYGROUND_WEB_TRACE_BASE_URL || 'http://127.0.0.1:5400/website-server/';
 const WP_VERSION = process.env.PLAYGROUND_WEB_TRACE_WP_VERSION || '6.8';
 const PHP_VERSION = process.env.PLAYGROUND_WEB_TRACE_PHP_VERSION || '8.3';

--- a/WordPress/wordpress-playground/bench/playground-cli-runphp-errors.bench.mjs
+++ b/WordPress/wordpress-playground/bench/playground-cli-runphp-errors.bench.mjs
@@ -24,16 +24,6 @@ const FATAL_BLUEPRINT = {
   ],
 };
 
-function expandHome(value) {
-  if (!value || value === '~') {
-    return os.homedir();
-  }
-  if (value.startsWith('~/')) {
-    return path.join(os.homedir(), value.slice(2));
-  }
-  return value;
-}
-
 function artifactRoot() {
   return (
     process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR ||
@@ -43,7 +33,10 @@ function artifactRoot() {
 }
 
 function componentPath() {
-  return expandHome(process.env.HOMEBOY_COMPONENT_PATH || '~/Developer/wordpress-playground');
+  if (!process.env.HOMEBOY_COMPONENT_PATH) {
+    throw new Error('HOMEBOY_COMPONENT_PATH is required and must point to the wordpress-playground component checkout.');
+  }
+  return process.env.HOMEBOY_COMPONENT_PATH;
 }
 
 function cliArgs(blueprintPath) {

--- a/woocommerce/woocommerce/bench/cart-session-overwrite-race.trace.mjs
+++ b/woocommerce/woocommerce/bench/cart-session-overwrite-race.trace.mjs
@@ -7,7 +7,7 @@ import { runWpCodeboxRecipe } from '../../../shared/wp-codebox/recipe.mjs';
 
 const packageRoot = process.env.HOMEBOY_COMPONENT_PATH;
 const componentPluginPath = path.join( packageRoot || '', 'plugins/woocommerce' );
-const woocommercePath = process.env.HOMEBOY_WOOCOMMERCE_CART_RACE_WOOCOMMERCE_PATH || process.env.HOMEBOY_SETTINGS_WOOCOMMERCE_CART_RACE_WOOCOMMERCE_PATH || ( existsSync( path.join( componentPluginPath, 'woocommerce.php' ) ) ? componentPluginPath : path.join( process.env.HOME || '', 'Developer/woocommerce/plugins/woocommerce' ) );
+const woocommercePath = process.env.HOMEBOY_WOOCOMMERCE_CART_RACE_WOOCOMMERCE_PATH || process.env.HOMEBOY_SETTINGS_WOOCOMMERCE_CART_RACE_WOOCOMMERCE_PATH || componentPluginPath;
 const componentId = process.env.HOMEBOY_COMPONENT_ID || 'woocommerce';
 const scenarioId = process.env.HOMEBOY_TRACE_SCENARIO || 'cart-session-overwrite-race';
 const resultsFile = process.env.HOMEBOY_TRACE_RESULTS_FILE;
@@ -25,7 +25,7 @@ if ( ! resultsFile ) {
 	throw new Error( 'HOMEBOY_TRACE_RESULTS_FILE is required' );
 }
 if ( ! existsSync( path.join( woocommercePath, 'woocommerce.php' ) ) ) {
-	throw new Error( `Missing WooCommerce plugin entrypoint at ${ woocommercePath }/woocommerce.php` );
+	throw new Error( `Missing WooCommerce plugin entrypoint at ${ woocommercePath }/woocommerce.php. Set HOMEBOY_COMPONENT_PATH to the woocommerce repository checkout or HOMEBOY_WOOCOMMERCE_CART_RACE_WOOCOMMERCE_PATH to the WooCommerce plugin directory.` );
 }
 
 await mkdir( artifactDir, { recursive: true } );


### PR DESCRIPTION
## Summary
- require declared component paths for Playground CLI diagnostics instead of falling back to ~/Developer
- require explicit Playground path or HOMEBOY_COMPONENT_PATH for the Studio Playground web trace
- require the declared WooCommerce component/plugin path for the cart session race trace

## Tests
- `node scripts/lint-rig-packages.mjs`
- `node --test scripts/lint-rig-packages.test.mjs`
- `node --test scripts/*.test.mjs shared/*.test.mjs shared/wp-codebox/*.test.mjs woocommerce/woocommerce/manifests/*.test.mjs Automattic/studio/bench/*.test.mjs woocommerce/woocommerce-gateway-stripe/bench/*.test.mjs` (fails: Studio site-build gate tests require unavailable `materialized-site-quality.js` via `HOMEBOY_WORDPRESS_HELPER_MANIFEST`; unrelated to this change)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 and OpenCode
- **Used for:** Implementing the portability cleanup, running local validation, and drafting this PR description.