### PR TITLE
Soften Studio combined setup mutations

### DIFF
--- a/Automattic/studio/rigs/studio-combined/rig.json
+++ b/Automattic/studio/rigs/studio-combined/rig.json
@@ -21,7 +21,7 @@
   "lifecycle": {
     "cleanup": {
       "intent": "pipeline",
-      "reason": "pipeline.down stops the Studio daemon and tarball server; component checkouts remain user-owned resources."
+      "reason": "pipeline.down stops the Studio daemon and tarball server and restores package manifests saved before local tarball rewrites; component checkouts, dependencies, and ordinary symlinks remain user-owned resources."
     }
   },
 
@@ -669,14 +669,14 @@
       },
       {
         "kind": "command",
-        "label": "Rewire Studio package.jsons to local tarballs",
-        "command": "VER=$(jq -r '.version' \"${components.wordpress-playground.path}/lerna.json\"); for pkg in apps/cli/package.json apps/studio/package.json tools/benchmark-site-editor/package.json tools/common/package.json; do PACKAGE_BASE_URL=http://127.0.0.1:9724/studio-dev PACKAGE_VERSION=$VER bash \"${components.wordpress-playground.path}/packages/playground/test-built-npm-packages/use-local-packages.sh\" \"$pkg\"; done",
+        "label": "Backup Studio package manifests before local tarball rewrite",
+        "command": "backup_dir=.homeboy-rig/studio-combined/package-backups; files='package-lock.json apps/cli/package.json apps/studio/package.json tools/benchmark-site-editor/package.json tools/common/package.json'; if [ ! -d \"$backup_dir\" ]; then for file in $files; do git diff --quiet -- \"$file\" && git diff --cached --quiet -- \"$file\" || { printf '%s\\n' \"Refusing to rewrite dirty Studio package manifest: $file\"; exit 1; }; done; fi; mkdir -p \"$backup_dir\"; for file in $files; do if [ -f \"$file\" ] && [ ! -f \"$backup_dir/$file\" ]; then mkdir -p \"$backup_dir/$(dirname \"$file\")\"; cp \"$file\" \"$backup_dir/$file\"; fi; done",
         "cwd": "${components.studio.path}"
       },
       {
         "kind": "command",
-        "label": "Bust stale Studio node_modules",
-        "command": "rm -rf node_modules/@wp-playground node_modules/@php-wasm apps/cli/node_modules/@wp-playground apps/cli/node_modules/@php-wasm",
+        "label": "Rewire Studio package manifests to local tarballs",
+        "command": "VER=$(jq -r '.version' \"${components.wordpress-playground.path}/lerna.json\"); for pkg in apps/cli/package.json apps/studio/package.json tools/benchmark-site-editor/package.json tools/common/package.json; do PACKAGE_BASE_URL=http://127.0.0.1:9724/studio-dev PACKAGE_VERSION=$VER bash \"${components.wordpress-playground.path}/packages/playground/test-built-npm-packages/use-local-packages.sh\" \"$pkg\"; done",
         "cwd": "${components.studio.path}"
       },
       {
@@ -708,6 +708,12 @@
         "kind": "service",
         "id": "tarball-server",
         "op": "stop"
+      },
+      {
+        "kind": "command",
+        "label": "Restore Studio package manifests from rig backup",
+        "command": "backup_dir=.homeboy-rig/studio-combined/package-backups; if [ ! -d \"$backup_dir\" ]; then exit 0; fi; restored=1; for backup in \"$backup_dir\"/package-lock.json \"$backup_dir\"/apps/cli/package.json \"$backup_dir\"/apps/studio/package.json \"$backup_dir\"/tools/benchmark-site-editor/package.json \"$backup_dir\"/tools/common/package.json; do [ -f \"$backup\" ] || continue; rel=${backup#$backup_dir/}; if [ -f \"$rel\" ] && grep -q 'http://127.0.0.1:9724/studio-dev/' \"$rel\"; then cp \"$backup\" \"$rel\"; else printf '%s\\n' \"Not restoring $rel because it no longer looks like a rig-owned local tarball rewrite. Restore manually from $backup if needed.\"; restored=0; fi; done; if [ \"$restored\" = 1 ]; then rm -rf .homeboy-rig/studio-combined; else exit 1; fi",
+        "cwd": "${components.studio.path}"
       }
     ]
   }

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Useful settings:
 
 `studio-combined` declares the local tarball server port, touched component paths, and adopted Studio/Playground process patterns in `resources` so concurrent rig commands can see the same ownership assumptions that the pipeline uses. The fixed tarball port remains `9724` because Homeboy `http-static` services currently require an integer port in the rig spec.
 
+`studio-combined` rewires selected Studio package manifests to local Playground tarballs during `up`. Before that rewrite, the rig refuses dirty package manifests and stores backups under `${components.studio.path}/.homeboy-rig/studio-combined/package-backups`; `down` restores those files when they still look like rig-owned local tarball rewrites. The rig no longer deletes Studio `node_modules` scopes during setup. Remaining manual remediation: ordinary symlinks declared by the rig are not cleaned by a typed Homeboy symlink lifecycle primitive, so remove `~/.local/bin/studio` or `${components.wordpress-playground.path}/node_modules/@wp-playground/wordpress-builds` manually if you want to undo those links after `homeboy rig down studio-combined`.
+
 ```bash
 homeboy rig check studio-combined
 homeboy rig up studio-combined


### PR DESCRIPTION
## Summary
- remove the broad Studio node_modules scope deletion from studio-combined setup
- back up Studio package manifests before local tarball rewrites and restore them during rig down when still rig-owned
- document remaining manual symlink cleanup because Homeboy does not expose a typed symlink cleanup lifecycle primitive here

## Validation
- node -e "JSON.parse(require('fs').readFileSync('Automattic/studio/rigs/studio-combined/rig.json','utf8')); console.log('rig json ok')"
- homeboy rig lint ./Automattic/studio/rigs/studio-combined/rig.json
- node scripts/lint-rig-packages.mjs Automattic/studio

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Investigated the Studio combined rig setup mutations, edited the rig/README, and ran validation under Chris's direction.