### PR TITLE
Declare Woo nested Codebox plugin source

### DIFF
--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -121,6 +121,9 @@ test('fuzz workload metadata does not fall back to benchmark transcripts', () =>
 
 test('Woo Composer prep declares dependency materialization for plugin vendor output', () => {
   const wordpressExtension = performanceRig.components.woocommerce.extensions.wordpress;
+  assert.equal(wordpressExtension.wp_codebox_source_path, '${env.HOMEBOY_RIG_COMPONENT_CHECKOUT_ROOT__WOOCOMMERCE_PERFORMANCE__WOOCOMMERCE}');
+  assert.equal(wordpressExtension.wp_codebox_source_subdir, 'plugins/woocommerce');
+  assert.equal(wordpressExtension.wp_codebox_mount_slug, 'woocommerce');
   assert.equal(wordpressExtension.wp_codebox_source_subpath, 'plugins/woocommerce');
   assert.equal(wordpressExtension.wp_codebox_plugin_file, 'plugins/woocommerce/woocommerce.php');
 

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -8,6 +8,9 @@
       "extensions": {
         "wordpress": {
           "wp_codebox_wordpress_version": "7.0",
+          "wp_codebox_source_path": "${env.HOMEBOY_RIG_COMPONENT_CHECKOUT_ROOT__WOOCOMMERCE_PERFORMANCE__WOOCOMMERCE}",
+          "wp_codebox_source_subdir": "plugins/woocommerce",
+          "wp_codebox_mount_slug": "woocommerce",
           "wp_codebox_source_root": "${env.HOMEBOY_RIG_COMPONENT_CHECKOUT_ROOT__WOOCOMMERCE_PERFORMANCE__WOOCOMMERCE}",
           "wp_codebox_source_subpath": "plugins/woocommerce",
           "wp_codebox_plugin_file": "plugins/woocommerce/woocommerce.php",


### PR DESCRIPTION
## Summary
- Add Woo rig metadata for WP Codebox #1667 nested plugin source shape: source path, source subdir, mount slug, and plugin file.
- Keep existing legacy source root/subpath metadata for current consumers.
- Update the Woo full-surface metadata test.

## Tests
- node woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting Woo rig metadata, updating the Codebox nested plugin source fields, and running focused verification.