### PR TITLE
Adopt Homeboy resource cleanup intent contract

### DIFF
--- a/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
+++ b/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
@@ -28,8 +28,15 @@
   },
   "lifecycle": {
     "cleanup": {
-      "intent": "external",
-      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; the Jetpack component checkout is user-owned."
+      "schema": "homeboy/resource-cleanup-intent/v1",
+      "intent": "dry_run",
+      "ownership": {
+        "dry_run": {
+          "owner": "wp-codebox-runner-namespace",
+          "declared_by": "homeboy-rigs",
+          "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; the Jetpack component checkout is user-owned."
+        }
+      }
     }
   },
   "bench": {

--- a/Automattic/jetpack/rigs/jetpack-browser-coverage/rig.json
+++ b/Automattic/jetpack/rigs/jetpack-browser-coverage/rig.json
@@ -19,8 +19,15 @@
   },
   "lifecycle": {
     "cleanup": {
-      "intent": "external",
-      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+      "schema": "homeboy/resource-cleanup-intent/v1",
+      "intent": "dry_run",
+      "ownership": {
+        "dry_run": {
+          "owner": "wp-codebox-runner-namespace",
+          "declared_by": "homeboy-rigs",
+          "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+        }
+      }
     }
   },
   "trace": {

--- a/Automattic/studio/rigs/studio-combined/rig.json
+++ b/Automattic/studio/rigs/studio-combined/rig.json
@@ -20,8 +20,15 @@
 
   "lifecycle": {
     "cleanup": {
-      "intent": "pipeline",
-      "reason": "pipeline.down stops the Studio daemon and tarball server; component checkouts remain user-owned resources."
+      "schema": "homeboy/resource-cleanup-intent/v1",
+      "intent": "dry_run",
+      "ownership": {
+        "dry_run": {
+          "owner": "pipeline.down",
+          "declared_by": "homeboy-rigs",
+          "reason": "pipeline.down stops the Studio daemon and tarball server; component checkouts remain user-owned resources."
+        }
+      }
     }
   },
 

--- a/Automattic/studio/rigs/studio-figma-to-wordpress-import/rig.json
+++ b/Automattic/studio/rigs/studio-figma-to-wordpress-import/rig.json
@@ -15,8 +15,15 @@
   },
   "lifecycle": {
     "cleanup": {
-      "intent": "manual",
-      "reason": "The rig runs a repo-local fixture matrix against a user-owned Blocks Engine checkout and does not create separate runtime resources."
+      "schema": "homeboy/resource-cleanup-intent/v1",
+      "intent": "dry_run",
+      "ownership": {
+        "dry_run": {
+          "owner": "operator",
+          "declared_by": "homeboy-rigs",
+          "reason": "The workload runs a repo-local fixture matrix against a user-owned Blocks Engine checkout and does not create separate runtime resources."
+        }
+      }
     }
   },
   "pipeline": {

--- a/README.md
+++ b/README.md
@@ -83,6 +83,26 @@ node scripts/lint-rig-packages.mjs
 
 GitHub Actions runs the package lint with PHP installed.
 
+## Resource Cleanup Intent
+
+Packages that declare resources and leave `pipeline.down` empty must declare `lifecycle.cleanup` using Homeboy's resource cleanup intent contract:
+
+```json
+{
+  "schema": "homeboy/resource-cleanup-intent/v1",
+  "intent": "dry_run",
+  "ownership": {
+    "dry_run": {
+      "owner": "wp-codebox-runner-namespace",
+      "declared_by": "homeboy-rigs",
+      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+    }
+  }
+}
+```
+
+Use `intent: "dry_run"` when metadata records ownership without asking Homeboy to delete resources. Use `intent: "apply"` only when cleanup should be applied and include matching `ownership.apply` metadata.
+
 ## Automattic/studio
 
 `rigs/studio-combined/rig.json` is the Studio + Playground combined-fixes dev environment: forks rebased onto trunk, open PRs cherry-picked, Docker-compiled PHP-WASM glue, tarball server, and Studio CLI rewired to local tarballs.

--- a/WordPress/gutenberg/rigs/gutenberg-api-route-inventory/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-api-route-inventory/rig.json
@@ -24,8 +24,15 @@
   },
   "lifecycle": {
     "cleanup": {
-      "intent": "external",
-      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+      "schema": "homeboy/resource-cleanup-intent/v1",
+      "intent": "dry_run",
+      "ownership": {
+        "dry_run": {
+          "owner": "wp-codebox-runner-namespace",
+          "declared_by": "homeboy-rigs",
+          "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+        }
+      }
     }
   },
   "bench": {

--- a/WordPress/gutenberg/rigs/gutenberg-browser-coverage/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-browser-coverage/rig.json
@@ -17,8 +17,15 @@
   },
   "lifecycle": {
     "cleanup": {
-      "intent": "external",
-      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+      "schema": "homeboy/resource-cleanup-intent/v1",
+      "intent": "dry_run",
+      "ownership": {
+        "dry_run": {
+          "owner": "wp-codebox-runner-namespace",
+          "declared_by": "homeboy-rigs",
+          "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+        }
+      }
     }
   },
   "trace": {

--- a/WordPress/gutenberg/rigs/gutenberg-notes-unsaved-attachment/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-notes-unsaved-attachment/rig.json
@@ -17,8 +17,15 @@
   },
   "lifecycle": {
     "cleanup": {
-      "intent": "external",
-      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+      "schema": "homeboy/resource-cleanup-intent/v1",
+      "intent": "dry_run",
+      "ownership": {
+        "dry_run": {
+          "owner": "wp-codebox-runner-namespace",
+          "declared_by": "homeboy-rigs",
+          "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+        }
+      }
     }
   },
   "trace": {

--- a/WordPress/gutenberg/rigs/gutenberg-pattern-preview-assets/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-pattern-preview-assets/rig.json
@@ -17,8 +17,15 @@
   },
   "lifecycle": {
     "cleanup": {
-      "intent": "external",
-      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+      "schema": "homeboy/resource-cleanup-intent/v1",
+      "intent": "dry_run",
+      "ownership": {
+        "dry_run": {
+          "owner": "wp-codebox-runner-namespace",
+          "declared_by": "homeboy-rigs",
+          "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+        }
+      }
     }
   },
   "trace": {

--- a/WordPress/wordpress-develop/rigs/wordpress-core-fuzz-coverage/rig.json
+++ b/WordPress/wordpress-develop/rigs/wordpress-core-fuzz-coverage/rig.json
@@ -24,8 +24,15 @@
   },
   "lifecycle": {
     "cleanup": {
-      "intent": "external",
-      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+      "schema": "homeboy/resource-cleanup-intent/v1",
+      "intent": "dry_run",
+      "ownership": {
+        "dry_run": {
+          "owner": "wp-codebox-runner-namespace",
+          "declared_by": "homeboy-rigs",
+          "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+        }
+      }
     }
   },
   "fuzz": {

--- a/WordPress/wordpress-playground/rigs/playground-cli-diagnostics/rig.json
+++ b/WordPress/wordpress-playground/rigs/playground-cli-diagnostics/rig.json
@@ -20,8 +20,15 @@
   },
   "lifecycle": {
     "cleanup": {
-      "intent": "manual",
-      "reason": "The rig may install dependencies into the user-owned Playground checkout; removing that checkout state is an operator decision."
+      "schema": "homeboy/resource-cleanup-intent/v1",
+      "intent": "dry_run",
+      "ownership": {
+        "dry_run": {
+          "owner": "operator",
+          "declared_by": "homeboy-rigs",
+          "reason": "The workload may install dependencies into the user-owned Playground checkout; removing that checkout state is an operator decision."
+        }
+      }
     }
   },
   "bench_workloads": {

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -36,7 +36,8 @@ const studioModelRigGenerator = join(root, 'scripts/generate-studio-agent-model-
 const personalPathPrefix = '/Users/' + 'chubes/';
 const localDeveloperCheckoutPattern = /(?:~|\$HOME)\/Developer\//;
 const tsrmlsPatchMarker = 'PHP-WASM-COMBINED-FIXES ' + 'TSRMLS fallback';
-const cleanupIntents = new Set(['none', 'external', 'manual', 'pipeline']);
+const resourceCleanupIntentSchema = 'homeboy/resource-cleanup-intent/v1';
+const cleanupIntents = new Set(['dry_run', 'apply']);
 
 if (!existsSync(root)) {
   console.error(`Lint root does not exist: ${root}`);
@@ -188,12 +189,20 @@ function lintLifecycleCleanup(rel, rig) {
   const cleanup = lifecycleCleanupPolicy(rig);
 
   if (cleanup) {
+    if (cleanup.schema !== resourceCleanupIntentSchema) {
+      failures.push(`${rel}: lifecycle.cleanup.schema must be ${resourceCleanupIntentSchema}`);
+    }
+
     if (!cleanupIntents.has(cleanup.intent)) {
       failures.push(`${rel}: lifecycle.cleanup.intent must be one of ${[...cleanupIntents].join(', ')}`);
     }
 
-    if (typeof cleanup.reason !== 'string' || cleanup.reason.trim() === '') {
-      failures.push(`${rel}: lifecycle.cleanup.reason must explain the cleanup boundary`);
+    lintCleanupOwnershipMetadata(rel, 'lifecycle.cleanup.ownership.dry_run', cleanup.ownership?.dry_run);
+
+    if (cleanup.intent === 'apply') {
+      lintCleanupOwnershipMetadata(rel, 'lifecycle.cleanup.ownership.apply', cleanup.ownership?.apply);
+    } else if (cleanup.ownership?.apply) {
+      lintCleanupOwnershipMetadata(rel, 'lifecycle.cleanup.ownership.apply', cleanup.ownership.apply);
     }
   }
 
@@ -201,7 +210,20 @@ function lintLifecycleCleanup(rel, rig) {
     return;
   }
 
-  failures.push(`${rel}: rigs with declared resources and empty pipeline.down must declare lifecycle.cleanup intent`);
+  failures.push(`${rel}: packages with declared resources and empty pipeline.down must declare lifecycle.cleanup resource cleanup intent`);
+}
+
+function lintCleanupOwnershipMetadata(rel, field, metadata) {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    failures.push(`${rel}: ${field} must declare cleanup ownership metadata`);
+    return;
+  }
+
+  for (const key of ['owner', 'declared_by', 'reason']) {
+    if (typeof metadata[key] !== 'string' || metadata[key].trim() === '') {
+      failures.push(`${rel}: ${field}.${key} must not be blank`);
+    }
+  }
 }
 
 function lintSharedPaths(rel, rig) {

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -316,7 +316,7 @@ export function validatePortableSource({ rel, contents }) {
   assert.match(result.stderr, /Woo Stripe ECE workload must use the declared WooCommerce component\/env path/);
 });
 
-test('rejects rigs with resources, empty down lifecycle, and no cleanup policy', () => {
+test('rejects packages with resources, empty down lifecycle, and no cleanup contract', () => {
   const directory = createRigPackage({
     rig: {
       resources: {
@@ -334,16 +334,23 @@ test('rejects rigs with resources, empty down lifecycle, and no cleanup policy',
   const result = runLint(directory);
 
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /declared resources and empty pipeline\.down must declare lifecycle\.cleanup intent/);
+  assert.match(result.stderr, /declared resources and empty pipeline\.down must declare lifecycle\.cleanup resource cleanup intent/);
 });
 
-test('accepts explicit cleanup policy for rigs with resources and empty down lifecycle', () => {
+test('accepts explicit cleanup contract for packages with resources and empty down lifecycle', () => {
   const directory = createRigPackage({
     rig: {
       lifecycle: {
         cleanup: {
-          intent: 'external',
-          reason: 'The runner owns the declared resource boundary.',
+          schema: 'homeboy/resource-cleanup-intent/v1',
+          intent: 'dry_run',
+          ownership: {
+            dry_run: {
+              owner: 'runner',
+              declared_by: 'homeboy-rigs',
+              reason: 'The runner owns the declared resource boundary.',
+            },
+          },
         },
       },
       resources: {
@@ -364,7 +371,7 @@ test('accepts explicit cleanup policy for rigs with resources and empty down lif
   assert.doesNotMatch(result.stderr, /declared resources and empty pipeline\.down/);
 });
 
-test('rejects invalid explicit cleanup policy', () => {
+test('rejects invalid explicit cleanup contract', () => {
   const directory = createRigPackage({
     rig: {
       lifecycle: {
@@ -381,8 +388,9 @@ test('rejects invalid explicit cleanup policy', () => {
   const result = runLint(directory);
 
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /lifecycle\.cleanup\.intent must be one of none, external, manual, pipeline/);
-  assert.match(result.stderr, /lifecycle\.cleanup\.reason must explain the cleanup boundary/);
+  assert.match(result.stderr, /lifecycle\.cleanup\.schema must be homeboy\/resource-cleanup-intent\/v1/);
+  assert.match(result.stderr, /lifecycle\.cleanup\.intent must be one of dry_run, apply/);
+  assert.match(result.stderr, /lifecycle\.cleanup\.ownership\.dry_run must declare cleanup ownership metadata/);
 });
 
 test('rejects committed local Developer checkout paths in stacks', () => {

--- a/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
+++ b/woocommerce/woocommerce-gateway-stripe/rigs/woocommerce-stripe-ece-product-page/rig.json
@@ -21,8 +21,15 @@
   },
   "lifecycle": {
     "cleanup": {
-      "intent": "external",
-      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+      "schema": "homeboy/resource-cleanup-intent/v1",
+      "intent": "dry_run",
+      "ownership": {
+        "dry_run": {
+          "owner": "wp-codebox-runner-namespace",
+          "declared_by": "homeboy-rigs",
+          "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+        }
+      }
     }
   },
   "trace": {

--- a/woocommerce/woocommerce/rigs/woocommerce-browser-coverage/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-browser-coverage/rig.json
@@ -17,8 +17,15 @@
   },
   "lifecycle": {
     "cleanup": {
-      "intent": "external",
-      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+      "schema": "homeboy/resource-cleanup-intent/v1",
+      "intent": "dry_run",
+      "ownership": {
+        "dry_run": {
+          "owner": "wp-codebox-runner-namespace",
+          "declared_by": "homeboy-rigs",
+          "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+        }
+      }
     }
   },
   "trace": {

--- a/woocommerce/woocommerce/rigs/woocommerce-cart-session-race-browser/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-cart-session-race-browser/rig.json
@@ -20,8 +20,15 @@
   },
   "lifecycle": {
     "cleanup": {
-      "intent": "external",
-      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+      "schema": "homeboy/resource-cleanup-intent/v1",
+      "intent": "dry_run",
+      "ownership": {
+        "dry_run": {
+          "owner": "wp-codebox-runner-namespace",
+          "declared_by": "homeboy-rigs",
+          "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; component checkouts are user-owned."
+        }
+      }
     }
   },
   "trace": {

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -59,8 +59,15 @@
   },
   "lifecycle": {
     "cleanup": {
-      "intent": "external",
-      "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; the WooCommerce component checkout is user-owned."
+      "schema": "homeboy/resource-cleanup-intent/v1",
+      "intent": "dry_run",
+      "ownership": {
+        "dry_run": {
+          "owner": "wp-codebox-runner-namespace",
+          "declared_by": "homeboy-rigs",
+          "reason": "WP Codebox sandbox teardown and the runner namespace own runtime cleanup; the WooCommerce component checkout is user-owned."
+        }
+      }
     }
   },
   "requirements": {


### PR DESCRIPTION
## Summary
- Align lifecycle cleanup metadata with Homeboy's resource cleanup intent contract schema.
- Update cleanup intent validation to use dry_run/apply and ownership metadata while preserving the resource/down guardrail.
- Document the cleanup contract and update existing rig examples.

## Tests
- node scripts/lint-rig-packages.mjs
- node --test scripts/*.test.mjs

Lint note: package lint still reports the existing warning for woocommerce/woocommerce/fuzz/codebox-fuzz-suite-contract.json optional artifact codebox_fuzz_suite_result, then passes.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code edits, validation updates, test/doc updates, and PR preparation.