### PR TITLE
Add Wave 3 fuzz proof recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ Gutenberg, and Jetpack is tracked in
 [`docs/fuzz-coverage-matrix.md`](docs/fuzz-coverage-matrix.md), including the
 difference between declared, executable, and proven coverage.
 
+Wave 3 fuzz proof recipes are tracked in
+[`docs/wave3-fuzz-proof-evidence.md`](docs/wave3-fuzz-proof-evidence.md). They
+show the deterministic chain from campaign manifest to core fuzz plan, Lab
+handoff, resource indexing, persisted artifacts/result envelope, and cleanup
+inspection. Validate the machine-readable recipe contract with
+`node scripts/wave3-proof-recipe-check.mjs`; the recipes remain blocked from
+`proven` status until durable reviewer-facing Homeboy run and artifact refs
+exist.
+
 ## Install
 
 Install a package subpath with Homeboy's rig package lifecycle:

--- a/docs/wave3-fuzz-proof-evidence.md
+++ b/docs/wave3-fuzz-proof-evidence.md
@@ -1,0 +1,164 @@
+# Wave 3 Fuzz Proof Evidence Recipes
+
+This is the Wave 3 proof recipe for turning a fuzz campaign declaration into
+reviewer-facing evidence without using local-only proof. It covers the complete
+chain:
+
+1. Campaign manifest.
+2. Core fuzz plan.
+3. Lab handoff.
+4. Resources indexed.
+5. Artifacts and result envelope.
+6. Cleanup inspection.
+
+The recipe is deterministic, but this repository does not claim the campaigns
+are proven until the commands produce durable Homeboy run and artifact refs from
+an approved Lab runner. Local paths, localhost URLs, and console output are not
+proof.
+
+Machine-readable recipes live in
+[`wave3-fuzz-proof-recipes.json`](wave3-fuzz-proof-recipes.json). Validate them
+without running hot fuzz workloads:
+
+```bash
+node scripts/wave3-proof-recipe-check.mjs
+```
+
+## Generic WordPress Core Recipe
+
+Use this recipe when the goal is to prove the generic Homeboy fuzz loop against a
+Core-owned manifest before layering product-specific assertions on top.
+
+```bash
+export HOMEBOY_RUNNER_ID=<approved-runner-id>
+export WAVE3_TRACKER_REF=github:owner/repo#issue-or-pr
+export WAVE3_OUT=./wave3-core-proof
+
+homeboy rig show wordpress-core-fuzz-coverage \
+  --output "$WAVE3_OUT/resources-index.json"
+
+homeboy fuzz plan \
+  --rig wordpress-core-fuzz-coverage \
+  --workload rest-api \
+  --run-id wave3-core-rest-api-plan \
+  --request-id wave3-core-rest-api-plan \
+  --strategy read-only \
+  --case-budget 25 \
+  --duration-budget-seconds 300 \
+  --max-duration 5m \
+  --seed 3 \
+  --tracker-ref "$WAVE3_TRACKER_REF" \
+  --lab-only \
+  --runner "$HOMEBOY_RUNNER_ID" \
+  --output "$WAVE3_OUT/core-fuzz-plan.json"
+
+homeboy fuzz run \
+  --rig wordpress-core-fuzz-coverage \
+  --workload rest-api \
+  --run-id wave3-core-rest-api \
+  --seed 3 \
+  --max-duration 5m \
+  --require-result-envelope \
+  --require-coverage-summary \
+  --tracker-ref "$WAVE3_TRACKER_REF" \
+  --lab-only \
+  --runner "$HOMEBOY_RUNNER_ID" \
+  --detach-after-handoff \
+  --output "$WAVE3_OUT/lab-handoff.json"
+
+homeboy runs evidence wave3-core-rest-api \
+  --output "$WAVE3_OUT/evidence.json"
+
+homeboy runs artifacts wave3-core-rest-api \
+  --output "$WAVE3_OUT/artifacts.json"
+
+homeboy runs refs \
+  --rig wordpress-core-fuzz-coverage \
+  --kind fuzz \
+  --tracker-ref "$WAVE3_TRACKER_REF" \
+  --output "$WAVE3_OUT/reviewer-refs.json"
+
+homeboy cleanup worktrees \
+  --provider datamachine-code \
+  --output "$WAVE3_OUT/cleanup-inspection.json"
+```
+
+## WooCommerce Product Recipe
+
+Use this recipe when the goal is to prove one product campaign using the same
+generic loop plus WooCommerce-owned campaign/artifact contracts.
+
+```bash
+export HOMEBOY_RUNNER_ID=<approved-runner-id>
+export WC_TRACKER_REF=github:woocommerce/woocommerce#issue-or-pr
+export WC_OUT=./wave3-woo-db-api-proof
+
+homeboy rig show woocommerce-performance \
+  --output "$WC_OUT/resources-index.json"
+
+homeboy fuzz plan \
+  --rig woocommerce-performance \
+  --workload generated-rest-request-cases \
+  --run-id wave3-woo-generated-rest-plan \
+  --request-id wave3-woo-generated-rest-plan \
+  --strategy read-only \
+  --case-budget 80 \
+  --duration-budget-seconds 1200 \
+  --max-duration 20m \
+  --seed 3 \
+  --tracker-ref "$WC_TRACKER_REF" \
+  --lab-only \
+  --runner "$HOMEBOY_RUNNER_ID" \
+  --output "$WC_OUT/core-fuzz-plan.json"
+
+homeboy fuzz run \
+  --rig woocommerce-performance \
+  --workload generated-rest-request-cases \
+  --run-id wave3-woo-generated-rest \
+  --seed 3 \
+  --max-duration 20m \
+  --require-case-log \
+  --require-result-envelope \
+  --require-coverage-summary \
+  --tracker-ref "$WC_TRACKER_REF" \
+  --lab-only \
+  --runner "$HOMEBOY_RUNNER_ID" \
+  --detach-after-handoff \
+  --output "$WC_OUT/lab-handoff.json"
+
+homeboy runs evidence wave3-woo-generated-rest \
+  --output "$WC_OUT/evidence.json"
+
+homeboy runs artifacts wave3-woo-generated-rest \
+  --output "$WC_OUT/artifacts.json"
+
+homeboy runs refs \
+  --rig woocommerce-performance \
+  --kind fuzz \
+  --tracker-ref "$WC_TRACKER_REF" \
+  --artifact-kind canonical_fuzz_envelope \
+  --artifact-kind homeboy_fuzz_coverage \
+  --output "$WC_OUT/reviewer-refs.json"
+
+homeboy cleanup worktrees \
+  --provider datamachine-code \
+  --output "$WC_OUT/cleanup-inspection.json"
+```
+
+For the broader Woo DB/API campaign, repeat the same `fuzz plan` and `fuzz run`
+shape for every workload named in
+`woocommerce/woocommerce/manifests/db-api-fuzz-campaign.json`, then collect the
+postprocess `coverage_gap_report` and `performance_hotspots_summary` refs listed
+by that manifest before promoting the campaign to proven.
+
+## Blocker Matrix
+
+| Requirement | Current status | Promotion blocker |
+|---|---|---|
+| Campaign manifest | Present for Core and WooCommerce. | None for planning. |
+| Core fuzz plan | `homeboy fuzz plan` is available and accepts deterministic seed, strategy, budgets, tracker ref, Lab runner, and JSON output. | Plan output is intent only; it is not execution proof. |
+| Lab handoff | `homeboy fuzz run --lab-only --detach-after-handoff` is available. | Requires an approved connected runner and accepted job id. |
+| Resources indexed | `homeboy rig show --output` records rig-declared resources before execution. | Any runtime-created resources must also appear in persisted run evidence or cleanup inspection. |
+| Artifacts/result envelope | `homeboy runs evidence`, `homeboy runs artifacts`, and `homeboy runs refs` are available. | Proven status requires durable refs for `canonical_fuzz_envelope`, coverage summary, and required product artifacts. |
+| Cleanup inspection | `homeboy cleanup worktrees` can preview cleanup across configured providers without `--apply`. | Reviewer proof must include the inspection output; destructive cleanup is a separate approved action. |
+| Woo postprocess reports | Woo campaign manifest declares `coverage_gap_report` and `performance_hotspots_summary`. | The campaign remains unproven until those report artifacts have reviewer-facing refs from the offloaded run set. |

--- a/docs/wave3-fuzz-proof-recipes.json
+++ b/docs/wave3-fuzz-proof-recipes.json
@@ -1,0 +1,137 @@
+{
+  "schema": "homeboy-rigs/wave3-fuzz-proof-recipes/v1",
+  "status": "recipes_ready_proof_blocked_on_persisted_refs",
+  "accepted_ref_schemes": [
+    "https://",
+    "gh:",
+    "homeboy-runs:",
+    "homeboy://run/",
+    "homeboy-artifact://",
+    "artifact:",
+    "run:"
+  ],
+  "required_phase_order": [
+    "campaign_manifest",
+    "core_fuzz_plan",
+    "lab_handoff",
+    "resources_indexed",
+    "artifacts_result_envelope",
+    "cleanup_inspection"
+  ],
+  "recipes": [
+    {
+      "id": "generic-wordpress-core-rest-api",
+      "kind": "generic",
+      "rig": "wordpress-core-fuzz-coverage",
+      "campaign_manifest": "WordPress/wordpress-develop/manifests/fuzzer-profile.json",
+      "workload": "rest-api",
+      "run_id": "wave3-core-rest-api",
+      "tracker_ref_placeholder": "$WAVE3_TRACKER_REF",
+      "proof_status": "not_proven_until_reviewer_refs_exist",
+      "phases": [
+        {
+          "id": "campaign_manifest",
+          "description": "Core-owned fuzz profile and workload declaration are the source of campaign intent.",
+          "artifacts": ["WordPress/wordpress-develop/manifests/fuzzer-profile.json"]
+        },
+        {
+          "id": "core_fuzz_plan",
+          "description": "Build a deterministic execution request without running fuzz locally.",
+          "command": "homeboy fuzz plan --rig wordpress-core-fuzz-coverage --workload rest-api --run-id wave3-core-rest-api-plan --request-id wave3-core-rest-api-plan --strategy read-only --case-budget 25 --duration-budget-seconds 300 --max-duration 5m --seed 3 --tracker-ref \"$WAVE3_TRACKER_REF\" --lab-only --runner \"$HOMEBOY_RUNNER_ID\" --output \"$WAVE3_OUT/core-fuzz-plan.json\""
+        },
+        {
+          "id": "lab_handoff",
+          "description": "Hand the run to an approved Lab runner and return after accepted handoff.",
+          "command": "homeboy fuzz run --rig wordpress-core-fuzz-coverage --workload rest-api --run-id wave3-core-rest-api --seed 3 --max-duration 5m --require-result-envelope --require-coverage-summary --tracker-ref \"$WAVE3_TRACKER_REF\" --lab-only --runner \"$HOMEBOY_RUNNER_ID\" --detach-after-handoff --output \"$WAVE3_OUT/lab-handoff.json\""
+        },
+        {
+          "id": "resources_indexed",
+          "description": "Capture rig-declared resource ownership before or alongside the handoff.",
+          "command": "homeboy rig show wordpress-core-fuzz-coverage --output \"$WAVE3_OUT/resources-index.json\""
+        },
+        {
+          "id": "artifacts_result_envelope",
+          "description": "Collect persisted evidence, artifacts, and stable reviewer refs after the run reaches a terminal state.",
+          "commands": [
+            "homeboy runs evidence wave3-core-rest-api --output \"$WAVE3_OUT/evidence.json\"",
+            "homeboy runs artifacts wave3-core-rest-api --output \"$WAVE3_OUT/artifacts.json\"",
+            "homeboy runs refs --rig wordpress-core-fuzz-coverage --kind fuzz --tracker-ref \"$WAVE3_TRACKER_REF\" --output \"$WAVE3_OUT/reviewer-refs.json\""
+          ],
+          "required_artifact_kinds": ["canonical_fuzz_envelope", "homeboy_fuzz_coverage"]
+        },
+        {
+          "id": "cleanup_inspection",
+          "description": "Inspect worktree cleanup state without applying destructive cleanup.",
+          "command": "homeboy cleanup worktrees --provider datamachine-code --output \"$WAVE3_OUT/cleanup-inspection.json\""
+        }
+      ],
+      "blockers_to_proven": [
+        "approved Lab runner id",
+        "accepted handoff job id",
+        "terminal persisted Homeboy run",
+        "reviewer-facing canonical_fuzz_envelope ref",
+        "reviewer-facing coverage summary ref",
+        "cleanup inspection artifact"
+      ]
+    },
+    {
+      "id": "woocommerce-db-api-generated-rest",
+      "kind": "product",
+      "product": "WooCommerce",
+      "rig": "woocommerce-performance",
+      "campaign_manifest": "woocommerce/woocommerce/manifests/db-api-fuzz-campaign.json",
+      "workload": "generated-rest-request-cases",
+      "run_id": "wave3-woo-generated-rest",
+      "tracker_ref_placeholder": "$WC_TRACKER_REF",
+      "proof_status": "not_proven_until_reviewer_refs_exist",
+      "phases": [
+        {
+          "id": "campaign_manifest",
+          "description": "Woo campaign manifest declares workloads and required result, coverage, gap, and hotspot artifacts.",
+          "artifacts": ["woocommerce/woocommerce/manifests/db-api-fuzz-campaign.json"]
+        },
+        {
+          "id": "core_fuzz_plan",
+          "description": "Build a deterministic Woo execution request through the generic Homeboy fuzz planner.",
+          "command": "homeboy fuzz plan --rig woocommerce-performance --workload generated-rest-request-cases --run-id wave3-woo-generated-rest-plan --request-id wave3-woo-generated-rest-plan --strategy read-only --case-budget 80 --duration-budget-seconds 1200 --max-duration 20m --seed 3 --tracker-ref \"$WC_TRACKER_REF\" --lab-only --runner \"$HOMEBOY_RUNNER_ID\" --output \"$WC_OUT/core-fuzz-plan.json\""
+        },
+        {
+          "id": "lab_handoff",
+          "description": "Hand the Woo workload to an approved Lab runner with result envelope, coverage summary, and case-log requirements.",
+          "command": "homeboy fuzz run --rig woocommerce-performance --workload generated-rest-request-cases --run-id wave3-woo-generated-rest --seed 3 --max-duration 20m --require-case-log --require-result-envelope --require-coverage-summary --tracker-ref \"$WC_TRACKER_REF\" --lab-only --runner \"$HOMEBOY_RUNNER_ID\" --detach-after-handoff --output \"$WC_OUT/lab-handoff.json\""
+        },
+        {
+          "id": "resources_indexed",
+          "description": "Capture Woo rig resource ownership before or alongside the handoff.",
+          "command": "homeboy rig show woocommerce-performance --output \"$WC_OUT/resources-index.json\""
+        },
+        {
+          "id": "artifacts_result_envelope",
+          "description": "Collect persisted evidence, artifacts, and stable reviewer refs after the run reaches a terminal state.",
+          "commands": [
+            "homeboy runs evidence wave3-woo-generated-rest --output \"$WC_OUT/evidence.json\"",
+            "homeboy runs artifacts wave3-woo-generated-rest --output \"$WC_OUT/artifacts.json\"",
+            "homeboy runs refs --rig woocommerce-performance --kind fuzz --tracker-ref \"$WC_TRACKER_REF\" --artifact-kind canonical_fuzz_envelope --artifact-kind homeboy_fuzz_coverage --output \"$WC_OUT/reviewer-refs.json\""
+          ],
+          "required_artifact_kinds": ["canonical_fuzz_envelope", "homeboy_fuzz_coverage"]
+        },
+        {
+          "id": "cleanup_inspection",
+          "description": "Inspect worktree cleanup state without applying destructive cleanup.",
+          "command": "homeboy cleanup worktrees --provider datamachine-code --output \"$WC_OUT/cleanup-inspection.json\""
+        }
+      ],
+      "blockers_to_proven": [
+        "approved Lab runner id",
+        "accepted handoff job id",
+        "terminal persisted Homeboy run",
+        "reviewer-facing canonical_fuzz_envelope ref",
+        "reviewer-facing case log ref",
+        "reviewer-facing Homeboy fuzz coverage ref",
+        "reviewer-facing coverage_gap_report ref for full DB/API campaign promotion",
+        "reviewer-facing performance_hotspots_summary ref for full DB/API campaign promotion",
+        "cleanup inspection artifact"
+      ]
+    }
+  ]
+}

--- a/scripts/wave3-proof-recipe-check.mjs
+++ b/scripts/wave3-proof-recipe-check.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const recipePath = join(root, 'docs/wave3-fuzz-proof-recipes.json');
+const localOnlyPattern = /(?:localhost|127\.0\.0\.1|file:\/\/|\/Users\/|https?:\/\/localhost|https?:\/\/127\.0\.0\.1)/i;
+const requiredPhases = [
+  'campaign_manifest',
+  'core_fuzz_plan',
+  'lab_handoff',
+  'resources_indexed',
+  'artifacts_result_envelope',
+  'cleanup_inspection',
+];
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function commandsForPhase(phase) {
+  return [phase.command, ...(phase.commands || [])].filter(Boolean);
+}
+
+function assertCommandContains(command, fragments, context) {
+  for (const fragment of fragments) {
+    assert.ok(command.includes(fragment), `${context} must include ${fragment}`);
+  }
+}
+
+const recipes = readJson(recipePath);
+
+assert.equal(recipes.schema, 'homeboy-rigs/wave3-fuzz-proof-recipes/v1');
+assert.deepEqual(recipes.required_phase_order, requiredPhases);
+assert.ok(Array.isArray(recipes.recipes) && recipes.recipes.length >= 2, 'expected generic and product recipes');
+assert.ok(recipes.recipes.some((recipe) => recipe.kind === 'generic'), 'expected one generic recipe');
+assert.ok(recipes.recipes.some((recipe) => recipe.kind === 'product'), 'expected one product recipe');
+
+for (const recipe of recipes.recipes) {
+  assert.ok(recipe.id, 'recipe id is required');
+  assert.ok(recipe.rig, `${recipe.id} must declare a rig`);
+  assert.ok(recipe.campaign_manifest, `${recipe.id} must declare a campaign manifest`);
+  assert.ok(existsSync(join(root, recipe.campaign_manifest)), `${recipe.id} campaign manifest must exist`);
+  assert.equal(recipe.proof_status, 'not_proven_until_reviewer_refs_exist');
+  assert.deepEqual(recipe.phases.map((phase) => phase.id), requiredPhases, `${recipe.id} phase order drifted`);
+  assert.ok(recipe.blockers_to_proven?.length > 0, `${recipe.id} must list proof blockers`);
+
+  const serialized = JSON.stringify(recipe);
+  assert.ok(!localOnlyPattern.test(serialized), `${recipe.id} contains local-only reviewer evidence`);
+
+  const plan = recipe.phases.find((phase) => phase.id === 'core_fuzz_plan');
+  assertCommandContains(plan.command, [
+    'homeboy fuzz plan',
+    `--rig ${recipe.rig}`,
+    `--workload ${recipe.workload}`,
+    '--seed 3',
+    '--tracker-ref',
+    '--lab-only',
+    '--runner',
+    '--output',
+  ], `${recipe.id} plan command`);
+
+  const handoff = recipe.phases.find((phase) => phase.id === 'lab_handoff');
+  assertCommandContains(handoff.command, [
+    'homeboy fuzz run',
+    `--rig ${recipe.rig}`,
+    `--workload ${recipe.workload}`,
+    `--run-id ${recipe.run_id}`,
+    '--require-result-envelope',
+    '--require-coverage-summary',
+    '--tracker-ref',
+    '--lab-only',
+    '--runner',
+    '--detach-after-handoff',
+    '--output',
+  ], `${recipe.id} handoff command`);
+
+  const resources = recipe.phases.find((phase) => phase.id === 'resources_indexed');
+  assertCommandContains(resources.command, [
+    'homeboy rig show',
+    recipe.rig,
+    '--output',
+  ], `${recipe.id} resources command`);
+
+  const artifactCommands = commandsForPhase(recipe.phases.find((phase) => phase.id === 'artifacts_result_envelope')).join('\n');
+  assertCommandContains(artifactCommands, [
+    `homeboy runs evidence ${recipe.run_id}`,
+    `homeboy runs artifacts ${recipe.run_id}`,
+    'homeboy runs refs',
+    `--rig ${recipe.rig}`,
+    '--tracker-ref',
+    '--output',
+  ], `${recipe.id} artifact commands`);
+
+  const cleanup = recipe.phases.find((phase) => phase.id === 'cleanup_inspection');
+  assertCommandContains(cleanup.command, [
+    'homeboy cleanup worktrees',
+    '--output',
+  ], `${recipe.id} cleanup command`);
+  assert.ok(!cleanup.command.includes('--apply'), `${recipe.id} cleanup inspection must not apply cleanup`);
+}
+
+console.log(`Validated ${recipes.recipes.length} Wave 3 proof recipes from ${relative(process.cwd(), recipePath)}`);


### PR DESCRIPTION
## Summary
- Add Wave 3 deterministic fuzz proof recipes for the generic Core loop and a WooCommerce product campaign.
- Add a machine-readable recipe contract and validator covering campaign manifest, core fuzz plan, Lab handoff, resources indexed, artifacts/result envelope, and cleanup inspection.
- Document the blocker matrix for promotion to proven status instead of claiming proof without persisted reviewer-facing run/artifact refs.

## Verification
- Validated 2 Wave 3 proof recipes from docs/wave3-fuzz-proof-recipes.json
- Rig package lint passed.
- PHP syntax: 0 file(s)
- rig portability: 0 rig(s)
- fuzz workloads: 0 workload(s)
- portable source paths: 1 file(s)

## Blocker matrix
- Recipes are ready and deterministic.
- Proven status remains blocked on approved Lab runner handoff, terminal persisted Homeboy runs, reviewer-facing canonical fuzz envelope and coverage refs, product artifact refs for Woo postprocess reports, and cleanup inspection artifacts.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Drafted the recipe docs, JSON contract, validator, and verification commands with Chris's requested scope and safety constraints.