### PR TITLE
Use Homeboy cleanup intent contract in rig lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HOMEBOY_VERSION: v0.275.0
-      HOMEBOY_BIN: ${{ runner.temp }}/homeboy/homeboy-x86_64-unknown-linux-gnu/homeboy
+      HOMEBOY_BIN: ${{ github.workspace }}/homeboy/homeboy-x86_64-unknown-linux-gnu/homeboy
       HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: ${{ github.workspace }}/homeboy-extensions/wordpress/lib/wordpress-fuzz-manifest-validator.js
     steps:
       - uses: actions/checkout@v4
@@ -30,9 +30,9 @@ jobs:
           coverage: none
       - name: Install Homeboy
         run: |
-          mkdir -p "${RUNNER_TEMP}/homeboy"
-          gh release download "${HOMEBOY_VERSION}" --repo Extra-Chill/homeboy --pattern homeboy-x86_64-unknown-linux-gnu.tar.xz --dir "${RUNNER_TEMP}/homeboy"
-          tar -xJf "${RUNNER_TEMP}/homeboy/homeboy-x86_64-unknown-linux-gnu.tar.xz" -C "${RUNNER_TEMP}/homeboy"
+          mkdir -p "${GITHUB_WORKSPACE}/homeboy"
+          gh release download "${HOMEBOY_VERSION}" --repo Extra-Chill/homeboy --pattern homeboy-x86_64-unknown-linux-gnu.tar.xz --dir "${GITHUB_WORKSPACE}/homeboy"
+          tar -xJf "${GITHUB_WORKSPACE}/homeboy/homeboy-x86_64-unknown-linux-gnu.tar.xz" -C "${GITHUB_WORKSPACE}/homeboy"
           "${HOMEBOY_BIN}" contract validate --help
       - run: node scripts/lint-rig-packages.mjs
         working-directory: homeboy-rigs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     env:
+      HOMEBOY_VERSION: v0.275.0
+      HOMEBOY_BIN: ${{ runner.temp }}/homeboy/homeboy-x86_64-unknown-linux-gnu/homeboy
       HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: ${{ github.workspace }}/homeboy-extensions/wordpress/lib/wordpress-fuzz-manifest-validator.js
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +28,12 @@ jobs:
         with:
           php-version: '8.3'
           coverage: none
+      - name: Install Homeboy
+        run: |
+          mkdir -p "${RUNNER_TEMP}/homeboy"
+          gh release download "${HOMEBOY_VERSION}" --repo Extra-Chill/homeboy --pattern homeboy-x86_64-unknown-linux-gnu.tar.xz --dir "${RUNNER_TEMP}/homeboy"
+          tar -xJf "${RUNNER_TEMP}/homeboy/homeboy-x86_64-unknown-linux-gnu.tar.xz" -C "${RUNNER_TEMP}/homeboy"
+          "${HOMEBOY_BIN}" contract validate --help
       - run: node scripts/lint-rig-packages.mjs
         working-directory: homeboy-rigs
       - name: Test fuzz contracts

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     env:
+      HOMEBOY_VERSION: v0.275.0
       HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: ${{ github.workspace }}/homeboy-extensions/wordpress/lib/wordpress-fuzz-manifest-validator.js
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +27,12 @@ jobs:
         with:
           php-version: '8.3'
           coverage: none
+      - name: Install released Homeboy
+        run: |
+          curl -fsSL -o /tmp/homeboy.tar.xz "https://github.com/Extra-Chill/homeboy/releases/download/${HOMEBOY_VERSION}/homeboy-x86_64-unknown-linux-gnu.tar.xz"
+          tar -xJf /tmp/homeboy.tar.xz -C /tmp
+          sudo install -m 0755 /tmp/homeboy-x86_64-unknown-linux-gnu/homeboy /usr/local/bin/homeboy
+          homeboy --version
       - run: node scripts/lint-rig-packages.mjs
         working-directory: homeboy-rigs
       - name: Test fuzz contracts

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,7 @@ jobs:
           tar -xJf /tmp/homeboy.tar.xz -C /tmp
           sudo install -m 0755 /tmp/homeboy-x86_64-unknown-linux-gnu/homeboy /usr/local/bin/homeboy
           homeboy --version
+          homeboy contract validate --help
       - run: node scripts/lint-rig-packages.mjs
         working-directory: homeboy-rigs
       - name: Test fuzz contracts

--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -363,10 +363,6 @@ export function assertFuzzMutationReadiness(mutation, { file } = {}) {
   return loadGenericFuzzManifestValidator().assertFuzzMutationReadiness(mutation, { file });
 }
 
-export function collectGenericFuzzWorkloadIssues(manifest, options = {}) {
-  return loadGenericFuzzManifestValidator().collectGenericFuzzWorkloadIssues(manifest, options);
-}
-
 export function assertFullSurfaceCoverageManifest(manifest, { file = manifest.property } = {}) {
   assert.equal(manifest.schema, 'homeboy-rigs/wordpress-full-surface-coverage/v1', `${file} schema mismatch`);
   assert.equal(typeof manifest.property, 'string', `${file} requires property`);

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { assertFuzzReadinessMetadata } from './fuzz-manifest-helpers.mjs';
@@ -33,6 +34,7 @@ const studioModelRigGenerator = join(root, 'scripts/generate-studio-agent-model-
 const personalPathPrefix = '/Users/' + 'chubes/';
 const localDeveloperCheckoutPattern = /(?:~|\$HOME)\/Developer\//;
 const tsrmlsPatchMarker = 'PHP-WASM-COMBINED-FIXES ' + 'TSRMLS fallback';
+const cleanupIntentContractSchema = 'homeboy/resource-cleanup-intent/v1';
 const cleanupIntents = new Set(['none', 'external', 'manual', 'pipeline']);
 const homeboyBin = process.env.HOMEBOY_BIN || 'homeboy';
 
@@ -186,6 +188,8 @@ function lintLifecycleCleanup(rel, rig) {
   const cleanup = lifecycleCleanupPolicy(rig);
 
   if (cleanup) {
+    validateHomeboyCleanupIntentContract(rel, cleanup);
+
     if (!cleanupIntents.has(cleanup.intent)) {
       failures.push(`${rel}: lifecycle.cleanup.intent must be one of ${[...cleanupIntents].join(', ')}`);
     }
@@ -200,6 +204,73 @@ function lintLifecycleCleanup(rel, rig) {
   }
 
   failures.push(`${rel}: rigs with declared resources and empty pipeline.down must declare lifecycle.cleanup intent`);
+}
+
+function cleanupContractForRigPolicy(rel, cleanup) {
+  const owner = typeof cleanup.intent === 'string' ? cleanup.intent : '';
+  const reason = typeof cleanup.reason === 'string' ? cleanup.reason : '';
+  const metadata = {
+    owner,
+    declared_by: rel,
+    reason,
+  };
+  const contract = {
+    schema: cleanupIntentContractSchema,
+    intent: cleanup.intent === 'pipeline' ? 'apply' : 'dry_run',
+    ownership: {
+      dry_run: metadata,
+    },
+  };
+
+  if (cleanup.intent === 'pipeline') {
+    contract.ownership.apply = metadata;
+  }
+
+  return contract;
+}
+
+function validateHomeboyCleanupIntentContract(rel, cleanup) {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'homeboy-rigs-cleanup-intent-'));
+  const contractFile = join(temporaryDirectory, 'cleanup-intent.json');
+
+  try {
+    writeFileSync(contractFile, `${JSON.stringify(cleanupContractForRigPolicy(rel, cleanup), null, 2)}\n`);
+    const result = spawnSync(homeboyBin, ['contract', 'validate', cleanupIntentContractSchema, '--file', contractFile], {
+      encoding: 'utf8',
+    });
+
+    if (result.error) {
+      failures.push(`${rel}: failed to run Homeboy cleanup intent contract validator: ${result.error.message}`);
+      return;
+    }
+
+    if (result.status === 0) {
+      return;
+    }
+
+    failures.push(`${rel}: lifecycle.cleanup failed Homeboy cleanup intent contract validation: ${formatHomeboyValidationFailure(result)}`);
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+function formatHomeboyValidationFailure(result) {
+  const output = `${result.stdout || ''}\n${result.stderr || ''}`.trim();
+
+  if (!output) {
+    return `validator exited with status ${result.status}`;
+  }
+
+  try {
+    const payload = JSON.parse(output);
+    const details = payload.error?.details || {};
+    const path = details.path || details.field;
+    const error = details.error || payload.error?.message;
+
+    return [path, error].filter(Boolean).join(': ') || output;
+  } catch {
+    return output;
+  }
 }
 
 function lintSharedPaths(rel, rig) {

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import {
@@ -36,7 +37,9 @@ const studioModelRigGenerator = join(root, 'scripts/generate-studio-agent-model-
 const personalPathPrefix = '/Users/' + 'chubes/';
 const localDeveloperCheckoutPattern = /(?:~|\$HOME)\/Developer\//;
 const tsrmlsPatchMarker = 'PHP-WASM-COMBINED-FIXES ' + 'TSRMLS fallback';
+const cleanupIntentContractSchema = 'homeboy/resource-cleanup-intent/v1';
 const cleanupIntents = new Set(['none', 'external', 'manual', 'pipeline']);
+const homeboyBin = process.env.HOMEBOY_BIN || 'homeboy';
 
 if (!existsSync(root)) {
   console.error(`Lint root does not exist: ${root}`);
@@ -188,6 +191,8 @@ function lintLifecycleCleanup(rel, rig) {
   const cleanup = lifecycleCleanupPolicy(rig);
 
   if (cleanup) {
+    validateHomeboyCleanupIntentContract(rel, cleanup);
+
     if (!cleanupIntents.has(cleanup.intent)) {
       failures.push(`${rel}: lifecycle.cleanup.intent must be one of ${[...cleanupIntents].join(', ')}`);
     }
@@ -202,6 +207,73 @@ function lintLifecycleCleanup(rel, rig) {
   }
 
   failures.push(`${rel}: rigs with declared resources and empty pipeline.down must declare lifecycle.cleanup intent`);
+}
+
+function cleanupContractForRigPolicy(rel, cleanup) {
+  const owner = typeof cleanup.intent === 'string' ? cleanup.intent : '';
+  const reason = typeof cleanup.reason === 'string' ? cleanup.reason : '';
+  const metadata = {
+    owner,
+    declared_by: rel,
+    reason,
+  };
+  const contract = {
+    schema: cleanupIntentContractSchema,
+    intent: cleanup.intent === 'pipeline' ? 'apply' : 'dry_run',
+    ownership: {
+      dry_run: metadata,
+    },
+  };
+
+  if (cleanup.intent === 'pipeline') {
+    contract.ownership.apply = metadata;
+  }
+
+  return contract;
+}
+
+function validateHomeboyCleanupIntentContract(rel, cleanup) {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'homeboy-rigs-cleanup-intent-'));
+  const contractFile = join(temporaryDirectory, 'cleanup-intent.json');
+
+  try {
+    writeFileSync(contractFile, `${JSON.stringify(cleanupContractForRigPolicy(rel, cleanup), null, 2)}\n`);
+    const result = spawnSync(homeboyBin, ['contract', 'validate', cleanupIntentContractSchema, '--file', contractFile], {
+      encoding: 'utf8',
+    });
+
+    if (result.error) {
+      failures.push(`${rel}: failed to run Homeboy cleanup intent contract validator: ${result.error.message}`);
+      return;
+    }
+
+    if (result.status === 0) {
+      return;
+    }
+
+    failures.push(`${rel}: lifecycle.cleanup failed Homeboy cleanup intent contract validation: ${formatHomeboyValidationFailure(result)}`);
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+function formatHomeboyValidationFailure(result) {
+  const output = `${result.stdout || ''}\n${result.stderr || ''}`.trim();
+
+  if (!output) {
+    return `validator exited with status ${result.status}`;
+  }
+
+  try {
+    const payload = JSON.parse(output);
+    const details = payload.error?.details || {};
+    const path = details.path || details.field;
+    const error = details.error || payload.error?.message;
+
+    return [path, error].filter(Boolean).join(': ') || output;
+  } catch {
+    return output;
+  }
 }
 
 function lintSharedPaths(rel, rig) {

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -4,10 +4,7 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import {
-  assertFuzzReadinessMetadata,
-  collectGenericFuzzWorkloadIssues,
-} from './fuzz-manifest-helpers.mjs';
+import { assertFuzzReadinessMetadata } from './fuzz-manifest-helpers.mjs';
 
 const args = process.argv.slice(2);
 const strictFuzzReadiness = args.includes('--strict-fuzz-readiness');
@@ -37,6 +34,7 @@ const personalPathPrefix = '/Users/' + 'chubes/';
 const localDeveloperCheckoutPattern = /(?:~|\$HOME)\/Developer\//;
 const tsrmlsPatchMarker = 'PHP-WASM-COMBINED-FIXES ' + 'TSRMLS fallback';
 const cleanupIntents = new Set(['none', 'external', 'manual', 'pipeline']);
+const homeboyBin = process.env.HOMEBOY_BIN || 'homeboy';
 
 if (!existsSync(root)) {
   console.error(`Lint root does not exist: ${root}`);
@@ -324,10 +322,8 @@ function collectFuzzWorkloads() {
   return fuzzWorkloadsByPackageRoot;
 }
 
-function validateFuzzWorkloadShape(rel, workload, context, packageRoot) {
-  for (const issue of collectGenericFuzzWorkloadIssues(workload, { context })) {
-    failures.push(`${rel}: ${issue}`);
-  }
+function validateFuzzWorkloadShape(rel, workloadFile, workload, context, packageRoot) {
+  validateGenericFuzzWorkloadContract(rel, workloadFile, context);
 
   if (workload.workload && typeof workload.workload === 'object' && !Array.isArray(workload.workload) && typeof workload.workload.path === 'string' && workload.workload.path.trim() !== '') {
     const workloadPath = resolvePackagePath(workload.workload.path, packageRoot);
@@ -337,6 +333,17 @@ function validateFuzzWorkloadShape(rel, workload, context, packageRoot) {
       failures.push(`${rel}: ${context} workload path ${relative(root, workloadPath)} does not exist`);
     }
   }
+}
+
+function validateGenericFuzzWorkloadContract(rel, file, context) {
+  const result = spawnSync(homeboyBin, ['contract', 'validate', '--file', file, 'homeboy/fuzz-workload/v1'], { encoding: 'utf8' });
+  if (result.status === 0) {
+    return;
+  }
+
+  const output = `${result.stdout || ''}${result.stderr || ''}`.trim();
+  const detail = output ? `: ${output}` : '';
+  failures.push(`${rel}: ${context} failed homeboy/fuzz-workload/v1 contract validation${detail}`);
 }
 
 function fuzzWorkloadId(workload, path) {
@@ -380,7 +387,7 @@ function lintFuzzWorkloads(rel, file, rig, fuzzWorkloadsByPackageRoot) {
         continue;
       }
 
-      validateFuzzWorkloadShape(rel, workload, `fuzz workload ${declarationRel}`, packageRoot);
+      validateFuzzWorkloadShape(rel, resolvedPath, workload, `fuzz workload ${declarationRel}`, packageRoot);
 
       const workloadId = fuzzWorkloadId(workload, resolvedPath);
       const packageWorkload = packageWorkloads.get(workloadId);
@@ -512,36 +519,9 @@ function lintFuzzWorkload(file, fuzzWorkloadValidators) {
     return;
   }
 
-  for (const issue of collectGenericFuzzWorkloadIssues(workload, { context: 'fuzz workload' })) {
-    failures.push(`${rel}: ${issue}`);
-  }
-
-  for (const field of ['surface_ids', 'operations', 'cases']) {
-    if (!Array.isArray(workload[field]) || workload[field].length === 0) {
-      failures.push(`${rel}: fuzz workload must define non-empty array field ${field}`);
-    }
-  }
-
-  if (!workload.target || typeof workload.target.type !== 'string') {
-    failures.push(`${rel}: fuzz workload must define target.type`);
-  }
-
-  if (!workload.metadata || typeof workload.metadata.kind !== 'string') {
-    failures.push(`${rel}: fuzz workload must define metadata.kind`);
-  }
-
+  validateGenericFuzzWorkloadContract(rel, file, 'fuzz workload');
   lintFuzzReadinessMetadata(rel, workload);
   lintProductFuzzWorkloadValidators(rel, file, workload, fuzzWorkloadValidators);
-
-  if (workload.limits) {
-    if (!Number.isInteger(workload.limits.max_cases) || workload.limits.max_cases < 1) {
-      failures.push(`${rel}: limits.max_cases must be a positive integer`);
-    }
-
-    if (!Number.isInteger(workload.limits.max_duration_seconds) || workload.limits.max_duration_seconds < 1) {
-      failures.push(`${rel}: limits.max_duration_seconds must be a positive integer`);
-    }
-  }
 }
 
 function lintFuzzReadinessMetadata(rel, workload) {

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -71,14 +71,61 @@ function writeFakeHomeboyBin(directory) {
   writeFileSync(bin, `#!/usr/bin/env node
 import { readFileSync } from 'node:fs';
 
-const [command, subcommand, flag, file, schema] = process.argv.slice(2);
-if (command !== 'contract' || subcommand !== 'validate' || flag !== '--file' || schema !== 'homeboy/fuzz-workload/v1') {
+const [command, subcommand, first, second, third] = process.argv.slice(2);
+if (command !== 'contract' || subcommand !== 'validate') {
   console.error(\`unexpected homeboy args: ${'${process.argv.slice(2).join(" ")}'}\`);
   process.exit(64);
 }
 
-const workload = JSON.parse(readFileSync(file, 'utf8'));
+const isFuzzWorkload = first === '--file' && third === 'homeboy/fuzz-workload/v1';
+const isCleanupIntent = first === 'homeboy/resource-cleanup-intent/v1' && second === '--file';
+const file = isFuzzWorkload ? second : third;
+const schema = isFuzzWorkload ? third : first;
+
+if (!isFuzzWorkload && !isCleanupIntent) {
+  console.error(\`unexpected homeboy args: ${'${process.argv.slice(2).join(" ")}'}\`);
+  process.exit(64);
+}
+
+const payload = JSON.parse(readFileSync(file, 'utf8'));
 const issues = [];
+
+function fail(path, error) {
+  console.log(JSON.stringify({
+    success: false,
+    error: {
+      code: 'validation.invalid_json',
+      message: 'Contract validation failed',
+      details: { path, error, schema, valid: false },
+    },
+  }));
+  process.exit(1);
+}
+
+if (isCleanupIntent) {
+  if (payload.schema !== 'homeboy/resource-cleanup-intent/v1') {
+    fail('schema', 'unexpected schema');
+  }
+  if (!['dry_run', 'apply'].includes(payload.intent)) {
+    fail('intent', 'unknown cleanup intent');
+  }
+  if (!payload.ownership?.dry_run?.owner?.trim()) {
+    fail('ownership.dry_run.owner', 'must not be blank');
+  }
+  if (!payload.ownership?.dry_run?.declared_by?.trim()) {
+    fail('ownership.dry_run.declared_by', 'must not be blank');
+  }
+  if (payload.ownership.dry_run.reason !== undefined && !payload.ownership.dry_run.reason.trim()) {
+    fail('ownership.dry_run.reason', 'must not be blank');
+  }
+  if (payload.intent === 'apply' && !payload.ownership?.apply?.owner?.trim()) {
+    fail('ownership.apply', 'apply cleanup intent requires explicit apply ownership metadata');
+  }
+  console.log(JSON.stringify({ success: true, data: { file, schema, valid: true } }));
+  process.exit(0);
+}
+
+const workload = payload;
 if (workload.schema !== 'homeboy/fuzz-workload/v1') {
   issues.push('must use schema homeboy/fuzz-workload/v1');
 }
@@ -128,7 +175,6 @@ console.log(JSON.stringify({ success: true, data: { file, schema, valid: true } 
   chmodSync(bin, 0o755);
   return bin;
 }
-
 function createRigPackage({ rig = {}, fuzzWorkloads = {}, benchWorkloads = {}, benchProfiles = {}, fuzzProfiles = {} } = {}) {
   const directory = mkdtempSync(join(tmpdir(), 'homeboy-rigs-lint-'));
   const packageRoot = join(directory, 'Vendor', 'product');
@@ -200,7 +246,7 @@ function fuzzWorkload(overrides = {}) {
   };
 }
 
-function runLint(directory) {
+function runLint(directory, env = {}) {
   return spawnSync(process.execPath, [script, directory], {
     encoding: 'utf8',
     env: {
@@ -208,6 +254,7 @@ function runLint(directory) {
       HOMEBOY_BIN: writeFakeHomeboyBin(directory),
       HOMEBOY_WORDPRESS_HELPER_MANIFEST: wordpressHelperManifest,
       HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: '',
+      ...env,
     },
   });
 }
@@ -440,6 +487,28 @@ test('accepts explicit cleanup policy for rigs with resources and empty down lif
 
   assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
   assert.doesNotMatch(result.stderr, /declared resources and empty pipeline\.down/);
+});
+
+test('validates cleanup policy metadata through the Homeboy cleanup intent contract', () => {
+  const directory = createRigPackage({
+    rig: {
+      lifecycle: {
+        cleanup: {
+          intent: 'external',
+          reason: '   ',
+        },
+      },
+    },
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+  });
+
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /lifecycle\.cleanup failed Homeboy cleanup intent contract validation/);
+  assert.match(result.stderr, /ownership\.dry_run\.reason: must not be blank/);
 });
 
 test('rejects invalid explicit cleanup policy', () => {

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -66,6 +66,65 @@ function writeJson(path, value) {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
 }
 
+function createHomeboyContractValidator() {
+  const directory = mkdtempSync(join(tmpdir(), 'homeboy-rigs-homeboy-bin-'));
+  const bin = join(directory, 'homeboy');
+
+  writeFileSync(bin, `#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+
+const [, , command, subcommand, schema, fileFlag, file] = process.argv;
+
+function fail(path, error) {
+  console.log(JSON.stringify({
+    success: false,
+    error: {
+      code: 'validation.invalid_json',
+      message: 'Contract validation failed',
+      details: { path, error, schema, valid: false },
+    },
+  }));
+  process.exit(1);
+}
+
+if (command !== 'contract' || subcommand !== 'validate' || schema !== 'homeboy/resource-cleanup-intent/v1' || fileFlag !== '--file') {
+  fail('.', 'unexpected homeboy contract validate invocation');
+}
+
+const payload = JSON.parse(readFileSync(file, 'utf8'));
+
+if (payload.schema !== 'homeboy/resource-cleanup-intent/v1') {
+  fail('schema', 'unexpected schema');
+}
+
+if (!['dry_run', 'apply'].includes(payload.intent)) {
+  fail('intent', 'unknown cleanup intent');
+}
+
+if (!payload.ownership?.dry_run?.owner?.trim()) {
+  fail('ownership.dry_run.owner', 'must not be blank');
+}
+
+if (!payload.ownership?.dry_run?.declared_by?.trim()) {
+  fail('ownership.dry_run.declared_by', 'must not be blank');
+}
+
+if (payload.ownership.dry_run.reason !== undefined && !payload.ownership.dry_run.reason.trim()) {
+  fail('ownership.dry_run.reason', 'must not be blank');
+}
+
+if (payload.intent === 'apply' && !payload.ownership?.apply?.owner?.trim()) {
+  fail('ownership.apply', 'apply cleanup intent requires explicit apply ownership metadata');
+}
+
+console.log(JSON.stringify({ success: true }));
+`, { mode: 0o755 });
+
+  return bin;
+}
+
+const homeboyContractValidator = createHomeboyContractValidator();
+
 function createRigPackage({ rig = {}, fuzzWorkloads = {}, benchWorkloads = {}, benchProfiles = {}, fuzzProfiles = {} } = {}) {
   const directory = mkdtempSync(join(tmpdir(), 'homeboy-rigs-lint-'));
   const packageRoot = join(directory, 'Vendor', 'product');
@@ -137,13 +196,15 @@ function fuzzWorkload(overrides = {}) {
   };
 }
 
-function runLint(directory) {
+function runLint(directory, env = {}) {
   return spawnSync(process.execPath, [script, directory], {
     encoding: 'utf8',
     env: {
       ...process.env,
+      HOMEBOY_BIN: homeboyContractValidator,
       HOMEBOY_WORDPRESS_HELPER_MANIFEST: wordpressHelperManifest,
       HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: '',
+      ...env,
     },
   });
 }
@@ -362,6 +423,28 @@ test('accepts explicit cleanup policy for rigs with resources and empty down lif
 
   assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
   assert.doesNotMatch(result.stderr, /declared resources and empty pipeline\.down/);
+});
+
+test('validates cleanup policy metadata through the Homeboy cleanup intent contract', () => {
+  const directory = createRigPackage({
+    rig: {
+      lifecycle: {
+        cleanup: {
+          intent: 'external',
+          reason: '   ',
+        },
+      },
+    },
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+  });
+
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /lifecycle\.cleanup failed Homeboy cleanup intent contract validation/);
+  assert.match(result.stderr, /ownership\.dry_run\.reason: must not be blank/);
 });
 
 test('rejects invalid explicit cleanup policy', () => {

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -64,6 +64,69 @@ export function validateFuzzWorkload({ rel, root, workload }) {
 
 function writeJson(path, value) {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeFakeHomeboyBin(directory) {
+  const bin = join(directory, 'fake-homeboy.mjs');
+  writeFileSync(bin, `#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+
+const [command, subcommand, flag, file, schema] = process.argv.slice(2);
+if (command !== 'contract' || subcommand !== 'validate' || flag !== '--file' || schema !== 'homeboy/fuzz-workload/v1') {
+  console.error(\`unexpected homeboy args: ${'${process.argv.slice(2).join(" ")}'}\`);
+  process.exit(64);
+}
+
+const workload = JSON.parse(readFileSync(file, 'utf8'));
+const issues = [];
+if (workload.schema !== 'homeboy/fuzz-workload/v1') {
+  issues.push('must use schema homeboy/fuzz-workload/v1');
+}
+if (typeof workload.label !== 'string' || workload.label.trim() === '') {
+  issues.push('must declare a non-empty string label');
+}
+if (!['read_only', 'idempotent', 'isolated_mutation', 'destructive'].includes(workload.safety_class)) {
+  issues.push('safety_class must be one of read_only, idempotent, isolated_mutation, destructive');
+}
+for (const testCase of workload.cases || []) {
+  if (testCase.metadata?.safety_class && testCase.metadata.safety_class !== workload.safety_class) {
+    issues.push(\`case ${'${testCase.case_id}'} metadata.safety_class must match workload safety_class ${'${workload.safety_class}'}\`);
+  }
+  if (testCase.intent && testCase.phases) {
+    issues.push('runner-neutral case intent must not embed runner command phases');
+  }
+}
+for (const field of ['surface_ids', 'operations', 'cases']) {
+  if (!Array.isArray(workload[field]) || workload[field].length === 0) {
+    issues.push(\`must define non-empty array field ${'${field}'}\`);
+  }
+}
+if (!workload.target || typeof workload.target.type !== 'string') {
+  issues.push('must define target.type');
+}
+if (!workload.metadata || typeof workload.metadata.kind !== 'string') {
+  issues.push('must define metadata.kind');
+}
+if (workload.limits) {
+  if (!Number.isInteger(workload.limits.max_cases) || workload.limits.max_cases < 1) {
+    issues.push('limits.max_cases must be a positive integer');
+  }
+  if (!Number.isInteger(workload.limits.max_duration_seconds) || workload.limits.max_duration_seconds < 1) {
+    issues.push('limits.max_duration_seconds must be a positive integer');
+  }
+}
+if (workload.intent) {
+  issues.push('top-level intent is not supported');
+}
+if (issues.length > 0) {
+  console.error(issues.join('\\n'));
+  process.exit(1);
+}
+
+console.log(JSON.stringify({ success: true, data: { file, schema, valid: true } }));
+`);
+  chmodSync(bin, 0o755);
+  return bin;
 }
 
 function createRigPackage({ rig = {}, fuzzWorkloads = {}, benchWorkloads = {}, benchProfiles = {}, fuzzProfiles = {} } = {}) {
@@ -142,6 +205,7 @@ function runLint(directory) {
     encoding: 'utf8',
     env: {
       ...process.env,
+      HOMEBOY_BIN: writeFakeHomeboyBin(directory),
       HOMEBOY_WORDPRESS_HELPER_MANIFEST: wordpressHelperManifest,
       HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: '',
     },
@@ -166,6 +230,20 @@ test('rejects missing declared fuzz workload files', () => {
 
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /declares missing file/);
+});
+
+test('delegates generic fuzz workload contract validation to Homeboy', () => {
+  const directory = createRigPackage({
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload({ schema: 'legacy/fuzz-workload' }),
+    },
+  });
+
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /failed homeboy\/fuzz-workload\/v1 contract validation/);
+  assert.match(result.stderr, /must use schema homeboy\/fuzz-workload\/v1/);
 });
 
 test('rejects committed local Developer checkout paths in rigs', () => {


### PR DESCRIPTION
## Summary
- Validate lifecycle cleanup metadata through released `homeboy contract validate homeboy/resource-cleanup-intent/v1`.
- Keep rig-specific cleanup resource policy intents local to `homeboy-rigs`.
- Add linter coverage with a test-local `HOMEBOY_BIN` contract validator shim so tests verify the integration without depending on the host Homeboy install.

## Tests
- `node --test scripts/lint-rig-packages.test.mjs`
- `node scripts/lint-rig-packages.mjs .`
- `node --test` fails in unrelated Studio bench helper fixture resolution (`HOMEBOY_WORDPRESS_HELPER_MANIFEST` / missing `wordpress-helper-consumer.js`).

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Implementing the cleanup contract validator integration, updating tests, running verification, and drafting this PR description.