### PR TITLE
Require Studio Figma SSI import ability

### DIFF
--- a/Automattic/studio/bench/studio-figma-ssi-import.bench.mjs
+++ b/Automattic/studio/bench/studio-figma-ssi-import.bench.mjs
@@ -45,7 +45,6 @@ function requestTitle(request) {
       request.title ||
       request.name ||
       request?.figma?.name ||
-      request?.artifact_bundle?.files?.find((file) => file.path?.endsWith('metadata.json'))?.title ||
       'Figma Studio Import'
   );
 }
@@ -71,85 +70,11 @@ if ( ! is_array( $payload ) ) {
     throw new RuntimeException( 'Figma runner request payload could not be decoded.' );
 }
 
-function homeboy_figma_studio_artifact_path( string $path, string $root ): string {
-    $path = str_replace( '\\\\', '/', $path );
-    $path = preg_replace( '#(^|/)\\.\\.(?=/|$)#', '', $path );
-    $path = preg_replace( '#[^A-Za-z0-9_./-]#', '-', (string) $path );
-    $path = trim( preg_replace( '#/+#', '/', (string) $path ), '/' );
-    $root = trim( str_replace( '\\\\', '/', $root ), '/' );
-    if ( '' !== $root && str_starts_with( $path, $root . '/' ) ) {
-        $path = substr( $path, strlen( $root ) + 1 );
-    }
-    return '' === $path ? '' : 'website/' . ltrim( $path, '/' );
+if ( ! function_exists( 'static_site_importer_ability_import_figma' ) ) {
+    throw new RuntimeException( 'Static Site Importer Figma import ability is unavailable.' );
 }
 
-function homeboy_figma_studio_artifact_from_bundle( array $bundle, array $payload ): array {
-    $root = isset( $bundle['root'] ) ? (string) $bundle['root'] : 'website/';
-    $files = array();
-    foreach ( isset( $bundle['files'] ) && is_array( $bundle['files'] ) ? $bundle['files'] : array() as $file ) {
-        if ( ! is_array( $file ) || ! isset( $file['path'] ) ) {
-            continue;
-        }
-        $path = homeboy_figma_studio_artifact_path( (string) $file['path'], $root );
-        if ( '' === $path ) {
-            continue;
-        }
-        $record = array( 'path' => $path );
-        if ( isset( $file['content_base64'] ) ) {
-            $record['content_base64'] = (string) $file['content_base64'];
-        } else {
-            $record['content'] = isset( $file['content'] ) ? (string) $file['content'] : '';
-        }
-        if ( isset( $file['mime_type'] ) ) {
-            $record['mime_type'] = (string) $file['mime_type'];
-        }
-        $files[] = $record;
-    }
-    if ( empty( $files ) ) {
-        throw new RuntimeException( 'Figma runner request did not include importable artifact files.' );
-    }
-    $paths = array_map( static fn( array $file ): string => (string) ( $file['path'] ?? '' ), $files );
-    $entrypoint = homeboy_figma_studio_artifact_path( isset( $bundle['entrypoint'] ) ? (string) $bundle['entrypoint'] : 'website/index.html', 'website' );
-    if ( '' === $entrypoint || ! in_array( $entrypoint, $paths, true ) ) {
-        $entrypoint = in_array( 'website/index.html', $paths, true ) ? 'website/index.html' : (string) reset( $paths );
-    }
-    return array(
-        'schema'     => 'blocks-engine/php-transformer/site-artifact/v1',
-        'root'       => 'website',
-        'entrypoint' => $entrypoint,
-        'files'      => $files,
-        'provenance' => array(
-            'source' => 'figma-to-wordpress-studio',
-            'schema' => isset( $payload['schema'] ) ? (string) $payload['schema'] : 'figma-to-wordpress-studio/runner-request/v1',
-        ),
-    );
-}
-
-$title = isset( $payload['site_title'] ) ? (string) $payload['site_title'] : ( isset( $payload['name'] ) ? (string) $payload['name'] : 'Figma Studio Import' );
-$slug = isset( $payload['slug'] ) ? (string) $payload['slug'] : sanitize_title( $title );
-
-if ( function_exists( 'static_site_importer_ability_import_figma' ) ) {
-    $result = static_site_importer_ability_import_figma( $payload );
-} else {
-    if ( ! function_exists( 'static_site_importer_ability_import_website_artifact' ) ) {
-        throw new RuntimeException( 'Static Site Importer website artifact import ability is unavailable.' );
-    }
-    if ( empty( $payload['artifact_bundle'] ) || ! is_array( $payload['artifact_bundle'] ) ) {
-        throw new RuntimeException( 'Static Site Importer Figma ability is unavailable and no artifact_bundle fallback was provided.' );
-    }
-    $result = static_site_importer_ability_import_website_artifact( array(
-        'artifact'        => homeboy_figma_studio_artifact_from_bundle( $payload['artifact_bundle'], $payload ),
-        'slug'            => $slug,
-        'name'            => $title,
-        'site_title'      => $title,
-        'activate'        => true,
-        'overwrite'       => true,
-        'source_metadata' => array(
-            'source' => 'figma-to-wordpress-studio',
-            'runner' => 'homeboy-rigs',
-        ),
-    ) );
-}
+$result = static_site_importer_ability_import_figma( $payload );
 
 update_option( 'figma_to_wordpress_studio_import_result', $result, false );
 
@@ -210,8 +135,8 @@ async function readFixture(fixturePath) {
   if (!request || typeof request !== 'object') {
     throw new Error(`Fixture did not decode to an object: ${fixturePath}`);
   }
-  if (!request.artifact_bundle && !request.figma && !request.scenegraph) {
-    throw new Error(`Fixture must include artifact_bundle, figma, or scenegraph: ${fixturePath}`);
+  if (!request.figma && !request.scenegraph) {
+    throw new Error(`Fixture must include figma or scenegraph data for the Figma import ability: ${fixturePath}`);
   }
   return request;
 }


### PR DESCRIPTION
## Summary
- Delete the Studio Figma SSI benchmark fallback that converted artifact bundles into website artifact imports.
- Require the explicit Static Site Importer Figma import ability and fail clearly when it is unavailable.
- Tighten fixture preflight so artifact-only requests are rejected before creating a Studio site.

## Verification
- `node --check Automattic/studio/bench/studio-figma-ssi-import.bench.mjs`
- Confirmed no fallback symbols remain in `studio-figma-ssi-import.bench.mjs`.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 / OpenCode
- **Used for:** Drafted and verified the targeted benchmark cleanup, commit, push, and PR setup.