### PR TITLE
Require injected helper paths in shared loaders

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HOMEBOY_VERSION: v0.275.0
+      HOMEBOY_NODEJS_WORKLOAD_UTILS: ${{ github.workspace }}/homeboy-extensions/nodejs/scripts/bench/lib/workload-utils.mjs
       HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: ${{ github.workspace }}/homeboy-extensions/wordpress/lib/wordpress-fuzz-manifest-validator.js
       HOMEBOY_WORDPRESS_HELPER_MANIFEST: ${{ github.workspace }}/homeboy-extensions/wordpress/lib/helper-manifest.js
     steps:
@@ -36,6 +37,12 @@ jobs:
           homeboy --version
           homeboy contract validate --help
       - run: node scripts/lint-rig-packages.mjs
+        working-directory: homeboy-rigs
+      - name: Test shared helper loaders
+        run: >-
+          node --test
+          shared/nodejs-workload-utils-loader.test.mjs
+          shared/wordpress-helper-loader.test.mjs
         working-directory: homeboy-rigs
       - name: Test fuzz contracts
         run: >-

--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ homeboy rig check studio-combined
 `homeboy rig check` reports generic package lint failures such as unresolved conflict markers and invalid JSON before running the rig's own check pipeline. This repo also keeps a lightweight package lint for PHP syntax, portable source paths, generated rig drift, `fuzz_profiles` references that drift from `fuzz_workloads`, and WordPress plugin fuzz workload IDs accidentally reappearing in `bench_workloads` or `bench_profiles`:
 
 ```bash
-export HOMEBOY_WORDPRESS_HELPER_MANIFEST=/path/to/homeboy-extension-wordpress/lib/helper-manifest.js
+export HOMEBOY_NODEJS_WORKLOAD_UTILS=/path/to/homeboy-extensions/nodejs/scripts/bench/lib/workload-utils.mjs
+export HOMEBOY_WORDPRESS_HELPER_MANIFEST=/path/to/homeboy-extensions/wordpress/lib/helper-manifest.js
 node scripts/lint-rig-packages.mjs
 ```
 
-GitHub Actions runs the package lint with PHP installed.
+GitHub Actions runs the package lint with PHP installed and injects Homeboy Extensions helper paths explicitly. Shared loaders fail with setup guidance when those paths are absent; they do not guess local sibling checkouts.
 
 ## Automattic/studio
 
@@ -264,8 +265,8 @@ Mixed-source prompt variants such as `astro-docs-content-collection`, `markdown-
 Keep the Studio bench harness layered so each repo owns the smallest stable surface it can support:
 
 - `homeboy-rigs` owns Studio-specific workloads, prompts, and experimental harness wiring while APIs are still moving.
-- `homeboy-extensions/nodejs` owns generic Node benchmark settings, command, artifact, and redaction helpers used by Studio workloads.
-- `homeboy-extensions/wordpress` owns generic WordPress helper discovery, WP Codebox recipe execution, and block quality probes once their contracts are stable.
+- `homeboy-extensions/nodejs` owns generic Node benchmark settings, command, artifact, and redaction helpers used by Studio workloads. Rigs consume those helpers through the injected `HOMEBOY_NODEJS_WORKLOAD_UTILS` path.
+- `homeboy-extensions/wordpress` owns generic WordPress helper manifests, WP Codebox recipe execution, and block quality probes once their contracts are stable. Rigs consume those helpers through `HOMEBOY_WORDPRESS_HELPER_MANIFEST` or a helper-specific injected env path.
 - `homeboy` core owns benchmark orchestration only; it should stay generic and substrate-agnostic.
 
 Issue [#185](https://github.com/chubes4/homeboy-rigs/issues/185) tracks thinning duplicated helper logic after upstream promotion. Studio native-block quality probing now uses the promoted Homeboy Extensions block quality probes from `Extra-Chill/homeboy-extensions#1009`; target post metrics remain tracked in `Extra-Chill/homeboy-extensions#1018`. Studio fixture plugin install/restore now delegates to the Homeboy Extensions fixture setup helper from `Extra-Chill/homeboy-extensions#1134`, and helper discovery consumes promoted helper-manifest paths from `Extra-Chill/homeboy-extensions#1141`; rigs should not add local fallback shims for those contracts.
@@ -350,7 +351,7 @@ performance-observation contracts without adding a `homeboy bench` fallback.
 ```bash
 homeboy rig install $HOME/Developer/homeboy-rigs@<branch>/WordPress/wordpress-develop
 homeboy rig check wordpress-core-fuzz-coverage
-export HOMEBOY_WORDPRESS_HELPER_MANIFEST=/path/to/homeboy-extension-wordpress/lib/helper-manifest.js
+export HOMEBOY_WORDPRESS_HELPER_MANIFEST=/path/to/homeboy-extensions/wordpress/lib/helper-manifest.js
 node scripts/lint-rig-packages.mjs WordPress/wordpress-develop
 ```
 

--- a/shared/nodejs-workload-utils-loader.mjs
+++ b/shared/nodejs-workload-utils-loader.mjs
@@ -1,35 +1,20 @@
-import { existsSync } from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import { pathToFileURL } from 'node:url';
 
 const bootstrapCommand = 'homeboy extension setup nodejs';
 const envVar = 'HOMEBOY_NODEJS_WORKLOAD_UTILS';
 const helperRelativePath = path.join('nodejs', 'scripts', 'bench', 'lib', 'workload-utils.mjs');
 
-function siblingExtensionsPath() {
-  // shared/ lives at the homeboy-rigs repo root; the homeboy-extensions
-  // checkout is a sibling of that repo root.
-  const repoRoot = path.resolve(__dirname, '..');
-  return path.join(path.dirname(repoRoot), 'homeboy-extensions', helperRelativePath);
-}
-
 function resolveWorkloadUtilsPath() {
-  const explicit = process.env[envVar];
-  if (explicit) {
-    return explicit;
-  }
-
-  const sibling = siblingExtensionsPath();
-  return existsSync(sibling) ? sibling : '';
+  return process.env[envVar] || '';
 }
 
 function workloadUtilsDiagnostic() {
   return [
     'Homeboy Extensions Node workload utilities are unavailable.',
-    `Run ${bootstrapCommand}, then export:`,
+    `Run ${bootstrapCommand}, then inject the helper path explicitly:`,
     `  ${envVar}=/path/to/homeboy-extensions/${helperRelativePath}`,
+    'This loader does not discover local sibling checkouts.',
   ].join('\n');
 }
 

--- a/shared/nodejs-workload-utils-loader.test.mjs
+++ b/shared/nodejs-workload-utils-loader.test.mjs
@@ -46,3 +46,13 @@ test('Node workload-utils loader imports the module named by HOMEBOY_NODEJS_WORK
   assert.equal(module.marker, 'explicit-env');
   assert.equal(module.metric(2.5), 2.5);
 });
+
+test('Node workload-utils loader reports actionable setup when no helper path is injected', async () => {
+  await assert.rejects(
+    () => withEnv(
+      { HOMEBOY_NODEJS_WORKLOAD_UTILS: undefined },
+      () => loadNodeWorkloadUtils()
+    ),
+    /homeboy extension setup nodejs[\s\S]*HOMEBOY_NODEJS_WORKLOAD_UTILS[\s\S]*does not discover local sibling checkouts/
+  );
+});

--- a/shared/wordpress-helper-loader.mjs
+++ b/shared/wordpress-helper-loader.mjs
@@ -7,7 +7,7 @@ const bootstrapCommand = 'homeboy extension setup wordpress';
 
 function helperDiagnostic({ helperName, envVar }) {
   const envLines = [
-    `HOMEBOY_WORDPRESS_HELPER_MANIFEST=/path/to/homeboy-extension-wordpress/lib/helper-manifest.js`,
+    `HOMEBOY_WORDPRESS_HELPER_MANIFEST=/path/to/homeboy-extensions/wordpress/lib/helper-manifest.js`,
   ];
 
   if (envVar) {
@@ -16,9 +16,20 @@ function helperDiagnostic({ helperName, envVar }) {
 
   return [
     `Homeboy WordPress helper "${helperName}" is unavailable.`,
-    `Run ${bootstrapCommand}, then export one of the injected helper contracts:`,
+    `Run ${bootstrapCommand}, then inject one of the helper contract paths explicitly:`,
     ...envLines.map((line) => `  ${line}`),
+    'This loader does not discover local sibling checkouts.',
   ].filter(Boolean).join('\n');
+}
+
+function invalidManifestDiagnostic({ helperName, manifestPath }) {
+  return [
+    `Homeboy WordPress helper "${helperName}" could not be resolved from HOMEBOY_WORDPRESS_HELPER_MANIFEST.`,
+    `Manifest path: ${manifestPath}`,
+    'Expected the manifest module to expose getWordPressHelperManifest() or WORDPRESS_HELPER_MANIFEST with an extensionRoot string.',
+    `Run ${bootstrapCommand}, then inject the generated helper manifest path explicitly:`,
+    '  HOMEBOY_WORDPRESS_HELPER_MANIFEST=/path/to/homeboy-extensions/wordpress/lib/helper-manifest.js',
+  ].join('\n');
 }
 
 function requireHelper(filePath, context) {
@@ -46,12 +57,13 @@ export function loadWordPressHelperModule({ helperName, envVar, manifestFileName
   const manifestPath = process.env.HOMEBOY_WORDPRESS_HELPER_MANIFEST;
   if (manifestPath) {
     const manifest = loadHelperManifest(manifestPath);
-    if (manifest?.extensionRoot) {
-      return requireHelper(
-        path.join(manifest.extensionRoot, 'lib', manifestFileName),
-        `Failed to load ${helperName} from HOMEBOY_WORDPRESS_HELPER_MANIFEST`
-      );
+    if (typeof manifest?.extensionRoot !== 'string' || manifest.extensionRoot.trim() === '') {
+      throw new Error(invalidManifestDiagnostic({ helperName, manifestPath }));
     }
+    return requireHelper(
+      path.join(manifest.extensionRoot, 'lib', manifestFileName),
+      `Failed to load ${helperName} from HOMEBOY_WORDPRESS_HELPER_MANIFEST`
+    );
   }
 
   throw new Error(helperDiagnostic({ helperName, envVar }));

--- a/shared/wordpress-helper-loader.test.mjs
+++ b/shared/wordpress-helper-loader.test.mjs
@@ -41,7 +41,28 @@ test('WordPress helper loader reports actionable setup when no helper contract i
       envVar: 'HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR',
       manifestFileName: 'wordpress-fuzz-manifest-validator.js',
     })),
-    /homeboy extension setup wordpress[\s\S]*HOMEBOY_WORDPRESS_HELPER_MANIFEST[\s\S]*HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR/
+    /homeboy extension setup wordpress[\s\S]*HOMEBOY_WORDPRESS_HELPER_MANIFEST[\s\S]*HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR[\s\S]*does not discover local sibling checkouts/
+  );
+});
+
+test('WordPress helper loader rejects manifest contracts without extensionRoot', async () => {
+  const extensionRoot = await mkdtemp(path.join(tmpdir(), 'wordpress-helper-extension-invalid-'));
+  const libRoot = path.join(extensionRoot, 'lib');
+  const manifestPath = path.join(libRoot, 'helper-manifest.js');
+
+  await mkdir(libRoot, { recursive: true });
+  await writeFile(manifestPath, `module.exports = { WORDPRESS_HELPER_MANIFEST: {} };\n`, 'utf8');
+
+  assert.throws(
+    () => withEnv({
+      HOMEBOY_WORDPRESS_HELPER_MANIFEST: manifestPath,
+      HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR: undefined,
+    }, () => loadWordPressHelperModule({
+      helperName: 'example-helper',
+      envVar: 'HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR',
+      manifestFileName: 'example-helper.js',
+    })),
+    /HOMEBOY_WORDPRESS_HELPER_MANIFEST[\s\S]*extensionRoot string[\s\S]*homeboy extension setup wordpress/
   );
 });
 


### PR DESCRIPTION
## Summary
- Remove local sibling-checkout discovery from the Node workload-utils loader so it only consumes HOMEBOY_NODEJS_WORKLOAD_UTILS.
- Tighten WordPress helper loader diagnostics for missing helper contracts and invalid helper manifests.
- Document explicit Homeboy Extensions helper path injection and run shared loader tests in CI.

## Tests
- node --test shared/nodejs-workload-utils-loader.test.mjs shared/wordpress-helper-loader.test.mjs
- HOMEBOY_WORDPRESS_HELPER_MANIFEST="/Users/chubes/Developer/homeboy-rigs@cook-remove-helper-fallbacks-20260701/scripts/fixtures/homeboy-extension-wordpress/lib/helper-manifest.js" node scripts/lint-rig-packages.mjs
- node --test WordPress/gutenberg/tools/fuzz-coverage.test.mjs WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated the shared helper loaders, removed local fallback discovery, updated docs/tests/CI, and ran verification checks.