### PR TITLE
Fix Woo firehose isolation proof plan

### DIFF
--- a/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs
+++ b/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -17,9 +17,15 @@ const runnableCommandsEnabled = executionSupported && !options.planOnly;
 const profileWorkloads = rig.fuzz_profiles?.[manifest.profile_id] || [];
 const plannedArtifactSemanticKeys = (manifest.planned_artifact_expectations || []).map((artifact) => artifact.semantic_key);
 const campaignInputs = buildCampaignInputs(manifest);
+const isolationProofPath = options.isolationProofPath || defaultIsolationProofPath(options);
 
 if (!Array.isArray(profileWorkloads) || profileWorkloads.length === 0) {
   throw new Error(`Rig fuzz profile ${manifest.profile_id} must declare at least one workload`);
+}
+
+if (options.writeIsolationProof) {
+  writeIsolationProof(options.writeIsolationProof, buildIsolationProof());
+  process.exit(0);
 }
 
 const payload = {
@@ -36,13 +42,9 @@ const payload = {
   upstream_contract_artifact_sources: [
     {
       contract: 'homeboy/isolation-proof/v1',
-      source: 'homeboy fuzz run Lab/offloaded runner metadata',
-      persisted_artifact_kind: 'fuzz_result_envelope',
-      persisted_fields: [
-        'results.planner.isolation_proof_source',
-        'results.isolation.proof_source',
-      ],
-      required_command_flags: ['--lab-only', '--allow-destructive', '--isolation', 'isolated', '--require-result-envelope'],
+      source: 'preflight command-plan artifact describing the disposable Homeboy Lab/WP Codebox boundary',
+      generated_artifact_path: isolationProofPath,
+      required_command_flags: ['--lab-only', '--allow-destructive', '--isolation', 'isolated', '--isolation-proof', isolationProofPath, '--require-result-envelope'],
     },
     {
       contract: 'wp-codebox/sandbox-isolation-proof/v1',
@@ -54,12 +56,26 @@ const payload = {
   blockers: executionSupported ? [] : [
     'manifest.readiness.execution_enabled is false because REST CRUD fixture-plan mutations are disabled',
   ],
+  generated_isolation_proof: buildIsolationProof(),
   plan_items: [
     {
       purpose: 'validate_disposable_rig',
       command_argv: withOptionalLabArgs(['homeboy', 'rig', 'check', 'woocommerce-performance'], options),
     },
     ...(executionSupported ? [
+      {
+        purpose: 'write_homeboy_isolation_proof',
+        command_argv: [
+          'node', 'tools/aggressive-firehose-command-plan.mjs',
+          '--write-isolation-proof', isolationProofPath,
+        ],
+        artifact: {
+          path: isolationProofPath,
+          schema: 'homeboy/isolation-proof/v1',
+          semantic_key: 'fuzz.homeboy_isolation_proof',
+          required_before_execution: true,
+        },
+      },
       ...profileWorkloads.map((workloadId, index) => ({
         purpose: `request_aggressive_isolated_firehose:${workloadId}`,
         command_argv: fuzzRunCommandForWorkload(workloadId, index, options),
@@ -73,7 +89,6 @@ const payload = {
           '--rig', 'woocommerce-performance',
           '--kind', 'fuzz',
           '--status', 'completed',
-          '--tracker-ref', options.trackerRef,
           '--artifact-kind', 'fuzz_result_envelope',
           '--artifact-kind', 'fuzz_artifacts',
           ...plannedArtifactSemanticKeys.flatMap((semanticKey) => ['--artifact-kind', semanticKey]),
@@ -118,7 +133,9 @@ function parseArgs(argv) {
     planOnly: false,
     runner: '',
     runIdPrefix: '',
+    isolationProofPath: '',
     trackerRef: '$WC_TRACKER_REF',
+    writeIsolationProof: '',
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -154,8 +171,14 @@ function parseArgs(argv) {
       case '--run-id-prefix':
         parsed.runIdPrefix = readValue(arg);
         break;
+      case '--isolation-proof':
+        parsed.isolationProofPath = readValue(arg);
+        break;
       case '--tracker-ref':
         parsed.trackerRef = readValue(arg);
+        break;
+      case '--write-isolation-proof':
+        parsed.writeIsolationProof = readValue(arg);
         break;
       case '--help':
       case '-h':
@@ -180,6 +203,7 @@ function fuzzRunCommandForWorkload(workloadId, index, options) {
     '--tracker-ref', options.trackerRef,
     '--allow-destructive',
     '--isolation', 'isolated',
+    '--isolation-proof', isolationProofPath,
     '--require-result-envelope',
   ];
 
@@ -225,6 +249,52 @@ function buildCampaignInputs(campaign) {
   };
 }
 
+function buildIsolationProof() {
+  return {
+    schema: 'homeboy/isolation-proof/v1',
+    id: 'woocommerce-aggressive-isolated-firehose-lab-codebox-boundary',
+    rig_id: 'woocommerce-performance',
+    profile_id: manifest.profile_id,
+    local_execution: false,
+    destructive_execution: {
+      allowed: true,
+      boundary: 'offloaded_homeboy_lab_wp_codebox_disposable_sandbox',
+    },
+    disposable_boundary: {
+      lab_runner_required: true,
+      wp_codebox_sandbox_required: true,
+      sandbox_lifetime: 'single offloaded fuzz run handoff',
+      host_wordpress_mutation_allowed: false,
+      component_checkout_mutation_allowed: false,
+    },
+    required_runner_flags: ['--lab-only', '--allow-destructive', '--isolation', 'isolated'],
+    workload_ids: profileWorkloads,
+    required_contracts: [
+      'homeboy/isolation-proof/v1',
+      'wp-codebox/sandbox-isolation-proof/v1',
+      'wp-codebox/mutation-isolation-artifact/v1',
+      'wp-codebox/delete-boundary-artifact/v1',
+    ],
+    evidence_semantics: {
+      runner_receives_artifact_with_flag: '--isolation-proof',
+      reviewer_facing_evidence_source: 'persisted Homeboy run artifacts emitted by the offloaded Lab runner',
+      operator_input_artifact: true,
+    },
+  };
+}
+
+function defaultIsolationProofPath(options) {
+  if (options.artifactRoot) {
+    return path.join(options.artifactRoot, 'isolation-proof/homeboy-isolation-proof.json');
+  }
+  return 'artifacts/woocommerce-aggressive-firehose/isolation-proof/homeboy-isolation-proof.json';
+}
+
+function writeIsolationProof(targetPath, proof) {
+  mkdirSync(path.dirname(targetPath), { recursive: true });
+  writeFileSync(targetPath, `${JSON.stringify(proof, null, 2)}\n`);
+}
+
 function withOptionalLabArgs(command, options) {
   const withOptions = [...command, '--lab-only'];
   if (options.runner) {
@@ -253,10 +323,12 @@ function printHelp() {
   process.stdout.write(`Options:\n`);
   process.stdout.write(`  --runner <id>             Add a Homeboy Lab runner id to commands.\n`);
   process.stdout.write(`  --artifact-root <dir>     Add a persisted artifact root to commands.\n`);
+  process.stdout.write(`  --isolation-proof <path>  Isolation proof artifact path passed to each fuzz run. Defaults under --artifact-root or artifacts/woocommerce-aggressive-firehose/.\n`);
   process.stdout.write(`  --run-id-prefix <id>      Firehose run id prefix. Defaults to the stable placeholder woo-firehose-$YYYYMMDD.\n`);
   process.stdout.write(`  --tracker-ref <kind:id>   Tracker ref for reviewer-facing evidence. Default: $WC_TRACKER_REF.\n`);
   process.stdout.write(`  --detach-after-handoff    Return after the Lab daemon accepts the run.\n`);
   process.stdout.write(`  --plan-only               Emit structured plan_items but withhold runnable command arrays.\n`);
   process.stdout.write(`  --runnable                Emit runnable offloaded command arrays. This is the default when execution is enabled.\n`);
   process.stdout.write(`  --json                    Emit structured JSON instead of shell commands.\n`);
+  process.stdout.write(`  --write-isolation-proof <path>  Write the homeboy/isolation-proof/v1 preflight artifact and exit.\n`);
 }

--- a/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.test.mjs
+++ b/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.test.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const toolPath = fileURLToPath(new URL('./aggressive-firehose-command-plan.mjs', import.meta.url));
+const packageRoot = fileURLToPath(new URL('..', import.meta.url));
+
+function runTool(args, options = {}) {
+  return spawnSync(process.execPath, [toolPath, ...args], {
+    cwd: packageRoot,
+    encoding: 'utf8',
+    ...options,
+  });
+}
+
+function readPlan(args = []) {
+  const result = runTool(['--json', ...args]);
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+test('command plan writes isolation proof before destructive fuzz run commands', () => {
+  const plan = readPlan(['--artifact-root', '/tmp/woo-firehose-artifacts']);
+  const writeIndex = plan.plan_items.findIndex((item) => item.purpose === 'write_homeboy_isolation_proof');
+  const firstRunIndex = plan.plan_items.findIndex((item) => item.purpose.startsWith('request_aggressive_isolated_firehose:'));
+
+  assert.ok(writeIndex > -1, 'plan must include isolation proof preflight command');
+  assert.ok(firstRunIndex > -1, 'plan must include fuzz run commands');
+  assert.ok(writeIndex < firstRunIndex, 'isolation proof must be generated before fuzz runs');
+  assert.deepEqual(plan.plan_items[writeIndex].command_argv, [
+    'node',
+    'tools/aggressive-firehose-command-plan.mjs',
+    '--write-isolation-proof',
+    '/tmp/woo-firehose-artifacts/isolation-proof/homeboy-isolation-proof.json',
+  ]);
+});
+
+test('generated fuzz run commands pass the isolation proof artifact to the runner', () => {
+  const plan = readPlan(['--artifact-root', '/tmp/woo-firehose-artifacts']);
+  const fuzzRunItems = plan.plan_items.filter((item) => item.purpose.startsWith('request_aggressive_isolated_firehose:'));
+
+  assert.ok(fuzzRunItems.length > 0, 'expected at least one fuzz run command');
+  for (const item of fuzzRunItems) {
+    const isolationProofIndex = item.command_argv.indexOf('--isolation-proof');
+    assert.ok(isolationProofIndex > -1, `${item.purpose} must include --isolation-proof`);
+    assert.equal(
+      item.command_argv[isolationProofIndex + 1],
+      '/tmp/woo-firehose-artifacts/isolation-proof/homeboy-isolation-proof.json'
+    );
+  }
+});
+
+test('isolation proof writer emits the homeboy isolation proof contract', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'woo-firehose-proof-'));
+  const proofPath = path.join(root, 'homeboy-isolation-proof.json');
+  const result = runTool(['--write-isolation-proof', proofPath]);
+
+  assert.equal(result.status, 0, result.stderr);
+
+  const proof = JSON.parse(readFileSync(proofPath, 'utf8'));
+  assert.equal(proof.schema, 'homeboy/isolation-proof/v1');
+  assert.equal(proof.destructive_execution.boundary, 'offloaded_homeboy_lab_wp_codebox_disposable_sandbox');
+  assert.equal(proof.disposable_boundary.lab_runner_required, true);
+  assert.equal(proof.disposable_boundary.wp_codebox_sandbox_required, true);
+  assert.equal(proof.disposable_boundary.host_wordpress_mutation_allowed, false);
+  assert.equal(proof.evidence_semantics.runner_receives_artifact_with_flag, '--isolation-proof');
+});
+
+test('reviewer artifact ref collection does not emit unsupported Homeboy flags', () => {
+  const plan = readPlan(['--artifact-root', '/tmp/woo-firehose-artifacts']);
+  const refsItem = plan.plan_items.find((item) => item.purpose === 'collect_reviewer_facing_artifact_refs');
+
+  assert.ok(refsItem, 'plan must include reviewer artifact ref collection');
+  assert.deepEqual(refsItem.command_argv.slice(0, 3), ['homeboy', 'runs', 'refs']);
+  assert.equal(refsItem.command_argv.includes('--tracker-ref'), false);
+});

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -762,12 +762,14 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
   const homeboyIsolationSource = upstreamArtifactSources.find((source) => source.contract === 'homeboy/isolation-proof/v1');
   const codeboxIsolationSource = upstreamArtifactSources.find((source) => source.contract === 'wp-codebox/sandbox-isolation-proof/v1');
   assert.ok(homeboyIsolationSource, 'aggressive firehose command plan must declare the Homeboy isolation proof artifact source');
-  assert.equal(homeboyIsolationSource.source, 'homeboy fuzz run Lab/offloaded runner metadata', 'Homeboy isolation proof must come from upstream run metadata');
-  assert.equal(homeboyIsolationSource.persisted_artifact_kind, 'fuzz_result_envelope', 'Homeboy isolation proof must be referenced through the persisted fuzz result envelope');
-  assert.ok(homeboyIsolationSource.persisted_fields.includes('results.isolation.proof_source'), 'Homeboy isolation proof source must name the persisted isolation field');
+  assert.equal(homeboyIsolationSource.source, 'preflight command-plan artifact describing the disposable Homeboy Lab/WP Codebox boundary', 'Homeboy isolation proof must come from the generated preflight artifact');
+  assert.equal(homeboyIsolationSource.generated_artifact_path, 'artifacts/woocommerce-aggressive-firehose/isolation-proof/homeboy-isolation-proof.json', 'Homeboy isolation proof path drifted');
+  assert.ok(homeboyIsolationSource.required_command_flags.includes('--isolation-proof'), 'Homeboy isolation proof source must require the fuzz runner proof flag');
   assert.ok(codeboxIsolationSource, 'aggressive firehose command plan must declare the WP Codebox sandbox proof artifact source');
   assert.equal(codeboxIsolationSource.persisted_artifact_kind, 'fuzz_artifacts', 'WP Codebox sandbox proof must be referenced through persisted fuzz artifacts');
   assert.equal(codeboxIsolationSource.semantic_key, 'fuzz.disposable_sandbox_boundary', 'WP Codebox sandbox proof must use the disposable boundary semantic key');
+  assert.equal(generatedAggressiveFirehoseCommandPlan.generated_isolation_proof?.schema, 'homeboy/isolation-proof/v1', 'generated isolation proof schema drifted');
+  assert.equal(generatedAggressiveFirehoseCommandPlan.generated_isolation_proof?.destructive_execution?.boundary, 'offloaded_homeboy_lab_wp_codebox_disposable_sandbox', 'generated isolation proof boundary drifted');
   assert.equal(generatedAggressiveFirehoseCommandPlan.profile_id, campaign.profile_id, 'aggressive firehose command plan profile id drifted');
   const aggressiveProfileWorkloads = rig.fuzz_profiles?.[campaign.profile_id] || [];
   assert.ok(aggressiveProfileWorkloads.length > 0, 'aggressive profile must declare workload ids');
@@ -777,17 +779,19 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
   assert.match(generatedAggressiveFirehoseTextPlan, /Offloaded Homeboy\/HBEX command plan/, 'text command plan must advertise offloaded execution');
   assert.match(generatedAggressiveFirehoseTextPlan, /^homeboy fuzz run /m, 'default text command plan must print runnable destructive fuzz commands');
   const generatedPlanItems = generatedAggressiveFirehoseCommandPlan.plan_items || [];
-	assert.equal(generatedPlanItems.length, aggressiveProfileWorkloads.length + 2, 'aggressive firehose command plan must include validation, workload requests, and artifact ref collection');
+	assert.equal(generatedPlanItems.length, aggressiveProfileWorkloads.length + 3, 'aggressive firehose command plan must include validation, isolation proof generation, workload requests, and artifact ref collection');
 	const validationCommand = generatedPlanItems.find((entry) => entry.purpose === 'validate_disposable_rig')?.command_argv || [];
   assert.deepEqual(validationCommand.slice(0, 3), ['homeboy', 'rig', 'check'], 'aggressive command plan must use Lab-portable rig check for validation');
   assert.ok(!validationCommand.includes('up'), 'aggressive command plan must not emit local-only rig up');
+  const proofWriterItem = generatedPlanItems.find((entry) => entry.purpose === 'write_homeboy_isolation_proof');
+  assert.equal(proofWriterItem?.artifact?.schema, 'homeboy/isolation-proof/v1', 'aggressive command plan must generate the Homeboy isolation proof artifact before execution');
   const requestItems = generatedPlanItems.filter((entry) => entry.purpose?.startsWith('request_aggressive_isolated_firehose:'));
   assert.equal(requestItems.length, aggressiveProfileWorkloads.length, 'aggressive command plan must include request items for each workload');
   for (const item of requestItems) {
     assert.ok(item.command_argv.includes('--allow-destructive'), `${item.purpose} must opt into destructive fuzzing`);
     assert.ok(item.command_argv.includes('--lab-only'), `${item.purpose} must require offloaded Lab execution for isolation proof`);
     assert.ok(item.command_argv.includes('--require-result-envelope'), `${item.purpose} must require the persisted upstream result envelope`);
-    assert.ok(!item.command_argv.includes('--isolation-proof'), `${item.purpose} must not point at a manual isolation proof file`);
+    assert.ok(item.command_argv.includes('--isolation-proof'), `${item.purpose} must pass the generated isolation proof artifact to the runner`);
     assert.equal(item.campaign_inputs?.campaign_manifest, 'manifests/aggressive-isolated-fuzz-campaign.json', `${item.purpose} must link the campaign manifest`);
     assert.equal(item.campaign_inputs?.target_inventory_manifest, 'manifests/target-inventory.json', `${item.purpose} must link the target inventory manifest`);
     assert.equal(item.campaign_inputs?.groups?.sequence_packs?.manifest, 'manifests/product-chaos-sequence-packs.json', `${item.purpose} must pass sequence pack inputs`);
@@ -807,6 +811,7 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
   const artifactRefCollector = generatedPlanItems.find((entry) => entry.purpose === 'collect_reviewer_facing_artifact_refs')?.command_argv || [];
   assert.ok(artifactRefCollector.includes('fuzz_result_envelope'), 'artifact ref collection must include the Homeboy fuzz result envelope');
   assert.ok(artifactRefCollector.includes('fuzz_artifacts'), 'artifact ref collection must include WP Codebox fuzz artifacts');
+  assert.ok(!artifactRefCollector.includes('--tracker-ref'), 'artifact ref collection must not emit unsupported Homeboy tracker filtering');
   assertNoLocalOnlyRefs(campaign, 'aggressive-isolated-fuzz-campaign');
   assertNoProofPlaceholders(campaign, 'aggressive-isolated-fuzz-campaign');
 }


### PR DESCRIPTION
## Summary
- Generate a deterministic `homeboy/isolation-proof/v1` preflight artifact for the Woo aggressive isolated firehose plan.
- Pass the generated artifact path to every `homeboy fuzz run` command with `--isolation-proof`.
- Remove unsupported `--tracker-ref` from the generated `homeboy runs refs` artifact collection command.
- Add focused command-plan tests for proof generation, command ordering, runner flags, and unsupported flag drift.

## Tests
- `node --test "woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs" "woocommerce/woocommerce/manifests/scale-profiles.test.mjs" "woocommerce/woocommerce/tools/db-api-fuzzer-artifacts.test.mjs" "woocommerce/woocommerce/tools/aggressive-firehose-command-plan.test.mjs" "woocommerce/woocommerce/bench/admin-page-coverage.test.mjs"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the command-plan fix, adding tests, and preparing the PR.