### PR TITLE
Thin Studio invocation runtime setup

### DIFF
--- a/Automattic/studio/bench/lib/site-build-runtime.mjs
+++ b/Automattic/studio/bench/lib/site-build-runtime.mjs
@@ -15,7 +15,7 @@ import {
 } from './studio-bench.mjs';
 
 const DEFAULT_STUDIO_PORT = 8881;
-const INVOCATION_NAMESPACE = 'studio-agent-site-build';
+export const INVOCATION_NAMESPACE = 'studio-agent-site-build';
 const WORKFLOW_BENCH_SCENARIO_SETTING = 'studio_workflow_bench_scenario_id';
 const WORKFLOW_BENCH_ROOT_SETTING = 'studio_workflow_bench_root';
 const MODEL_SETTING = 'studio_agent_model';
@@ -34,7 +34,7 @@ function envPath(key) {
   return typeof process.env[key] === 'string' && process.env[key] ? process.env[key] : '';
 }
 
-export async function createStudioBenchRuntime(sharedState = SHARED_STATE) {
+export async function createInvocationRuntime({ namespace, sharedState = SHARED_STATE }) {
   const helperPath = envPath('HOMEBOY_NODEJS_INVOCATION_RUNTIME_HELPER');
   if (!helperPath) {
     throw new Error(
@@ -43,39 +43,50 @@ export async function createStudioBenchRuntime(sharedState = SHARED_STATE) {
   }
 
   const { resolveHomeboyInvocationRuntime } = await import(helperPath);
-  const invocationRuntime = resolveHomeboyInvocationRuntime({ namespace: INVOCATION_NAMESPACE });
+  const invocationRuntime = resolveHomeboyInvocationRuntime({ namespace });
   const stateDir = invocationRuntime.dirs.state || '';
   const artifactDir =
-    invocationRuntime.baseDirs.artifact || path.join(sharedState, 'studio-agent-site-build-artifacts');
+    invocationRuntime.baseDirs.artifact || path.join(sharedState, `${namespace}-artifacts`);
   const tmpDir = invocationRuntime.dirs.tmp || (stateDir ? path.join(stateDir, 'tmp') : '');
-  const cliConfigDir = stateDir ? path.join(stateDir, 'cli-config') : '';
-  const appDataDir = stateDir ? path.join(stateDir, 'appdata') : '';
-  const processManagerHome = stateDir ? path.join(stateDir, 'daemon') : '';
-  const portBase = invocationRuntime.portRange?.base ?? null;
-  const portMax = invocationRuntime.portRange?.max ?? null;
 
   return {
     invocationId: invocationRuntime.invocationId || '',
     artifactDir,
-    siteRoot: stateDir ? path.join(stateDir, 'sites') : path.join(artifactDir, 'sites'),
     stateDir,
+    tmpDir,
+    portBase: invocationRuntime.portRange?.base ?? null,
+    portMax: invocationRuntime.portRange?.max ?? null,
+    childEnv: (extra = {}) => (invocationRuntime.isolated ? invocationRuntime.childEnv(extra) : {}),
+    prepareDirs: () => invocationRuntime.prepareDirs(),
+    assertPort: invocationRuntime.assertPort,
+  };
+}
+
+export async function createStudioBenchRuntime(sharedState = SHARED_STATE) {
+  const invocationRuntime = await createInvocationRuntime({
+    namespace: INVOCATION_NAMESPACE,
+    sharedState,
+  });
+  const cliConfigDir = invocationRuntime.stateDir ? path.join(invocationRuntime.stateDir, 'cli-config') : '';
+  const appDataDir = invocationRuntime.stateDir ? path.join(invocationRuntime.stateDir, 'appdata') : '';
+  const processManagerHome = invocationRuntime.stateDir ? path.join(invocationRuntime.stateDir, 'daemon') : '';
+  const siteRoot = invocationRuntime.stateDir
+    ? path.join(invocationRuntime.stateDir, 'sites')
+    : path.join(invocationRuntime.artifactDir, 'sites');
+
+  return {
+    ...invocationRuntime,
+    siteRoot,
     cliConfigDir,
     appDataDir,
     processManagerHome,
-    tmpDir,
-    portBase,
-    portMax,
-    env: invocationRuntime.isolated
-      ? invocationRuntime.childEnv({
-          E2E: '1',
-          E2E_CLI_CONFIG_PATH: cliConfigDir,
-          E2E_APP_DATA_PATH: appDataDir,
-          STUDIO_PROCESS_MANAGER_HOME: processManagerHome,
-          ...(tmpDir ? { TMPDIR: tmpDir } : {}),
-        })
-      : {},
-    prepareDirs: () => invocationRuntime.prepareDirs(),
-    assertPort: invocationRuntime.assertPort,
+    env: invocationRuntime.childEnv({
+      E2E: '1',
+      E2E_CLI_CONFIG_PATH: cliConfigDir,
+      E2E_APP_DATA_PATH: appDataDir,
+      STUDIO_PROCESS_MANAGER_HOME: processManagerHome,
+      ...(invocationRuntime.tmpDir ? { TMPDIR: invocationRuntime.tmpDir } : {}),
+    }),
   };
 }
 

--- a/Automattic/studio/bench/site-build-runtime.test.mjs
+++ b/Automattic/studio/bench/site-build-runtime.test.mjs
@@ -113,7 +113,45 @@ async function withEnv(values, callback) {
   }
 }
 
-const { createFreshSite, siteStatus } = await import('./lib/site-build-runtime.mjs');
+const { INVOCATION_NAMESPACE, createFreshSite, createInvocationRuntime, siteStatus } = await import(
+  './lib/site-build-runtime.mjs'
+);
+
+test('invocation runtime seam exposes generic isolated state only', async () => {
+  await withEnv(
+    {
+      HOMEBOY_NODEJS_INVOCATION_RUNTIME_HELPER: invocationRuntimeHelper,
+      HOMEBOY_INVOCATION_ID: 'inv-seam-test',
+      HOMEBOY_INVOCATION_STATE_DIR: '/tmp/inv-seam/state',
+      HOMEBOY_INVOCATION_ARTIFACT_DIR: '/tmp/inv-seam/artifacts',
+      HOMEBOY_INVOCATION_TMP_DIR: '/tmp/inv-seam/tmp',
+      HOMEBOY_INVOCATION_PORT_BASE: '22000',
+      HOMEBOY_INVOCATION_PORT_MAX: '22009',
+    },
+    async () => {
+      const runtime = await createInvocationRuntime({ namespace: INVOCATION_NAMESPACE });
+
+      assert.equal(runtime.invocationId, 'inv-seam-test');
+      assert.equal(runtime.stateDir, '/tmp/inv-seam/state/studio-agent-site-build');
+      assert.equal(runtime.artifactDir, '/tmp/inv-seam/artifacts');
+      assert.equal(runtime.tmpDir, '/tmp/inv-seam/tmp/studio-agent-site-build');
+      assert.equal(runtime.portBase, 22000);
+      assert.equal(runtime.portMax, 22009);
+      assert.equal(runtime.cliConfigDir, undefined);
+      assert.equal(runtime.appDataDir, undefined);
+      assert.equal(runtime.processManagerHome, undefined);
+
+      assert.deepEqual(runtime.childEnv({ EXTRA_ENV: 'extra-value' }), {
+        HOMEBOY_INVOCATION_NAMESPACE: 'studio-agent-site-build',
+        HOMEBOY_INVOCATION_STATE_DIR: '/tmp/inv-seam/state/studio-agent-site-build',
+        HOMEBOY_INVOCATION_ARTIFACT_DIR: '/tmp/inv-seam/artifacts/studio-agent-site-build',
+        HOMEBOY_INVOCATION_TMP_DIR: '/tmp/inv-seam/tmp/studio-agent-site-build',
+        TMPDIR: '/tmp/inv-seam/tmp/studio-agent-site-build',
+        EXTRA_ENV: 'extra-value',
+      });
+    }
+  );
+});
 
 test('site-build CLI wrappers pass resolved invocation env objects', async () => {
   await withEnv(


### PR DESCRIPTION
## Summary
- Split Studio site-build invocation helper loading into a small generic \ seam.
- Keep Studio-owned CLI config, appdata, daemon home, site root, and E2E env composition in \.
- Add unit coverage proving the seam exposes generic invocation state without Studio product dirs/env.

## Testing
- \
- \✔ invocation runtime seam exposes generic isolated state only (1.253791ms)
✔ site-build CLI wrappers pass resolved invocation env objects (0.532041ms)
✔ site-build prompt resolves from canonical Workflow Bench scenarios (8.966917ms)
✔ site-build rejects unknown Workflow Bench scenario IDs (3.253084ms)
✔ bench runtime requires the Homeboy invocation helper (0.325666ms)
✔ bench runtime composes the Homeboy invocation helper output for Studio (1.145166ms)
✔ bench restores missing SSI source files from Studio Write tool path input (2.586416ms)
✔ bench normalizes import reports without a reportPath (0.133708ms)
✔ bench source restore tolerates import reports without a reportPath (0.070667ms)
✔ generated-theme discovery reports missing SSI import instead of throwing (1.470041ms)
✔ semantic-fidelity mismatches hard-fail the agent success gate (1.407125ms)
✔ zero semantic-fidelity mismatches keep successful agent runs green (0.187167ms)
✔ semantic fidelity treats core/button wrappers as link-preserving (0.451ms)
✔ semantic fidelity still reports wrappers that lose link hrefs (0.097833ms)
✔ importer block-quality counters hard-fail the agent success gate (0.149667ms)
✔ importer block-quality metrics use zero as the clean threshold (0.166792ms)
✔ importer timing metrics flatten SSI report performance fields (0.212125ms)
✔ editor visual parity metrics hard-fail the agent success gate (0.109917ms)
✔ editor visual parity failure details distinguish upstream conversion failures (0.089292ms)
✔ visual pixel diff ratio hard-fails the agent success gate (0.073458ms)
✔ visual pixel diff ratio accepts values at the threshold (0.047583ms)
✔ semantic target metrics sum artifact target details for top-level output (0.051208ms)
✔ generated-theme UX gate accepts broad .reveal editor override for .reveal.hidden (0.989958ms)
✔ generated-theme UX gate accepts broad .hidden editor override for .reveal.hidden (0.154584ms)
✔ generated-theme UX gate still fails hidden reveal selectors without editor override (0.045084ms)
✔ generated-theme UX gate does not accept narrower editor overrides for compound hidden selectors (0.063166ms)
✔ generated-theme UX gate fails source hero structural selector drift (0.436917ms)
✔ generated-theme UX gate keeps matching source hero structural selectors clean (0.292791ms)
ℹ tests 28
ℹ suites 0
ℹ pass 28
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 84.196

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Investigated the Studio bench runtime boundary, implemented the seam refactor and targeted tests, ran safe JS checks, and drafted this PR.