### PR TITLE
Remove remaining helper discovery fallbacks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       HOMEBOY_VERSION: v0.275.0
       HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: ${{ github.workspace }}/homeboy-extensions/wordpress/lib/wordpress-fuzz-manifest-validator.js
+      HOMEBOY_WORDPRESS_HELPER_MANIFEST: ${{ github.workspace }}/homeboy-extensions/wordpress/lib/helper-manifest.js
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Automattic/studio/bench/lib/wordpress-helper-discovery.mjs
+++ b/Automattic/studio/bench/lib/wordpress-helper-discovery.mjs
@@ -24,14 +24,7 @@ function loadWordPressHelperConsumerModule(options = {}) {
     }
   }
 
-  try {
-    return require('homeboy-extension-wordpress/wordpress-helper-consumer');
-  } catch (error) {
-    if (error?.code !== 'MODULE_NOT_FOUND') {
-      throw error;
-    }
-    return null;
-  }
+  return null;
 }
 
 function missingHandle(resolvedPath = '', reason = 'WordPress helper consumer is unavailable') {

--- a/Automattic/studio/bench/studio-agent-site-build.test.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.test.mjs
@@ -5,6 +5,10 @@ import path from 'node:path';
 import test from 'node:test';
 
 process.env.HOMEBOY_COMPONENT_PATH ||= '/tmp/homeboy-rigs-test-component';
+process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST ||= path.join(
+  process.cwd(),
+  'scripts/fixtures/homeboy-extension-wordpress/lib/helper-manifest.js'
+);
 
 const {
   agentSuccessGate,

--- a/Automattic/studio/docs/studio-canonical-loop-proof.md
+++ b/Automattic/studio/docs/studio-canonical-loop-proof.md
@@ -20,6 +20,7 @@ The first real runtime proof is `studio-native-live-runtime-open.mjs`: it opens 
 node Automattic/studio/proofs/studio-canonical-loop-proof.mjs --check
 HOMEBOY_INVOCATION_ARTIFACT_DIR=/path/to/artifacts \
   node Automattic/studio/proofs/studio-canonical-loop-proof.mjs
+export HOMEBOY_WORDPRESS_HELPER_MANIFEST=/path/to/homeboy-extension-wordpress/lib/helper-manifest.js
 node scripts/lint-rig-packages.mjs Automattic/studio
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ homeboy rig check studio-combined
 `homeboy rig check` reports generic package lint failures such as unresolved conflict markers and invalid JSON before running the rig's own check pipeline. This repo also keeps a lightweight package lint for PHP syntax, portable source paths, generated rig drift, `fuzz_profiles` references that drift from `fuzz_workloads`, and WordPress plugin fuzz workload IDs accidentally reappearing in `bench_workloads` or `bench_profiles`:
 
 ```bash
+export HOMEBOY_WORDPRESS_HELPER_MANIFEST=/path/to/homeboy-extension-wordpress/lib/helper-manifest.js
 node scripts/lint-rig-packages.mjs
 ```
 
@@ -349,6 +350,7 @@ performance-observation contracts without adding a `homeboy bench` fallback.
 ```bash
 homeboy rig install $HOME/Developer/homeboy-rigs@<branch>/WordPress/wordpress-develop
 homeboy rig check wordpress-core-fuzz-coverage
+export HOMEBOY_WORDPRESS_HELPER_MANIFEST=/path/to/homeboy-extension-wordpress/lib/helper-manifest.js
 node scripts/lint-rig-packages.mjs WordPress/wordpress-develop
 ```
 
@@ -445,6 +447,8 @@ Use Homeboy's visual compare hook with the WP Codebox provider when collecting
 reviewer-facing parity proof for a PR:
 
 ```bash
+wp_codebox_visual_compare_provider="$(node -e 'const path = require("node:path"); const loaded = require(process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST); const manifest = typeof loaded.getWordPressHelperManifest === "function" ? loaded.getWordPressHelperManifest() : loaded.WORDPRESS_HELPER_MANIFEST; process.stdout.write(path.join(manifest.extensionRoot, "lib", "wp-codebox-visual-compare.js"));')"
+
 homeboy trace compare \
   --rig woocommerce-stripe-ece-product-page \
   --baseline-target origin/develop \
@@ -454,7 +458,7 @@ homeboy trace compare \
   --report markdown \
   --visual-compare \
   --visual-compare-provider node \
-  --visual-provider-arg "$HOME/Developer/homeboy-extensions/wordpress/lib/wp-codebox-visual-compare.js" \
+  --visual-provider-arg "$wp_codebox_visual_compare_provider" \
   --visual-threshold 0.1 \
   woocommerce-gateway-stripe ece-product-page-waterfall \
   --output /tmp/wc-stripe-ece-product-page-proof.md

--- a/WordPress/wordpress-develop/README.md
+++ b/WordPress/wordpress-develop/README.md
@@ -14,6 +14,7 @@ Validate the rig package without running workloads:
 
 ```sh
 homeboy rig check wordpress-core-fuzz-coverage
+export HOMEBOY_WORDPRESS_HELPER_MANIFEST=/path/to/homeboy-extension-wordpress/lib/helper-manifest.js
 node scripts/lint-rig-packages.mjs WordPress/wordpress-develop
 ```
 

--- a/docs/fuzz-coverage-matrix.md
+++ b/docs/fuzz-coverage-matrix.md
@@ -36,9 +36,10 @@ packages can use this shared shape to distinguish planned CRUD/mutation coverage
 from executable workloads and reviewer-facing proof artifacts.
 
 The repo-wide package linter reports missing `metadata.readiness` on fuzz
-manifests as a warning. Use `node scripts/lint-rig-packages.mjs
---strict-fuzz-readiness` when a package is ready to make readiness metadata a
-hard gate. Manifests that opt into `level: proven` must keep their proof
+manifests as a warning. Run it with `HOMEBOY_WORDPRESS_HELPER_MANIFEST` pointing
+at the injected Homeboy Extensions WordPress helper manifest, and use
+`node scripts/lint-rig-packages.mjs --strict-fuzz-readiness` when a package is
+ready to make readiness metadata a hard gate. Manifests that opt into `level: proven` must keep their proof
 artifacts required and linked through the proof bundle so proof claims cannot
 silently pass with optional output or local-only evidence.
 

--- a/scripts/fixtures/homeboy-extension-wordpress/lib/materialized-site-quality.js
+++ b/scripts/fixtures/homeboy-extension-wordpress/lib/materialized-site-quality.js
@@ -1,0 +1,84 @@
+const VISUAL_PIXEL_DIFF_THRESHOLD = 0.05;
+
+function importerBlockQualityMetrics(importReport = {}) {
+  const quality = importReport.report?.quality || {};
+  return {
+    importerCoreHtmlBlockCount: Number(quality.core_html_block_count || 0),
+    importerFreeformBlockCount: Number(quality.freeform_block_count || 0),
+    importerFallbackCount: Number(quality.fallback_count || 0),
+  };
+}
+
+function importerBlockQualityFailureDetails(metrics = {}) {
+  if (!metrics.importerCoreHtmlBlockCount && !metrics.importerFreeformBlockCount && !metrics.importerFallbackCount) {
+    return [];
+  }
+  return [
+    `importer block quality: core/html=${metrics.importerCoreHtmlBlockCount || 0}, freeform=${metrics.importerFreeformBlockCount || 0}, fallback=${metrics.importerFallbackCount || 0}`,
+  ];
+}
+
+function visualEditorParityMetrics(visualComparison = {}) {
+  return {
+    visualEditorVsSourcePixelDiffRatio: Number(visualComparison.visual_editor_vs_source_pixel_diff_ratio || 0),
+    visualEditorVsFrontendPixelDiffRatio: Number(visualComparison.visual_editor_vs_frontend_pixel_diff_ratio || 0),
+    visualSourceVsFrontendPixelDiffRatio: Number(visualComparison.visual_source_vs_frontend_pixel_diff_ratio_diagnostic || 0),
+    visualEditorParityErrorCount: Number(visualComparison.visual_editor_error_count || 0),
+  };
+}
+
+function visualEditorParityFailureDetails(metrics = {}) {
+  if (metrics.visualEditorVsSourcePixelDiffRatio <= VISUAL_PIXEL_DIFF_THRESHOLD) {
+    return [];
+  }
+  if (metrics.visualSourceVsFrontendPixelDiffRatio > VISUAL_PIXEL_DIFF_THRESHOLD) {
+    return [
+      `editor and frontend both diverge from source (editor: ${metrics.visualEditorVsSourcePixelDiffRatio}, frontend: ${metrics.visualSourceVsFrontendPixelDiffRatio}) - conversion failed before editor concern`,
+    ];
+  }
+  return [
+    `editor render diverges from frontend (editor diff: ${metrics.visualEditorVsSourcePixelDiffRatio}, frontend diff: ${metrics.visualSourceVsFrontendPixelDiffRatio}) - likely block-validation or unscoped CSS`,
+  ];
+}
+
+function visualPixelDiffFailureDetails(visualComparison = {}, options = {}) {
+  const threshold = Number(options.visualPixelDiffThreshold || VISUAL_PIXEL_DIFF_THRESHOLD);
+  const ratio = Number(visualComparison.pixel_diff_ratio || 0);
+  return ratio > threshold ? [`visual pixel diff: ${ratio.toFixed(3)} (threshold: ${threshold.toFixed(3)})`] : [];
+}
+
+function evaluateMaterializedSiteQuality({ result = {}, semanticComparison = {}, importReport = {}, visualComparison = {} }) {
+  const importerBlockQuality = importerBlockQualityMetrics(importReport);
+  const visualEditorParity = visualEditorParityMetrics(visualComparison);
+  const visualPixelDiffRatio = Number(visualComparison.pixel_diff_ratio || 0);
+  const semanticMismatchCount = Number(semanticComparison.mismatch_count || 0);
+  const failures = [
+    semanticMismatchCount > 0,
+    importerBlockQualityFailureDetails(importerBlockQuality).length > 0,
+    visualEditorParityFailureDetails(visualEditorParity).length > 0,
+    visualPixelDiffFailureDetails(visualComparison).length > 0,
+    !result.success,
+  ];
+  const passed = !failures.some(Boolean);
+
+  return {
+    passed,
+    semanticMismatchCount,
+    importerBlockQuality,
+    visualEditorParity,
+    visualPixelDiffRatio,
+    metrics: {
+      success_rate: passed ? 1 : 0,
+      agent_error_rate: passed ? 0 : 1,
+    },
+  };
+}
+
+module.exports = {
+  evaluateMaterializedSiteQuality,
+  importerBlockQualityMetrics,
+  importerBlockQualityFailureDetails,
+  visualEditorParityMetrics,
+  visualEditorParityFailureDetails,
+  visualPixelDiffFailureDetails,
+};

--- a/scripts/fixtures/homeboy-extension-wordpress/lib/wordpress-helper-consumer.js
+++ b/scripts/fixtures/homeboy-extension-wordpress/lib/wordpress-helper-consumer.js
@@ -1,0 +1,31 @@
+const path = require('node:path');
+
+function loadWordPressHelperManifest() {
+  const manifestModule = require('./helper-manifest.js');
+  const manifest = typeof manifestModule.getWordPressHelperManifest === 'function'
+    ? manifestModule.getWordPressHelperManifest()
+    : manifestModule.WORDPRESS_HELPER_MANIFEST;
+  return { path: path.join(__dirname, 'helper-manifest.js'), manifest, found: true };
+}
+
+function wordpressHelperPath(key, options = {}) {
+  const { manifest } = loadWordPressHelperManifest(options);
+  return manifest?.helpers?.[key] || '';
+}
+
+function wordpressLibHelperPath(fileName, options = {}) {
+  const { manifest } = loadWordPressHelperManifest(options);
+  return manifest?.extensionRoot ? path.join(manifest.extensionRoot, 'lib', fileName) : '';
+}
+
+function loadWordPressLibHelper(fileName, options = {}) {
+  const helperPath = wordpressLibHelperPath(fileName, options);
+  return helperPath ? { path: helperPath, module: require(helperPath), found: true } : { path: '', module: null, found: false };
+}
+
+module.exports = {
+  loadWordPressHelperManifest,
+  wordpressHelperPath,
+  wordpressLibHelperPath,
+  loadWordPressLibHelper,
+};

--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -15,7 +15,6 @@ function loadGenericFuzzManifestValidator() {
     helperName: 'wordpress-fuzz-manifest-validator',
     envVar: 'HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR',
     manifestFileName: 'wordpress-fuzz-manifest-validator.js',
-    packageImport: 'homeboy-extension-wordpress/wordpress-fuzz-manifest-validator',
   });
 }
 

--- a/shared/wordpress-helper-loader.mjs
+++ b/shared/wordpress-helper-loader.mjs
@@ -1,15 +1,13 @@
 import { createRequire } from 'node:module';
-import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 const require = createRequire(import.meta.url);
 
 const bootstrapCommand = 'homeboy extension setup wordpress';
 
-function helperDiagnostic({ helperName, envVar, packageImport }) {
+function helperDiagnostic({ helperName, envVar }) {
   const envLines = [
     `HOMEBOY_WORDPRESS_HELPER_MANIFEST=/path/to/homeboy-extension-wordpress/lib/helper-manifest.js`,
-    `HOMEBOY_WORDPRESS_EXTENSION_ROOT=/path/to/homeboy-extension-wordpress`,
   ];
 
   if (envVar) {
@@ -18,8 +16,7 @@ function helperDiagnostic({ helperName, envVar, packageImport }) {
 
   return [
     `Homeboy WordPress helper "${helperName}" is unavailable.`,
-    packageImport ? `Missing fallback package import: ${packageImport}` : '',
-    `Run ${bootstrapCommand}, then export one of:`,
+    `Run ${bootstrapCommand}, then export one of the injected helper contracts:`,
     ...envLines.map((line) => `  ${line}`),
   ].filter(Boolean).join('\n');
 }
@@ -40,28 +37,13 @@ function loadHelperManifest(manifestPath) {
     : manifestModule.WORDPRESS_HELPER_MANIFEST;
 }
 
-function defaultHelperManifestPath() {
-  const extensionRoot = process.env.HOMEBOY_WORDPRESS_EXTENSION_ROOT;
-  if (extensionRoot) {
-    return path.join(extensionRoot, 'lib', 'helper-manifest.js');
-  }
-
-  const home = process.env.HOME;
-  if (!home) {
-    return '';
-  }
-
-  const installedManifest = path.join(home, '.config', 'homeboy', 'extensions', 'wordpress', 'lib', 'helper-manifest.js');
-  return existsSync(installedManifest) ? installedManifest : '';
-}
-
-export function loadWordPressHelperModule({ helperName, envVar, manifestFileName, packageImport }) {
+export function loadWordPressHelperModule({ helperName, envVar, manifestFileName }) {
   const explicit = envVar ? process.env[envVar] : '';
   if (explicit) {
     return requireHelper(explicit, `Failed to load ${envVar} at ${explicit}`);
   }
 
-  const manifestPath = process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST || defaultHelperManifestPath();
+  const manifestPath = process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST;
   if (manifestPath) {
     const manifest = loadHelperManifest(manifestPath);
     if (manifest?.extensionRoot) {
@@ -72,17 +54,7 @@ export function loadWordPressHelperModule({ helperName, envVar, manifestFileName
     }
   }
 
-  if (packageImport) {
-    try {
-      return require(packageImport);
-    } catch (error) {
-      if (error?.code !== 'MODULE_NOT_FOUND' || !String(error.message).includes(packageImport)) {
-        throw error;
-      }
-    }
-  }
-
-  throw new Error(helperDiagnostic({ helperName, envVar, packageImport }));
+  throw new Error(helperDiagnostic({ helperName, envVar }));
 }
 
 export { bootstrapCommand as wordpressHelperBootstrapCommand };

--- a/shared/wordpress-helper-loader.test.mjs
+++ b/shared/wordpress-helper-loader.test.mjs
@@ -28,22 +28,20 @@ function withEnv(env, callback) {
   }
 }
 
-test('WordPress helper loader reports actionable setup when fallback package is unavailable', () => {
+test('WordPress helper loader reports actionable setup when no helper contract is injected', () => {
   const isolatedHome = path.join(tmpdir(), 'wordpress-helper-loader-missing-home');
 
   assert.throws(
     () => withEnv({
       HOME: isolatedHome,
       HOMEBOY_WORDPRESS_HELPER_MANIFEST: undefined,
-      HOMEBOY_WORDPRESS_EXTENSION_ROOT: undefined,
       HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: undefined,
     }, () => loadWordPressHelperModule({
       helperName: 'wordpress-fuzz-manifest-validator',
       envVar: 'HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR',
       manifestFileName: 'wordpress-fuzz-manifest-validator.js',
-      packageImport: 'homeboy-extension-wordpress/wordpress-fuzz-manifest-validator',
     })),
-    /homeboy extension setup wordpress[\s\S]*HOMEBOY_WORDPRESS_HELPER_MANIFEST[\s\S]*HOMEBOY_WORDPRESS_EXTENSION_ROOT[\s\S]*HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR/
+    /homeboy extension setup wordpress[\s\S]*HOMEBOY_WORDPRESS_HELPER_MANIFEST[\s\S]*HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR/
   );
 });
 
@@ -65,13 +63,11 @@ module.exports = { getWordPressHelperManifest };
 
   const helper = withEnv({
     HOMEBOY_WORDPRESS_HELPER_MANIFEST: manifestPath,
-    HOMEBOY_WORDPRESS_EXTENSION_ROOT: undefined,
     HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: undefined,
   }, () => loadWordPressHelperModule({
     helperName: 'example-helper',
     envVar: 'HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR',
     manifestFileName: 'example-helper.js',
-    packageImport: 'homeboy-extension-wordpress/example-helper',
   }));
 
   assert.equal(helper.loaded, true);


### PR DESCRIPTION
## Summary
- remove WordPress helper loader fallback discovery through extension roots, package imports, and implicit installed helper locations
- require explicit helper contract injection through direct helper env vars or `HOMEBOY_WORDPRESS_HELPER_MANIFEST`
- update docs, CI, and fixtures to exercise the manifest contract instead of local checkout guesses

## Verification
- `node --test`
- `HOMEBOY_WORDPRESS_HELPER_MANIFEST="$PWD/scripts/fixtures/homeboy-extension-wordpress/lib/helper-manifest.js" node scripts/lint-rig-packages.mjs`
- targeted searches for `HOMEBOY_WORDPRESS_HELPER_MANIFEST`, `helper-loader`, `Developer/homeboy-extensions`, and `fallback`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Auditing helper fallback references, editing loader/docs/tests, running validation, and drafting this PR.