### PR TITLE
Fix Woo dependency materialization env

### DIFF
--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -124,7 +124,9 @@ test('Woo Composer prep declares dependency materialization for plugin vendor ou
   const composerStep = dependencySteps.find((step) => step.id === 'woocommerce-php-package-dependencies');
 
   assert.ok(composerStep, 'expected WooCommerce PHP dependency materialization step');
-  assert.equal(composerStep.command, 'XDEBUG_MODE=off homeboy deps install --path "${components.woocommerce.path}/plugins/woocommerce"');
+  assert.equal(composerStep.command, 'homeboy deps install --path "${components.woocommerce.path}/plugins/woocommerce"');
+  assert.deepEqual(composerStep.env, { XDEBUG_MODE: 'off' });
+  assert.doesNotMatch(composerStep.command, /^[A-Za-z_][A-Za-z0-9_]*=/);
   assert.equal(composerStep.inputs.recipe, 'wordpress-php-package-dependencies');
   assert.doesNotMatch(composerStep.command, /prepare-runtime-dependency\.sh/);
   assert.doesNotMatch(composerStep.command, /\$\{components\.woocommerce\.path\}\/tools\//);

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -67,7 +67,10 @@
     "dependency_materialization": [
       {
         "id": "woocommerce-php-package-dependencies",
-        "command": "XDEBUG_MODE=off homeboy deps install --path \"${components.woocommerce.path}/plugins/woocommerce\"",
+        "command": "homeboy deps install --path \"${components.woocommerce.path}/plugins/woocommerce\"",
+        "env": {
+          "XDEBUG_MODE": "off"
+        },
         "component": "woocommerce",
         "cwd": "${components.woocommerce.path}/plugins/woocommerce",
         "inputs": {

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -102,7 +102,9 @@ const runtimePrepFiles = new Set([
 const composerDependencyStep = (rig.requirements?.dependency_materialization || []).find((step) => step.id === 'woocommerce-php-package-dependencies');
 
 assert.ok(composerDependencyStep, 'WooCommerce Composer dependency materialization step must be declared');
-assert.equal(composerDependencyStep.command, 'XDEBUG_MODE=off homeboy deps install --path "${components.woocommerce.path}/plugins/woocommerce"');
+assert.equal(composerDependencyStep.command, 'homeboy deps install --path "${components.woocommerce.path}/plugins/woocommerce"');
+assert.deepEqual(composerDependencyStep.env, { XDEBUG_MODE: 'off' });
+assert.doesNotMatch(composerDependencyStep.command, /^[A-Za-z_][A-Za-z0-9_]*=/);
 assert.equal(composerDependencyStep.inputs?.recipe, 'wordpress-php-package-dependencies');
 assert.ok(!/prepare-runtime-dependency\.sh/.test(composerDependencyStep.command), 'Composer dependency materialization must not depend on a rig script path in Lab');
 assert.ok(!/\$\{components\.woocommerce\.path\}\/tools\//.test(composerDependencyStep.command), 'Composer dependency materialization must not reference a Woo checkout tools script unless the component supplies it');


### PR DESCRIPTION
## Summary
- Move `XDEBUG_MODE=off` out of the Woo dependency materialization command string and into the step `env` map.
- Keep the command as the executable/args string expected by non-shell runner spawn paths.
- Add manifest coverage so the command cannot regress to a shell env-prefix form.

## Tests
- `node --test woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Diagnosing the Remote Lab spawn failure, updating the Woo rig declaration, and adding regression coverage.