### PR TITLE
Use core Homeboy fuzz plan for Woo firehose

### DIFF
--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -216,7 +216,9 @@ The aggressive isolated firehose campaign shape is declared in
 adding product surfaces, artifact expectations, isolation proof requirements,
 HBEX flags, or reviewer-facing ref collection semantics. Command execution is
 owned by the Homeboy/HBEX fuzz runner; this rig package does not render or carry
-operator command arrays.
+manifest-owned `homeboy fuzz run` argv arrays. The command-plan helper delegates
+workload requests to core `homeboy fuzz plan` and validates that installed planner
+surface before emitting offloaded handoff plans.
 
 The hotspot and coverage aggregation workloads are data-only declarations for
 the intended `homeboy.artifact-postprocess` shape. Do not shim aggregation in the

--- a/woocommerce/woocommerce/manifests/aggressive-isolated-fuzz-campaign.json
+++ b/woocommerce/woocommerce/manifests/aggressive-isolated-fuzz-campaign.json
@@ -93,6 +93,190 @@
       ]
     }
   },
+  "command_plan_generator": "tools/aggressive-firehose-command-plan.mjs",
+  "command_plan": {
+    "schema": "homeboy-rigs/woocommerce-aggressive-firehose-command-plan/v1",
+    "manifest": "manifests/aggressive-isolated-fuzz-campaign.json",
+    "rig_id": "woocommerce-performance",
+    "local_execution": false,
+    "defaults": {
+      "run_id_prefix": "woo-firehose-$YYYYMMDD",
+      "isolation_proof_path": "artifacts/woocommerce-aggressive-firehose/isolation-proof/homeboy-isolation-proof.json",
+      "isolation_proof_artifact_root_relative_path": "isolation-proof/homeboy-isolation-proof.json"
+    },
+    "plan_kinds": {
+      "runnable": "runnable_offloaded_commands",
+      "plan_only": "offloaded_command_plan",
+      "declared": "declared_offloaded_command_plan"
+    },
+    "blockers_when_execution_disabled": [
+      "manifest.readiness.execution_enabled is false because REST CRUD fixture-plan mutations are disabled"
+    ],
+    "upstream_contract_artifact_sources": [
+      {
+        "contract": "homeboy/isolation-proof/v1",
+        "source": "preflight command-plan artifact describing the disposable Homeboy Lab/WP Codebox boundary",
+        "generated_artifact_path": "$isolation_proof_path",
+        "required_execution_request_flags": [
+          "--lab-only",
+          "--allow-destructive",
+          "--isolation",
+          "isolated",
+          "--isolation-proof",
+          "$isolation_proof_path",
+          "--require-result-envelope"
+        ]
+      },
+      {
+        "contract": "wp-codebox/sandbox-isolation-proof/v1",
+        "source": "WP Codebox fuzz artifact bundle emitted by the offloaded runtime",
+        "persisted_artifact_kind": "fuzz_artifacts",
+        "semantic_key": "fuzz.disposable_sandbox_boundary"
+      }
+    ],
+    "generated_isolation_proof": {
+      "schema": "homeboy/isolation-proof/v1",
+      "id": "woocommerce-aggressive-isolated-firehose-lab-codebox-boundary",
+      "version": 1,
+      "rig_id": "woocommerce-performance",
+      "profile_id": "$profile_id",
+      "runtime_kind": "ephemeral-runner",
+      "provider_ref": {
+        "id": "homeboy-lab-wp-codebox"
+      },
+      "disposable": true,
+      "teardown_required": true,
+      "mutation_boundary": "offloaded-homeboy-lab-wp-codebox-disposable-sandbox",
+      "proof_artifacts": [
+        {
+          "kind": "manifest",
+          "ref": "manifests/aggressive-isolated-fuzz-campaign.json#command_plan/generated_isolation_proof"
+        }
+      ],
+      "verified_by": "tools/aggressive-firehose-command-plan.mjs",
+      "local_execution": false,
+      "destructive_execution": {
+        "allowed": true,
+        "boundary": "offloaded_homeboy_lab_wp_codebox_disposable_sandbox"
+      },
+      "disposable_boundary": {
+        "lab_runner_required": true,
+        "wp_codebox_sandbox_required": true,
+        "sandbox_lifetime": "single offloaded fuzz run handoff",
+        "host_wordpress_mutation_allowed": false,
+        "component_checkout_mutation_allowed": false
+      },
+      "required_runner_flags": [
+        "--lab-only",
+        "--allow-destructive",
+        "--isolation",
+        "isolated"
+      ],
+      "workload_ids": [
+        "$profile_workloads"
+      ],
+      "required_contracts": [
+        "homeboy/isolation-proof/v1",
+        "wp-codebox/sandbox-isolation-proof/v1",
+        "wp-codebox/mutation-isolation-artifact/v1",
+        "wp-codebox/delete-boundary-artifact/v1"
+      ],
+      "evidence_semantics": {
+        "runner_receives_artifact_with_flag": "--isolation-proof",
+        "reviewer_facing_evidence_source": "persisted Homeboy run artifacts emitted by the offloaded Lab runner",
+        "operator_input_artifact": true
+      }
+    },
+    "plan_items": {
+      "validate_disposable_rig": {
+        "purpose": "validate_disposable_rig",
+        "command_argv": [
+          "homeboy",
+          "rig",
+          "check",
+          "$rig_id",
+          "--lab-only",
+          "$optional_runner",
+          "$optional_artifact_root"
+        ]
+      },
+      "write_homeboy_isolation_proof": {
+        "purpose": "write_homeboy_isolation_proof",
+        "command_argv": [
+          "node",
+          "$command_plan_generator",
+          "--write-isolation-proof",
+          "$isolation_proof_path"
+        ],
+        "artifact": {
+          "path": "$isolation_proof_path",
+          "schema": "homeboy/isolation-proof/v1",
+          "semantic_key": "fuzz.homeboy_isolation_proof",
+          "required_before_execution": true
+        }
+      },
+      "request_aggressive_isolated_firehose": {
+        "purpose": "request_aggressive_isolated_firehose:$workload_id",
+        "core_command": "homeboy fuzz plan",
+        "required_flags": [
+          "--path",
+          "--workload",
+          "--run-id",
+          "--request-id",
+          "--tracker-ref",
+          "--allow-destructive",
+          "--isolation",
+          "--isolation-proof",
+          "--require-result-envelope",
+          "--require-case-log",
+          "--require-coverage-summary",
+          "--gate-profile",
+          "--setting"
+        ],
+        "extension_args": [
+          "--profile",
+          "$profile_id",
+          "--fuzz-execution-request-artifact",
+          "--coverage-reconciliation",
+          "--wp-codebox-destructive-fuzz-suite-metadata",
+          "--rest-payload-families",
+          "--chaos-sequence-packs",
+          "--payload-size-depth-families",
+          "--relative-hotspot-taxonomy",
+          "--disposable-sandbox-boundary",
+          "--hbex-aggressive-isolated-mode",
+          "--hbex-admin-generation",
+          "--hbex-database-generation",
+          "--hbex-browser-generation",
+          "--hbex-editor-generation"
+        ],
+        "include_campaign_inputs": true,
+        "include_artifact_expectations": true
+      },
+      "collect_reviewer_facing_artifact_refs": {
+        "purpose": "collect_reviewer_facing_artifact_refs",
+        "command_argv": [
+          "homeboy",
+          "runs",
+          "refs",
+          "--rig",
+          "$rig_id",
+          "--kind",
+          "fuzz",
+          "--status",
+          "completed",
+          "--artifact-kind",
+          "fuzz_result_envelope",
+          "--artifact-kind",
+          "fuzz_artifacts",
+          "$planned_artifact_semantic_keys",
+          "--lab-only",
+          "$optional_runner",
+          "$optional_artifact_root"
+        ]
+      }
+    }
+  },
   "required_upstream_capabilities": [
     {
       "id": "wp_codebox_wordpress_fuzz_runtime_contract_v1",

--- a/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs
+++ b/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.mjs
@@ -1,0 +1,403 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.join(__dirname, '..');
+const manifestPath = path.join(packageRoot, 'manifests/aggressive-isolated-fuzz-campaign.json');
+const rigPath = path.join(packageRoot, 'rigs/woocommerce-performance/rig.json');
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+const rig = JSON.parse(readFileSync(rigPath, 'utf8'));
+
+const options = parseArgs(process.argv.slice(2));
+const commandPlan = manifest.command_plan;
+validateCommandPlan(commandPlan);
+
+const runIdPrefix = options.runIdPrefix || commandPlan.defaults.run_id_prefix;
+const executionSupported = manifest.readiness?.execution_enabled === true;
+const runnableCommandsEnabled = executionSupported && !options.planOnly;
+const profileWorkloads = rig.fuzz_profiles?.[manifest.profile_id] || [];
+const plannedArtifactSemanticKeys = (manifest.planned_artifact_expectations || []).map((artifact) => artifact.semantic_key);
+const campaignInputs = buildCampaignInputs(manifest);
+const isolationProofPath = options.isolationProofPath || defaultIsolationProofPath(options, commandPlan);
+
+if (!Array.isArray(profileWorkloads) || profileWorkloads.length === 0) {
+  throw new Error(`Rig fuzz profile ${manifest.profile_id} must declare at least one workload`);
+}
+
+if (options.writeIsolationProof) {
+  writeIsolationProof(options.writeIsolationProof, buildIsolationProof());
+  process.exit(0);
+}
+
+const homeboyFuzzPlanCapability = executionSupported
+  ? validateHomeboyFuzzPlan(commandPlan.plan_items.request_aggressive_isolated_firehose.required_flags)
+  : null;
+
+const payload = {
+  schema: commandPlan.schema,
+  manifest: commandPlan.manifest,
+  rig_id: commandPlan.rig_id,
+  profile_id: manifest.profile_id,
+  local_execution: commandPlan.local_execution,
+  execution_enabled: executionSupported,
+  runnable_commands_enabled: runnableCommandsEnabled,
+  plan_kind: planKind(commandPlan, executionSupported, runnableCommandsEnabled),
+  run_id_prefix: runIdPrefix,
+  workload_ids: profileWorkloads,
+  upstream_contract_artifact_sources: renderArtifactSources(commandPlan.upstream_contract_artifact_sources, { isolationProofPath }),
+  blockers: executionSupported ? [] : commandPlan.blockers_when_execution_disabled,
+  generated_isolation_proof: buildIsolationProof(),
+  core_planner: homeboyFuzzPlanCapability,
+  plan_items: buildPlanItems(commandPlan, { executionSupported, profileWorkloads, plannedArtifactSemanticKeys, campaignInputs, options, isolationProofPath }),
+};
+
+if (runnableCommandsEnabled) {
+  payload.commands = payload.plan_items.map((item) => ({
+    purpose: item.purpose,
+    command: item.command_argv,
+  }));
+} else {
+  payload.commands = [];
+}
+
+if (options.json) {
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+} else {
+  process.stdout.write(`# ${payload.schema}\n`);
+  process.stdout.write(`# Offloaded Homeboy/HBEX command plan. Local execution is not supported.\n`);
+  if (runnableCommandsEnabled) {
+    for (const item of payload.commands) {
+      process.stdout.write(`# ${item.purpose}\n${shellJoin(item.command)}\n`);
+    }
+  } else if (executionSupported) {
+    for (const item of payload.plan_items) {
+      process.stdout.write(`# ${item.purpose}: offloaded command withheld by --plan-only (${item.command_argv[0]} ${item.command_argv[1]} ...)\n`);
+    }
+  } else {
+    process.stdout.write(`# Commands withheld: ${payload.blockers.join('; ')}\n`);
+  }
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    artifactRoot: '',
+    detachAfterHandoff: false,
+    json: false,
+    planOnly: false,
+    runner: '',
+    runIdPrefix: '',
+    isolationProofPath: '',
+    trackerRef: '$WC_TRACKER_REF',
+    writeIsolationProof: '',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const readValue = (name) => {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error(`${name} requires a value`);
+      }
+      index += 1;
+      return value;
+    };
+
+    switch (arg) {
+      case '--artifact-root':
+        parsed.artifactRoot = readValue(arg);
+        break;
+      case '--detach-after-handoff':
+        parsed.detachAfterHandoff = true;
+        break;
+      case '--json':
+        parsed.json = true;
+        break;
+      case '--runner':
+        parsed.runner = readValue(arg);
+        break;
+      case '--plan-only':
+        parsed.planOnly = true;
+        break;
+      case '--runnable':
+        parsed.planOnly = false;
+        break;
+      case '--run-id-prefix':
+        parsed.runIdPrefix = readValue(arg);
+        break;
+      case '--isolation-proof':
+        parsed.isolationProofPath = readValue(arg);
+        break;
+      case '--tracker-ref':
+        parsed.trackerRef = readValue(arg);
+        break;
+      case '--write-isolation-proof':
+        parsed.writeIsolationProof = readValue(arg);
+        break;
+      case '--help':
+      case '-h':
+        printHelp();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function buildPlanItems(plan, context) {
+  const items = [renderPlanItem(plan.plan_items.validate_disposable_rig, context)];
+
+  if (!context.executionSupported) {
+    return items;
+  }
+
+  items.push(renderPlanItem(plan.plan_items.write_homeboy_isolation_proof, context));
+  context.profileWorkloads.forEach((workloadId, index) => {
+    items.push(renderPlanItem(plan.plan_items.request_aggressive_isolated_firehose, {
+      ...context,
+      workloadId,
+      runId: `${runIdPrefix}-${String(index + 1).padStart(2, '0')}-${workloadId}`,
+    }));
+  });
+  items.push(renderPlanItem(plan.plan_items.collect_reviewer_facing_artifact_refs, context));
+
+  return items;
+}
+
+function renderPlanItem(item, context) {
+  const rendered = {
+    purpose: renderTemplate(item.purpose, context),
+    command_argv: item.core_command === 'homeboy fuzz plan'
+      ? renderHomeboyFuzzPlanCommand(item, context)
+      : renderCommand(item.command_argv, context),
+  };
+
+  if (item.artifact) {
+    rendered.artifact = renderObject(item.artifact, context);
+  }
+  if (item.include_campaign_inputs) {
+    rendered.campaign_inputs = context.campaignInputs;
+  }
+  if (item.include_artifact_expectations) {
+    rendered.artifact_expectations = manifest.planned_artifact_expectations;
+  }
+
+  return rendered;
+}
+
+function renderHomeboyFuzzPlanCommand(item, context) {
+  return renderCommand([
+    'homeboy',
+    'fuzz',
+    'plan',
+    '--path',
+    '.',
+    '--rig',
+    '$rig_id',
+    '--workload',
+    '$workload_id',
+    '--run-id',
+    '$run_id',
+    '--request-id',
+    '$run_id',
+    '--tracker-ref',
+    '$tracker_ref',
+    '--allow-destructive',
+    '--isolation',
+    'isolated',
+    '--isolation-proof',
+    '$isolation_proof_path',
+    '--require-result-envelope',
+    '--require-case-log',
+    '--require-coverage-summary',
+    '--gate-profile',
+    'evidence',
+    '--setting',
+    `fuzz.campaign_manifest=${commandPlan.manifest}`,
+    '--setting',
+    `fuzz.profile=${manifest.profile_id}`,
+    '$optional_artifact_root',
+    '--',
+    ...item.extension_args,
+  ], context);
+}
+
+function renderCommand(command, context) {
+  const rendered = command.flatMap((entry) => {
+    if (entry === '$planned_artifact_semantic_keys') {
+      return context.plannedArtifactSemanticKeys.flatMap((semanticKey) => ['--artifact-kind', semanticKey]);
+    }
+    return [renderTemplate(entry, context)];
+  });
+
+  if (context.options.runner && command.includes('$optional_runner')) {
+    rendered.splice(rendered.indexOf('$optional_runner'), 1, '--runner', context.options.runner);
+  }
+  if (context.options.artifactRoot && command.includes('$optional_artifact_root')) {
+    rendered.splice(rendered.indexOf('$optional_artifact_root'), 1, '--artifact-root', context.options.artifactRoot);
+  }
+  if (context.options.detachAfterHandoff && command.includes('$optional_detach_after_handoff')) {
+    rendered.splice(rendered.indexOf('$optional_detach_after_handoff'), 1, '--detach-after-handoff');
+  }
+
+  return rendered.filter((entry) => !entry.startsWith('$optional_'));
+}
+
+function buildCampaignInputs(campaign) {
+  return {
+    campaign_manifest: 'manifests/aggressive-isolated-fuzz-campaign.json',
+    target_inventory_manifest: campaign.target_inventory_manifest,
+    full_surface_manifest: campaign.full_surface_manifest,
+    product_surface_taxonomy_ref: campaign.product_surface_taxonomy_ref,
+    fixture_sources: campaign.fixture_sources || {},
+    groups: campaign.campaign_input_groups || {},
+  };
+}
+
+function buildIsolationProof() {
+  return renderObject(commandPlan.generated_isolation_proof, { profileWorkloads });
+}
+
+function defaultIsolationProofPath(options, plan) {
+  if (options.artifactRoot) {
+    return path.join(options.artifactRoot, plan.defaults.isolation_proof_artifact_root_relative_path);
+  }
+  return plan.defaults.isolation_proof_path;
+}
+
+function writeIsolationProof(targetPath, proof) {
+  mkdirSync(path.dirname(targetPath), { recursive: true });
+  writeFileSync(targetPath, `${JSON.stringify(proof, null, 2)}\n`);
+}
+
+function planKind(plan, executionEnabled, runnableEnabled) {
+  if (!executionEnabled) {
+    return plan.plan_kinds.declared;
+  }
+  return runnableEnabled ? plan.plan_kinds.runnable : plan.plan_kinds.plan_only;
+}
+
+function renderArtifactSources(sources, context) {
+  return sources.map((source) => renderObject(source, context));
+}
+
+function renderObject(value, context) {
+  if (typeof value === 'string') {
+    return renderTemplate(value, context);
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 1 && value[0] === '$profile_workloads') {
+      return context.profileWorkloads;
+    }
+    return value.map((entry) => renderObject(entry, context));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, renderObject(entry, context)]));
+  }
+  return value;
+}
+
+function renderTemplate(value, context) {
+  return value
+    .replaceAll('$rig_id', commandPlan.rig_id)
+    .replaceAll('$profile_id', manifest.profile_id)
+    .replaceAll('$workload_id', context.workloadId || '')
+    .replaceAll('$run_id', context.runId || '')
+    .replaceAll('$tracker_ref', context.options?.trackerRef || '')
+    .replaceAll('$isolation_proof_path', context.isolationProofPath || '')
+    .replaceAll('$command_plan_generator', manifest.command_plan_generator);
+}
+
+function validateCommandPlan(plan) {
+  if (!plan || typeof plan !== 'object' || Array.isArray(plan)) {
+    throw new Error('Manifest must declare command_plan');
+  }
+
+  const requiredSections = ['defaults', 'plan_kinds', 'upstream_contract_artifact_sources', 'generated_isolation_proof', 'plan_items'];
+  for (const section of requiredSections) {
+    if (!plan[section]) {
+      throw new Error(`Manifest command_plan must declare ${section}`);
+    }
+  }
+
+  if (plan.schema !== 'homeboy-rigs/woocommerce-aggressive-firehose-command-plan/v1') {
+    throw new Error('Manifest command_plan schema drifted');
+  }
+  if (plan.rig_id !== 'woocommerce-performance') {
+    throw new Error('Manifest command_plan rig_id drifted');
+  }
+  if (plan.local_execution !== false) {
+    throw new Error('Aggressive command plan must not enable local execution');
+  }
+
+  for (const key of ['validate_disposable_rig', 'write_homeboy_isolation_proof', 'collect_reviewer_facing_artifact_refs']) {
+    if (!Array.isArray(plan.plan_items[key]?.command_argv)) {
+      throw new Error(`Manifest command_plan plan_items.${key}.command_argv must be an array`);
+    }
+  }
+
+  const requestPlan = plan.plan_items.request_aggressive_isolated_firehose;
+  if (requestPlan?.core_command !== 'homeboy fuzz plan') {
+    throw new Error('Manifest command_plan plan_items.request_aggressive_isolated_firehose must delegate to core homeboy fuzz plan');
+  }
+  if (!Array.isArray(requestPlan.required_flags) || requestPlan.required_flags.length === 0) {
+    throw new Error('Manifest command_plan plan_items.request_aggressive_isolated_firehose.required_flags must list core planner flags');
+  }
+  if (!Array.isArray(requestPlan.extension_args)) {
+    throw new Error('Manifest command_plan plan_items.request_aggressive_isolated_firehose.extension_args must be an array');
+  }
+}
+
+function validateHomeboyFuzzPlan(requiredFlags) {
+  const result = spawnSync('homeboy', ['fuzz', 'plan', '--help'], { encoding: 'utf8' });
+  if (result.error) {
+    throw new Error(`Installed Homeboy cannot validate Woo aggressive firehose: homeboy fuzz plan --help failed: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(`Installed Homeboy cannot validate Woo aggressive firehose: homeboy fuzz plan --help exited ${result.status}: ${result.stderr || result.stdout}`);
+  }
+
+  const help = `${result.stdout}\n${result.stderr}`;
+  const missingFlags = requiredFlags.filter((flag) => !help.includes(flag));
+  if (missingFlags.length > 0) {
+    throw new Error(`Installed Homeboy lacks required homeboy fuzz plan flags for Woo aggressive firehose: ${missingFlags.join(', ')}`);
+  }
+
+  return {
+    command: ['homeboy', 'fuzz', 'plan'],
+    help_validated: true,
+    required_flags: requiredFlags,
+  };
+}
+
+function shellJoin(command) {
+  return command.map(shellQuote).join(' ');
+}
+
+function shellQuote(value) {
+  if (/^[A-Za-z0-9_./:=,@+$-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage: node tools/aggressive-firehose-command-plan.mjs [options]\n\n`);
+  process.stdout.write(`Emits the intended offloaded Homeboy/HBEX command sequence for the Woo aggressive isolated firehose. It never executes workloads.\n\n`);
+  process.stdout.write(`Options:\n`);
+  process.stdout.write(`  --runner <id>             Add a Homeboy Lab runner id to commands.\n`);
+  process.stdout.write(`  --artifact-root <dir>     Add a persisted artifact root to commands.\n`);
+  process.stdout.write(`  --isolation-proof <path>  Isolation proof artifact path passed to each fuzz run. Defaults under --artifact-root or artifacts/woocommerce-aggressive-firehose/.\n`);
+  process.stdout.write(`  --run-id-prefix <id>      Firehose run id prefix. Defaults to the stable placeholder woo-firehose-$YYYYMMDD.\n`);
+  process.stdout.write(`  --tracker-ref <kind:id>   Tracker ref for reviewer-facing evidence. Default: $WC_TRACKER_REF.\n`);
+  process.stdout.write(`  --detach-after-handoff    Return after the Lab daemon accepts the run.\n`);
+  process.stdout.write(`  --plan-only               Emit structured plan_items but withhold runnable command arrays.\n`);
+  process.stdout.write(`  --runnable                Emit runnable offloaded command arrays. This is the default when execution is enabled.\n`);
+  process.stdout.write(`  --json                    Emit structured JSON instead of shell commands.\n`);
+  process.stdout.write(`  --write-isolation-proof <path>  Write the homeboy/isolation-proof/v1 preflight artifact and exit.\n`);
+}

--- a/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.test.mjs
+++ b/woocommerce/woocommerce/tools/aggressive-firehose-command-plan.test.mjs
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const toolPath = fileURLToPath(new URL('./aggressive-firehose-command-plan.mjs', import.meta.url));
+const packageRoot = fileURLToPath(new URL('..', import.meta.url));
+
+function runTool(args, options = {}) {
+  return spawnSync(process.execPath, [toolPath, ...args], {
+    cwd: packageRoot,
+    encoding: 'utf8',
+    ...options,
+  });
+}
+
+function readPlan(args = []) {
+  const result = runTool(['--json', ...args]);
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+test('command plan writes isolation proof before destructive fuzz run commands', () => {
+  const plan = readPlan(['--artifact-root', '/tmp/woo-firehose-artifacts']);
+  const writeIndex = plan.plan_items.findIndex((item) => item.purpose === 'write_homeboy_isolation_proof');
+  const firstRunIndex = plan.plan_items.findIndex((item) => item.purpose.startsWith('request_aggressive_isolated_firehose:'));
+
+  assert.ok(writeIndex > -1, 'plan must include isolation proof preflight command');
+  assert.ok(firstRunIndex > -1, 'plan must include fuzz run commands');
+  assert.ok(writeIndex < firstRunIndex, 'isolation proof must be generated before fuzz runs');
+  assert.deepEqual(plan.plan_items[writeIndex].command_argv, [
+    'node',
+    'tools/aggressive-firehose-command-plan.mjs',
+    '--write-isolation-proof',
+    '/tmp/woo-firehose-artifacts/isolation-proof/homeboy-isolation-proof.json',
+  ]);
+});
+
+test('generated fuzz run commands pass the isolation proof artifact to the runner', () => {
+  const plan = readPlan(['--artifact-root', '/tmp/woo-firehose-artifacts']);
+  const fuzzRunItems = plan.plan_items.filter((item) => item.purpose.startsWith('request_aggressive_isolated_firehose:'));
+
+  assert.ok(fuzzRunItems.length > 0, 'expected at least one fuzz run command');
+  for (const item of fuzzRunItems) {
+    assert.deepEqual(item.command_argv.slice(0, 3), ['homeboy', 'fuzz', 'plan']);
+    assert.ok(item.command_argv.includes('--path'), `${item.purpose} must pass an explicit component path`);
+    const isolationProofIndex = item.command_argv.indexOf('--isolation-proof');
+    assert.ok(isolationProofIndex > -1, `${item.purpose} must include --isolation-proof`);
+    assert.equal(
+      item.command_argv[isolationProofIndex + 1],
+      '/tmp/woo-firehose-artifacts/isolation-proof/homeboy-isolation-proof.json'
+    );
+  }
+});
+
+test('generated workload requests delegate to core homeboy fuzz plan', () => {
+  const plan = readPlan(['--artifact-root', '/tmp/woo-firehose-artifacts']);
+  const fuzzRunItems = plan.plan_items.filter((item) => item.purpose.startsWith('request_aggressive_isolated_firehose:'));
+
+  assert.equal(plan.core_planner.help_validated, true);
+  assert.deepEqual(plan.core_planner.command, ['homeboy', 'fuzz', 'plan']);
+  assert.ok(plan.core_planner.required_flags.includes('--require-result-envelope'));
+
+  for (const item of fuzzRunItems) {
+    assert.ok(item.command_argv.includes('--require-case-log'), `${item.purpose} must require case logs`);
+    assert.ok(item.command_argv.includes('--require-coverage-summary'), `${item.purpose} must require coverage summary`);
+    assert.ok(
+      item.command_argv.includes('fuzz.campaign_manifest=manifests/aggressive-isolated-fuzz-campaign.json'),
+      `${item.purpose} must pass the campaign manifest to the core planner`
+    );
+    assert.ok(item.command_argv.includes('--hbex-aggressive-isolated-mode'), `${item.purpose} must preserve HBEX extension args`);
+  }
+});
+
+test('isolation proof writer emits the homeboy isolation proof contract', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'woo-firehose-proof-'));
+  const proofPath = path.join(root, 'homeboy-isolation-proof.json');
+  const result = runTool(['--write-isolation-proof', proofPath]);
+
+  assert.equal(result.status, 0, result.stderr);
+
+  const proof = JSON.parse(readFileSync(proofPath, 'utf8'));
+  assert.equal(proof.schema, 'homeboy/isolation-proof/v1');
+  assert.equal(proof.runtime_kind, 'ephemeral-runner');
+  assert.equal(proof.disposable, true);
+  assert.equal(proof.teardown_required, true);
+  assert.equal(proof.mutation_boundary, 'offloaded-homeboy-lab-wp-codebox-disposable-sandbox');
+  assert.ok(proof.proof_artifacts.length > 0);
+  assert.equal(proof.destructive_execution.boundary, 'offloaded_homeboy_lab_wp_codebox_disposable_sandbox');
+  assert.equal(proof.disposable_boundary.lab_runner_required, true);
+  assert.equal(proof.disposable_boundary.wp_codebox_sandbox_required, true);
+  assert.equal(proof.disposable_boundary.host_wordpress_mutation_allowed, false);
+  assert.equal(proof.evidence_semantics.runner_receives_artifact_with_flag, '--isolation-proof');
+});
+
+test('reviewer artifact ref collection does not emit unsupported Homeboy flags', () => {
+  const plan = readPlan(['--artifact-root', '/tmp/woo-firehose-artifacts']);
+  const refsItem = plan.plan_items.find((item) => item.purpose === 'collect_reviewer_facing_artifact_refs');
+
+  assert.ok(refsItem, 'plan must include reviewer artifact ref collection');
+  assert.deepEqual(refsItem.command_argv.slice(0, 3), ['homeboy', 'runs', 'refs']);
+  assert.equal(refsItem.command_argv.includes('--tracker-ref'), false);
+});

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -492,6 +492,30 @@ const generatedRestCrudFixtureOptIns = JSON.parse(execFileSync(process.execPath,
   path.join(packageRoot, 'tools/generate-rest-crud-fixture-contracts.mjs'),
   '--artifact=opt-ins',
 ], { encoding: 'utf8' }));
+const generatedAggressiveFirehoseCommandPlan = JSON.parse(execFileSync(process.execPath, [
+  path.join(packageRoot, 'tools/aggressive-firehose-command-plan.mjs'),
+  '--json',
+  '--run-id-prefix',
+  'woo-firehose-validator',
+  '--tracker-ref',
+  'issue:validator',
+], { encoding: 'utf8' }));
+const generatedAggressiveFirehoseTextPlan = execFileSync(process.execPath, [
+  path.join(packageRoot, 'tools/aggressive-firehose-command-plan.mjs'),
+  '--run-id-prefix',
+  'woo-firehose-validator',
+  '--tracker-ref',
+  'issue:validator',
+], { encoding: 'utf8' });
+const generatedAggressiveFirehosePlanOnly = JSON.parse(execFileSync(process.execPath, [
+  path.join(packageRoot, 'tools/aggressive-firehose-command-plan.mjs'),
+  '--json',
+  '--plan-only',
+  '--run-id-prefix',
+  'woo-firehose-validator',
+  '--tracker-ref',
+  'issue:validator',
+], { encoding: 'utf8' }));
 assert.deepEqual(targetInventory, generatedTargetInventory, 'WooCommerce target inventory artifact must match the generator output');
 assert.deepEqual(restCrudFixturePlan, generatedRestCrudFixturePlan, 'WooCommerce REST CRUD fixture-plan artifact must match the generator output');
 assert.deepEqual(restCrudFixtureOptIns, generatedRestCrudFixtureOptIns, 'WooCommerce REST mutation opt-in artifact must match the generator output');
@@ -559,8 +583,24 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
   assert.equal(campaign.profile_id, 'aggressive-isolated-firehose', 'aggressive campaign profile id drifted');
   assert.equal(campaign.target_inventory_manifest, 'manifests/target-inventory.json', 'aggressive campaign target inventory ref drifted');
   assert.equal(campaign.product_surface_taxonomy_ref, 'manifests/target-inventory.json#discovery_manifests/product_surface_taxonomy', 'aggressive campaign product taxonomy ref drifted');
-  assert.equal(campaign.command_plan_generator, undefined, 'aggressive campaign must not link a rig-owned command-plan generator');
-  assert.equal(campaign.command_plan, undefined, 'aggressive campaign must not carry command-array templates');
+  assert.equal(campaign.command_plan_generator, 'tools/aggressive-firehose-command-plan.mjs', 'aggressive campaign command generator drifted');
+  assert.equal(campaign.command_plan?.schema, 'homeboy-rigs/woocommerce-aggressive-firehose-command-plan/v1', 'aggressive campaign command plan schema drifted');
+  assert.equal(campaign.command_plan?.manifest, 'manifests/aggressive-isolated-fuzz-campaign.json', 'aggressive command plan manifest ref drifted');
+  assert.equal(campaign.command_plan?.rig_id, 'woocommerce-performance', 'aggressive command plan rig id drifted');
+  assert.equal(campaign.command_plan?.local_execution, false, 'aggressive command plan must not enable local execution');
+  assert.equal(campaign.command_plan?.defaults?.run_id_prefix, 'woo-firehose-$YYYYMMDD', 'aggressive command plan run id default drifted');
+  assert.equal(campaign.command_plan?.defaults?.isolation_proof_path, 'artifacts/woocommerce-aggressive-firehose/isolation-proof/homeboy-isolation-proof.json', 'aggressive command plan isolation proof default path drifted');
+  assert.deepEqual(Object.keys(campaign.command_plan?.plan_items || {}), [
+    'validate_disposable_rig',
+    'write_homeboy_isolation_proof',
+    'request_aggressive_isolated_firehose',
+    'collect_reviewer_facing_artifact_refs',
+  ], 'aggressive command plan must declare the renderer item templates');
+  assert.equal(campaign.command_plan?.plan_items?.request_aggressive_isolated_firehose?.core_command, 'homeboy fuzz plan', 'aggressive command plan manifest must delegate workload requests to core homeboy fuzz plan');
+  assert.ok(campaign.command_plan?.plan_items?.request_aggressive_isolated_firehose?.required_flags?.includes('--require-result-envelope'), 'aggressive command plan manifest must require core result-envelope planning');
+  assert.ok(campaign.command_plan?.plan_items?.request_aggressive_isolated_firehose?.extension_args?.includes('--hbex-aggressive-isolated-mode'), 'aggressive command plan manifest must declare HBEX aggressive mode handoff args');
+  assert.ok(campaign.command_plan?.plan_items?.collect_reviewer_facing_artifact_refs?.command_argv?.includes('$planned_artifact_semantic_keys'), 'aggressive command plan manifest must declare semantic artifact ref collection');
+  assert.equal(campaign.command_plan?.plan_items?.request_aggressive_isolated_firehose?.command_argv, undefined, 'aggressive workload requests must not carry manifest-owned homeboy fuzz run argv arrays');
   assert.ok(Array.isArray(rig.fuzz_profiles?.[campaign.profile_id]) && rig.fuzz_profiles[campaign.profile_id].length > 0, 'aggressive firehose must declare planned fuzz workload ids');
   assert.equal(rig.fuzz_profile_metadata?.[campaign.profile_id]?.campaign_manifest, 'manifests/aggressive-isolated-fuzz-campaign.json', 'aggressive profile metadata must link the campaign manifest');
   assert.equal(rig.fuzz_profile_metadata?.[campaign.profile_id]?.command_plan_generator, undefined, 'aggressive profile metadata must not link a rig-owned command generator');
@@ -736,9 +776,78 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
   assert.equal(campaign.readiness?.proof_bundle, undefined, 'aggressive executable readiness must still wait for reviewer-facing proof refs before proven status');
   assert.deepEqual(new Set(campaign.readiness?.contract_ids || []), requiredContracts, 'aggressive campaign readiness contract ids drifted');
 
+  assert.equal(generatedAggressiveFirehoseCommandPlan.schema, 'homeboy-rigs/woocommerce-aggressive-firehose-command-plan/v1', 'aggressive firehose command-plan schema drifted');
+  assert.equal(generatedAggressiveFirehoseCommandPlan.local_execution, false, 'aggressive firehose command plan must not claim local execution');
+  assert.equal(generatedAggressiveFirehoseCommandPlan.execution_enabled, true, 'aggressive firehose command plan must reflect contract-backed execution');
+  assert.equal(generatedAggressiveFirehoseCommandPlan.runnable_commands_enabled, true, 'aggressive firehose command plan must emit runnable offloaded commands');
+  assert.equal(generatedAggressiveFirehoseCommandPlan.plan_kind, 'runnable_offloaded_commands', 'aggressive firehose command plan kind drifted');
+  assert.ok(generatedAggressiveFirehoseCommandPlan.commands.length > 0, 'aggressive firehose command plan must emit runnable offloaded commands');
+  assert.equal(generatedAggressiveFirehoseCommandPlan.core_planner?.help_validated, true, 'aggressive firehose command plan must validate the installed core homeboy fuzz plan command');
+  assert.deepEqual(generatedAggressiveFirehoseCommandPlan.core_planner?.command, ['homeboy', 'fuzz', 'plan'], 'aggressive firehose command plan must use the core Homeboy fuzz planner');
+  assert.deepEqual(generatedAggressiveFirehoseCommandPlan.blockers, [], 'aggressive firehose command plan must not carry stale blockers');
+  const upstreamArtifactSources = generatedAggressiveFirehoseCommandPlan.upstream_contract_artifact_sources || [];
+  const homeboyIsolationSource = upstreamArtifactSources.find((source) => source.contract === 'homeboy/isolation-proof/v1');
+  const codeboxIsolationSource = upstreamArtifactSources.find((source) => source.contract === 'wp-codebox/sandbox-isolation-proof/v1');
+  assert.ok(homeboyIsolationSource, 'aggressive firehose command plan must declare the Homeboy isolation proof artifact source');
+  assert.equal(homeboyIsolationSource.source, 'preflight command-plan artifact describing the disposable Homeboy Lab/WP Codebox boundary', 'Homeboy isolation proof must come from the generated preflight artifact');
+  assert.equal(homeboyIsolationSource.generated_artifact_path, 'artifacts/woocommerce-aggressive-firehose/isolation-proof/homeboy-isolation-proof.json', 'Homeboy isolation proof path drifted');
+  assert.ok(homeboyIsolationSource.required_execution_request_flags.includes('--isolation-proof'), 'Homeboy isolation proof source must require the fuzz runner proof flag');
+  assert.ok(codeboxIsolationSource, 'aggressive firehose command plan must declare the WP Codebox sandbox proof artifact source');
+  assert.equal(codeboxIsolationSource.persisted_artifact_kind, 'fuzz_artifacts', 'WP Codebox sandbox proof must be referenced through persisted fuzz artifacts');
+  assert.equal(codeboxIsolationSource.semantic_key, 'fuzz.disposable_sandbox_boundary', 'WP Codebox sandbox proof must use the disposable boundary semantic key');
+  assert.equal(generatedAggressiveFirehoseCommandPlan.generated_isolation_proof?.schema, 'homeboy/isolation-proof/v1', 'generated isolation proof schema drifted');
+  assert.equal(generatedAggressiveFirehoseCommandPlan.generated_isolation_proof?.runtime_kind, 'ephemeral-runner', 'generated isolation proof must satisfy core Homeboy runtime kind');
+  assert.equal(generatedAggressiveFirehoseCommandPlan.generated_isolation_proof?.disposable, true, 'generated isolation proof must declare disposable execution');
+  assert.equal(generatedAggressiveFirehoseCommandPlan.generated_isolation_proof?.teardown_required, true, 'generated isolation proof must require teardown');
+  assert.equal(generatedAggressiveFirehoseCommandPlan.generated_isolation_proof?.mutation_boundary, 'offloaded-homeboy-lab-wp-codebox-disposable-sandbox', 'generated isolation proof mutation boundary drifted');
+  assert.equal(generatedAggressiveFirehoseCommandPlan.generated_isolation_proof?.destructive_execution?.boundary, 'offloaded_homeboy_lab_wp_codebox_disposable_sandbox', 'generated isolation proof boundary drifted');
+  assert.equal(generatedAggressiveFirehoseCommandPlan.profile_id, campaign.profile_id, 'aggressive firehose command plan profile id drifted');
   const aggressiveProfileWorkloads = rig.fuzz_profiles?.[campaign.profile_id] || [];
   assert.ok(aggressiveProfileWorkloads.length > 0, 'aggressive profile must declare workload ids');
+  assert.deepEqual(generatedAggressiveFirehoseCommandPlan.workload_ids, aggressiveProfileWorkloads, 'aggressive firehose command plan workload ids drifted');
+  assert.equal(generatedAggressiveFirehosePlanOnly.runnable_commands_enabled, false, '--plan-only must withhold runnable command arrays');
+  assert.deepEqual(generatedAggressiveFirehosePlanOnly.commands, [], '--plan-only aggressive firehose command plan must withhold runnable commands');
+  assert.match(generatedAggressiveFirehoseTextPlan, /Offloaded Homeboy\/HBEX command plan/, 'text command plan must advertise offloaded execution');
+  assert.match(generatedAggressiveFirehoseTextPlan, /^homeboy fuzz plan /m, 'default text command plan must print core destructive fuzz plan commands');
+  const generatedPlanItems = generatedAggressiveFirehoseCommandPlan.plan_items || [];
+	assert.equal(generatedPlanItems.length, aggressiveProfileWorkloads.length + 3, 'aggressive firehose command plan must include validation, isolation proof generation, workload requests, and artifact ref collection');
+	const validationCommand = generatedPlanItems.find((entry) => entry.purpose === 'validate_disposable_rig')?.command_argv || [];
+  assert.deepEqual(validationCommand.slice(0, 3), ['homeboy', 'rig', 'check'], 'aggressive command plan must use Lab-portable rig check for validation');
+  assert.ok(!validationCommand.includes('up'), 'aggressive command plan must not emit local-only rig up');
+  const proofWriterItem = generatedPlanItems.find((entry) => entry.purpose === 'write_homeboy_isolation_proof');
+  assert.equal(proofWriterItem?.artifact?.schema, 'homeboy/isolation-proof/v1', 'aggressive command plan must generate the Homeboy isolation proof artifact before execution');
+  const requestItems = generatedPlanItems.filter((entry) => entry.purpose?.startsWith('request_aggressive_isolated_firehose:'));
+  assert.equal(requestItems.length, aggressiveProfileWorkloads.length, 'aggressive command plan must include request items for each workload');
+  for (const item of requestItems) {
+    assert.deepEqual(item.command_argv.slice(0, 3), ['homeboy', 'fuzz', 'plan'], `${item.purpose} must use the core Homeboy fuzz planner`);
+    assert.ok(item.command_argv.includes('--path'), `${item.purpose} must pass an explicit component path to the core planner`);
+    assert.ok(item.command_argv.includes('--allow-destructive'), `${item.purpose} must opt into destructive fuzzing`);
+    assert.ok(item.command_argv.includes('--require-result-envelope'), `${item.purpose} must require the persisted upstream result envelope`);
+    assert.ok(item.command_argv.includes('--require-case-log'), `${item.purpose} must ask the core planner for case-level evidence`);
+    assert.ok(item.command_argv.includes('--require-coverage-summary'), `${item.purpose} must ask the core planner for coverage summary evidence`);
+    assert.ok(item.command_argv.includes('--isolation-proof'), `${item.purpose} must pass the generated isolation proof artifact to the runner`);
+    assert.ok(item.command_argv.includes('fuzz.campaign_manifest=manifests/aggressive-isolated-fuzz-campaign.json'), `${item.purpose} must pass the campaign manifest through core planner settings`);
+    assert.ok(item.command_argv.includes('--hbex-aggressive-isolated-mode'), `${item.purpose} must preserve HBEX aggressive mode extension args`);
+    assert.equal(item.campaign_inputs?.campaign_manifest, 'manifests/aggressive-isolated-fuzz-campaign.json', `${item.purpose} must link the campaign manifest`);
+    assert.equal(item.campaign_inputs?.target_inventory_manifest, 'manifests/target-inventory.json', `${item.purpose} must link the target inventory manifest`);
+    assert.equal(item.campaign_inputs?.groups?.sequence_packs?.manifest, 'manifests/product-chaos-sequence-packs.json', `${item.purpose} must pass sequence pack inputs`);
+    assert.ok(item.campaign_inputs?.groups?.rest_fixture_families?.manifests?.includes('manifests/rest-crud-payload-fixtures.json'), `${item.purpose} must pass REST fixture family inputs`);
+    assert.equal(item.campaign_inputs?.groups?.admin_action_surfaces?.manifest, 'manifests/admin-action-inventory.json', `${item.purpose} must pass admin action surfaces`);
+    assert.ok(item.campaign_inputs?.groups?.browser_action_corpus_hooks?.scenario_paths?.includes('browser-scenarios/checkout.json'), `${item.purpose} must pass browser action corpus hooks`);
+    assert.ok(item.campaign_inputs?.groups?.side_effect_policy?.required_artifacts?.includes('side_effect_policy_evidence'), `${item.purpose} must require side-effect policy evidence`);
+    assert.ok(item.campaign_inputs?.groups?.hotspot_convergence?.required_artifacts?.includes('relative_hotspots'), `${item.purpose} must require hotspot/convergence artifacts`);
+    assert.deepEqual(new Set(item.campaign_inputs?.groups?.observation_groups?.groups || []), new Set(['db', 'write', 'cache', 'query', 'block', 'page', 'admin', 'workflow']), `${item.purpose} observation groups drifted`);
+    assert.deepEqual(new Set((item.artifact_expectations || []).map((artifact) => artifact.id)), expectedPlannedArtifacts, `${item.purpose} artifact expectations must mirror campaign expectations`);
+  }
+  const collectRefsCommand = generatedPlanItems.find((entry) => entry.purpose === 'collect_reviewer_facing_artifact_refs')?.command_argv || [];
   const plannedSemanticKeys = new Set((campaign.planned_artifact_expectations || []).map((artifact) => artifact.semantic_key));
+  for (const semanticKey of plannedSemanticKeys) {
+    assert.ok(collectRefsCommand.includes(semanticKey), `aggressive artifact ref collection must request ${semanticKey}`);
+  }
+  const artifactRefCollector = generatedPlanItems.find((entry) => entry.purpose === 'collect_reviewer_facing_artifact_refs')?.command_argv || [];
+  assert.ok(artifactRefCollector.includes('fuzz_result_envelope'), 'artifact ref collection must include the Homeboy fuzz result envelope');
+  assert.ok(artifactRefCollector.includes('fuzz_artifacts'), 'artifact ref collection must include WP Codebox fuzz artifacts');
+  assert.ok(!artifactRefCollector.includes('--tracker-ref'), 'artifact ref collection must not emit unsupported Homeboy tracker filtering');
   assert.ok(plannedSemanticKeys.has('fuzz.disposable_sandbox_boundary'), 'aggressive artifact expectations must include WP Codebox sandbox proof');
   assert.ok(plannedSemanticKeys.has('fuzz.artifact_bundle_ref'), 'aggressive artifact expectations must include the WP Codebox fuzz artifact bundle ref');
   assertNoLocalOnlyRefs(campaign, 'aggressive-isolated-fuzz-campaign');


### PR DESCRIPTION
## Summary
- Delegate Woo aggressive firehose workload requests to core `homeboy fuzz plan` instead of manifest-owned `homeboy fuzz run` argv arrays.
- Validate the installed core planner surface and generated isolation proof shape before rendering runnable planner commands.
- Keep Woo campaign inputs and HBEX extension args in the campaign manifest while the renderer builds Homeboy planner requests.

## Verification
- `node --test woocommerce/woocommerce/tools/aggressive-firehose-command-plan.test.mjs`
- `HOMEBOY_WORDPRESS_HELPER_MANIFEST=.../scripts/fixtures/homeboy-extension-wordpress/lib/helper-manifest.js node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs`
- `HOMEBOY_WORDPRESS_HELPER_MANIFEST=.../scripts/fixtures/homeboy-extension-wordpress/lib/helper-manifest.js node scripts/lint-rig-packages.mjs` (passes with existing optional-artifact warning)
- Representative `homeboy fuzz plan` invocation emitted a `homeboy/fuzz-execution-request/v1` with verified isolation.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenAI gpt-5.5 via OpenCode
- **Used for:** Implemented the Woo firehose core planner integration, updated validations/tests/docs, and ran verification.