### PR TITLE
Align fuzz proof refs with Homeboy artifact semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ missing upstream fuzz primitives.
 `metadata.readiness.level: proven` is gated by proof-bundle linkage: reviewer-
 facing artifact refs, run IDs, gap reports, and required fuzz result artifact
 names. Keep rows at declared/executable until those links exist; local paths,
-localhost URLs, and optional artifacts are not proof.
+localhost URLs, and optional artifacts are not proof. Reviewer-facing artifact
+refs follow Homeboy's shared semantics: non-local `http://` or `https://` URLs,
+`homeboy://` refs, and `runner-artifact://` refs.
 
 Reusable helper patterns live under `shared/`. The first shared web performance
 pattern is `shared/webperf/deferred-init-webperf.mjs`, which lets trace workloads

--- a/docs/fuzz-coverage-matrix.md
+++ b/docs/fuzz-coverage-matrix.md
@@ -30,10 +30,12 @@ optional `proof_refs`, optional `upstream_blockers`, optional CRUD operation
 levels for `create`, `read`, `update`, and `delete`, and optional mutation
 safety fields (`safety_boundary`, `mutation_artifacts`). `level: proven`
 requires a `proof_bundle` with reviewer-facing `canonical_fuzz_envelope_ref` as
-the primary proof pointer, or legacy `artifact_refs`, `run_ids`, `gap_reports`,
-and `fuzz_result_artifacts` for manifests that have not yet migrated. Product
-packages can use this shared shape to distinguish planned CRUD/mutation coverage
-from executable workloads and reviewer-facing proof artifacts.
+the primary proof pointer. Reviewer-facing artifact refs use Homeboy's shared ref
+semantics: non-local `http://` or `https://` URLs, `homeboy://` refs, or
+`runner-artifact://` refs. Localhost URLs, `file://` URLs, and absolute local
+paths are not proof. Product packages can use this shared shape to distinguish
+planned CRUD/mutation coverage from executable workloads and reviewer-facing
+proof artifacts.
 
 The repo-wide package linter reports missing `metadata.readiness` on fuzz
 manifests as a warning. Use `node scripts/lint-rig-packages.mjs

--- a/scripts/fixtures/shared-fuzz-validator.cjs
+++ b/scripts/fixtures/shared-fuzz-validator.cjs
@@ -176,11 +176,8 @@ function assertFuzzReadinessLevel(level, label) {
 }
 
 function assertReviewerFacingRef(value, context) {
-  if (!/^(https:\/\/|gh:|homeboy-runs:|homeboy:\/\/run\/|artifact:|run:)/.test(value)) {
+  if (!reviewerFacingRef(value)) {
     throw new Error(`${context} entries must be reviewer-facing refs`);
-  }
-  if (localOnlyReviewerFacingRef(value)) {
-    throw new Error(`${context} entries must not use local evidence`);
   }
 }
 
@@ -188,11 +185,8 @@ function assertReviewerFacingArtifactRef(value, context) {
   if (typeof value !== 'string' || value.trim() === '') {
     throw new Error(`${context} must be a reviewer-facing artifact ref string`);
   }
-  if (!/^(https:\/\/|gh:|homeboy-runs:|homeboy:\/\/run\/|homeboy-artifact:\/\/|artifact:|run:)/.test(value)) {
+  if (!reviewerFacingRef(value)) {
     throw new Error(`${context} must be a reviewer-facing artifact ref`);
-  }
-  if (localOnlyReviewerFacingRef(value)) {
-    throw new Error(`${context} must not use local evidence`);
   }
 }
 
@@ -201,21 +195,23 @@ function localOnlyReviewerFacingRef(value) {
     return false;
   }
   const ref = value.trim();
-  return localOnlyRefValue(ref) || localOnlySchemePayload(ref);
+  return localOnlyRefValue(ref);
 }
 
-function localOnlySchemePayload(ref) {
-  const match = /^(?:artifact:|run:|homeboy-runs:|homeboy-artifact:\/\/)(.*)$/i.exec(ref);
-  return Boolean(match && localOnlyRefValue(match[1]));
+function reviewerFacingRef(value) {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const ref = value.trim();
+  return /^(https?:\/\/|homeboy:\/\/|runner-artifact:\/\/)/i.test(ref)
+    && !localOnlyReviewerFacingRef(ref);
 }
 
 function localOnlyRefValue(ref) {
   return /^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::|\/|$)/i.test(ref)
     || /^file:\/\//i.test(ref)
-    || /^\/Users\//.test(ref)
-    || /^\/private\//.test(ref)
-    || /^\/tmp(?:\/|$)/.test(ref)
-    || /^\.\.?(?:\/|$)/.test(ref);
+    || /^\//.test(ref)
+    || /^[a-z]:[\\/]/i.test(ref);
 }
 
 function assertStringArray(value, label, options = {}) {

--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -189,12 +189,8 @@ export function assertReviewerFacingFuzzRef(value, context) {
   assert.equal(typeof value, 'string', `${context} must be a reviewer-facing artifact ref string`);
   assert.ok(value.trim().length > 0, `${context} must be a reviewer-facing artifact ref string`);
   assert.ok(
-    /^(https:\/\/|gh:|homeboy-runs:|homeboy:\/\/run\/|homeboy-artifact:\/\/|artifact:|run:)/.test(value),
+    reviewerFacingFuzzRef(value),
     `${context} must be a reviewer-facing artifact ref`
-  );
-  assert.ok(
-    !localOnlyReviewerFacingRef(value),
-    `${context} must not use local evidence`
   );
 }
 
@@ -203,21 +199,20 @@ export function localOnlyReviewerFacingRef(value) {
     return false;
   }
   const ref = value.trim();
-  return localOnlyRefValue(ref) || localOnlySchemePayload(ref);
+  return localOnlyRefValue(ref);
 }
 
-function localOnlySchemePayload(ref) {
-  const match = /^(?:artifact:|run:|homeboy-runs:|homeboy-artifact:\/\/)(.*)$/i.exec(ref);
-  return Boolean(match && localOnlyRefValue(match[1]));
+function reviewerFacingFuzzRef(value) {
+  const ref = value.trim();
+  return /^(https?:\/\/|homeboy:\/\/|runner-artifact:\/\/)/i.test(ref)
+    && !localOnlyReviewerFacingRef(ref);
 }
 
 function localOnlyRefValue(ref) {
   return /^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::|\/|$)/i.test(ref)
     || /^file:\/\//i.test(ref)
-    || /^\/Users\//.test(ref)
-    || /^\/private\//.test(ref)
-    || /^\/tmp(?:\/|$)/.test(ref)
-    || /^\.\.?(?:\/|$)/.test(ref);
+    || /^\//.test(ref)
+    || /^[a-z]:[\\/]/i.test(ref);
 }
 
 function assertOptionalFuzzResultArtifacts(proofBundle, manifest, { file = manifest.id } = {}) {

--- a/scripts/fuzz-manifest-helpers.test.mjs
+++ b/scripts/fuzz-manifest-helpers.test.mjs
@@ -288,7 +288,7 @@ test('assertGenericFuzzManifest can require readiness metadata', () => {
 test('assertFuzzProofBundle accepts a canonical fuzz envelope artifact ref as the primary proof pointer', () => {
   assert.ok(fuzzProofBundleFields.has('canonical_fuzz_envelope_ref'));
   assert.doesNotThrow(() => assertFuzzProofBundle({
-    canonical_fuzz_envelope_ref: 'homeboy-runs:product-fuzz/artifacts/fuzz-envelope.json',
+    canonical_fuzz_envelope_ref: 'runner-artifact://lab/product-fuzz/fuzz-envelope.json',
   }, fuzzManifest(), { file: 'product-fuzz.json' }));
 });
 
@@ -310,9 +310,7 @@ test('assertFuzzProofBundle rejects local canonical fuzz envelope artifact refs'
     'file:///tmp/fuzz-envelope.json',
     '/tmp/fuzz-envelope.json',
     '/Users/chris/fuzz-envelope.json',
-    './fuzz-envelope.json',
-    '../fuzz-envelope.json',
-    'homeboy-artifact:///tmp/fuzz-envelope.json',
+    'C:\\Users\\chris\\fuzz-envelope.json',
     'artifact:./fuzz-envelope.json',
   ]) {
     assert.throws(
@@ -330,15 +328,27 @@ test('assertFuzzProofBundle rejects local canonical fuzz envelope artifact refs'
 });
 
 test('reviewer-facing fuzz refs accept durable refs and reject placeholders/local refs', () => {
+  assert.doesNotThrow(() => assertReviewerFacingFuzzRef('http://example.test/report.json', 'proof ref'));
+  assert.doesNotThrow(() => assertReviewerFacingFuzzRef('https://example.test/report.json', 'proof ref'));
   assert.doesNotThrow(() => assertReviewerFacingFuzzRef('homeboy://run/product-fuzz/artifact/report', 'proof ref'));
-  assert.equal(localOnlyReviewerFacingRef('artifact:./report.json'), true);
-  assert.equal(localOnlyReviewerFacingRef('homeboy-artifact:///tmp/report.json'), true);
+  assert.doesNotThrow(() => assertReviewerFacingFuzzRef('runner-artifact://lab/product-fuzz/report.json', 'proof ref'));
+  assert.equal(localOnlyReviewerFacingRef('http://localhost:8881/report.json'), true);
+  assert.equal(localOnlyReviewerFacingRef('/tmp/report.json'), true);
+  assert.equal(localOnlyReviewerFacingRef('file:///tmp/report.json'), true);
   assert.throws(
     () => assertReviewerFacingFuzzRef('<artifact-ref>', 'proof ref'),
     /must be a reviewer-facing artifact ref/
   );
   assert.throws(
     () => assertReviewerFacingFuzzRef('artifact:./report.json', 'proof ref'),
-    /must not use local evidence/
+    /must be a reviewer-facing artifact ref/
+  );
+  assert.throws(
+    () => assertReviewerFacingFuzzRef('https://localhost:8881/report.json', 'proof ref'),
+    /must be a reviewer-facing artifact ref/
+  );
+  assert.throws(
+    () => assertReviewerFacingFuzzRef('/tmp/report.json', 'proof ref'),
+    /must be a reviewer-facing artifact ref/
   );
 });


### PR DESCRIPTION
## Summary
- Align fuzz proof reviewer-facing ref validation with Homeboy's shared accepted schemes: non-local http(s), homeboy://, and runner-artifact://.
- Reject localhost URLs, file:// URLs, and absolute filesystem paths without preserving older local scheme payload parsing.
- Update README and fuzz coverage docs to describe the accepted proof ref shapes.

## Verification
- node --test scripts/fuzz-manifest-helpers.test.mjs
- node --test scripts/lint-rig-packages.test.mjs
- node --test scripts/fuzz-coverage-matrix.test.mjs
- node scripts/lint-rig-packages.mjs --strict-fuzz-readiness

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code changes, focused test updates, documentation edits, and PR preparation.