### PR TITLE
Move Woo artifact helper checks to Woo validators

### DIFF
--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -276,7 +276,7 @@ export function assertRequiredFuzzProofContracts(manifest, {
   }
 }
 
-export function assertArtifactPostprocessWorkloadContract(workload, { id, action, artifact, outputPath, schema, runnerSupportStatus = 'supported', readinessLevel = 'executable' }) {
+export function assertGenericArtifactPostprocessWorkloadContract(workload, { id, helper, action, artifact, outputPath, schema, runnerSupportStatus = 'supported', readinessLevel = 'executable' }) {
   assert.equal(workload.schema, 'wp-codebox/wordpress-workload-run/v1', `${id} workload must use the generic workload-run contract`);
   assert.equal(workload.id, id, `${id} workload id drifted`);
   assert.equal(workload.steps?.length, 1, `${id} must declare one artifact postprocess step`);
@@ -285,7 +285,9 @@ export function assertArtifactPostprocessWorkloadContract(workload, { id, action
   assert.equal(workload.steps[0].runner_support_status, undefined, `${id} runner support status belongs in metadata, not the executable step`);
 
   const args = workload.steps[0].args;
-  assert.equal(args.helper, '${package.root}/tools/db-api-fuzzer-artifacts.mjs', `${id} helper drifted`);
+  assert.equal(typeof args.helper, 'string', `${id} helper must be a package-relative helper path`);
+  assert.ok(args.helper.startsWith('${package.root}/'), `${id} helper must be package-relative`);
+  assert.equal(args.helper, helper, `${id} helper drifted`);
   assert.equal(args.action, action, `${id} action drifted`);
   assert.deepEqual(args.input, {
     type: 'artifact-root',

--- a/scripts/fuzz-manifest-helpers.test.mjs
+++ b/scripts/fuzz-manifest-helpers.test.mjs
@@ -193,15 +193,15 @@ test('fuzzManifestHasExecutableArtifactContract excludes declared or blocked con
   })), false);
 });
 
-test('assertArtifactPostprocessWorkloadContract accepts explicit upstream-blocked declarations', async () => {
-  const { assertArtifactPostprocessWorkloadContract } = await import('./fuzz-manifest-helpers.mjs');
+test('assertGenericArtifactPostprocessWorkloadContract accepts explicit upstream-blocked declarations', async () => {
+  const { assertGenericArtifactPostprocessWorkloadContract } = await import('./fuzz-manifest-helpers.mjs');
   const workload = {
     schema: 'wp-codebox/wordpress-workload-run/v1',
     id: 'coverage-gap-report',
     steps: [{
       command: 'homeboy.artifact-postprocess',
       args: {
-        helper: '${package.root}/tools/db-api-fuzzer-artifacts.mjs',
+        helper: '${package.root}/tools/generic-artifact-helper.mjs',
         action: 'coverage-gap-report',
         input: { type: 'artifact-root', path: '${artifacts.root}', artifact_globs: ['**/*.json'], max_bytes: 1048576 },
         output: {
@@ -233,8 +233,9 @@ test('assertArtifactPostprocessWorkloadContract accepts explicit upstream-blocke
     },
   };
 
-  assert.doesNotThrow(() => assertArtifactPostprocessWorkloadContract(workload, {
+  assert.doesNotThrow(() => assertGenericArtifactPostprocessWorkloadContract(workload, {
     id: 'coverage-gap-report',
+    helper: '${package.root}/tools/generic-artifact-helper.mjs',
     action: 'coverage-gap-report',
     artifact: 'coverage_gap_report',
     outputPath: 'coverage-gap-report/coverage_gap_report.json',

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -4,7 +4,7 @@ import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import {
-  assertArtifactPostprocessWorkloadContract,
+  assertGenericArtifactPostprocessWorkloadContract,
   assertFullSurfaceCoverageManifest,
 } from '../../../scripts/fuzz-manifest-helpers.mjs';
 import {
@@ -38,6 +38,7 @@ const coverageGapReport = JSON.parse(readFileSync(path.join(packageRoot, 'fuzz/c
 const coverageGapReportWorkload = JSON.parse(readFileSync(path.join(packageRoot, 'bench/coverage-gap-report.workload.json'), 'utf8'));
 const performanceHotspotsWorkload = JSON.parse(readFileSync(path.join(packageRoot, 'bench/performance-hotspots-artifact-summary.workload.json'), 'utf8'));
 const runtimePrepScript = readFileSync(path.join(packageRoot, 'tools/prepare-runtime-dependency.sh'), 'utf8');
+const wooArtifactPostprocessHelper = '${package.root}/tools/db-api-fuzzer-artifacts.mjs';
 
 const workloadIdFromPath = (workloadPath) => path.basename(workloadPath, path.extname(workloadPath));
 const genericExecutableReadinessStates = new Set([
@@ -237,7 +238,7 @@ test('coverage gap and hotspot reports declare the generic artifact postprocess 
   assert.equal(coverageGapReport.workload.type, 'json');
   assert.equal(coverageGapReport.safety_class, 'read_only');
   assert.equal(coverageGapReport.artifacts.expected[0].name, 'coverage_gap_report');
-  assertArtifactPostprocessWorkloadContract(coverageGapReportWorkload, {
+  assertWooArtifactPostprocessWorkloadContract(coverageGapReportWorkload, {
     id: 'coverage-gap-report',
     action: 'coverage-gap-report',
     artifact: 'coverage_gap_report',
@@ -250,7 +251,7 @@ test('coverage gap and hotspot reports declare the generic artifact postprocess 
   assert.equal(performanceHotspots.workload.type, 'json');
   assert.equal(performanceHotspots.safety_class, 'read_only');
   assert.equal(performanceHotspots.artifacts.expected[0].name, 'performance_hotspots_summary');
-  assertArtifactPostprocessWorkloadContract(performanceHotspotsWorkload, {
+  assertWooArtifactPostprocessWorkloadContract(performanceHotspotsWorkload, {
     id: 'performance-hotspots-artifact-summary',
     action: 'performance-hotspots-summary',
     artifact: 'performance_hotspots_summary',
@@ -258,6 +259,13 @@ test('coverage gap and hotspot reports declare the generic artifact postprocess 
     schema: 'homeboy-rigs/woocommerce-performance-hotspots-summary/v1',
   });
 });
+
+function assertWooArtifactPostprocessWorkloadContract(workload, contract) {
+  assertGenericArtifactPostprocessWorkloadContract(workload, {
+    ...contract,
+    helper: wooArtifactPostprocessHelper,
+  });
+}
 
 test('DB/API campaign consumes executable Codebox fixture contracts without proof refs', () => {
   assert.equal(dbApiFuzzCampaign.suite_manifest, 'manifests/codebox-fuzz-suite-contract.json');

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -5,7 +5,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
-  assertArtifactPostprocessWorkloadContract,
+  assertGenericArtifactPostprocessWorkloadContract,
   assertExecutableCrudMutationSafety,
   assertFullSurfaceCoverageManifest,
   assertFuzzProofBundleRequirements,
@@ -49,6 +49,7 @@ const stableWorkloads = readJson(packageRoot, 'manifests/stable-workloads.json')
 const coverageGapReportWorkload = readJson(packageRoot, 'bench/coverage-gap-report.workload.json');
 const performanceHotspotsWorkload = readJson(packageRoot, 'bench/performance-hotspots-artifact-summary.workload.json');
 const runtimeDependencyHelper = path.join(packageRoot, 'tools/prepare-runtime-dependency.sh');
+const wooArtifactPostprocessHelper = '${package.root}/tools/db-api-fuzzer-artifacts.mjs';
 
 assertFullSurfaceCoverageManifest(coverageManifest, { file: 'WooCommerce full-surface coverage' });
 
@@ -461,7 +462,7 @@ function assertRestMutationFixtureOptInsContract(optIns, payloadFixtures, routeC
   }
 }
 
-assertArtifactPostprocessWorkloadContract(coverageGapReportWorkload, {
+assertWooArtifactPostprocessWorkloadContract(coverageGapReportWorkload, {
   id: 'coverage-gap-report',
   action: 'coverage-gap-report',
   artifact: 'coverage_gap_report',
@@ -469,13 +470,20 @@ assertArtifactPostprocessWorkloadContract(coverageGapReportWorkload, {
   schema: 'homeboy-rigs/wordpress-coverage-gap-report/v1',
 });
 
-assertArtifactPostprocessWorkloadContract(performanceHotspotsWorkload, {
+assertWooArtifactPostprocessWorkloadContract(performanceHotspotsWorkload, {
   id: 'performance-hotspots-artifact-summary',
   action: 'performance-hotspots-summary',
   artifact: 'performance_hotspots_summary',
   outputPath: 'performance-hotspots-artifact-summary/performance_hotspots_summary.json',
   schema: 'homeboy-rigs/woocommerce-performance-hotspots-summary/v1',
 });
+
+function assertWooArtifactPostprocessWorkloadContract(workload, contract) {
+  assertGenericArtifactPostprocessWorkloadContract(workload, {
+    ...contract,
+    helper: wooArtifactPostprocessHelper,
+  });
+}
 
 for (const workloadId of fullSurfaceFuzzIds) {
   assert.ok(declaredIds.has(workloadId), `${workloadId} full-surface coverage is not backed by a fuzz workload`);


### PR DESCRIPTION
## Summary
- Rename the generic artifact postprocess helper assertion for clearer ownership.
- Remove the Woo helper path assertion from generic fuzz helper code.
- Add Woo-owned assertions where Woo pins its artifact postprocess helper path.

## Verification
- node --test scripts/fuzz-manifest-helpers.test.mjs
- node --test woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
- HOMEBOY_WORDPRESS_HELPER_MANIFEST=$PWD/scripts/fixtures/homeboy-extension-wordpress/lib/helper-manifest.js node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
- HOMEBOY_WORDPRESS_HELPER_MANIFEST=$PWD/scripts/fixtures/homeboy-extension-wordpress/lib/helper-manifest.js node Automattic/jetpack/tools/validate-fuzz-manifests.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Split generic fuzz helper validation from Woo product-specific assertions and ran targeted validators.