### PR TITLE
Consume scoped Node invocation runtime

### DIFF
--- a/Automattic/studio/bench/lib/site-build-runtime.mjs
+++ b/Automattic/studio/bench/lib/site-build-runtime.mjs
@@ -44,10 +44,10 @@ export async function createInvocationRuntime({ namespace, sharedState = SHARED_
 
   const { resolveHomeboyInvocationRuntime } = await import(helperPath);
   const invocationRuntime = resolveHomeboyInvocationRuntime({ namespace });
-  const stateDir = invocationRuntime.dirs.state || '';
+  const stateDir = invocationRuntime.dirs?.state || '';
   const artifactDir =
-    invocationRuntime.baseDirs.artifact || path.join(sharedState, `${namespace}-artifacts`);
-  const tmpDir = invocationRuntime.dirs.tmp || (stateDir ? path.join(stateDir, 'tmp') : '');
+    invocationRuntime.dirs?.artifact || path.join(sharedState, `${namespace}-artifacts`);
+  const tmpDir = invocationRuntime.dirs?.tmp || (stateDir ? path.join(stateDir, 'tmp') : '');
 
   return {
     invocationId: invocationRuntime.invocationId || '',
@@ -56,7 +56,7 @@ export async function createInvocationRuntime({ namespace, sharedState = SHARED_
     tmpDir,
     portBase: invocationRuntime.portRange?.base ?? null,
     portMax: invocationRuntime.portRange?.max ?? null,
-    childEnv: (extra = {}) => (invocationRuntime.isolated ? invocationRuntime.childEnv(extra) : {}),
+    childEnv: (extra = {}) => invocationRuntime.childEnv(extra),
     prepareDirs: () => invocationRuntime.prepareDirs(),
     assertPort: invocationRuntime.assertPort,
   };

--- a/Automattic/studio/bench/site-build-runtime.test.mjs
+++ b/Automattic/studio/bench/site-build-runtime.test.mjs
@@ -59,6 +59,20 @@ export function resolveHomeboyInvocationRuntime({ namespace }) {
   const state = process.env.HOMEBOY_INVOCATION_STATE_DIR ? process.env.HOMEBOY_INVOCATION_STATE_DIR + '/' + namespace : null;
   const artifact = process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR ? process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR + '/' + namespace : null;
   const tmp = process.env.HOMEBOY_INVOCATION_TMP_DIR ? process.env.HOMEBOY_INVOCATION_TMP_DIR + '/' + namespace : null;
+  const env = {
+    HOMEBOY_INVOCATION_NAMESPACE: namespace,
+    HOMEBOY_INVOCATION_STATE_DIR: state,
+    HOMEBOY_INVOCATION_ARTIFACT_DIR: artifact,
+    HOMEBOY_INVOCATION_TMP_DIR: tmp,
+    TMPDIR: tmp,
+    TMP: tmp,
+    TEMP: tmp,
+    HOME: state + '/home',
+    XDG_CONFIG_HOME: state + '/config',
+    XDG_CACHE_HOME: state + '/cache',
+    XDG_DATA_HOME: state + '/data',
+    XDG_STATE_HOME: state,
+  };
   return {
     isolated: true,
     namespace,
@@ -73,15 +87,9 @@ export function resolveHomeboyInvocationRuntime({ namespace }) {
       base: Number(process.env.HOMEBOY_INVOCATION_PORT_BASE),
       max: Number(process.env.HOMEBOY_INVOCATION_PORT_MAX),
     },
+    env,
     childEnv(extra = {}) {
-      return {
-        HOMEBOY_INVOCATION_NAMESPACE: namespace,
-        HOMEBOY_INVOCATION_STATE_DIR: state,
-        HOMEBOY_INVOCATION_ARTIFACT_DIR: artifact,
-        HOMEBOY_INVOCATION_TMP_DIR: tmp,
-        TMPDIR: tmp,
-        ...extra,
-      };
+      return { ...env, ...extra };
     },
     async prepareDirs() {},
     assertPort(port) { return Number(port); },
@@ -133,7 +141,7 @@ test('invocation runtime seam exposes generic isolated state only', async () => 
 
       assert.equal(runtime.invocationId, 'inv-seam-test');
       assert.equal(runtime.stateDir, '/tmp/inv-seam/state/studio-agent-site-build');
-      assert.equal(runtime.artifactDir, '/tmp/inv-seam/artifacts');
+      assert.equal(runtime.artifactDir, '/tmp/inv-seam/artifacts/studio-agent-site-build');
       assert.equal(runtime.tmpDir, '/tmp/inv-seam/tmp/studio-agent-site-build');
       assert.equal(runtime.portBase, 22000);
       assert.equal(runtime.portMax, 22009);
@@ -147,6 +155,13 @@ test('invocation runtime seam exposes generic isolated state only', async () => 
         HOMEBOY_INVOCATION_ARTIFACT_DIR: '/tmp/inv-seam/artifacts/studio-agent-site-build',
         HOMEBOY_INVOCATION_TMP_DIR: '/tmp/inv-seam/tmp/studio-agent-site-build',
         TMPDIR: '/tmp/inv-seam/tmp/studio-agent-site-build',
+        TMP: '/tmp/inv-seam/tmp/studio-agent-site-build',
+        TEMP: '/tmp/inv-seam/tmp/studio-agent-site-build',
+        HOME: '/tmp/inv-seam/state/studio-agent-site-build/home',
+        XDG_CONFIG_HOME: '/tmp/inv-seam/state/studio-agent-site-build/config',
+        XDG_CACHE_HOME: '/tmp/inv-seam/state/studio-agent-site-build/cache',
+        XDG_DATA_HOME: '/tmp/inv-seam/state/studio-agent-site-build/data',
+        XDG_STATE_HOME: '/tmp/inv-seam/state/studio-agent-site-build',
         EXTRA_ENV: 'extra-value',
       });
     }
@@ -194,6 +209,11 @@ test('site-build CLI wrappers pass resolved invocation env objects', async () =>
         assert.equal(call.options.env.HOMEBOY_INVOCATION_STATE_DIR, '/tmp/inv-env/state/studio-agent-site-build');
         assert.equal(call.options.env.HOMEBOY_INVOCATION_ARTIFACT_DIR, '/tmp/inv-env/artifacts/studio-agent-site-build');
         assert.equal(call.options.env.HOMEBOY_INVOCATION_TMP_DIR, '/tmp/inv-env/tmp/studio-agent-site-build');
+        assert.equal(call.options.env.HOME, '/tmp/inv-env/state/studio-agent-site-build/home');
+        assert.equal(call.options.env.XDG_CONFIG_HOME, '/tmp/inv-env/state/studio-agent-site-build/config');
+        assert.equal(call.options.env.XDG_CACHE_HOME, '/tmp/inv-env/state/studio-agent-site-build/cache');
+        assert.equal(call.options.env.XDG_DATA_HOME, '/tmp/inv-env/state/studio-agent-site-build/data');
+        assert.equal(call.options.env.XDG_STATE_HOME, '/tmp/inv-env/state/studio-agent-site-build');
         assert.equal(call.options.env.E2E, '1');
         assert.equal(call.options.env.E2E_CLI_CONFIG_PATH, '/tmp/inv-env/state/studio-agent-site-build/cli-config');
         assert.equal(call.options.env.E2E_APP_DATA_PATH, '/tmp/inv-env/state/studio-agent-site-build/appdata');

--- a/Automattic/studio/bench/studio-agent-site-build.test.mjs
+++ b/Automattic/studio/bench/studio-agent-site-build.test.mjs
@@ -39,6 +39,20 @@ export function resolveHomeboyInvocationRuntime({ namespace }) {
   const state = process.env.HOMEBOY_INVOCATION_STATE_DIR ? process.env.HOMEBOY_INVOCATION_STATE_DIR + '/' + namespace : null;
   const artifact = process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR ? process.env.HOMEBOY_INVOCATION_ARTIFACT_DIR + '/' + namespace : null;
   const tmp = process.env.HOMEBOY_INVOCATION_TMP_DIR ? process.env.HOMEBOY_INVOCATION_TMP_DIR + '/' + namespace : null;
+  const env = {
+    HOMEBOY_INVOCATION_NAMESPACE: namespace,
+    HOMEBOY_INVOCATION_STATE_DIR: state,
+    HOMEBOY_INVOCATION_ARTIFACT_DIR: artifact,
+    HOMEBOY_INVOCATION_TMP_DIR: tmp,
+    TMPDIR: tmp,
+    TMP: tmp,
+    TEMP: tmp,
+    HOME: state + '/home',
+    XDG_CONFIG_HOME: state + '/config',
+    XDG_CACHE_HOME: state + '/cache',
+    XDG_DATA_HOME: state + '/data',
+    XDG_STATE_HOME: state,
+  };
   return {
     isolated: true,
     namespace,
@@ -53,15 +67,9 @@ export function resolveHomeboyInvocationRuntime({ namespace }) {
       base: Number(process.env.HOMEBOY_INVOCATION_PORT_BASE),
       max: Number(process.env.HOMEBOY_INVOCATION_PORT_MAX),
     },
+    env,
     childEnv(extra = {}) {
-      return {
-        HOMEBOY_INVOCATION_NAMESPACE: namespace,
-        HOMEBOY_INVOCATION_STATE_DIR: state,
-        HOMEBOY_INVOCATION_ARTIFACT_DIR: artifact,
-        HOMEBOY_INVOCATION_TMP_DIR: tmp,
-        TMPDIR: tmp,
-        ...extra,
-      };
+      return { ...env, ...extra };
     },
     async prepareDirs() {},
     assertPort(port) { return Number(port); },
@@ -217,7 +225,7 @@ test('bench runtime composes the Homeboy invocation helper output for Studio', a
       const runtime = await createStudioBenchRuntime('/tmp/shared-state');
 
       assert.equal(runtime.invocationId, 'inv-test');
-      assert.equal(runtime.artifactDir, '/tmp/inv/artifacts');
+      assert.equal(runtime.artifactDir, '/tmp/inv/artifacts/studio-agent-site-build');
       assert.equal(runtime.siteRoot, '/tmp/inv/state/studio-agent-site-build/sites');
       assert.equal(runtime.cliConfigDir, '/tmp/inv/state/studio-agent-site-build/cli-config');
       assert.equal(runtime.appDataDir, '/tmp/inv/state/studio-agent-site-build/appdata');
@@ -231,6 +239,13 @@ test('bench runtime composes the Homeboy invocation helper output for Studio', a
         HOMEBOY_INVOCATION_ARTIFACT_DIR: '/tmp/inv/artifacts/studio-agent-site-build',
         HOMEBOY_INVOCATION_TMP_DIR: '/tmp/inv/tmp/studio-agent-site-build',
         TMPDIR: '/tmp/inv/tmp/studio-agent-site-build',
+        TMP: '/tmp/inv/tmp/studio-agent-site-build',
+        TEMP: '/tmp/inv/tmp/studio-agent-site-build',
+        HOME: '/tmp/inv/state/studio-agent-site-build/home',
+        XDG_CONFIG_HOME: '/tmp/inv/state/studio-agent-site-build/config',
+        XDG_CACHE_HOME: '/tmp/inv/state/studio-agent-site-build/cache',
+        XDG_DATA_HOME: '/tmp/inv/state/studio-agent-site-build/data',
+        XDG_STATE_HOME: '/tmp/inv/state/studio-agent-site-build',
         E2E: '1',
         E2E_CLI_CONFIG_PATH: '/tmp/inv/state/studio-agent-site-build/cli-config',
         E2E_APP_DATA_PATH: '/tmp/inv/state/studio-agent-site-build/appdata',


### PR DESCRIPTION
## Summary
- consume the Homeboy Extensions Node invocation runtime's scoped artifact/temp/state directories for Studio site-build benches
- pass through the helper's child env so standard isolation variables like HOME, TMP/TEMP, and XDG dirs reach Studio CLI calls
- update Studio bench tests to assert the promoted helper contract shape

## Tests
- `node --test Automattic/studio/bench/site-build-runtime.test.mjs`
- `HOMEBOY_NODEJS_WORKLOAD_UTILS=/Users/chubes/Developer/homeboy-extensions/nodejs/scripts/bench/lib/workload-utils.mjs node --test Automattic/studio/bench/studio-agent-site-build.test.mjs`
- `HOMEBOY_NODEJS_WORKLOAD_UTILS=/Users/chubes/Developer/homeboy-extensions/nodejs/scripts/bench/lib/workload-utils.mjs node --test scripts/*.test.mjs shared/*.test.mjs shared/*/*.test.mjs WordPress/wordpress-develop/fuzz/*.test.mjs Automattic/jetpack/tools/*.test.mjs woocommerce/woocommerce-gateway-stripe/bench/*.test.mjs WordPress/gutenberg/tools/*.test.mjs woocommerce/woocommerce/manifests/*.test.mjs Automattic/studio/bench/*.test.mjs woocommerce/woocommerce/tools/*.test.mjs woocommerce/woocommerce/bench/*.test.mjs` (fails 1 existing/unrelated assertion in `studio-site-editor-diagnostics.test.mjs`: sanitized artifact output still contains the key name `autoLoginUrl`, matching `/login/`)

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Inspected the Studio bench seam, updated the runtime consumption/tests, ran verification, and prepared this PR.