### PR TITLE
Centralize Homeboy lint workflow install paths

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HOMEBOY_VERSION: v0.275.0
+      HOMEBOY_RELEASE_TARGET: x86_64-unknown-linux-gnu
       HOMEBOY_NODEJS_WORKLOAD_UTILS: ${{ github.workspace }}/homeboy-extensions/nodejs/scripts/bench/lib/workload-utils.mjs
       HOMEBOY_WORDPRESS_HELPER_MANIFEST: ${{ github.workspace }}/homeboy-extensions/wordpress/lib/helper-manifest.js
+    defaults:
+      run:
+        working-directory: homeboy-rigs
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,23 +34,24 @@ jobs:
           coverage: none
       - name: Install released Homeboy
         run: |
-          curl -fsSL -o /tmp/homeboy.tar.xz "https://github.com/Extra-Chill/homeboy/releases/download/${HOMEBOY_VERSION}/homeboy-x86_64-unknown-linux-gnu.tar.xz"
-          tar -xJf /tmp/homeboy.tar.xz -C /tmp
-          sudo install -m 0755 /tmp/homeboy-x86_64-unknown-linux-gnu/homeboy /usr/local/bin/homeboy
+          homeboy_release_dir="/tmp/homeboy-${HOMEBOY_RELEASE_TARGET}"
+          homeboy_archive="${homeboy_release_dir}.tar.xz"
+          homeboy_release_url="https://github.com/Extra-Chill/homeboy/releases/download/${HOMEBOY_VERSION}/homeboy-${HOMEBOY_RELEASE_TARGET}.tar.xz"
+
+          curl -fsSL -o "${homeboy_archive}" "${homeboy_release_url}"
+          tar -xJf "${homeboy_archive}" -C /tmp
+          sudo install -m 0755 "${homeboy_release_dir}/homeboy" /usr/local/bin/homeboy
           homeboy --version
           homeboy contract validate --help
           homeboy contract normalize artifact-ref --help
       - run: node scripts/lint-rig-packages.mjs
-        working-directory: homeboy-rigs
       - name: Test lint harness
         run: >-
           node --test
           scripts/lint-rig-packages.test.mjs
-        working-directory: homeboy-rigs
       - name: Test fuzz contracts
         run: >-
           node --test
           WordPress/gutenberg/tools/fuzz-coverage.test.mjs
           WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs
           woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
-        working-directory: homeboy-rigs


### PR DESCRIPTION
## Summary
- Centralize the Homeboy release target used by the lint workflow install block.
- Derive the release archive URL, archive path, and extracted install directory from that single target.
- Set a job-level default working directory for run steps to remove repeated per-step checkout path ceremony.

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/lint.yml"); puts "YAML OK"'
- node --test scripts/lint-rig-packages.test.mjs
- node --test WordPress/gutenberg/tools/fuzz-coverage.test.mjs WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 / OpenCode
- **Used for:** Investigated the lint workflow, made the small YAML cleanup, ran safe targeted validation, and drafted this PR description.