### PR TITLE
Consume Wave 3 campaign proof commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ difference between declared, executable, and proven coverage.
 
 Wave 3 fuzz proof recipes are tracked in
 [`docs/wave3-fuzz-proof-evidence.md`](docs/wave3-fuzz-proof-evidence.md). They
-show the deterministic chain from campaign manifest to core fuzz plan, Lab
-handoff, resource indexing, persisted artifacts/result envelope, and cleanup
+show the deterministic chain from campaign manifest to campaign dispatch,
+resource lifecycle indexing, persisted artifacts/outcome envelope, and cleanup
 inspection. Validate the machine-readable recipe contract with
 `node scripts/wave3-proof-recipe-check.mjs`; the recipes remain blocked from
 `proven` status until durable reviewer-facing Homeboy run and artifact refs

--- a/docs/wave3-fuzz-proof-evidence.md
+++ b/docs/wave3-fuzz-proof-evidence.md
@@ -5,11 +5,10 @@ reviewer-facing evidence without using local-only proof. It covers the complete
 chain:
 
 1. Campaign manifest.
-2. Core fuzz plan.
-3. Lab handoff.
-4. Resources indexed.
-5. Artifacts and result envelope.
-6. Cleanup inspection.
+2. Campaign dispatch through Homeboy's fuzz campaign primitive.
+3. Resource lifecycle index inspection.
+4. Artifacts and canonical outcome envelope.
+5. Cleanup inspection.
 
 The recipe is deterministic, but this repository does not claim the campaigns
 are proven until the commands produce durable Homeboy run and artifact refs from
@@ -33,49 +32,45 @@ Core-owned manifest before layering product-specific assertions on top.
 export HOMEBOY_RUNNER_ID=<approved-runner-id>
 export WAVE3_TRACKER_REF=github:owner/repo#issue-or-pr
 export WAVE3_OUT=./wave3-core-proof
+export WAVE3_CORE_RESOURCE_INDEX=<resource-lifecycle-index-artifact-json>
 
-homeboy rig show wordpress-core-fuzz-coverage \
-  --output "$WAVE3_OUT/resources-index.json"
-
-homeboy fuzz plan \
+homeboy fuzz run-campaign \
   --rig wordpress-core-fuzz-coverage \
-  --workload rest-api \
-  --run-id wave3-core-rest-api-plan \
-  --request-id wave3-core-rest-api-plan \
+  --campaign-workload rest-api \
+  --request-id wave3-core-rest-api-campaign \
   --strategy read-only \
   --case-budget 25 \
   --duration-budget-seconds 300 \
   --max-duration 5m \
   --seed 3 \
   --tracker-ref "$WAVE3_TRACKER_REF" \
-  --lab-only \
-  --runner "$HOMEBOY_RUNNER_ID" \
-  --output "$WAVE3_OUT/core-fuzz-plan.json"
-
-homeboy fuzz run \
-  --rig wordpress-core-fuzz-coverage \
-  --workload rest-api \
-  --run-id wave3-core-rest-api \
-  --seed 3 \
-  --max-duration 5m \
-  --require-result-envelope \
-  --require-coverage-summary \
-  --tracker-ref "$WAVE3_TRACKER_REF" \
+  --required-artifact canonical_fuzz_envelope \
+  --required-artifact homeboy_fuzz_coverage \
   --lab-only \
   --runner "$HOMEBOY_RUNNER_ID" \
   --detach-after-handoff \
-  --output "$WAVE3_OUT/lab-handoff.json"
+  --output "$WAVE3_OUT/campaign-dispatch.json"
 
-homeboy runs evidence wave3-core-rest-api \
+homeboy runs watch wave3-core-rest-api-campaign-rest-api \
+  --output "$WAVE3_OUT/terminal-run.json"
+
+homeboy runs resources \
+  --file "$WAVE3_CORE_RESOURCE_INDEX" \
+  --run-id wave3-core-rest-api-campaign-rest-api \
+  --output "$WAVE3_OUT/resources-index.json"
+
+homeboy runs evidence wave3-core-rest-api-campaign-rest-api \
   --output "$WAVE3_OUT/evidence.json"
 
-homeboy runs artifacts wave3-core-rest-api \
+homeboy runs artifacts wave3-core-rest-api-campaign-rest-api \
   --output "$WAVE3_OUT/artifacts.json"
 
 homeboy runs refs \
   --rig wordpress-core-fuzz-coverage \
   --kind fuzz \
   --tracker-ref "$WAVE3_TRACKER_REF" \
+  --artifact-kind canonical_fuzz_envelope \
+  --artifact-kind homeboy_fuzz_coverage \
   --output "$WAVE3_OUT/reviewer-refs.json"
 
 homeboy cleanup worktrees \
@@ -92,44 +87,39 @@ generic loop plus WooCommerce-owned campaign/artifact contracts.
 export HOMEBOY_RUNNER_ID=<approved-runner-id>
 export WC_TRACKER_REF=github:woocommerce/woocommerce#issue-or-pr
 export WC_OUT=./wave3-woo-db-api-proof
+export WC_RESOURCE_INDEX=<resource-lifecycle-index-artifact-json>
 
-homeboy rig show woocommerce-performance \
-  --output "$WC_OUT/resources-index.json"
-
-homeboy fuzz plan \
+homeboy fuzz run-campaign \
   --rig woocommerce-performance \
-  --workload generated-rest-request-cases \
-  --run-id wave3-woo-generated-rest-plan \
-  --request-id wave3-woo-generated-rest-plan \
+  --campaign-manifest woocommerce/woocommerce/manifests/db-api-fuzz-campaign.json \
+  --request-id wave3-woo-db-api-campaign \
   --strategy read-only \
   --case-budget 80 \
   --duration-budget-seconds 1200 \
   --max-duration 20m \
   --seed 3 \
   --tracker-ref "$WC_TRACKER_REF" \
-  --lab-only \
-  --runner "$HOMEBOY_RUNNER_ID" \
-  --output "$WC_OUT/core-fuzz-plan.json"
-
-homeboy fuzz run \
-  --rig woocommerce-performance \
-  --workload generated-rest-request-cases \
-  --run-id wave3-woo-generated-rest \
-  --seed 3 \
-  --max-duration 20m \
-  --require-case-log \
-  --require-result-envelope \
-  --require-coverage-summary \
-  --tracker-ref "$WC_TRACKER_REF" \
+  --required-artifact canonical_fuzz_envelope \
+  --required-artifact homeboy_fuzz_coverage \
+  --required-artifact coverage_gap_report \
+  --required-artifact performance_hotspots_summary \
   --lab-only \
   --runner "$HOMEBOY_RUNNER_ID" \
   --detach-after-handoff \
-  --output "$WC_OUT/lab-handoff.json"
+  --output "$WC_OUT/campaign-dispatch.json"
 
-homeboy runs evidence wave3-woo-generated-rest \
+homeboy runs watch wave3-woo-db-api-campaign-generated-rest-request-cases \
+  --output "$WC_OUT/terminal-run.json"
+
+homeboy runs resources \
+  --file "$WC_RESOURCE_INDEX" \
+  --run-id wave3-woo-db-api-campaign-generated-rest-request-cases \
+  --output "$WC_OUT/resources-index.json"
+
+homeboy runs evidence wave3-woo-db-api-campaign-generated-rest-request-cases \
   --output "$WC_OUT/evidence.json"
 
-homeboy runs artifacts wave3-woo-generated-rest \
+homeboy runs artifacts wave3-woo-db-api-campaign-generated-rest-request-cases \
   --output "$WC_OUT/artifacts.json"
 
 homeboy runs refs \
@@ -145,20 +135,18 @@ homeboy cleanup worktrees \
   --output "$WC_OUT/cleanup-inspection.json"
 ```
 
-For the broader Woo DB/API campaign, repeat the same `fuzz plan` and `fuzz run`
-shape for every workload named in
-`woocommerce/woocommerce/manifests/db-api-fuzz-campaign.json`, then collect the
-postprocess `coverage_gap_report` and `performance_hotspots_summary` refs listed
-by that manifest before promoting the campaign to proven.
+For the broader Woo DB/API campaign, `fuzz run-campaign` expands every workload
+named in `woocommerce/woocommerce/manifests/db-api-fuzz-campaign.json`. Do not
+promote the campaign to proven until the resulting persisted run set includes
+reviewer-facing `coverage_gap_report` and `performance_hotspots_summary` refs.
 
 ## Blocker Matrix
 
 | Requirement | Current status | Promotion blocker |
 |---|---|---|
 | Campaign manifest | Present for Core and WooCommerce. | None for planning. |
-| Core fuzz plan | `homeboy fuzz plan` is available and accepts deterministic seed, strategy, budgets, tracker ref, Lab runner, and JSON output. | Plan output is intent only; it is not execution proof. |
-| Lab handoff | `homeboy fuzz run --lab-only --detach-after-handoff` is available. | Requires an approved connected runner and accepted job id. |
-| Resources indexed | `homeboy rig show --output` records rig-declared resources before execution. | Any runtime-created resources must also appear in persisted run evidence or cleanup inspection. |
-| Artifacts/result envelope | `homeboy runs evidence`, `homeboy runs artifacts`, and `homeboy runs refs` are available. | Proven status requires durable refs for `canonical_fuzz_envelope`, coverage summary, and required product artifacts. |
+| Campaign dispatch | `homeboy fuzz run-campaign` consumes `--campaign-manifest` or repeatable `--campaign-workload`, expands entry run IDs, records required artifacts, and offloads with `--lab-only --detach-after-handoff`. | Requires an approved connected runner, accepted handoff job IDs, and terminal entry runs. |
+| Resources indexed | `homeboy runs resources --file <resource-lifecycle-index> --run-id <run-id>` filters the persisted resource lifecycle index from the run artifact set. | The resource lifecycle index must be a durable artifact from the approved run, not a local-only file. |
+| Artifacts/outcome envelope | `homeboy runs evidence`, `homeboy runs artifacts`, and `homeboy runs refs` are available; terminal runs must expose `homeboy/run-outcome-envelope/v1`. | Proven status requires durable refs for `canonical_fuzz_envelope`, coverage summary, and required product artifacts. |
 | Cleanup inspection | `homeboy cleanup worktrees` can preview cleanup across configured providers without `--apply`. | Reviewer proof must include the inspection output; destructive cleanup is a separate approved action. |
 | Woo postprocess reports | Woo campaign manifest declares `coverage_gap_report` and `performance_hotspots_summary`. | The campaign remains unproven until those report artifacts have reviewer-facing refs from the offloaded run set. |

--- a/docs/wave3-fuzz-proof-recipes.json
+++ b/docs/wave3-fuzz-proof-recipes.json
@@ -12,10 +12,9 @@
   ],
   "required_phase_order": [
     "campaign_manifest",
-    "core_fuzz_plan",
-    "lab_handoff",
+    "campaign_dispatch",
     "resources_indexed",
-    "artifacts_result_envelope",
+    "artifacts_outcome_envelope",
     "cleanup_inspection"
   ],
   "recipes": [
@@ -25,7 +24,9 @@
       "rig": "wordpress-core-fuzz-coverage",
       "campaign_manifest": "WordPress/wordpress-develop/manifests/fuzzer-profile.json",
       "workload": "rest-api",
-      "run_id": "wave3-core-rest-api",
+      "run_id": "wave3-core-rest-api-campaign-rest-api",
+      "request_id": "wave3-core-rest-api-campaign",
+      "resource_index_placeholder": "$WAVE3_CORE_RESOURCE_INDEX",
       "tracker_ref_placeholder": "$WAVE3_TRACKER_REF",
       "proof_status": "not_proven_until_reviewer_refs_exist",
       "phases": [
@@ -35,28 +36,25 @@
           "artifacts": ["WordPress/wordpress-develop/manifests/fuzzer-profile.json"]
         },
         {
-          "id": "core_fuzz_plan",
-          "description": "Build a deterministic execution request without running fuzz locally.",
-          "command": "homeboy fuzz plan --rig wordpress-core-fuzz-coverage --workload rest-api --run-id wave3-core-rest-api-plan --request-id wave3-core-rest-api-plan --strategy read-only --case-budget 25 --duration-budget-seconds 300 --max-duration 5m --seed 3 --tracker-ref \"$WAVE3_TRACKER_REF\" --lab-only --runner \"$HOMEBOY_RUNNER_ID\" --output \"$WAVE3_OUT/core-fuzz-plan.json\""
-        },
-        {
-          "id": "lab_handoff",
-          "description": "Hand the run to an approved Lab runner and return after accepted handoff.",
-          "command": "homeboy fuzz run --rig wordpress-core-fuzz-coverage --workload rest-api --run-id wave3-core-rest-api --seed 3 --max-duration 5m --require-result-envelope --require-coverage-summary --tracker-ref \"$WAVE3_TRACKER_REF\" --lab-only --runner \"$HOMEBOY_RUNNER_ID\" --detach-after-handoff --output \"$WAVE3_OUT/lab-handoff.json\""
+          "id": "campaign_dispatch",
+          "description": "Build and dispatch the deterministic campaign through Homeboy's campaign primitive without executing fuzz locally.",
+          "command": "homeboy fuzz run-campaign --rig wordpress-core-fuzz-coverage --campaign-workload rest-api --request-id wave3-core-rest-api-campaign --strategy read-only --case-budget 25 --duration-budget-seconds 300 --max-duration 5m --seed 3 --tracker-ref \"$WAVE3_TRACKER_REF\" --required-artifact canonical_fuzz_envelope --required-artifact homeboy_fuzz_coverage --lab-only --runner \"$HOMEBOY_RUNNER_ID\" --detach-after-handoff --output \"$WAVE3_OUT/campaign-dispatch.json\""
         },
         {
           "id": "resources_indexed",
-          "description": "Capture rig-declared resource ownership before or alongside the handoff.",
-          "command": "homeboy rig show wordpress-core-fuzz-coverage --output \"$WAVE3_OUT/resources-index.json\""
+          "description": "Filter the persisted resource lifecycle index artifact for the accepted campaign entry run.",
+          "command": "homeboy runs resources --file \"$WAVE3_CORE_RESOURCE_INDEX\" --run-id wave3-core-rest-api-campaign-rest-api --output \"$WAVE3_OUT/resources-index.json\""
         },
         {
-          "id": "artifacts_result_envelope",
-          "description": "Collect persisted evidence, artifacts, and stable reviewer refs after the run reaches a terminal state.",
+          "id": "artifacts_outcome_envelope",
+          "description": "Collect persisted evidence, artifacts, and stable reviewer refs after the run reaches a terminal state, including the canonical outcome envelope.",
           "commands": [
-            "homeboy runs evidence wave3-core-rest-api --output \"$WAVE3_OUT/evidence.json\"",
-            "homeboy runs artifacts wave3-core-rest-api --output \"$WAVE3_OUT/artifacts.json\"",
-            "homeboy runs refs --rig wordpress-core-fuzz-coverage --kind fuzz --tracker-ref \"$WAVE3_TRACKER_REF\" --output \"$WAVE3_OUT/reviewer-refs.json\""
+            "homeboy runs watch wave3-core-rest-api-campaign-rest-api --output \"$WAVE3_OUT/terminal-run.json\"",
+            "homeboy runs evidence wave3-core-rest-api-campaign-rest-api --output \"$WAVE3_OUT/evidence.json\"",
+            "homeboy runs artifacts wave3-core-rest-api-campaign-rest-api --output \"$WAVE3_OUT/artifacts.json\"",
+            "homeboy runs refs --rig wordpress-core-fuzz-coverage --kind fuzz --tracker-ref \"$WAVE3_TRACKER_REF\" --artifact-kind canonical_fuzz_envelope --artifact-kind homeboy_fuzz_coverage --output \"$WAVE3_OUT/reviewer-refs.json\""
           ],
+          "required_outcome_schema": "homeboy/run-outcome-envelope/v1",
           "required_artifact_kinds": ["canonical_fuzz_envelope", "homeboy_fuzz_coverage"]
         },
         {
@@ -68,7 +66,7 @@
       "blockers_to_proven": [
         "approved Lab runner id",
         "accepted handoff job id",
-        "terminal persisted Homeboy run",
+        "terminal persisted Homeboy run with homeboy/run-outcome-envelope/v1",
         "reviewer-facing canonical_fuzz_envelope ref",
         "reviewer-facing coverage summary ref",
         "cleanup inspection artifact"
@@ -81,7 +79,9 @@
       "rig": "woocommerce-performance",
       "campaign_manifest": "woocommerce/woocommerce/manifests/db-api-fuzz-campaign.json",
       "workload": "generated-rest-request-cases",
-      "run_id": "wave3-woo-generated-rest",
+      "run_id": "wave3-woo-db-api-campaign-generated-rest-request-cases",
+      "request_id": "wave3-woo-db-api-campaign",
+      "resource_index_placeholder": "$WC_RESOURCE_INDEX",
       "tracker_ref_placeholder": "$WC_TRACKER_REF",
       "proof_status": "not_proven_until_reviewer_refs_exist",
       "phases": [
@@ -91,28 +91,25 @@
           "artifacts": ["woocommerce/woocommerce/manifests/db-api-fuzz-campaign.json"]
         },
         {
-          "id": "core_fuzz_plan",
-          "description": "Build a deterministic Woo execution request through the generic Homeboy fuzz planner.",
-          "command": "homeboy fuzz plan --rig woocommerce-performance --workload generated-rest-request-cases --run-id wave3-woo-generated-rest-plan --request-id wave3-woo-generated-rest-plan --strategy read-only --case-budget 80 --duration-budget-seconds 1200 --max-duration 20m --seed 3 --tracker-ref \"$WC_TRACKER_REF\" --lab-only --runner \"$HOMEBOY_RUNNER_ID\" --output \"$WC_OUT/core-fuzz-plan.json\""
-        },
-        {
-          "id": "lab_handoff",
-          "description": "Hand the Woo workload to an approved Lab runner with result envelope, coverage summary, and case-log requirements.",
-          "command": "homeboy fuzz run --rig woocommerce-performance --workload generated-rest-request-cases --run-id wave3-woo-generated-rest --seed 3 --max-duration 20m --require-case-log --require-result-envelope --require-coverage-summary --tracker-ref \"$WC_TRACKER_REF\" --lab-only --runner \"$HOMEBOY_RUNNER_ID\" --detach-after-handoff --output \"$WC_OUT/lab-handoff.json\""
+          "id": "campaign_dispatch",
+          "description": "Build and dispatch the Woo DB/API campaign manifest through Homeboy's campaign primitive without executing fuzz locally.",
+          "command": "homeboy fuzz run-campaign --rig woocommerce-performance --campaign-manifest woocommerce/woocommerce/manifests/db-api-fuzz-campaign.json --request-id wave3-woo-db-api-campaign --strategy read-only --case-budget 80 --duration-budget-seconds 1200 --max-duration 20m --seed 3 --tracker-ref \"$WC_TRACKER_REF\" --required-artifact canonical_fuzz_envelope --required-artifact homeboy_fuzz_coverage --required-artifact coverage_gap_report --required-artifact performance_hotspots_summary --lab-only --runner \"$HOMEBOY_RUNNER_ID\" --detach-after-handoff --output \"$WC_OUT/campaign-dispatch.json\""
         },
         {
           "id": "resources_indexed",
-          "description": "Capture Woo rig resource ownership before or alongside the handoff.",
-          "command": "homeboy rig show woocommerce-performance --output \"$WC_OUT/resources-index.json\""
+          "description": "Filter the persisted resource lifecycle index artifact for the accepted campaign entry run.",
+          "command": "homeboy runs resources --file \"$WC_RESOURCE_INDEX\" --run-id wave3-woo-db-api-campaign-generated-rest-request-cases --output \"$WC_OUT/resources-index.json\""
         },
         {
-          "id": "artifacts_result_envelope",
-          "description": "Collect persisted evidence, artifacts, and stable reviewer refs after the run reaches a terminal state.",
+          "id": "artifacts_outcome_envelope",
+          "description": "Collect persisted evidence, artifacts, and stable reviewer refs after the run reaches a terminal state, including the canonical outcome envelope.",
           "commands": [
-            "homeboy runs evidence wave3-woo-generated-rest --output \"$WC_OUT/evidence.json\"",
-            "homeboy runs artifacts wave3-woo-generated-rest --output \"$WC_OUT/artifacts.json\"",
+            "homeboy runs watch wave3-woo-db-api-campaign-generated-rest-request-cases --output \"$WC_OUT/terminal-run.json\"",
+            "homeboy runs evidence wave3-woo-db-api-campaign-generated-rest-request-cases --output \"$WC_OUT/evidence.json\"",
+            "homeboy runs artifacts wave3-woo-db-api-campaign-generated-rest-request-cases --output \"$WC_OUT/artifacts.json\"",
             "homeboy runs refs --rig woocommerce-performance --kind fuzz --tracker-ref \"$WC_TRACKER_REF\" --artifact-kind canonical_fuzz_envelope --artifact-kind homeboy_fuzz_coverage --output \"$WC_OUT/reviewer-refs.json\""
           ],
+          "required_outcome_schema": "homeboy/run-outcome-envelope/v1",
           "required_artifact_kinds": ["canonical_fuzz_envelope", "homeboy_fuzz_coverage"]
         },
         {
@@ -124,7 +121,7 @@
       "blockers_to_proven": [
         "approved Lab runner id",
         "accepted handoff job id",
-        "terminal persisted Homeboy run",
+        "terminal persisted Homeboy run with homeboy/run-outcome-envelope/v1",
         "reviewer-facing canonical_fuzz_envelope ref",
         "reviewer-facing case log ref",
         "reviewer-facing Homeboy fuzz coverage ref",

--- a/scripts/wave3-proof-recipe-check.mjs
+++ b/scripts/wave3-proof-recipe-check.mjs
@@ -10,10 +10,9 @@ const recipePath = join(root, 'docs/wave3-fuzz-proof-recipes.json');
 const localOnlyPattern = /(?:localhost|127\.0\.0\.1|file:\/\/|\/Users\/|https?:\/\/localhost|https?:\/\/127\.0\.0\.1)/i;
 const requiredPhases = [
   'campaign_manifest',
-  'core_fuzz_plan',
-  'lab_handoff',
+  'campaign_dispatch',
   'resources_indexed',
-  'artifacts_result_envelope',
+  'artifacts_outcome_envelope',
   'cleanup_inspection',
 ];
 
@@ -51,42 +50,42 @@ for (const recipe of recipes.recipes) {
   const serialized = JSON.stringify(recipe);
   assert.ok(!localOnlyPattern.test(serialized), `${recipe.id} contains local-only reviewer evidence`);
 
-  const plan = recipe.phases.find((phase) => phase.id === 'core_fuzz_plan');
-  assertCommandContains(plan.command, [
-    'homeboy fuzz plan',
+  const dispatch = recipe.phases.find((phase) => phase.id === 'campaign_dispatch');
+  assertCommandContains(dispatch.command, [
+    'homeboy fuzz run-campaign',
     `--rig ${recipe.rig}`,
-    `--workload ${recipe.workload}`,
+    '--request-id',
     '--seed 3',
     '--tracker-ref',
-    '--lab-only',
-    '--runner',
-    '--output',
-  ], `${recipe.id} plan command`);
-
-  const handoff = recipe.phases.find((phase) => phase.id === 'lab_handoff');
-  assertCommandContains(handoff.command, [
-    'homeboy fuzz run',
-    `--rig ${recipe.rig}`,
-    `--workload ${recipe.workload}`,
-    `--run-id ${recipe.run_id}`,
-    '--require-result-envelope',
-    '--require-coverage-summary',
-    '--tracker-ref',
+    '--required-artifact canonical_fuzz_envelope',
+    '--required-artifact homeboy_fuzz_coverage',
     '--lab-only',
     '--runner',
     '--detach-after-handoff',
     '--output',
-  ], `${recipe.id} handoff command`);
+  ], `${recipe.id} campaign dispatch command`);
+  assert.ok(
+    dispatch.command.includes(`--campaign-workload ${recipe.workload}`) ||
+      dispatch.command.includes(`--campaign-manifest ${recipe.campaign_manifest}`),
+    `${recipe.id} campaign dispatch command must consume a campaign workload or manifest`,
+  );
+  assert.ok(!dispatch.command.includes('homeboy fuzz plan'), `${recipe.id} must not use plan-only proof`);
+  assert.ok(!dispatch.command.includes('homeboy fuzz run --'), `${recipe.id} must use run-campaign`);
 
   const resources = recipe.phases.find((phase) => phase.id === 'resources_indexed');
   assertCommandContains(resources.command, [
-    'homeboy rig show',
-    recipe.rig,
+    'homeboy runs resources',
+    '--file',
+    `--run-id ${recipe.run_id}`,
     '--output',
   ], `${recipe.id} resources command`);
+  assert.ok(!resources.command.includes('homeboy rig show'), `${recipe.id} resources must use persisted run resources`);
 
-  const artifactCommands = commandsForPhase(recipe.phases.find((phase) => phase.id === 'artifacts_result_envelope')).join('\n');
+  const artifactPhase = recipe.phases.find((phase) => phase.id === 'artifacts_outcome_envelope');
+  assert.equal(artifactPhase.required_outcome_schema, 'homeboy/run-outcome-envelope/v1');
+  const artifactCommands = commandsForPhase(artifactPhase).join('\n');
   assertCommandContains(artifactCommands, [
+    `homeboy runs watch ${recipe.run_id}`,
     `homeboy runs evidence ${recipe.run_id}`,
     `homeboy runs artifacts ${recipe.run_id}`,
     'homeboy runs refs',


### PR DESCRIPTION
## Summary
- Update Wave 3 proof recipes to consume landed campaign-level fuzz dispatch via `homeboy fuzz run-campaign`.
- Replace rig-show resource placeholders with `homeboy runs resources --file ... --run-id ...` against persisted resource lifecycle indexes.
- Require the machine-readable recipe validator to enforce campaign dispatch, persisted resources, and `homeboy/run-outcome-envelope/v1` outcome-envelope metadata.

## Verification
- `node scripts/wave3-proof-recipe-check.mjs`
- `node scripts/lint-rig-packages.mjs` with the documented Homeboy Extensions helper environment variables set. Passed with existing warning: `woocommerce/woocommerce/fuzz/codebox-fuzz-suite-contract.json: executable fuzz readiness has optional artifact(s): codebox_fuzz_suite_result`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Drafted and validated the Wave 3 proof recipe docs, JSON contract, and validator updates with Chris reviewing/owning the change.