### PR TITLE
Prune dead rig lint scaffolding

### DIFF
--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -11,15 +11,7 @@ const args = process.argv.slice(2);
 const strictFuzzReadiness = args.includes('--strict-fuzz-readiness');
 const rootArg = args.find((arg) => !arg.startsWith('--'));
 const root = rootArg ? resolve(process.cwd(), rootArg) : process.cwd();
-// Keep this set a superset of homeboy core's `IGNORED_DIRECTORIES`
-// (src/core/rig/lint.rs) so a rig package never passes one linter and fails the
-// other. Core ignores `.sampleplugin` (generated WP Codebox sample-plugin
-// scaffolds); homeboy-rigs additionally has a real top-level `.datamachine/`.
-// The unified policy is the union of both. Converging this linter onto the core
-// primitive is tracked in Extra-Chill/homeboy#6783; the lint-only entry point
-// CI needs to consume `run_package_lint` (and the matching core `.datamachine`
-// ignore) is tracked in Extra-Chill/homeboy#6825.
-const ignoredDirectories = new Set(['.git', '.claude', '.sampleplugin', '.datamachine', '.opencode', 'node_modules', 'vendor']);
+const ignoredDirectories = new Set(['.git', '.claude', '.datamachine', '.opencode', 'node_modules', 'vendor']);
 const phpFiles = [];
 const rigFiles = [];
 const jsonFiles = [];
@@ -30,7 +22,6 @@ const fuzzWorkloadValidatorFiles = [];
 const portableSourceValidatorFiles = [];
 const failures = [];
 const warnings = [];
-const studioModelRigGenerator = join(root, 'scripts/generate-studio-agent-model-rigs.mjs');
 const personalPathPrefix = '/Users/' + 'chubes/';
 const localDeveloperCheckoutPattern = /(?:~|\$HOME)\/Developer\//;
 const tsrmlsPatchMarker = 'PHP-WASM-COMBINED-FIXES ' + 'TSRMLS fallback';
@@ -705,18 +696,6 @@ function reportWarnings() {
   }
 }
 
-function lintGeneratedStudioModelRigs() {
-  if (!existsSync(studioModelRigGenerator)) {
-    return;
-  }
-
-  const result = spawnSync('node', [studioModelRigGenerator, '--check'], { encoding: 'utf8' });
-  if (result.status !== 0) {
-    const output = `${result.stdout || ''}${result.stderr || ''}`.trim();
-    failures.push(`Studio agent model rig generation check failed${output ? `: ${output}` : ''}`);
-  }
-}
-
 function lintFuzzManifestValidators() {
   for (const validator of fuzzManifestValidators) {
     const result = spawnSync('node', [validator], { encoding: 'utf8' });
@@ -736,7 +715,6 @@ const fuzzWorkloadsByPackageRoot = collectFuzzWorkloads();
 rigFiles.forEach((file) => lintRigPortability(file, fuzzWorkloadsByPackageRoot));
 fuzzWorkloadFiles.forEach((file) => lintFuzzWorkload(file, fuzzWorkloadValidators));
 portableSourceFiles.forEach((file) => lintPortableSource(file, portableSourceValidators));
-lintGeneratedStudioModelRigs();
 lintFuzzManifestValidators();
 
 reportFailures();

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -92,7 +92,6 @@ if (!isFuzzWorkload && !isCleanupIntent) {
 }
 
 const payload = JSON.parse(readFileSync(file, 'utf8'));
-const issues = [];
 
 function fail(path, error) {
   console.log(JSON.stringify({
@@ -131,46 +130,7 @@ if (isCleanupIntent) {
 
 const workload = payload;
 if (workload.schema !== 'homeboy/fuzz-workload/v1') {
-  issues.push('must use schema homeboy/fuzz-workload/v1');
-}
-if (typeof workload.label !== 'string' || workload.label.trim() === '') {
-  issues.push('must declare a non-empty string label');
-}
-if (!['read_only', 'idempotent', 'isolated_mutation', 'destructive'].includes(workload.safety_class)) {
-  issues.push('safety_class must be one of read_only, idempotent, isolated_mutation, destructive');
-}
-for (const testCase of workload.cases || []) {
-  if (testCase.metadata?.safety_class && testCase.metadata.safety_class !== workload.safety_class) {
-    issues.push(\`case ${'${testCase.case_id}'} metadata.safety_class must match workload safety_class ${'${workload.safety_class}'}\`);
-  }
-  if (testCase.intent && testCase.phases) {
-    issues.push('runner-neutral case intent must not embed runner command phases');
-  }
-}
-for (const field of ['surface_ids', 'operations', 'cases']) {
-  if (!Array.isArray(workload[field]) || workload[field].length === 0) {
-    issues.push(\`must define non-empty array field ${'${field}'}\`);
-  }
-}
-if (!workload.target || typeof workload.target.type !== 'string') {
-  issues.push('must define target.type');
-}
-if (!workload.metadata || typeof workload.metadata.kind !== 'string') {
-  issues.push('must define metadata.kind');
-}
-if (workload.limits) {
-  if (!Number.isInteger(workload.limits.max_cases) || workload.limits.max_cases < 1) {
-    issues.push('limits.max_cases must be a positive integer');
-  }
-  if (!Number.isInteger(workload.limits.max_duration_seconds) || workload.limits.max_duration_seconds < 1) {
-    issues.push('limits.max_duration_seconds must be a positive integer');
-  }
-}
-if (workload.intent) {
-  issues.push('top-level intent is not supported');
-}
-if (issues.length > 0) {
-  console.error(issues.join('\\n'));
+  console.error('must use schema homeboy/fuzz-workload/v1');
   process.exit(1);
 }
 
@@ -555,79 +515,6 @@ test('rejects committed local Developer checkout paths in stacks', () => {
 
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /stacks\/combined\.json: use portable component path settings/);
-});
-
-test('rejects invalid declared fuzz workload shapes', () => {
-  const directory = createRigPackage({
-    fuzzWorkloads: {
-      'generic-fuzz': fuzzWorkload({ schema: 'wrong', label: '' }),
-    },
-  });
-  const result = runLint(directory);
-
-  assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /must use schema homeboy\/fuzz-workload\/v1/);
-  assert.match(result.stderr, /must declare a non-empty string label/);
-});
-
-test('rejects fuzz workload safety classes outside the Homeboy contract', () => {
-  const directory = createRigPackage({
-    fuzzWorkloads: {
-      'generic-fuzz': fuzzWorkload({ safety_class: 'read_only_inventory' }),
-    },
-  });
-  const result = runLint(directory);
-
-  assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /safety_class must be one of read_only, idempotent, isolated_mutation, destructive/);
-});
-
-test('rejects fuzz case safety classes that drift from the workload', () => {
-  const directory = createRigPackage({
-    fuzzWorkloads: {
-      'generic-fuzz': fuzzWorkload({
-        safety_class: 'read_only',
-        cases: [
-          { case_id: 'generic-fuzz:default', metadata: { safety_class: 'isolated_mutation' } },
-        ],
-      }),
-    },
-  });
-  const result = runLint(directory);
-
-  assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /case generic-fuzz:default metadata\.safety_class must match workload safety_class read_only/);
-});
-
-test('rejects runner-neutral fuzz intent that embeds command phases', () => {
-  const directory = createRigPackage({
-    fuzzWorkloads: {
-      'generic-fuzz': fuzzWorkload({
-        cases: [
-          {
-            case_id: 'generic-fuzz:default',
-            phases: { action: [{ command: 'wordpress.run-workload' }] },
-            artifacts: [{ name: 'generic_report' }],
-            intent: {
-              schema: 'homeboy/fuzz-workload-intent/v1',
-              type: 'wordpress-plugin-workload',
-              plugin: { activation: 'generic/generic.php' },
-              execute: {
-                workload_ref: 'default',
-                path: '${package.root}/bench/generic.workload.json',
-                type: 'json',
-              },
-              collect: [{ artifact: 'generic_report' }],
-            },
-          },
-        ],
-      }),
-    },
-  });
-  const result = runLint(directory);
-
-  assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /runner-neutral case intent must not embed runner command phases/);
 });
 
 test('rejects missing fuzz workload backing files', () => {


### PR DESCRIPTION
## Summary
- Remove the dead Studio model rig generator check from the rig package linter now that model comparison rigs use Homeboy template inheritance.
- Stop mirroring Homeboy core ignored-directory scaffolding in the rigs lint walker; keep only repo-local ignores.
- Trim lint tests that duplicated Homeboy's generic fuzz workload contract internals while keeping delegation and product-specific validator coverage.

## Tests
- `node --test scripts/lint-rig-packages.test.mjs scripts/fuzz-manifest-helpers.test.mjs scripts/fuzz-coverage-matrix.test.mjs`
- `HOMEBOY_WORDPRESS_HELPER_MANIFEST=/Users/chubes/Developer/homeboy-extensions@cook-remove-dead-compat-wrappers-20260701/wordpress/lib/helper-manifest.js HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR=/Users/chubes/Developer/homeboy-extensions@cook-remove-dead-compat-wrappers-20260701/wordpress/lib/wordpress-fuzz-manifest-validator.js node scripts/lint-rig-packages.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated the rig lint scaffolding, made the cleanup, ran focused tests/lint, and drafted this PR description.