### PR TITLE
Fix Woo dependency materialization command

### DIFF
--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -124,7 +124,10 @@ test('Woo Composer prep declares dependency materialization for plugin vendor ou
   const composerStep = dependencySteps.find((step) => step.id === 'woocommerce-php-package-dependencies');
 
   assert.ok(composerStep, 'expected WooCommerce PHP dependency materialization step');
-  assert.match(composerStep.command, /prepare-runtime-dependency\.sh" composer/);
+  assert.equal(composerStep.command, 'XDEBUG_MODE=off homeboy deps install --path "${components.woocommerce.path}/plugins/woocommerce"');
+  assert.equal(composerStep.inputs.recipe, 'wordpress-php-package-dependencies');
+  assert.doesNotMatch(composerStep.command, /prepare-runtime-dependency\.sh/);
+  assert.doesNotMatch(composerStep.command, /\$\{components\.woocommerce\.path\}\/tools\//);
   assert.equal(composerStep.component, 'woocommerce');
   assert.equal(composerStep.cwd, '${components.woocommerce.path}/plugins/woocommerce');
   assert.deepEqual(composerStep.cache_key_inputs, [

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -67,11 +67,11 @@
     "dependency_materialization": [
       {
         "id": "woocommerce-php-package-dependencies",
-        "command": "bash \"${package.root}/tools/prepare-runtime-dependency.sh\" composer \"${components.woocommerce.path}/plugins/woocommerce\"",
+        "command": "XDEBUG_MODE=off homeboy deps install --path \"${components.woocommerce.path}/plugins/woocommerce\"",
         "component": "woocommerce",
         "cwd": "${components.woocommerce.path}/plugins/woocommerce",
         "inputs": {
-          "recipe": "wordpress-plugin-php-package-dependencies",
+          "recipe": "wordpress-php-package-dependencies",
           "manifest": "${components.woocommerce.path}/plugins/woocommerce/composer.json",
           "lockfile": "${components.woocommerce.path}/plugins/woocommerce/composer.lock"
         },

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -99,6 +99,13 @@ const runtimePrepFiles = new Set([
   '${components.woocommerce.path}/plugins/woocommerce/includes/react-admin/feature-config.php',
   '${components.woocommerce.path}/plugins/woocommerce/assets/client/admin/wp-admin-scripts/command-palette.asset.php',
 ]);
+const composerDependencyStep = (rig.requirements?.dependency_materialization || []).find((step) => step.id === 'woocommerce-php-package-dependencies');
+
+assert.ok(composerDependencyStep, 'WooCommerce Composer dependency materialization step must be declared');
+assert.equal(composerDependencyStep.command, 'XDEBUG_MODE=off homeboy deps install --path "${components.woocommerce.path}/plugins/woocommerce"');
+assert.equal(composerDependencyStep.inputs?.recipe, 'wordpress-php-package-dependencies');
+assert.ok(!/prepare-runtime-dependency\.sh/.test(composerDependencyStep.command), 'Composer dependency materialization must not depend on a rig script path in Lab');
+assert.ok(!/\$\{components\.woocommerce\.path\}\/tools\//.test(composerDependencyStep.command), 'Composer dependency materialization must not reference a Woo checkout tools script unless the component supplies it');
 const runtimePrepCheckSteps = (rig.pipeline?.check || []).filter((step) => runtimePrepFiles.has(step.file));
 
 assert.equal(runtimePrepCheckSteps.length, runtimePrepFiles.size, 'WooCommerce runtime dependency prep must be declared once in check');


### PR DESCRIPTION
## Summary
- Replace the Woo dependency materialization script invocation with the generic Homeboy dependency installer against the synced Woo plugin path.
- Align the recipe id with the HBEX WordPress dependency recipe declaration.
- Add Woo validations that reject dependency materialization commands pointing at an unavailable Woo checkout tools script.

## Tests
- node woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
- node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
- HOMEBOY_WORDPRESS_HELPER_MANIFEST="$PWD/scripts/fixtures/homeboy-extension-wordpress/lib/helper-manifest.js" node --test scripts/*.test.mjs shared/*.test.mjs shared/*/*.test.mjs WordPress/wordpress-develop/fuzz/*.test.mjs WordPress/gutenberg/tools/*.test.mjs woocommerce/woocommerce/bench/*.test.mjs woocommerce/woocommerce/manifests/*.test.mjs woocommerce/woocommerce/tools/*.test.mjs woocommerce/woocommerce-gateway-stripe/bench/*.test.mjs Automattic/studio/bench/*.test.mjs Automattic/jetpack/tools/*.test.mjs (fails in unrelated Studio fixture tests: missing scripts/fixtures/homeboy-extension-wordpress/lib/wordpress-helper-consumer.js)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Lab dependency materialization path blocker, editing the Woo rig declaration and validators, and running targeted validation.