### PR TITLE
Centralize fuzz doc command examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,11 +369,10 @@ homeboy rig check gutenberg-api-route-inventory
 homeboy bench --rig gutenberg-api-route-inventory --scenario gutenberg-rest-route-inventory --iterations 1 --shared-state /tmp/gutenberg-api-inventory
 ```
 
-`WordPress/gutenberg/manifests/fuzzer-profile.json` adds a rig-owned fuzzer profile shape for REST route coverage, wp-admin/editor page coverage, block editor load/action probes, DB query/profile hooks, external HTTP guardrails, and coverage-gap reporting. Inspect its fuzz declarations through Homeboy's generic fuzz command and run browser coverage separately:
+`WordPress/gutenberg/manifests/fuzzer-profile.json` adds a rig-owned fuzzer profile shape for REST route coverage, wp-admin/editor page coverage, block editor load/action probes, DB query/profile hooks, external HTTP guardrails, and coverage-gap reporting. Inspect its fuzz declarations through Homeboy's generic fuzz command, use `WordPress/gutenberg/docs/fuzzer-profile.md` for focused fuzz run examples, and run browser coverage separately:
 
 ```bash
 homeboy fuzz list --rig gutenberg-api-route-inventory
-homeboy fuzz run --rig gutenberg-api-route-inventory --workload gutenberg-rest-route-fuzz --run-id gutenberg-rest-route-fuzz --seed 1 --max-duration 10m
 homeboy trace --rig gutenberg-browser-coverage --profile fuzzer
 ```
 

--- a/WordPress/gutenberg/README.md
+++ b/WordPress/gutenberg/README.md
@@ -18,12 +18,11 @@ Run the route inventory workload:
 homeboy bench --rig gutenberg-api-route-inventory --scenario gutenberg-rest-route-inventory --iterations 1 --shared-state /tmp/gutenberg-api-inventory
 ```
 
-Inspect the declared fuzz workloads and run an individual workload through
-Homeboy's generic fuzz command:
+Inspect the declared fuzz workloads and run focused examples through Homeboy's
+generic fuzz command using the command shape in `docs/fuzzer-profile.md`:
 
 ```sh
 homeboy fuzz list --rig gutenberg-api-route-inventory
-homeboy fuzz run --rig gutenberg-api-route-inventory --workload gutenberg-rest-route-fuzz --run-id gutenberg-rest-route-fuzz --seed 1 --max-duration 10m
 ```
 
 The coverage manifest lives at `manifests/rest-route-coverage.json`. It keeps
@@ -34,11 +33,10 @@ stay generic.
 
 `manifests/fuzzer-profile.json` defines a rig-owned Gutenberg fuzzer profile analogous to the Woo full-surface shape. It composes REST route coverage, safe `wp-admin` and editor page enumeration, block editor load/action probes, Site Editor probes, block rendering, frontend rendering/request coverage, DB query/profile hooks, hook/option/postmeta/runtime-state inventory, editor performance observation summaries, external HTTP guardrails, and coverage-gap reporting without moving Gutenberg-specific knowledge into Homeboy core or Homeboy Extensions.
 
-Inspect and run fuzzer manifests through Homeboy's generic fuzz command:
+Inspect fuzzer manifests through Homeboy's generic fuzz command:
 
 ```sh
 homeboy fuzz list --rig gutenberg-api-route-inventory
-homeboy fuzz run --rig gutenberg-api-route-inventory --workload gutenberg-rest-route-fuzz --run-id gutenberg-rest-route-fuzz --seed 1 --max-duration 10m
 ```
 
 The rig exposes `smoke`, `fuzzer`, and `full-surface` `fuzz_profiles` for fleet

--- a/WordPress/gutenberg/docs/fuzzer-profile.md
+++ b/WordPress/gutenberg/docs/fuzzer-profile.md
@@ -33,8 +33,17 @@ Inspect and run fuzzer manifests through Homeboy's generic fuzz command:
 
 ```sh
 homeboy fuzz list --rig gutenberg-api-route-inventory
-homeboy fuzz run --rig gutenberg-api-route-inventory --workload gutenberg-rest-route-fuzz --run-id gutenberg-rest-route-fuzz --seed 1 --max-duration 10m
 ```
+
+Run focused examples with the shared command shape:
+
+```sh
+homeboy fuzz run --rig gutenberg-api-route-inventory --workload <workload> --run-id <run-id> --seed 1 --max-duration <duration>
+```
+
+| Workload | Example run id | Duration |
+|---|---|---|
+| `gutenberg-rest-route-fuzz` | `gutenberg-rest-route-fuzz` | `10m` |
 
 Run heavy campaigns through the offloaded Lab path and use persisted `homeboy runs` artifacts as proof; listing workloads does not prove execution.
 

--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -132,26 +132,35 @@ WooCommerce plugin directory.
 ```bash
 homeboy rig up woocommerce-performance
 homeboy fuzz list --rig woocommerce-performance
-homeboy fuzz run --rig woocommerce-performance --workload cart-session-overwrite-race --run-id wc-cart-session-overwrite-race --seed 1 --max-duration 10m
-homeboy fuzz run --rig woocommerce-performance --workload checkout-concurrent-create-order --run-id wc-checkout-atomicity --seed 1 --max-duration 10m
-homeboy fuzz run --rig woocommerce-performance --workload checkout-gateway-compatibility-matrix --run-id wc-gateway-matrix --seed 1 --max-duration 15m
-homeboy fuzz run --rig woocommerce-performance --workload checkout-shipping-cache --run-id wc-shipping-cache --seed 1 --max-duration 15m
-homeboy fuzz run --rig woocommerce-performance --workload layered-nav-count-cache --run-id wc-layered-nav-count-cache --seed 1 --max-duration 15m
-homeboy fuzz run --rig woocommerce-performance --workload layered-nav-catalog-crawl --run-id wc-layered-nav-catalog-crawl --seed 1 --max-duration 15m
-homeboy fuzz run --rig woocommerce-performance --workload admin-page-coverage --run-id wc-admin-coverage --seed 1 --max-duration 15m
-homeboy fuzz run --rig woocommerce-performance --workload woocommerce-rest-route-inventory --run-id wc-rest-route-inventory --seed 1 --max-duration 10m
-homeboy fuzz run --rig woocommerce-performance --workload generated-rest-request-cases --run-id wc-rest-generated-cases --seed 1 --max-duration 20m
-homeboy fuzz run --rig woocommerce-performance --workload rest-db-query-profile --run-id wc-rest-db-query-profile --seed 1 --max-duration 20m
-homeboy fuzz run --rig woocommerce-performance --workload db-inventory --run-id wc-db-inventory --seed 1 --max-duration 10m
-homeboy fuzz run --rig woocommerce-performance --workload rest-permission-boundary-matrix --run-id wc-rest-permission-boundary-matrix --seed 1 --max-duration 20m
-homeboy fuzz run --rig woocommerce-performance --workload rest-namespace-generated-cases --run-id wc-rest-namespace-generated-cases --seed 1 --max-duration 20m
-homeboy fuzz run --rig woocommerce-performance --workload rest-schema-query-attribution --run-id wc-rest-schema-query-attribution --seed 1 --max-duration 20m
-homeboy fuzz run --rig woocommerce-performance --workload action-scheduler-lookup-table-coverage --run-id wc-action-scheduler-lookup-table-coverage --seed 1 --max-duration 15m
-homeboy fuzz run --rig woocommerce-performance --workload options-transients-coverage --run-id wc-options-transients-coverage --seed 1 --max-duration 15m
-homeboy fuzz run --rig woocommerce-performance --workload rollback-safe-options-transients-mutations --run-id wc-rollback-safe-options-transients-mutations --seed 1 --max-duration 15m
-homeboy fuzz run --rig woocommerce-performance --workload frontend-rendering-request-coverage --run-id wc-frontend-rendering-request-coverage --seed 1 --max-duration 15m
-homeboy fuzz run --rig woocommerce-performance --workload woocommerce-external-http-guardrail --run-id wc-external-http-guardrail --seed 1 --max-duration 10m
 ```
+
+Run a focused workload from the table with the shared command shape:
+
+```bash
+homeboy fuzz run --rig woocommerce-performance --workload <workload> --run-id <run-id> --seed 1 --max-duration <duration>
+```
+
+| Workload | Example run id | Duration |
+|---|---|---|
+| `cart-session-overwrite-race` | `wc-cart-session-overwrite-race` | `10m` |
+| `checkout-concurrent-create-order` | `wc-checkout-atomicity` | `10m` |
+| `checkout-gateway-compatibility-matrix` | `wc-gateway-matrix` | `15m` |
+| `checkout-shipping-cache` | `wc-shipping-cache` | `15m` |
+| `layered-nav-count-cache` | `wc-layered-nav-count-cache` | `15m` |
+| `layered-nav-catalog-crawl` | `wc-layered-nav-catalog-crawl` | `15m` |
+| `admin-page-coverage` | `wc-admin-coverage` | `15m` |
+| `woocommerce-rest-route-inventory` | `wc-rest-route-inventory` | `10m` |
+| `generated-rest-request-cases` | `wc-rest-generated-cases` | `20m` |
+| `rest-db-query-profile` | `wc-rest-db-query-profile` | `20m` |
+| `db-inventory` | `wc-db-inventory` | `10m` |
+| `rest-permission-boundary-matrix` | `wc-rest-permission-boundary-matrix` | `20m` |
+| `rest-namespace-generated-cases` | `wc-rest-namespace-generated-cases` | `20m` |
+| `rest-schema-query-attribution` | `wc-rest-schema-query-attribution` | `20m` |
+| `action-scheduler-lookup-table-coverage` | `wc-action-scheduler-lookup-table-coverage` | `15m` |
+| `options-transients-coverage` | `wc-options-transients-coverage` | `15m` |
+| `rollback-safe-options-transients-mutations` | `wc-rollback-safe-options-transients-mutations` | `15m` |
+| `frontend-rendering-request-coverage` | `wc-frontend-rendering-request-coverage` | `15m` |
+| `woocommerce-external-http-guardrail` | `wc-external-http-guardrail` | `10m` |
 
 `homeboy fuzz list --rig woocommerce-performance` resolves the rig's
 WooCommerce component and `fuzz_workloads.wordpress` declarations before any

--- a/woocommerce/woocommerce/docs/checkout-shipping-cache-matrix-report.md
+++ b/woocommerce/woocommerce/docs/checkout-shipping-cache-matrix-report.md
@@ -37,13 +37,21 @@ node woocommerce/woocommerce/tools/checkout-shipping-cache-matrix-report.mjs \
 ```bash
 homeboy rig up woocommerce-performance
 homeboy rig check woocommerce-performance
-
-homeboy fuzz run --rig woocommerce-performance --workload checkout-shipping-cache --run-id woocommerce-shipping-cache-40x1 --seed 1 --max-duration 15m
-homeboy fuzz run --rig woocommerce-performance --workload checkout-shipping-cache --run-id woocommerce-shipping-cache-40x8 --seed 1 --max-duration 15m
-homeboy fuzz run --rig woocommerce-performance --workload checkout-shipping-cache --run-id woocommerce-shipping-cache-200x8 --seed 1 --max-duration 15m
-homeboy fuzz run --rig woocommerce-performance --workload checkout-shipping-cache --run-id woocommerce-shipping-cache-200x40 --seed 1 --max-duration 15m
-homeboy fuzz run --rig woocommerce-performance --workload checkout-shipping-cache --run-id woocommerce-shipping-cache-1000x40 --seed 1 --max-duration 15m
 ```
+
+Run each matrix row with the shared shipping-cache command shape:
+
+```bash
+homeboy fuzz run --rig woocommerce-performance --workload checkout-shipping-cache --run-id <run-id> --seed 1 --max-duration 15m
+```
+
+| Matrix row | Run id |
+|---|---|
+| `40x1` | `woocommerce-shipping-cache-40x1` |
+| `40x8` | `woocommerce-shipping-cache-40x8` |
+| `200x8` | `woocommerce-shipping-cache-200x8` |
+| `200x40` | `woocommerce-shipping-cache-200x40` |
+| `1000x40` | `woocommerce-shipping-cache-1000x40` |
 
 ## Dependency Blockers
 

--- a/woocommerce/woocommerce/docs/db-api-performance-fuzzer.md
+++ b/woocommerce/woocommerce/docs/db-api-performance-fuzzer.md
@@ -181,27 +181,24 @@ so a future postprocess primitive can consume the same persisted artifact root.
 Use the selected WooCommerce checkout through `--path` when the runner is
 validating a specific baseline or candidate worktree.
 
-Baseline:
+Use the same command shape for every baseline and candidate row:
 
 ```bash
-homeboy fuzz run --rig woocommerce-performance --path <runner-woocommerce-baseline-plugin-path> --workload codebox-fuzz-suite-contract --run-id wc-db-api-codebox-suite-baseline --seed 1 --max-duration 10m --require-result-envelope --require-coverage-summary --tracker-ref "$WC_TRACKER_REF" --lab-only --runner "$HOMEBOY_RUNNER_ID" --detach-after-handoff
-homeboy fuzz run --rig woocommerce-performance --path <runner-woocommerce-baseline-plugin-path> --workload woocommerce-rest-route-inventory --run-id wc-db-api-route-inventory-baseline --seed 1 --max-duration 10m --require-result-envelope --require-coverage-summary --tracker-ref "$WC_TRACKER_REF" --lab-only --runner "$HOMEBOY_RUNNER_ID" --detach-after-handoff
-homeboy fuzz run --rig woocommerce-performance --path <runner-woocommerce-baseline-plugin-path> --workload generated-rest-request-cases --run-id wc-db-api-generated-cases-baseline --seed 1 --max-duration 20m --require-result-envelope --require-case-log --require-coverage-summary --tracker-ref "$WC_TRACKER_REF" --lab-only --runner "$HOMEBOY_RUNNER_ID" --detach-after-handoff
-homeboy fuzz run --rig woocommerce-performance --path <runner-woocommerce-baseline-plugin-path> --workload rest-db-query-profile --run-id wc-db-api-query-profile-baseline --seed 1 --max-duration 20m --require-result-envelope --require-case-log --require-coverage-summary --tracker-ref "$WC_TRACKER_REF" --lab-only --runner "$HOMEBOY_RUNNER_ID" --detach-after-handoff
-homeboy fuzz run --rig woocommerce-performance --path <runner-woocommerce-baseline-plugin-path> --workload db-inventory --run-id wc-db-api-db-inventory-baseline --seed 1 --max-duration 10m --require-result-envelope --require-coverage-summary --tracker-ref "$WC_TRACKER_REF" --lab-only --runner "$HOMEBOY_RUNNER_ID" --detach-after-handoff
-homeboy fuzz run --rig woocommerce-performance --path <runner-woocommerce-baseline-plugin-path> --workload rest-schema-query-attribution --run-id wc-db-api-schema-query-attribution-baseline --seed 1 --max-duration 20m --require-result-envelope --require-case-log --require-coverage-summary --tracker-ref "$WC_TRACKER_REF" --lab-only --runner "$HOMEBOY_RUNNER_ID" --detach-after-handoff
+homeboy fuzz run --rig woocommerce-performance --path <runner-woocommerce-{baseline|candidate}-plugin-path> --workload <workload> --run-id <run-id> --seed 1 --max-duration <duration> <case-log-flag> --require-result-envelope --require-coverage-summary --tracker-ref "$WC_TRACKER_REF" --lab-only --runner "$HOMEBOY_RUNNER_ID" --detach-after-handoff
 ```
 
-Candidate:
+| Workload | Baseline run id | Candidate run id | Duration | Extra flag |
+|---|---|---|---|---|
+| `codebox-fuzz-suite-contract` | `wc-db-api-codebox-suite-baseline` | `wc-db-api-codebox-suite-candidate` | `10m` |  |
+| `woocommerce-rest-route-inventory` | `wc-db-api-route-inventory-baseline` | `wc-db-api-route-inventory-candidate` | `10m` |  |
+| `generated-rest-request-cases` | `wc-db-api-generated-cases-baseline` | `wc-db-api-generated-cases-candidate` | `20m` | `--require-case-log` |
+| `rest-db-query-profile` | `wc-db-api-query-profile-baseline` | `wc-db-api-query-profile-candidate` | `20m` | `--require-case-log` |
+| `db-inventory` | `wc-db-api-db-inventory-baseline` | `wc-db-api-db-inventory-candidate` | `10m` |  |
+| `rest-schema-query-attribution` | `wc-db-api-schema-query-attribution-baseline` | `wc-db-api-schema-query-attribution-candidate` | `20m` | `--require-case-log` |
 
-```bash
-homeboy fuzz run --rig woocommerce-performance --path <runner-woocommerce-candidate-plugin-path> --workload codebox-fuzz-suite-contract --run-id wc-db-api-codebox-suite-candidate --seed 1 --max-duration 10m --require-result-envelope --require-coverage-summary --tracker-ref "$WC_TRACKER_REF" --lab-only --runner "$HOMEBOY_RUNNER_ID" --detach-after-handoff
-homeboy fuzz run --rig woocommerce-performance --path <runner-woocommerce-candidate-plugin-path> --workload woocommerce-rest-route-inventory --run-id wc-db-api-route-inventory-candidate --seed 1 --max-duration 10m --require-result-envelope --require-coverage-summary --tracker-ref "$WC_TRACKER_REF" --lab-only --runner "$HOMEBOY_RUNNER_ID" --detach-after-handoff
-homeboy fuzz run --rig woocommerce-performance --path <runner-woocommerce-candidate-plugin-path> --workload generated-rest-request-cases --run-id wc-db-api-generated-cases-candidate --seed 1 --max-duration 20m --require-result-envelope --require-case-log --require-coverage-summary --tracker-ref "$WC_TRACKER_REF" --lab-only --runner "$HOMEBOY_RUNNER_ID" --detach-after-handoff
-homeboy fuzz run --rig woocommerce-performance --path <runner-woocommerce-candidate-plugin-path> --workload rest-db-query-profile --run-id wc-db-api-query-profile-candidate --seed 1 --max-duration 20m --require-result-envelope --require-case-log --require-coverage-summary --tracker-ref "$WC_TRACKER_REF" --lab-only --runner "$HOMEBOY_RUNNER_ID" --detach-after-handoff
-homeboy fuzz run --rig woocommerce-performance --path <runner-woocommerce-candidate-plugin-path> --workload db-inventory --run-id wc-db-api-db-inventory-candidate --seed 1 --max-duration 10m --require-result-envelope --require-coverage-summary --tracker-ref "$WC_TRACKER_REF" --lab-only --runner "$HOMEBOY_RUNNER_ID" --detach-after-handoff
-homeboy fuzz run --rig woocommerce-performance --path <runner-woocommerce-candidate-plugin-path> --workload rest-schema-query-attribution --run-id wc-db-api-schema-query-attribution-candidate --seed 1 --max-duration 20m --require-result-envelope --require-case-log --require-coverage-summary --tracker-ref "$WC_TRACKER_REF" --lab-only --runner "$HOMEBOY_RUNNER_ID" --detach-after-handoff
-```
+Use the baseline plugin path with the baseline run ids, then repeat with the
+candidate plugin path and candidate run ids. Omit `<case-log-flag>` when the row
+does not list an extra flag.
 
 `coverage-gap-report` and `performance-hotspots-artifact-summary` are declared
 data-only artifact-postprocess contracts. Do not run them as proof until Homeboy


### PR DESCRIPTION
## Summary
- Replace repeated Woo fuzz command arrays with shared command shapes plus declarative workload/run-id tables.
- Move duplicated Gutenberg fuzz-run example into the fuzzer profile doc and point README/root docs at that source.
- Preserve setup/list/check commands and evidence-oriented notes while avoiding local fuzz or benchmark execution.

## Verification
- `HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR=/Users/chubes/Developer/homeboy-extensions@cook-wp-codebox-workflow-wrapper-20260702/wordpress/lib/wordpress-fuzz-manifest-validator.js node scripts/lint-rig-packages.mjs woocommerce/woocommerce`
- `HOMEBOY_WORDPRESS_FUZZ_MANIFEST_VALIDATOR=/Users/chubes/Developer/homeboy-extensions@cook-wp-codebox-workflow-wrapper-20260702/wordpress/lib/wordpress-fuzz-manifest-validator.js node scripts/lint-rig-packages.mjs WordPress/gutenberg`

## Notes
- Running lint without the explicit helper env failed because the primary `homeboy-extensions` checkout lacks `wordpress/lib/wordpress-fuzz-manifest-validator.js`; rerunning with an explicit helper path passed.
- Woo lint reports the existing warning: `fuzz/codebox-fuzz-suite-contract.json: executable fuzz readiness has optional artifact(s): codebox_fuzz_suite_result`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Investigated repeated fuzz command docs, edited markdown, ran safe lint, and prepared this PR.