### PR TITLE
Thin generic rig shims

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ WP Codebox helper ownership is documented in `shared/wp-codebox/README.md`. Arti
 
 Rig-side WP Codebox recipe execution should import `shared/wp-codebox/recipe.mjs`, which is a pass-through to promoted upstream helpers. Rigs must not duplicate `command -v wp-codebox`, local checkout guesses, env-var precedence, watchdogs, duplicate-run dedupe, or artifact fallback. The remaining upstream primitive gaps are typed rig requirements for executable discovery, shared node dependency availability, temporary symlink setup, command-scoped filesystem assertions, child reaping, and structured recipe failure reporting; keep affected rigs downscoped until Homeboy/Homeboy Extensions exposes those contracts.
 
+`shared/stable-workload-lab-command-planner.mjs` remains rig-local until Homeboy owns a first-class stable workload Lab planning command. The upstream command should read `manifests/stable-workloads.json`, emit `homeboy fuzz run --lab-only` plans, and produce persisted-run comparison commands so product wrappers only pass product identity and schema metadata.
+
 Cleanup should move in small waves:
 
 1. Build a shared local Studio bench helper foundation for repeated filesystem, artifact, CLI, and appdata setup.

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -8,60 +8,8 @@ import { resolveTestHomeboyWordPressHelperManifest } from './test-homeboy-wordpr
 
 const script = new URL('./lint-rig-packages.mjs', import.meta.url).pathname;
 const wordpressHelperManifest = resolveTestHomeboyWordPressHelperManifest();
-const wordpressCoreFuzzValidatorSource = `
-export function validateFuzzWorkload({ rel, root, workload }) {
-  const failures = [];
-  const isWordPressDevelopFuzz = rel.startsWith('WordPress/wordpress-develop/fuzz/')
-    || (rel.startsWith('fuzz/') && root.endsWith('/WordPress/wordpress-develop'));
-  const surfaceIds = Array.isArray(workload.surface_ids) ? workload.surface_ids : [];
-  const isWordPressCoreFuzz = workload.target?.type === 'wordpress-core'
-    || workload.target?.component === 'wordpress-develop'
-    || workload.metadata?.kind === 'wordpress-core-fuzz'
-    || surfaceIds.some((surfaceId) => typeof surfaceId === 'string' && surfaceId.startsWith('wordpress-core-'));
-
-  if (isWordPressCoreFuzz && !isWordPressDevelopFuzz) {
-    failures.push(\`${'${rel}'}: WordPress Core fuzz workloads must live under WordPress/wordpress-develop/fuzz\`);
-  }
-
-  if (!isWordPressDevelopFuzz) {
-    return failures;
-  }
-
-  const semanticKeys = new Set((workload.artifacts?.expected || []).map((artifact) => artifact?.semantic_key).filter(Boolean));
-  if (workload.id === 'rest-api') {
-    for (const operation of ['rest-route-inventory', 'generated-rest-case-plan', 'request-case-execution', 'permission-boundary-classification', 'role-boundary-execution']) {
-      if (!workload.operations?.includes(operation)) {
-        failures.push(\`${'${rel}'}: rest-api must include ${'${operation}'} in operations\`);
-      }
-    }
-    for (const semanticKey of ['fuzz.rest.route_inventory', 'fuzz.rest.generated_cases', 'fuzz.rest.permission_boundaries']) {
-      if (!semanticKeys.has(semanticKey)) {
-        failures.push(\`${'${rel}'}: rest-api must declare expected artifact semantic key ${'${semanticKey}'}\`);
-      }
-    }
-  }
-
-  if (workload.id === 'db-inventory-query-profile') {
-    for (const surfaceId of ['wordpress-core-database', 'wordpress-core-rest-routes', 'wordpress-core-options', 'wordpress-core-postmeta', 'wordpress-core-rewrites']) {
-      if (!workload.surface_ids?.includes(surfaceId)) {
-        failures.push(\`${'${rel}'}: db-inventory-query-profile must include ${'${surfaceId}'} in surface_ids\`);
-      }
-    }
-    for (const operation of ['schema-inventory', 'rest-query-profile', 'options-query-attribution', 'postmeta-query-attribution', 'rewrite-query-attribution']) {
-      if (!workload.operations?.includes(operation)) {
-        failures.push(\`${'${rel}'}: db-inventory-query-profile must include ${'${operation}'} in operations\`);
-      }
-    }
-    for (const semanticKey of ['fuzz.db.schema_inventory', 'fuzz.db.rest_query_attribution', 'fuzz.db.options_postmeta_rewrite_attribution']) {
-      if (!semanticKeys.has(semanticKey)) {
-        failures.push(\`${'${rel}'}: db-inventory-query-profile must declare expected artifact semantic key ${'${semanticKey}'}\`);
-      }
-    }
-  }
-
-  return failures;
-}
-`;
+const wordpressCoreFuzzValidatorModule = new URL('../WordPress/wordpress-develop/tools/fuzz-workload-validator.mjs', import.meta.url).href;
+const wordpressCoreFuzzValidatorSource = `export { validateFuzzWorkload } from ${JSON.stringify(wordpressCoreFuzzValidatorModule)};\n`;
 
 function writeJson(path, value) {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);

--- a/shared/wp-codebox/contract.test.mjs
+++ b/shared/wp-codebox/contract.test.mjs
@@ -83,27 +83,6 @@ module.exports = {
   }
 });
 
-test('WP Codebox shared adapters do not carry quarantined generic helper behavior', () => {
-  const forbidden = [
-    /DEFAULT_RECIPE_TIMEOUT_MS/,
-    /WATCHDOG_TIMEOUT_EXIT_CODE/,
-    /inFlightRecipeRuns/,
-    /Promise\.race/,
-    /AbortController/,
-    /command -v wp-codebox/,
-    /files\/browser\/\*/,
-    /packageImport/,
-  ];
-
-  for (const file of ['artifacts.mjs', 'browser-coverage-trace.mjs', 'recipe.mjs'].map((name) => path.join(__dirname, name))) {
-    const rel = path.relative(repoRoot, file);
-    const contents = readFileSync(file, 'utf8');
-    for (const pattern of forbidden) {
-      assert.doesNotMatch(contents, pattern, `${rel} must not contain ${pattern}`);
-    }
-  }
-});
-
 test('shared WP Codebox docs name explicit upstream contract ids', () => {
   const readme = readFileSync(path.join(__dirname, 'README.md'), 'utf8');
 

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -13,7 +13,7 @@ import { evaluateEceFixtureHealth, fixtureHealthSummary } from './ece-product-pa
 import { summarizeEceReadinessMetrics } from './ece-product-page-readiness-metrics.mjs';
 import { DEFAULT_ECE_SCENARIO_ID, eceInteractionScript, eceLayoutScript, eceProductPageScenario, eceSimulatedClsScript } from './ece-product-page-scenarios.mjs';
 import { classifyEceWalletFanoutEvidence, groupedWalletLayoutSummary } from './ece-product-page-wallet-classification.mjs';
-import { runWpCodeboxRecipe } from './ece-product-page-wp-codebox.mjs';
+import { runWpCodeboxRecipe } from '../../../shared/wp-codebox/recipe.mjs';
 import { wpCodeboxBrowserArtifacts } from '../../../shared/wp-codebox/artifacts.mjs';
 
 const execFileAsync = promisify(execFile);

--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-wp-codebox.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-wp-codebox.mjs
@@ -1,1 +1,0 @@
-export { runWpCodeboxRecipe, wpCodeboxBin, wpCodeboxCommand } from '../../../shared/wp-codebox/recipe.mjs';


### PR DESCRIPTION
## Summary
- Delete a one-line Woo Stripe WP Codebox shim.
- Import the real WordPress Core fuzz validator instead of copying validator logic into tests.
- Remove a low-value absence test for deleted legacy helper behavior.
- Document that stable workload planning remains local until Homeboy owns that command.

## Tests
- node --test shared/wp-codebox/contract.test.mjs
- node --test --test-name-pattern "WordPress Core|product fuzz workload validators|product portable source validators" scripts/lint-rig-packages.test.mjs
- node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs

## Blocked checks
- Full `node --test scripts/lint-rig-packages.test.mjs` and `node scripts/lint-rig-packages.mjs` are blocked because `HOMEBOY_WORDPRESS_HELPER_MANIFEST` resolves to a Homeboy Extensions checkout missing `wordpress-fuzz-manifest-validator.js`.

## Dependencies
- Follow-up deletion of generic stable workload planner depends on Extra-Chill/homeboy#7358.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** openai/gpt-5.5 via OpenCode
- **Used for:** Thinned safe generic shims and updated tests under Chris direction.