### PR TITLE
Drop helper discovery shims

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     env:
-      HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: ${{ github.workspace }}/homeboy-extensions/wordpress/lib/wordpress-fuzz-manifest-validator.js
+      HOMEBOY_WORDPRESS_HELPER_MANIFEST: ${{ github.workspace }}/homeboy-extensions/wordpress/lib/helper-manifest.js
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Automattic/studio/bench/lib/site-editor-timing-deltas.mjs
+++ b/Automattic/studio/bench/lib/site-editor-timing-deltas.mjs
@@ -49,15 +49,21 @@ export function requestProfilerPath() {
  * @returns {string}
  */
 export function timingCorrelatorPath(options = {}) {
-  const explicit = options.override ?? (setting('wordpress_timing_correlator_path') || wordpressHelperPath('timingCorrelator', {
-    envVar: 'HOMEBOY_WORDPRESS_TIMING_CORRELATOR_HELPER',
-  }));
+  const explicit = options.override ?? (setting('wordpress_timing_correlator_path') || process.env.HOMEBOY_WORDPRESS_TIMING_CORRELATOR_HELPER);
   if (explicit) {
     return explicit;
   }
   const profiler = options.profilerPath ?? requestProfilerPath();
   if (!profiler) {
     return '';
+  }
+  if (!options.profilerPath) {
+    const manifestPath = wordpressHelperPath('timingCorrelator', {
+      envVar: 'HOMEBOY_WORDPRESS_TIMING_CORRELATOR_HELPER',
+    });
+    if (manifestPath) {
+      return manifestPath;
+    }
   }
   return path.join(path.dirname(profiler), TIMING_CORRELATOR_FILENAME);
 }

--- a/Automattic/studio/bench/lib/wordpress-helper-discovery.mjs
+++ b/Automattic/studio/bench/lib/wordpress-helper-discovery.mjs
@@ -1,37 +1,14 @@
-import { createRequire } from 'node:module';
 import path from 'node:path';
-
-const require = createRequire(import.meta.url);
-
-function resolveManifestPath(options = {}) {
-  return options.manifestPath || process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST || '';
-}
+import { loadWordPressHelperModule } from '../../../../shared/wordpress-helper-loader.mjs';
 
 function loadWordPressHelperConsumerModule(options = {}) {
-  const explicit = options.consumerPath || process.env.HOMEBOY_WORDPRESS_HELPER_CONSUMER;
-  if (explicit) {
-    return require(explicit);
-  }
-
-  const manifestPath = resolveManifestPath(options);
-  if (manifestPath) {
-    const manifestModule = require(manifestPath);
-    const manifest = typeof manifestModule.getWordPressHelperManifest === 'function'
-      ? manifestModule.getWordPressHelperManifest()
-      : manifestModule.WORDPRESS_HELPER_MANIFEST;
-    if (manifest?.extensionRoot) {
-      return require(path.join(manifest.extensionRoot, 'lib', 'wordpress-helper-consumer.js'));
-    }
-  }
-
-  try {
-    return require('homeboy-extension-wordpress/wordpress-helper-consumer');
-  } catch (error) {
-    if (error?.code !== 'MODULE_NOT_FOUND') {
-      throw error;
-    }
-    return null;
-  }
+  return loadWordPressHelperModule({
+    helperName: 'wordpress-helper-consumer',
+    envVar: 'HOMEBOY_WORDPRESS_HELPER_CONSUMER',
+    manifestFileName: 'wordpress-helper-consumer.js',
+    helperPath: options.consumerPath,
+    manifestPath: options.manifestPath,
+  });
 }
 
 function missingHandle(resolvedPath = '', reason = 'WordPress helper consumer is unavailable') {

--- a/Automattic/studio/bench/lib/wordpress-page-profiler.mjs
+++ b/Automattic/studio/bench/lib/wordpress-page-profiler.mjs
@@ -78,14 +78,15 @@ export function pageProfilerPath(options = {}) {
     return explicit;
   }
 
-  const manifestPath = wordpressLibHelperPath(PAGE_PROFILER_FILENAME, options);
-  if (manifestPath) {
-    return manifestPath;
-  }
-
   const profiler = options.profilerPath || requestProfilerPath();
   if (!profiler) {
     return '';
+  }
+  if (!options.profilerPath) {
+    const manifestPath = wordpressLibHelperPath(PAGE_PROFILER_FILENAME, options);
+    if (manifestPath) {
+      return manifestPath;
+    }
   }
   return path.join(path.dirname(profiler), PAGE_PROFILER_FILENAME);
 }
@@ -96,14 +97,15 @@ export function adminPageScenariosPath(options = {}) {
     return explicit;
   }
 
-  const manifestPath = wordpressLibHelperPath(ADMIN_PAGE_SCENARIOS_FILENAME, options);
-  if (manifestPath) {
-    return manifestPath;
-  }
-
   const profiler = options.pageProfilerPath || pageProfilerPath(options);
   if (!profiler) {
     return '';
+  }
+  if (!options.pageProfilerPath && !options.profilerPath) {
+    const manifestPath = wordpressLibHelperPath(ADMIN_PAGE_SCENARIOS_FILENAME, options);
+    if (manifestPath) {
+      return manifestPath;
+    }
   }
   return path.join(path.dirname(profiler), ADMIN_PAGE_SCENARIOS_FILENAME);
 }

--- a/Automattic/studio/bench/studio-agent-site-build.test.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.test.mjs
@@ -5,6 +5,94 @@ import path from 'node:path';
 import test from 'node:test';
 
 process.env.HOMEBOY_COMPONENT_PATH ||= '/tmp/homeboy-rigs-test-component';
+if (!process.env.HOMEBOY_NODEJS_WORKLOAD_UTILS) {
+  const workloadUtilsFixtureDir = await mkdtemp(path.join(os.tmpdir(), 'homeboy-node-workload-utils-'));
+  const workloadUtilsFixture = path.join(workloadUtilsFixtureDir, 'workload-utils.mjs');
+  await writeFile(workloadUtilsFixture, `
+export function artifactDir(name, { sharedState = '/tmp' } = {}) { return sharedState + '/' + name; }
+export function expandHome(value) { const text = String(value || ''); return text === '~' || text.startsWith('~/') ? (process.env.HOME || '') + text.slice(1) : text; }
+export function metric(value, fallback = 0) { const number = Number(value ?? fallback); return Number.isFinite(number) ? number : fallback; }
+export function redactText(value) { return String(value || '').replace(/(token|nonce)=([^&\\s]+)/g, '$1=[redacted]'); }
+export async function runNode() { return { code: 0, stdout: '', stderr: '', elapsedMs: 0 }; }
+export function safeResult(value) { return value || {}; }
+export async function sanitizeArtifactFile() {}
+export function setting(key, fallback = '') { const settings = process.env.HOMEBOY_SETTINGS_JSON ? JSON.parse(process.env.HOMEBOY_SETTINGS_JSON) : {}; return settings[key] ?? process.env['HOMEBOY_SETTINGS_' + String(key).toUpperCase()] ?? fallback; }
+`);
+  process.env.HOMEBOY_NODEJS_WORKLOAD_UTILS = workloadUtilsFixture;
+}
+
+if (!process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST && !process.env.HOMEBOY_WORDPRESS_HELPER_CONSUMER) {
+  const wordpressHelperFixtureRoot = await mkdtemp(path.join(os.tmpdir(), 'homeboy-wordpress-helper-'));
+  const wordpressHelperLib = path.join(wordpressHelperFixtureRoot, 'lib');
+  await mkdir(wordpressHelperLib, { recursive: true });
+  await writeFile(path.join(wordpressHelperLib, 'helper-manifest.js'), `
+const path = require('node:path');
+function getWordPressHelperManifest() { return { extensionRoot: path.resolve(__dirname, '..') }; }
+module.exports = { getWordPressHelperManifest };
+`);
+  await writeFile(path.join(wordpressHelperLib, 'wordpress-helper-consumer.js'), `
+const path = require('node:path');
+function loadWordPressHelperManifest() { return { path: path.join(__dirname, 'helper-manifest.js'), manifest: { extensionRoot: path.resolve(__dirname, '..') }, found: true }; }
+function wordpressLibHelperPath(fileName) { return path.join(__dirname, fileName); }
+function loadWordPressLibHelper(fileName) { const resolved = wordpressLibHelperPath(fileName); return { path: resolved, module: require(resolved), found: true }; }
+module.exports = { loadWordPressHelperManifest, wordpressLibHelperPath, loadWordPressLibHelper };
+`);
+  await writeFile(path.join(wordpressHelperLib, 'materialized-site-quality.js'), `
+const VISUAL_PIXEL_DIFF_THRESHOLD = 0.05;
+function number(value) { const parsed = Number(value || 0); return Number.isFinite(parsed) ? parsed : 0; }
+function importerBlockQualityMetrics(importReport = {}) {
+  const quality = importReport.report?.quality || {};
+  return {
+    importerCoreHtmlBlockCount: number(quality.core_html_block_count),
+    importerFreeformBlockCount: number(quality.freeform_block_count),
+    importerFallbackCount: number(quality.fallback_count),
+  };
+}
+function importerBlockQualityFailureDetails(metrics) {
+  return metrics.importerCoreHtmlBlockCount || metrics.importerFreeformBlockCount || metrics.importerFallbackCount
+    ? [\`importer block quality: core/html=\${metrics.importerCoreHtmlBlockCount}, freeform=\${metrics.importerFreeformBlockCount}, fallback=\${metrics.importerFallbackCount}\`]
+    : [];
+}
+function visualEditorParityMetrics(visualComparison = {}) {
+  return {
+    visualEditorVsSourcePixelDiffRatio: number(visualComparison.visual_editor_vs_source_pixel_diff_ratio),
+    visualEditorVsFrontendPixelDiffRatio: number(visualComparison.visual_editor_vs_frontend_pixel_diff_ratio),
+    visualSourceVsFrontendPixelDiffRatio: number(visualComparison.visual_source_vs_frontend_pixel_diff_ratio_diagnostic),
+    visualEditorParityErrorCount: 0,
+  };
+}
+function visualEditorParityFailureDetails(parity) {
+  if (parity.visualEditorVsSourcePixelDiffRatio <= VISUAL_PIXEL_DIFF_THRESHOLD) {
+    return [];
+  }
+  if (parity.visualSourceVsFrontendPixelDiffRatio > VISUAL_PIXEL_DIFF_THRESHOLD) {
+    return [\`editor and frontend both diverge from source (editor: \${parity.visualEditorVsSourcePixelDiffRatio}, frontend: \${parity.visualSourceVsFrontendPixelDiffRatio}) - conversion failed before editor concern\`];
+  }
+  return [\`editor render diverges from frontend (editor diff: \${parity.visualEditorVsSourcePixelDiffRatio}, frontend diff: \${parity.visualSourceVsFrontendPixelDiffRatio}) - likely block-validation or unscoped CSS\`];
+}
+function visualPixelDiffFailureDetails(visualComparison = {}) {
+  const ratio = number(visualComparison.pixel_diff_ratio);
+  return ratio > VISUAL_PIXEL_DIFF_THRESHOLD ? [\`visual pixel diff: \${ratio.toFixed(3)} (threshold: 0.050)\`] : [];
+}
+function evaluateMaterializedSiteQuality({ result = {}, semanticComparison = {}, importReport = {}, visualComparison = {} }) {
+  const semanticMismatchCount = number(semanticComparison.mismatch_count);
+  const importerBlockQuality = importerBlockQualityMetrics(importReport);
+  const visualEditorParity = visualEditorParityMetrics(visualComparison);
+  const visualPixelDiffRatio = number(visualComparison.pixel_diff_ratio);
+  const failed = !result.success || semanticMismatchCount > 0 || importerBlockQualityFailureDetails(importerBlockQuality).length > 0 || visualEditorParityFailureDetails(visualEditorParity).length > 0 || visualPixelDiffFailureDetails(visualComparison).length > 0;
+  return {
+    passed: !failed,
+    semanticMismatchCount,
+    importerBlockQuality,
+    visualEditorParity,
+    visualPixelDiffRatio,
+    metrics: { success_rate: failed ? 0 : 1, agent_error_rate: failed ? 1 : 0 },
+  };
+}
+module.exports = { evaluateMaterializedSiteQuality, importerBlockQualityMetrics, importerBlockQualityFailureDetails, visualEditorParityMetrics, visualEditorParityFailureDetails, visualPixelDiffFailureDetails };
+`);
+  process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST = path.join(wordpressHelperLib, 'helper-manifest.js');
+}
 
 const {
   agentSuccessGate,

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ mark feature-not-needed and feature-needed phases, count feature/third-party
 requests before and after the trigger, and emit assertions proving no early
 initialization plus post-trigger success.
 
+Shared Homeboy Extensions helpers must be injected explicitly by the caller.
+WordPress helper consumers should set `HOMEBOY_WORDPRESS_HELPER_MANIFEST` to the
+absolute path for the Homeboy Extensions `wordpress/lib/helper-manifest.js`, or
+set the specific helper env named by the workload. Node.js bench workloads should set
+`HOMEBOY_NODEJS_WORKLOAD_UTILS` to the absolute path for the Homeboy Extensions
+`nodejs/scripts/bench/lib/workload-utils.mjs` source file. The rig package does
+not guess sibling checkout paths, default install locations, or package imports.
+
 `shared/wordpress-plugin-performance-template/` documents the reusable
 full-surface performance rig shape for WordPress plugins: discovery, safe admin,
 frontend, and REST coverage, readiness checks, fixtures, metrics, artifacts,

--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -15,7 +15,6 @@ function loadGenericFuzzManifestValidator() {
     helperName: 'wordpress-fuzz-manifest-validator',
     envVar: 'HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR',
     manifestFileName: 'wordpress-fuzz-manifest-validator.js',
-    packageImport: 'homeboy-extension-wordpress/wordpress-fuzz-manifest-validator',
   });
 }
 

--- a/shared/nodejs-workload-utils-loader.mjs
+++ b/shared/nodejs-workload-utils-loader.mjs
@@ -1,28 +1,12 @@
-import { existsSync } from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import { pathToFileURL } from 'node:url';
 
 const bootstrapCommand = 'homeboy extension setup nodejs';
 const envVar = 'HOMEBOY_NODEJS_WORKLOAD_UTILS';
 const helperRelativePath = path.join('nodejs', 'scripts', 'bench', 'lib', 'workload-utils.mjs');
 
-function siblingExtensionsPath() {
-  // shared/ lives at the homeboy-rigs repo root; the homeboy-extensions
-  // checkout is a sibling of that repo root.
-  const repoRoot = path.resolve(__dirname, '..');
-  return path.join(path.dirname(repoRoot), 'homeboy-extensions', helperRelativePath);
-}
-
 function resolveWorkloadUtilsPath() {
-  const explicit = process.env[envVar];
-  if (explicit) {
-    return explicit;
-  }
-
-  const sibling = siblingExtensionsPath();
-  return existsSync(sibling) ? sibling : '';
+  return process.env[envVar] || '';
 }
 
 function workloadUtilsDiagnostic() {

--- a/shared/nodejs-workload-utils-loader.test.mjs
+++ b/shared/nodejs-workload-utils-loader.test.mjs
@@ -46,3 +46,10 @@ test('Node workload-utils loader imports the module named by HOMEBOY_NODEJS_WORK
   assert.equal(module.marker, 'explicit-env');
   assert.equal(module.metric(2.5), 2.5);
 });
+
+test('Node workload-utils loader requires the injected source env', async () => {
+  await assert.rejects(
+    () => withEnv({ HOMEBOY_NODEJS_WORKLOAD_UTILS: undefined }, () => loadNodeWorkloadUtils()),
+    /Homeboy Extensions Node workload utilities are unavailable[\s\S]*HOMEBOY_NODEJS_WORKLOAD_UTILS/
+  );
+});

--- a/shared/wordpress-helper-loader.mjs
+++ b/shared/wordpress-helper-loader.mjs
@@ -1,15 +1,13 @@
 import { createRequire } from 'node:module';
-import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 const require = createRequire(import.meta.url);
 
 const bootstrapCommand = 'homeboy extension setup wordpress';
 
-function helperDiagnostic({ helperName, envVar, packageImport }) {
+function helperDiagnostic({ helperName, envVar }) {
   const envLines = [
     `HOMEBOY_WORDPRESS_HELPER_MANIFEST=/path/to/homeboy-extension-wordpress/lib/helper-manifest.js`,
-    `HOMEBOY_WORDPRESS_EXTENSION_ROOT=/path/to/homeboy-extension-wordpress`,
   ];
 
   if (envVar) {
@@ -18,7 +16,6 @@ function helperDiagnostic({ helperName, envVar, packageImport }) {
 
   return [
     `Homeboy WordPress helper "${helperName}" is unavailable.`,
-    packageImport ? `Missing fallback package import: ${packageImport}` : '',
     `Run ${bootstrapCommand}, then export one of:`,
     ...envLines.map((line) => `  ${line}`),
   ].filter(Boolean).join('\n');
@@ -40,28 +37,13 @@ function loadHelperManifest(manifestPath) {
     : manifestModule.WORDPRESS_HELPER_MANIFEST;
 }
 
-function defaultHelperManifestPath() {
-  const extensionRoot = process.env.HOMEBOY_WORDPRESS_EXTENSION_ROOT;
-  if (extensionRoot) {
-    return path.join(extensionRoot, 'lib', 'helper-manifest.js');
-  }
-
-  const home = process.env.HOME;
-  if (!home) {
-    return '';
-  }
-
-  const installedManifest = path.join(home, '.config', 'homeboy', 'extensions', 'wordpress', 'lib', 'helper-manifest.js');
-  return existsSync(installedManifest) ? installedManifest : '';
-}
-
-export function loadWordPressHelperModule({ helperName, envVar, manifestFileName, packageImport }) {
-  const explicit = envVar ? process.env[envVar] : '';
+export function loadWordPressHelperModule({ helperName, envVar, manifestFileName, helperPath = '', manifestPath: injectedManifestPath = '' }) {
+  const explicit = helperPath || (envVar ? process.env[envVar] : '');
   if (explicit) {
     return requireHelper(explicit, `Failed to load ${envVar} at ${explicit}`);
   }
 
-  const manifestPath = process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST || defaultHelperManifestPath();
+  const manifestPath = injectedManifestPath || process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST || '';
   if (manifestPath) {
     const manifest = loadHelperManifest(manifestPath);
     if (manifest?.extensionRoot) {
@@ -72,17 +54,7 @@ export function loadWordPressHelperModule({ helperName, envVar, manifestFileName
     }
   }
 
-  if (packageImport) {
-    try {
-      return require(packageImport);
-    } catch (error) {
-      if (error?.code !== 'MODULE_NOT_FOUND' || !String(error.message).includes(packageImport)) {
-        throw error;
-      }
-    }
-  }
-
-  throw new Error(helperDiagnostic({ helperName, envVar, packageImport }));
+  throw new Error(helperDiagnostic({ helperName, envVar }));
 }
 
 export { bootstrapCommand as wordpressHelperBootstrapCommand };

--- a/shared/wordpress-helper-loader.test.mjs
+++ b/shared/wordpress-helper-loader.test.mjs
@@ -28,22 +28,35 @@ function withEnv(env, callback) {
   }
 }
 
-test('WordPress helper loader reports actionable setup when fallback package is unavailable', () => {
+test('WordPress helper loader reports actionable setup when no helper contract is injected', () => {
   const isolatedHome = path.join(tmpdir(), 'wordpress-helper-loader-missing-home');
 
   assert.throws(
     () => withEnv({
       HOME: isolatedHome,
       HOMEBOY_WORDPRESS_HELPER_MANIFEST: undefined,
-      HOMEBOY_WORDPRESS_EXTENSION_ROOT: undefined,
       HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: undefined,
     }, () => loadWordPressHelperModule({
       helperName: 'wordpress-fuzz-manifest-validator',
       envVar: 'HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR',
       manifestFileName: 'wordpress-fuzz-manifest-validator.js',
-      packageImport: 'homeboy-extension-wordpress/wordpress-fuzz-manifest-validator',
     })),
-    /homeboy extension setup wordpress[\s\S]*HOMEBOY_WORDPRESS_HELPER_MANIFEST[\s\S]*HOMEBOY_WORDPRESS_EXTENSION_ROOT[\s\S]*HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR/
+    /homeboy extension setup wordpress[\s\S]*HOMEBOY_WORDPRESS_HELPER_MANIFEST[\s\S]*HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR/
+  );
+});
+
+test('WordPress helper loader does not use extension-root discovery or package imports', () => {
+  assert.throws(
+    () => withEnv({
+      HOMEBOY_WORDPRESS_HELPER_MANIFEST: undefined,
+      HOMEBOY_WORDPRESS_EXTENSION_ROOT: path.join(tmpdir(), 'homeboy-extension-wordpress'),
+      HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: undefined,
+    }, () => loadWordPressHelperModule({
+      helperName: 'wordpress-fuzz-manifest-validator',
+      envVar: 'HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR',
+      manifestFileName: 'wordpress-fuzz-manifest-validator.js',
+    })),
+    /HOMEBOY_WORDPRESS_HELPER_MANIFEST/
   );
 });
 
@@ -65,13 +78,11 @@ module.exports = { getWordPressHelperManifest };
 
   const helper = withEnv({
     HOMEBOY_WORDPRESS_HELPER_MANIFEST: manifestPath,
-    HOMEBOY_WORDPRESS_EXTENSION_ROOT: undefined,
     HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: undefined,
   }, () => loadWordPressHelperModule({
     helperName: 'example-helper',
     envVar: 'HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR',
     manifestFileName: 'example-helper.js',
-    packageImport: 'homeboy-extension-wordpress/example-helper',
   }));
 
   assert.equal(helper.loaded, true);


### PR DESCRIPTION
## Summary
- Require explicit WordPress helper manifest/helper env injection instead of extension-root, default-install, or package-import guessing.
- Require explicit Node workload-utils source env instead of sibling checkout discovery.
- Update Studio helper consumers/tests, CI lint env, and README helper contract docs.

## Verification
- `node --test shared/wordpress-helper-loader.test.mjs shared/nodejs-workload-utils-loader.test.mjs shared/wp-codebox/contract.test.mjs scripts/fuzz-manifest-helpers.test.mjs scripts/lint-rig-packages.test.mjs woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs Automattic/studio/bench/studio-site-editor-diagnostics.test.mjs Automattic/studio/bench/site-build-runtime.test.mjs Automattic/studio/bench/studio-agent-site-build.test.mjs woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`
- `HOMEBOY_WORDPRESS_HELPER_MANIFEST="/Users/chubes/Developer/homeboy-rigs@cleanup-drop-rig-helper-discovery-shims-20260630/scripts/fixtures/homeboy-extension-wordpress/lib/helper-manifest.js" node scripts/lint-rig-packages.mjs` (passes with existing optional-artifact warning for `woocommerce/woocommerce/fuzz/codebox-fuzz-suite-contract.json`)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code changes, focused test updates, verification, commit and PR preparation.