### PR TITLE
Fix Woo Codebox plugin file metadata

### DIFF
--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -125,7 +125,7 @@ test('Woo Composer prep declares dependency materialization for plugin vendor ou
   assert.equal(wordpressExtension.wp_codebox_source_subdir, 'plugins/woocommerce');
   assert.equal(wordpressExtension.wp_codebox_mount_slug, 'woocommerce');
   assert.equal(wordpressExtension.wp_codebox_source_subpath, 'plugins/woocommerce');
-  assert.equal(wordpressExtension.wp_codebox_plugin_file, 'plugins/woocommerce/woocommerce.php');
+  assert.equal(wordpressExtension.wp_codebox_plugin_file, 'woocommerce/woocommerce.php');
 
   const dependencySteps = performanceRig.requirements?.dependency_materialization || [];
   const composerStep = dependencySteps.find((step) => step.id === 'woocommerce-php-package-dependencies');

--- a/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-performance/rig.json
@@ -13,7 +13,7 @@
           "wp_codebox_mount_slug": "woocommerce",
           "wp_codebox_source_root": "${env.HOMEBOY_RIG_COMPONENT_CHECKOUT_ROOT__WOOCOMMERCE_PERFORMANCE__WOOCOMMERCE}",
           "wp_codebox_source_subpath": "plugins/woocommerce",
-          "wp_codebox_plugin_file": "plugins/woocommerce/woocommerce.php",
+          "wp_codebox_plugin_file": "woocommerce/woocommerce.php",
           "bench_env": {
             "WC_CHECKOUT_GATEWAY_MATRIX_PROFILE_SET": "core_only",
             "WC_CHECKOUT_GATEWAY_MATRIX_PROFILES": "",


### PR DESCRIPTION
## Summary
- Correct the WooCommerce performance rig's WP Codebox plugin file metadata.
- Keep the nested Woo source path in `wp_codebox_source_subpath` and declare `wp_codebox_plugin_file` relative to the mounted `woocommerce` slug.

## Tests
- `node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs`
- HBEX mapper verification: `node wordpress/tests/wp-codebox-fuzz-run-smoke.js` in `homeboy-extensions@fix-codebox-plugin-file-mount-slug`
- WP Codebox validator cross-check: `npx tsx tests/recipe-extra-plugin-nested-source.test.ts` in `wp-codebox@nested-plugin-source-mount`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspecting the failed Homeboy run artifacts, identifying stale Woo Codebox metadata, updating the rig declaration, and running verification.
