### PR TITLE
feat(ssi): consume bench workload context args

### DIFF
--- a/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
+++ b/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
@@ -32,8 +32,9 @@ async function main() {
   }
 }
 
-export default async function runFixtureMatrixBench() {
-  const options = { ...optionsFromEnv(), ...parseArgs(process.argv.slice(2)) };
+export default async function runFixtureMatrixBench(context = {}) {
+  const args = Array.isArray(context.args) ? context.args : process.argv.slice(2);
+  const options = { ...optionsFromEnv(), ...parseArgs(args) };
   const { summary, runtimeError } = await runFixtureMatrix(options);
   if (runtimeError) {
     throw runtimeError;

--- a/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
+++ b/WordPress/static-site-importer/bench/static-site-fixture-matrix.bench.mjs
@@ -280,14 +280,38 @@ function updateComposerPathRepository(pluginPath, packagePath) {
 }
 
 function configureComposerPathRepository(pluginPath, packagePath) {
-  const result = spawnSync('composer', ['config', 'repositories.blocks-engine-php-transformer-dev', 'path', packagePath], {
-    cwd: pluginPath,
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-  if (result.status !== 0) {
-    throw new Error(`Composer path repository configuration failed for ${pluginPath}: ${result.stderr || result.stdout || `exit ${result.status}`}`);
+  const composerFile = path.join(pluginPath, 'composer.json');
+  const composer = JSON.parse(fs.readFileSync(composerFile, 'utf8'));
+  composer.repositories = composer.repositories && typeof composer.repositories === 'object' && !Array.isArray(composer.repositories)
+    ? composer.repositories
+    : {};
+  composer.repositories['blocks-engine-php-transformer-dev'] = composerPathRepositoryConfig(composer, packagePath);
+  fs.writeFileSync(composerFile, `${JSON.stringify(composer, null, 2)}\n`);
+}
+
+export function composerPathRepositoryConfig(rootComposer, packagePath) {
+  return {
+    type: 'path',
+    url: packagePath,
+    canonical: false,
+    options: {
+      symlink: false,
+      versions: {
+        'automattic/blocks-engine-php-transformer': composerPathRepositoryVersion(rootComposer),
+      },
+    },
+  };
+}
+
+function composerPathRepositoryVersion(rootComposer) {
+  const constraint = rootComposer?.require?.['automattic/blocks-engine-php-transformer'];
+  if (typeof constraint !== 'string') {
+    return '0.1.15';
   }
+
+  const trimmed = constraint.trim();
+  const match = trimmed.match(/^\^?(\d+\.\d+\.\d+)$/);
+  return match ? match[1] : '0.1.15';
 }
 
 function runtimeSummary(runtime, runtimeError) {

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
-import {
+import runFixtureMatrixBench, {
   composerPathRepositoryConfig,
   resolveBlocksEnginePhpTransformerPath,
 } from '../bench/static-site-fixture-matrix.bench.mjs';
@@ -23,6 +23,14 @@ import { materializeGeneratedArtifactFixtures } from '../lib/artifact-intake.mjs
 
 const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const fixtureRoot = path.join(packageRoot, 'fixtures');
+
+function restoreEnv(key, value) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
 
 test('discovers SSI fixtures and writes Blocks Engine site artifacts', () => {
   const outputDirectory = mkdtempSync(path.join(tmpdir(), 'ssi-fixture-matrix-'));
@@ -137,6 +145,63 @@ test('builds Composer path repository override matching SSI constraints', () => 
       },
     },
   });
+});
+
+test('runFixtureMatrixBench reads workload args from context.args when imported', async () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'ssi-bench-context-args-'));
+  const contextFixtureRoot = path.join(root, 'context-fixtures');
+  const argvFixtureRoot = path.join(root, 'argv-fixtures');
+  const outputDirectory = path.join(root, 'context-artifacts');
+  const argvOutputDirectory = path.join(root, 'argv-artifacts');
+  const staticSiteImporter = path.join(root, 'static-site-importer');
+  mkdirSync(path.join(contextFixtureRoot, 'context-fixture'), { recursive: true });
+  mkdirSync(path.join(argvFixtureRoot, 'argv-fixture'), { recursive: true });
+  mkdirSync(staticSiteImporter, { recursive: true });
+  writeFileSync(path.join(contextFixtureRoot, 'context-fixture', 'index.html'), '<h1>Context fixture</h1>');
+  writeFileSync(path.join(argvFixtureRoot, 'argv-fixture', 'index.html'), '<h1>Argv fixture</h1>');
+
+  const previousArgv = process.argv;
+  const benchEnvKeys = [
+    'SSI_FIXTURE_MATRIX_FIXTURE_ROOT',
+    'SSI_FIXTURE_MATRIX_OUTPUT_DIRECTORY',
+    'SSI_FIXTURE_MATRIX_STATIC_SITE_IMPORTER_PATH',
+    'SSI_FIXTURE_MATRIX_RUN',
+    'HOMEBOY_BENCH_ARTIFACTS_DIR',
+  ];
+  const benchEnvSnapshot = Object.fromEntries(benchEnvKeys.map((key) => [key, process.env[key]]));
+
+  for (const key of benchEnvKeys) {
+    delete process.env[key];
+  }
+  process.argv = [
+    'node',
+    'homeboy-nodejs-bench-runner',
+    '--fixture-root', argvFixtureRoot,
+    '--output-directory', argvOutputDirectory,
+    '--static-site-importer-path', staticSiteImporter,
+  ];
+
+  try {
+    const benchResult = await runFixtureMatrixBench({
+      args: [
+        '--fixture-root', contextFixtureRoot,
+        '--output-directory', outputDirectory,
+        '--static-site-importer-path', staticSiteImporter,
+      ],
+    });
+
+    assert.equal(benchResult.metrics.fixture_count, 1);
+    assert.equal(benchResult.metadata.fixture_root, path.resolve(contextFixtureRoot));
+    assert.equal(benchResult.metadata.output_directory, path.resolve(outputDirectory));
+    const matrix = JSON.parse(readFileSync(benchResult.artifacts.matrix.path, 'utf8'));
+    assert.deepEqual(matrix.fixtures.map((fixture) => fixture.id), ['context-fixture']);
+    assert.equal(existsSync(path.join(argvOutputDirectory, 'matrix.json')), false);
+  } finally {
+    process.argv = previousArgv;
+    for (const key of benchEnvKeys) {
+      restoreEnv(key, benchEnvSnapshot[key]);
+    }
+  }
 });
 
 test('compares finding packet deltas by repair dimensions', () => {

--- a/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
+++ b/WordPress/static-site-importer/tools/fixture-matrix.test.mjs
@@ -4,7 +4,10 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { resolveBlocksEnginePhpTransformerPath } from '../bench/static-site-fixture-matrix.bench.mjs';
+import {
+  composerPathRepositoryConfig,
+  resolveBlocksEnginePhpTransformerPath,
+} from '../bench/static-site-fixture-matrix.bench.mjs';
 import {
   compareFindingPackets,
   selectorFamily,
@@ -114,6 +117,26 @@ test('resolves Blocks Engine PHP transformer override paths', () => {
 
   assert.equal(resolveBlocksEnginePhpTransformerPath(repoRoot), packageRoot);
   assert.equal(resolveBlocksEnginePhpTransformerPath(packageRoot), packageRoot);
+});
+
+test('builds Composer path repository override matching SSI constraints', () => {
+  const config = composerPathRepositoryConfig({
+    require: {
+      'automattic/blocks-engine-php-transformer': '^0.1.15',
+    },
+  }, '/tmp/blocks-engine/php-transformer');
+
+  assert.deepEqual(config, {
+    type: 'path',
+    url: '/tmp/blocks-engine/php-transformer',
+    canonical: false,
+    options: {
+      symlink: false,
+      versions: {
+        'automattic/blocks-engine-php-transformer': '0.1.15',
+      },
+    },
+  });
 });
 
 test('compares finding packet deltas by repair dimensions', () => {


### PR DESCRIPTION
## Summary
- Update the SSI fixture matrix bench workload to consume `context.args` when imported by the generic Node.js bench runner.
- Preserve direct CLI behavior with `process.argv.slice(2)` fallback.
- Add focused coverage proving imported workload args win over runner `process.argv`.

This consumes the generic bench workload context added in:
- Extra-Chill/homeboy#7220
- Extra-Chill/homeboy-extensions#2100

## Verification
- `node --test --test-name-pattern "runFixtureMatrixBench reads workload args from context.args when imported" "WordPress/static-site-importer/tools/fixture-matrix.test.mjs"`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode; subagent coding workflow
- **Used for:** Applying the SSI consumer layer for the generic bench workload args primitive and adding focused verification.
