### PR TITLE
Use released Homeboy fuzz workload validator

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     env:
+      HOMEBOY_VERSION: v0.275.0
       HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: ${{ github.workspace }}/homeboy-extensions/wordpress/lib/wordpress-fuzz-manifest-validator.js
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +27,12 @@ jobs:
         with:
           php-version: '8.3'
           coverage: none
+      - name: Install released Homeboy
+        run: |
+          curl -fsSL -o /tmp/homeboy.tar.xz "https://github.com/Extra-Chill/homeboy/releases/download/${HOMEBOY_VERSION}/homeboy-x86_64-unknown-linux-gnu.tar.xz"
+          tar -xJf /tmp/homeboy.tar.xz -C /tmp
+          sudo install -m 0755 /tmp/homeboy-x86_64-unknown-linux-gnu/homeboy /usr/local/bin/homeboy
+          homeboy --version
       - run: node scripts/lint-rig-packages.mjs
         working-directory: homeboy-rigs
       - name: Test fuzz contracts

--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -363,10 +363,6 @@ export function assertFuzzMutationReadiness(mutation, { file } = {}) {
   return loadGenericFuzzManifestValidator().assertFuzzMutationReadiness(mutation, { file });
 }
 
-export function collectGenericFuzzWorkloadIssues(manifest, options = {}) {
-  return loadGenericFuzzManifestValidator().collectGenericFuzzWorkloadIssues(manifest, options);
-}
-
 export function assertFullSurfaceCoverageManifest(manifest, { file = manifest.property } = {}) {
   assert.equal(manifest.schema, 'homeboy-rigs/wordpress-full-surface-coverage/v1', `${file} schema mismatch`);
   assert.equal(typeof manifest.property, 'string', `${file} requires property`);

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -4,10 +4,7 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import {
-  assertFuzzReadinessMetadata,
-  collectGenericFuzzWorkloadIssues,
-} from './fuzz-manifest-helpers.mjs';
+import { assertFuzzReadinessMetadata } from './fuzz-manifest-helpers.mjs';
 
 const args = process.argv.slice(2);
 const strictFuzzReadiness = args.includes('--strict-fuzz-readiness');
@@ -37,6 +34,7 @@ const personalPathPrefix = '/Users/' + 'chubes/';
 const localDeveloperCheckoutPattern = /(?:~|\$HOME)\/Developer\//;
 const tsrmlsPatchMarker = 'PHP-WASM-COMBINED-FIXES ' + 'TSRMLS fallback';
 const cleanupIntents = new Set(['none', 'external', 'manual', 'pipeline']);
+const homeboyBin = process.env.HOMEBOY_BIN || 'homeboy';
 
 if (!existsSync(root)) {
   console.error(`Lint root does not exist: ${root}`);
@@ -324,10 +322,8 @@ function collectFuzzWorkloads() {
   return fuzzWorkloadsByPackageRoot;
 }
 
-function validateFuzzWorkloadShape(rel, workload, context, packageRoot) {
-  for (const issue of collectGenericFuzzWorkloadIssues(workload, { context })) {
-    failures.push(`${rel}: ${issue}`);
-  }
+function validateFuzzWorkloadShape(rel, workloadFile, workload, context, packageRoot) {
+  validateGenericFuzzWorkloadContract(rel, workloadFile, context);
 
   if (workload.workload && typeof workload.workload === 'object' && !Array.isArray(workload.workload) && typeof workload.workload.path === 'string' && workload.workload.path.trim() !== '') {
     const workloadPath = resolvePackagePath(workload.workload.path, packageRoot);
@@ -337,6 +333,17 @@ function validateFuzzWorkloadShape(rel, workload, context, packageRoot) {
       failures.push(`${rel}: ${context} workload path ${relative(root, workloadPath)} does not exist`);
     }
   }
+}
+
+function validateGenericFuzzWorkloadContract(rel, file, context) {
+  const result = spawnSync(homeboyBin, ['contract', 'validate', '--file', file, 'homeboy/fuzz-workload/v1'], { encoding: 'utf8' });
+  if (result.status === 0) {
+    return;
+  }
+
+  const output = `${result.stdout || ''}${result.stderr || ''}`.trim();
+  const detail = output ? `: ${output}` : '';
+  failures.push(`${rel}: ${context} failed homeboy/fuzz-workload/v1 contract validation${detail}`);
 }
 
 function fuzzWorkloadId(workload, path) {
@@ -380,7 +387,7 @@ function lintFuzzWorkloads(rel, file, rig, fuzzWorkloadsByPackageRoot) {
         continue;
       }
 
-      validateFuzzWorkloadShape(rel, workload, `fuzz workload ${declarationRel}`, packageRoot);
+      validateFuzzWorkloadShape(rel, resolvedPath, workload, `fuzz workload ${declarationRel}`, packageRoot);
 
       const workloadId = fuzzWorkloadId(workload, resolvedPath);
       const packageWorkload = packageWorkloads.get(workloadId);
@@ -512,36 +519,9 @@ function lintFuzzWorkload(file, fuzzWorkloadValidators) {
     return;
   }
 
-  for (const issue of collectGenericFuzzWorkloadIssues(workload, { context: 'fuzz workload' })) {
-    failures.push(`${rel}: ${issue}`);
-  }
-
-  for (const field of ['surface_ids', 'operations', 'cases']) {
-    if (!Array.isArray(workload[field]) || workload[field].length === 0) {
-      failures.push(`${rel}: fuzz workload must define non-empty array field ${field}`);
-    }
-  }
-
-  if (!workload.target || typeof workload.target.type !== 'string') {
-    failures.push(`${rel}: fuzz workload must define target.type`);
-  }
-
-  if (!workload.metadata || typeof workload.metadata.kind !== 'string') {
-    failures.push(`${rel}: fuzz workload must define metadata.kind`);
-  }
-
+  validateGenericFuzzWorkloadContract(rel, file, 'fuzz workload');
   lintFuzzReadinessMetadata(rel, workload);
   lintProductFuzzWorkloadValidators(rel, file, workload, fuzzWorkloadValidators);
-
-  if (workload.limits) {
-    if (!Number.isInteger(workload.limits.max_cases) || workload.limits.max_cases < 1) {
-      failures.push(`${rel}: limits.max_cases must be a positive integer`);
-    }
-
-    if (!Number.isInteger(workload.limits.max_duration_seconds) || workload.limits.max_duration_seconds < 1) {
-      failures.push(`${rel}: limits.max_duration_seconds must be a positive integer`);
-    }
-  }
 }
 
 function lintFuzzReadinessMetadata(rel, workload) {

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -64,6 +64,69 @@ export function validateFuzzWorkload({ rel, root, workload }) {
 
 function writeJson(path, value) {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeFakeHomeboyBin(directory) {
+  const bin = join(directory, 'fake-homeboy.mjs');
+  writeFileSync(bin, `#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+
+const [command, subcommand, flag, file, schema] = process.argv.slice(2);
+if (command !== 'contract' || subcommand !== 'validate' || flag !== '--file' || schema !== 'homeboy/fuzz-workload/v1') {
+  console.error(\`unexpected homeboy args: ${'${process.argv.slice(2).join(" ")}'}\`);
+  process.exit(64);
+}
+
+const workload = JSON.parse(readFileSync(file, 'utf8'));
+const issues = [];
+if (workload.schema !== 'homeboy/fuzz-workload/v1') {
+  issues.push('must use schema homeboy/fuzz-workload/v1');
+}
+if (typeof workload.label !== 'string' || workload.label.trim() === '') {
+  issues.push('must declare a non-empty string label');
+}
+if (!['read_only', 'idempotent', 'isolated_mutation', 'destructive'].includes(workload.safety_class)) {
+  issues.push('safety_class must be one of read_only, idempotent, isolated_mutation, destructive');
+}
+for (const testCase of workload.cases || []) {
+  if (testCase.metadata?.safety_class && testCase.metadata.safety_class !== workload.safety_class) {
+    issues.push(\`case ${'${testCase.case_id}'} metadata.safety_class must match workload safety_class ${'${workload.safety_class}'}\`);
+  }
+  if (testCase.intent && testCase.phases) {
+    issues.push('runner-neutral case intent must not embed runner command phases');
+  }
+}
+for (const field of ['surface_ids', 'operations', 'cases']) {
+  if (!Array.isArray(workload[field]) || workload[field].length === 0) {
+    issues.push(\`must define non-empty array field ${'${field}'}\`);
+  }
+}
+if (!workload.target || typeof workload.target.type !== 'string') {
+  issues.push('must define target.type');
+}
+if (!workload.metadata || typeof workload.metadata.kind !== 'string') {
+  issues.push('must define metadata.kind');
+}
+if (workload.limits) {
+  if (!Number.isInteger(workload.limits.max_cases) || workload.limits.max_cases < 1) {
+    issues.push('limits.max_cases must be a positive integer');
+  }
+  if (!Number.isInteger(workload.limits.max_duration_seconds) || workload.limits.max_duration_seconds < 1) {
+    issues.push('limits.max_duration_seconds must be a positive integer');
+  }
+}
+if (workload.intent) {
+  issues.push('top-level intent is not supported');
+}
+if (issues.length > 0) {
+  console.error(issues.join('\\n'));
+  process.exit(1);
+}
+
+console.log(JSON.stringify({ success: true, data: { file, schema, valid: true } }));
+`);
+  chmodSync(bin, 0o755);
+  return bin;
 }
 
 function createRigPackage({ rig = {}, fuzzWorkloads = {}, benchWorkloads = {}, benchProfiles = {}, fuzzProfiles = {} } = {}) {
@@ -142,6 +205,7 @@ function runLint(directory) {
     encoding: 'utf8',
     env: {
       ...process.env,
+      HOMEBOY_BIN: writeFakeHomeboyBin(directory),
       HOMEBOY_WORDPRESS_HELPER_MANIFEST: wordpressHelperManifest,
       HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: '',
     },
@@ -166,6 +230,20 @@ test('rejects missing declared fuzz workload files', () => {
 
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /declares missing file/);
+});
+
+test('delegates generic fuzz workload contract validation to Homeboy', () => {
+  const directory = createRigPackage({
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload({ schema: 'legacy/fuzz-workload' }),
+    },
+  });
+
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /failed homeboy\/fuzz-workload\/v1 contract validation/);
+  assert.match(result.stderr, /must use schema homeboy\/fuzz-workload\/v1/);
 });
 
 test('rejects committed local Developer checkout paths in rigs', () => {


### PR DESCRIPTION
## Summary
- Delegate generic fuzz workload shape validation in rig lint to `homeboy contract validate --file <path> homeboy/fuzz-workload/v1`.
- Keep rig-local policy checks, product validators, readiness metadata checks, path existence, uniqueness, and profile validation local.
- Remove the unused generic fuzz issue collector wrapper and cover the CLI delegation in lint tests with a fake Homeboy binary.

## Tests
- `HOMEBOY_BIN=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-v0.275.0/homeboy-aarch64-apple-darwin/homeboy node scripts/lint-rig-packages.mjs .`
- `node --test scripts/lint-rig-packages.test.mjs scripts/fuzz-manifest-helpers.test.mjs`
- `HOMEBOY_BIN=/var/folders/lr/c_cmmt7s0592m4njz99v5yb40000gn/T/opencode/homeboy-v0.275.0/homeboy-aarch64-apple-darwin/homeboy node --test **/*.test.mjs` failed with 8 pre-existing Studio helper fixture env failures around missing `HOMEBOY_WORDPRESS_HELPER_MANIFEST`.
- Retried full suite with `HOMEBOY_WORDPRESS_HELPER_MANIFEST` set; still failed with 11 missing `wordpress-helper-consumer.js` fixture errors unrelated to this lint path.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Code changes, test updates, verification, and PR preparation.