### PR TITLE
Remove duplicated fuzz workload shape lint

### DIFF
--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -516,20 +516,6 @@ function lintFuzzWorkload(file, fuzzWorkloadValidators) {
     failures.push(`${rel}: ${issue}`);
   }
 
-  for (const field of ['surface_ids', 'operations', 'cases']) {
-    if (!Array.isArray(workload[field]) || workload[field].length === 0) {
-      failures.push(`${rel}: fuzz workload must define non-empty array field ${field}`);
-    }
-  }
-
-  if (!workload.target || typeof workload.target.type !== 'string') {
-    failures.push(`${rel}: fuzz workload must define target.type`);
-  }
-
-  if (!workload.metadata || typeof workload.metadata.kind !== 'string') {
-    failures.push(`${rel}: fuzz workload must define metadata.kind`);
-  }
-
   lintFuzzReadinessMetadata(rel, workload);
   lintProductFuzzWorkloadValidators(rel, file, workload, fuzzWorkloadValidators);
 


### PR DESCRIPTION
## Summary
- Remove homeboy-rigs lint checks that duplicated generic fuzz workload structural validation now provided by the Homeboy fuzz workload validator.
- Keep rig-owned policy validation in place, including workload path existence, package uniqueness, profile references, readiness policy, and product-local validators.

## Verification
- node --test scripts/lint-rig-packages.test.mjs scripts/fuzz-manifest-helpers.test.mjs scripts/fuzz-coverage-matrix.test.mjs
- node scripts/lint-rig-packages.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspected validation ownership, removed redundant lint checks, ran focused verification, and drafted this PR.