### PR TITLE
Use Homeboy artifact ref normalizer

### DIFF
--- a/scripts/fixtures/homeboy-artifact-ref-normalizer.mjs
+++ b/scripts/fixtures/homeboy-artifact-ref-normalizer.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+const ref = process.argv.at(-1) || '';
+
+if (ref === '<artifact-ref>') {
+  console.error('must be a reviewer-facing artifact ref');
+  process.exit(1);
+}
+
+if (ref === 'artifact:./report.json' || ref.startsWith('homeboy-artifact:///tmp/')) {
+  console.error('must not use local evidence');
+  process.exit(1);
+}
+
+if (!ref.startsWith('homeboy://run/') && !ref.startsWith('homeboy-runs:')) {
+  console.error('must be a reviewer-facing artifact ref');
+  process.exit(1);
+}
+
+process.stdout.write(`${ref}\n`);

--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { loadWordPressHelperModule } from '../shared/wordpress-helper-loader.mjs';
@@ -188,17 +189,74 @@ export function assertCanonicalFuzzEnvelopeRef(proofBundle, { file = 'fuzz workl
 export function assertReviewerFacingFuzzRef(value, context) {
   assert.equal(typeof value, 'string', `${context} must be a reviewer-facing artifact ref string`);
   assert.ok(value.trim().length > 0, `${context} must be a reviewer-facing artifact ref string`);
-  assert.ok(
-    /^(https:\/\/|gh:|homeboy-runs:|homeboy:\/\/run\/|homeboy-artifact:\/\/|artifact:|run:)/.test(value),
-    `${context} must be a reviewer-facing artifact ref`
-  );
-  assert.ok(
-    !localOnlyReviewerFacingRef(value),
-    `${context} must not use local evidence`
-  );
+
+  const result = normalizeReviewerFacingFuzzRef(value);
+  if (!result.ok) {
+    assert.fail(`${context} ${result.message}`);
+  }
 }
 
-export function localOnlyReviewerFacingRef(value) {
+export function normalizeReviewerFacingFuzzRef(value) {
+  const cliResult = normalizeReviewerFacingFuzzRefWithHomeboy(value);
+  if (cliResult.status !== 'unavailable') {
+    return cliResult;
+  }
+
+  return normalizeReviewerFacingFuzzRefWithTransitionalFallback(value);
+}
+
+function normalizeReviewerFacingFuzzRefWithHomeboy(value) {
+  const command = homeboyArtifactRefNormalizerCommand();
+  const result = spawnSync(command[0], [...command.slice(1), value], {
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024,
+  });
+
+  if (result.error?.code === 'ENOENT') {
+    return { status: 'unavailable', ok: false, message: 'homeboy artifact ref normalizer is unavailable' };
+  }
+
+  const stderr = (result.stderr || '').trim();
+  if (result.status === 0) {
+    return { status: 'normalized', ok: true, value: (result.stdout || '').trim() || value };
+  }
+
+  if (/unrecognized subcommand 'normalize'|unrecognized subcommand 'artifact-ref'|Usage: homeboy contract\b/.test(stderr)) {
+    return { status: 'unavailable', ok: false, message: 'homeboy artifact ref normalizer is unavailable' };
+  }
+
+  return { status: 'rejected', ok: false, message: stderr || 'must be a reviewer-facing artifact ref' };
+}
+
+function homeboyArtifactRefNormalizerCommand() {
+  if (process.env.HOMEBOY_ARTIFACT_REF_NORMALIZER_COMMAND) {
+    const command = JSON.parse(process.env.HOMEBOY_ARTIFACT_REF_NORMALIZER_COMMAND);
+    assert.ok(Array.isArray(command) && command.length > 0, 'HOMEBOY_ARTIFACT_REF_NORMALIZER_COMMAND must be a JSON command array');
+    return command;
+  }
+
+  return ['homeboy', 'contract', 'normalize', 'artifact-ref'];
+}
+
+// Transitional only: local Studio machines may still have a pre-normalizer
+// Homeboy release on PATH. Remove when the released CLI is ubiquitous.
+function normalizeReviewerFacingFuzzRefWithTransitionalFallback(value) {
+  if (!reviewerFacingArtifactRefScheme(value)) {
+    return { status: 'fallback', ok: false, message: 'must be a reviewer-facing artifact ref' };
+  }
+
+  if (localOnlyReviewerFacingRef(value)) {
+    return { status: 'fallback', ok: false, message: 'must not use local evidence' };
+  }
+
+  return { status: 'fallback', ok: true, value };
+}
+
+function reviewerFacingArtifactRefScheme(value) {
+  return /^(https:\/\/|gh:|homeboy-runs:|homeboy:\/\/run\/|homeboy-artifact:\/\/|artifact:|run:)/.test(value);
+}
+
+function localOnlyReviewerFacingRef(value) {
   if (typeof value !== 'string' || value.trim() === '') {
     return false;
   }

--- a/scripts/fuzz-manifest-helpers.test.mjs
+++ b/scripts/fuzz-manifest-helpers.test.mjs
@@ -9,11 +9,15 @@ import {
   fullSurfaceRequiredArtifactIds,
   fuzzManifestHasExecutableArtifactContract,
   fuzzProofBundleFields,
-  localOnlyReviewerFacingRef,
+  normalizeReviewerFacingFuzzRef,
   workloadIdFromPath,
 } from './fuzz-manifest-helpers.mjs';
 
 process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST = new URL('./fixtures/homeboy-extension-wordpress/lib/helper-manifest.js', import.meta.url).pathname;
+process.env.HOMEBOY_ARTIFACT_REF_NORMALIZER_COMMAND = JSON.stringify([
+  process.execPath,
+  new URL('./fixtures/homeboy-artifact-ref-normalizer.mjs', import.meta.url).pathname,
+]);
 delete process.env.HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR;
 
 function fuzzManifest(overrides = {}) {
@@ -331,8 +335,7 @@ test('assertFuzzProofBundle rejects local canonical fuzz envelope artifact refs'
 
 test('reviewer-facing fuzz refs accept durable refs and reject placeholders/local refs', () => {
   assert.doesNotThrow(() => assertReviewerFacingFuzzRef('homeboy://run/product-fuzz/artifact/report', 'proof ref'));
-  assert.equal(localOnlyReviewerFacingRef('artifact:./report.json'), true);
-  assert.equal(localOnlyReviewerFacingRef('homeboy-artifact:///tmp/report.json'), true);
+  assert.equal(normalizeReviewerFacingFuzzRef('homeboy://run/product-fuzz/artifact/report').status, 'normalized');
   assert.throws(
     () => assertReviewerFacingFuzzRef('<artifact-ref>', 'proof ref'),
     /must be a reviewer-facing artifact ref/

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -7,6 +7,10 @@ import test from 'node:test';
 
 const script = new URL('./lint-rig-packages.mjs', import.meta.url).pathname;
 const wordpressHelperManifest = new URL('./fixtures/homeboy-extension-wordpress/lib/helper-manifest.js', import.meta.url).pathname;
+const artifactRefNormalizerCommand = JSON.stringify([
+  process.execPath,
+  new URL('./fixtures/homeboy-artifact-ref-normalizer.mjs', import.meta.url).pathname,
+]);
 const wordpressCoreFuzzValidatorSource = `
 export function validateFuzzWorkload({ rel, root, workload }) {
   const failures = [];
@@ -254,6 +258,7 @@ function runLint(directory, env = {}) {
       HOMEBOY_BIN: writeFakeHomeboyBin(directory),
       HOMEBOY_WORDPRESS_HELPER_MANIFEST: wordpressHelperManifest,
       HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: '',
+      HOMEBOY_ARTIFACT_REF_NORMALIZER_COMMAND: artifactRefNormalizerCommand,
       ...env,
     },
   });


### PR DESCRIPTION
## Summary
- Route reviewer-facing fuzz artifact ref validation through `homeboy contract normalize artifact-ref` by default.
- Keep a clearly transitional fallback for machines with a pre-normalizer Homeboy binary on PATH.
- Update helper and lint tests to exercise a Homeboy normalizer command fixture instead of duplicating local accept/reject assertions.

## Tests
- `node --test scripts/fuzz-manifest-helpers.test.mjs`
- `node --test scripts/lint-rig-packages.test.mjs`
- `node scripts/lint-rig-packages.mjs`

## Notes
- Local `homeboy 0.274.0` does not expose `homeboy contract normalize artifact-ref`; the transitional fallback remains required until the released CLI is ubiquitous in reviewer/dev environments.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implemented the helper/test changes, ran focused verification, and drafted this PR description.