### PR TITLE
Declare Woo Codebox plugin file metadata

### DIFF
--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -120,6 +120,10 @@ test('fuzz workload metadata does not fall back to benchmark transcripts', () =>
 });
 
 test('Woo Composer prep declares dependency materialization for plugin vendor output', () => {
+  const wordpressExtension = performanceRig.components.woocommerce.extensions.wordpress;
+  assert.equal(wordpressExtension.wp_codebox_source_subpath, 'plugins/woocommerce');
+  assert.equal(wordpressExtension.wp_codebox_plugin_file, 'plugins/woocommerce/woocommerce.php');
+
   const dependencySteps = performanceRig.requirements?.dependency_materialization || [];
   const composerStep = dependencySteps.find((step) => step.id === 'woocommerce-php-package-dependencies');
 

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -10,6 +10,7 @@
           "wp_codebox_wordpress_version": "7.0",
           "wp_codebox_source_root": "${env.HOMEBOY_RIG_COMPONENT_CHECKOUT_ROOT__WOOCOMMERCE_PERFORMANCE__WOOCOMMERCE}",
           "wp_codebox_source_subpath": "plugins/woocommerce",
+          "wp_codebox_plugin_file": "plugins/woocommerce/woocommerce.php",
           "bench_env": {
             "WC_CHECKOUT_GATEWAY_MATRIX_PROFILE_SET": "core_only",
             "WC_CHECKOUT_GATEWAY_MATRIX_PROFILES": "",


### PR DESCRIPTION
## Summary
- declare WooCommerce's checkout-relative WP Codebox plugin file in the Woo performance rig
- assert the rig keeps the source subpath and plugin file metadata together

## Tests
- node woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5, OpenCode
- **Used for:** Adding Woo rig metadata and focused contract coverage.