### PR TITLE
Require cleanup intent for resource rigs

### DIFF
--- a/Automattic/studio/rigs/studio-agent-model-comparison.base.json
+++ b/Automattic/studio/rigs/studio-agent-model-comparison.base.json
@@ -4,6 +4,12 @@
       "${components.studio.path}"
     ]
   },
+  "lifecycle": {
+    "cleanup": {
+      "intent": "manual",
+      "reason": "The inherited Studio agent rigs install dependencies and build CLI artifacts inside a user-owned Studio checkout; removing that checkout state is an operator decision. Site-build runtime fixtures use their benchmark-owned cleanup hooks."
+    }
+  },
   "bench": {
     "default_component": "studio"
   },

--- a/Automattic/studio/rigs/studio-canonical-loop-proof/rig.json
+++ b/Automattic/studio/rigs/studio-canonical-loop-proof/rig.json
@@ -22,6 +22,12 @@
       "${components.wp-codebox.path}"
     ]
   },
+  "lifecycle": {
+    "cleanup": {
+      "intent": "manual",
+      "reason": "The proof harness reads user-owned component checkouts and does not create a separate runtime resource; checkout cleanup remains an operator decision."
+    }
+  },
   "pipeline": {
     "check": [
       {

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -3,7 +3,7 @@
 import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, join, normalize, relative, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { assertFuzzReadinessMetadata } from './fuzz-manifest-helpers.mjs';
 
@@ -129,6 +129,8 @@ function lintRigPortability(file, fuzzWorkloadsByPackageRoot) {
     return;
   }
 
+  const materializedRig = materializeRigSpec(file, rig);
+
   const pipelineCommands = Object.values(rig.pipeline || {})
     .flatMap((steps) => Array.isArray(steps) ? steps : [])
     .map((step) => step.command || '')
@@ -154,12 +156,75 @@ function lintRigPortability(file, fuzzWorkloadsByPackageRoot) {
     failures.push(`${rel}: WP Codebox executable discovery belongs upstream; do not add rig-local CLI checks or fallback discovery`);
   }
 
-  lintSharedPaths(rel, rig);
-  lintLifecycleCleanup(rel, rig);
+  lintSharedPaths(rel, materializedRig);
+  lintLifecycleCleanup(rel, materializedRig);
 
   lintFuzzWorkloads(rel, file, rig, fuzzWorkloadsByPackageRoot);
   lintFuzzProfiles(rel, rig);
   lintBenchProfiles(rel, file, rig, fuzzWorkloadsByPackageRoot);
+}
+
+function materializeRigSpec(file, rig, seen = new Set()) {
+  const extendPath = typeof rig.extends === 'string' ? rig.extends.trim() : '';
+
+  if (!extendPath) {
+    return rig;
+  }
+
+  const parentFile = resolve(dirname(file), extendPath);
+  const parentRel = relative(root, parentFile);
+
+  if (seen.has(parentFile)) {
+    failures.push(`${relative(root, file)}: rig extends cycle includes ${parentRel}`);
+    return rig;
+  }
+
+  if (!existsSync(parentFile)) {
+    failures.push(`${relative(root, file)}: extends missing rig spec ${normalize(extendPath)}`);
+    return rig;
+  }
+
+  let parentRig;
+  try {
+    parentRig = JSON.parse(readFileSync(parentFile, 'utf8'));
+  } catch (error) {
+    failures.push(`${parentRel}: invalid JSON: ${error.message}`);
+    return rig;
+  }
+
+  seen.add(parentFile);
+  const materializedParent = materializeRigSpec(parentFile, parentRig, seen);
+  seen.delete(parentFile);
+
+  return deepMergeRigSpec(materializedParent, rig);
+}
+
+function deepMergeRigSpec(parent, child) {
+  if (!parent || typeof parent !== 'object' || Array.isArray(parent)) {
+    return child;
+  }
+
+  if (!child || typeof child !== 'object' || Array.isArray(child)) {
+    return child;
+  }
+
+  const merged = { ...parent };
+  for (const [key, value] of Object.entries(child)) {
+    if (key === 'extends') {
+      continue;
+    }
+
+    const parentValue = merged[key];
+    merged[key] = parentValue && value
+      && typeof parentValue === 'object'
+      && typeof value === 'object'
+      && !Array.isArray(parentValue)
+      && !Array.isArray(value)
+      ? deepMergeRigSpec(parentValue, value)
+      : value;
+  }
+
+  return merged;
 }
 
 function hasDeclaredResources(resources) {
@@ -190,11 +255,13 @@ function lintLifecycleCleanup(rel, rig) {
     }
   }
 
-  if (!hasDeclaredResources(rig.resources) || !Array.isArray(rig.pipeline?.down) || rig.pipeline.down.length > 0 || cleanup) {
+  const down = Array.isArray(rig.pipeline?.down) ? rig.pipeline.down : [];
+
+  if (!hasDeclaredResources(rig.resources) || down.length > 0 || cleanup) {
     return;
   }
 
-  failures.push(`${rel}: rigs with declared resources and empty pipeline.down must declare lifecycle.cleanup intent`);
+  failures.push(`${rel}: rigs with declared resources and empty or missing pipeline.down must declare lifecycle.cleanup intent`);
 }
 
 function cleanupContractForRigPolicy(rel, cleanup) {

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -365,7 +365,115 @@ test('rejects rigs with resources, empty down lifecycle, and no cleanup policy',
   const result = runLint(directory);
 
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /declared resources and empty pipeline\.down must declare lifecycle\.cleanup intent/);
+  assert.match(result.stderr, /declared resources and empty or missing pipeline\.down must declare lifecycle\.cleanup intent/);
+});
+
+test('rejects rigs with resources, missing down lifecycle, and no cleanup policy', () => {
+  const directory = createRigPackage({
+    rig: {
+      resources: {
+        ports: [8080],
+      },
+      pipeline: {
+        up: [
+          {
+            kind: 'check',
+            label: 'generic check',
+            command: 'true',
+          },
+        ],
+      },
+    },
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+  });
+
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /declared resources and empty or missing pipeline\.down must declare lifecycle\.cleanup intent/);
+});
+
+test('rejects inherited resources with missing down lifecycle and no cleanup policy', () => {
+  const directory = createRigPackage({
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+  });
+  const packageRoot = join(directory, 'Vendor', 'product');
+  writeJson(join(packageRoot, 'rigs', 'base.json'), {
+    resources: {
+      paths: ['${components.product.path}'],
+    },
+    pipeline: {
+      up: [
+        {
+          kind: 'check',
+          label: 'generic check',
+          command: 'true',
+        },
+      ],
+    },
+  });
+  writeJson(join(packageRoot, 'rigs', 'generic-rig', 'rig.json'), {
+    extends: '../base.json',
+    id: 'generic-rig',
+    description: 'Generic lint fixture rig.',
+    fuzz_workloads: {
+      generic: [
+        { path: '${package.root}/fuzz/generic-fuzz.json' },
+      ],
+    },
+  });
+
+  const result = runLint(directory);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /declared resources and empty or missing pipeline\.down must declare lifecycle\.cleanup intent/);
+});
+
+test('accepts inherited cleanup policy for inherited resources with missing down lifecycle', () => {
+  const directory = createRigPackage({
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+  });
+  const packageRoot = join(directory, 'Vendor', 'product');
+  writeJson(join(packageRoot, 'rigs', 'base.json'), {
+    lifecycle: {
+      cleanup: {
+        intent: 'manual',
+        reason: 'The inherited rig resources are user-owned checkout state.',
+      },
+    },
+    resources: {
+      paths: ['${components.product.path}'],
+    },
+    pipeline: {
+      up: [
+        {
+          kind: 'check',
+          label: 'generic check',
+          command: 'true',
+        },
+      ],
+    },
+  });
+  writeJson(join(packageRoot, 'rigs', 'generic-rig', 'rig.json'), {
+    extends: '../base.json',
+    id: 'generic-rig',
+    description: 'Generic lint fixture rig.',
+    fuzz_workloads: {
+      generic: [
+        { path: '${package.root}/fuzz/generic-fuzz.json' },
+      ],
+    },
+  });
+
+  const result = runLint(directory);
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
 });
 
 test('accepts explicit cleanup policy for rigs with resources and empty down lifecycle', () => {
@@ -392,7 +500,7 @@ test('accepts explicit cleanup policy for rigs with resources and empty down lif
   const result = runLint(directory);
 
   assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
-  assert.doesNotMatch(result.stderr, /declared resources and empty pipeline\.down/);
+  assert.doesNotMatch(result.stderr, /declared resources and empty or missing pipeline\.down/);
 });
 
 test('validates cleanup policy metadata through the Homeboy cleanup intent contract', () => {


### PR DESCRIPTION
## Summary
- Treat missing pipeline.down like empty pipeline.down when rigs declare resources without cleanup intent.
- Materialize simple extends chains for cleanup lint.
- Add explicit cleanup intent to Studio resource rigs.

## Verification
- node scripts/lint-rig-packages.test.mjs
- HOMEBOY_WORDPRESS_HELPER_MANIFEST=$PWD/scripts/fixtures/homeboy-extension-wordpress/lib/helper-manifest.js node scripts/lint-rig-packages.mjs
- git diff --check

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Tightened rig cleanup lint, added inherited-resource coverage, and ran targeted lint checks.