### PR TITLE
Keep Playground runPHP bench temp files in artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ homeboy rig show studio-agent-claude-trunk
 ```bash
 homeboy rig install --all ./WordPress/wordpress-playground
 homeboy rig check playground-cli-diagnostics
-homeboy bench --rig playground-cli-diagnostics --scenario playground-cli-runphp-errors --iterations 1 --shared-state /tmp/playground-cli-diagnostics
+homeboy bench --rig playground-cli-diagnostics --scenario playground-cli-runphp-errors --iterations 1
 ```
 
 ## WordPress/wordpress-develop

--- a/WordPress/wordpress-playground/bench/playground-cli-runphp-errors.bench.mjs
+++ b/WordPress/wordpress-playground/bench/playground-cli-runphp-errors.bench.mjs
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -111,13 +111,10 @@ export default async function playgroundCliRunphpErrorsBench() {
   const blueprintsDir = path.join(artifactsDir, 'blueprints');
   await mkdir(blueprintsDir, { recursive: true });
 
-  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'playground-cli-runphp-errors-'));
-  const controlBlueprint = path.join(tmpDir, 'control.json');
-  const fatalBlueprint = path.join(tmpDir, 'fatal-runphp.json');
+  const controlBlueprint = path.join(blueprintsDir, 'control.json');
+  const fatalBlueprint = path.join(blueprintsDir, 'fatal-runphp.json');
   await writeFile(controlBlueprint, JSON.stringify(CONTROL_BLUEPRINT, null, 2));
   await writeFile(fatalBlueprint, JSON.stringify(FATAL_BLUEPRINT, null, 2));
-  await writeFile(path.join(blueprintsDir, 'control.json'), JSON.stringify(CONTROL_BLUEPRINT, null, 2));
-  await writeFile(path.join(blueprintsDir, 'fatal-runphp.json'), JSON.stringify(FATAL_BLUEPRINT, null, 2));
 
   const playgroundPath = componentPath();
   const control = await runCliProbe(playgroundPath, controlBlueprint);
@@ -171,8 +168,8 @@ export default async function playgroundCliRunphpErrorsBench() {
       report: reportPath,
       control_output: controlOutputPath,
       fatal_output: fatalOutputPath,
-      control_blueprint: path.join(blueprintsDir, 'control.json'),
-      fatal_blueprint: path.join(blueprintsDir, 'fatal-runphp.json'),
+      control_blueprint: controlBlueprint,
+      fatal_blueprint: fatalBlueprint,
     },
     metadata: {
       fatal_error_line: fatalAnalysis.errorLine,


### PR DESCRIPTION
## Summary
- Use the benchmark artifact blueprint files directly instead of creating duplicate unmanaged OS temp files.
- Remove the README example that hardcodes /tmp shared-state for the Playground CLI diagnostic bench.

## Verification
- node --check WordPress/wordpress-playground/bench/playground-cli-runphp-errors.bench.mjs
- node scripts/lint-rig-packages.mjs WordPress/wordpress-playground

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 / OpenCode
- **Used for:** Implemented the scoped temp-file cleanup, ran safe validation, and drafted this PR description.