### PR TITLE
Prepare rigs for core lifecycle planning

### DIFF
--- a/Automattic/jetpack/README.md
+++ b/Automattic/jetpack/README.md
@@ -30,13 +30,14 @@ Generate Lab-only commands for stable Jetpack profiling proof runs:
 
 ```sh
 node Automattic/jetpack/tools/stable-workload-lab-commands.mjs \
+  --prefer-core-planner \
   --runner LAB_RUNNER_ID \
   --artifact-root ARTIFACT_ROOT \
   --run-id-prefix jetpack-stable-YYYYMMDD \
   --tracker-ref github:Automattic/jetpack#ISSUE_OR_PR
 ```
 
-The generator emits one `homeboy fuzz run --lab-only` command per stable workload entry and compare commands for persisted refs, elapsed-time trends, and hotspot deltas. It does not execute workloads locally.
+The generator emits one `homeboy fuzz run --lab-only` command per stable workload entry and compare commands for persisted refs, elapsed-time trends, and hotspot deltas. It does not execute workloads locally. When the installed Homeboy includes `homeboy fuzz stable-plan`, `--prefer-core-planner` delegates planning to core; otherwise the rig-local migration planner emits the same Lab-only command surface.
 
 The rig exposes `smoke`, `fuzzer`, and `full-surface` `fuzz_profiles` for fleet
 orchestration. These profiles only group existing fuzz workload declarations;

--- a/README.md
+++ b/README.md
@@ -277,7 +277,9 @@ WP Codebox helper ownership is documented in `shared/wp-codebox/README.md`. Arti
 
 Rig-side WP Codebox recipe execution should import `shared/wp-codebox/recipe.mjs`, which is a pass-through to promoted upstream helpers. Rigs must not duplicate `command -v wp-codebox`, local checkout guesses, env-var precedence, watchdogs, duplicate-run dedupe, or artifact fallback. The remaining upstream primitive gaps are typed rig requirements for executable discovery, shared node dependency availability, temporary symlink setup, command-scoped filesystem assertions, child reaping, and structured recipe failure reporting; keep affected rigs downscoped until Homeboy/Homeboy Extensions exposes those contracts.
 
-`shared/stable-workload-lab-command-planner.mjs` remains rig-local until Homeboy owns a first-class stable workload Lab planning command. The upstream command should read `manifests/stable-workloads.json`, emit `homeboy fuzz run --lab-only` plans, and produce persisted-run comparison commands so product wrappers only pass product identity and schema metadata.
+`shared/stable-workload-lab-command-planner.mjs` remains rig-local until Homeboy owns a first-class stable workload Lab planning command. Wrappers can pass `--prefer-core-planner` to delegate to `homeboy fuzz stable-plan` when an installed Homeboy exposes it, or `--use-core-planner` to require it. Until that command is released, the local planner is a migration shim that reads `manifests/stable-workloads.json`, emits `homeboy fuzz run --lab-only` plans, and produces persisted-run comparison commands so product wrappers only pass product identity and schema metadata.
+
+Rig cleanup proof is now owned by Homeboy lifecycle artifacts. Rigs keep product-specific `lifecycle.cleanup` metadata for package review, while runtime evidence should come from Homeboy-emitted `rig_resource_lifecycle_index` artifacts rather than rig-local cleanup intent contract checks.
 
 Cleanup should move in small waves:
 

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { basename, dirname, isAbsolute, join, normalize, relative, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { assertFuzzReadinessMetadata } from './fuzz-manifest-helpers.mjs';
@@ -25,7 +24,6 @@ const warnings = [];
 const personalPathPrefix = '/Users/' + 'chubes/';
 const localDeveloperCheckoutPattern = /(?:~|\$HOME)\/Developer\//;
 const tsrmlsPatchMarker = 'PHP-WASM-COMBINED-FIXES ' + 'TSRMLS fallback';
-const cleanupIntentContractSchema = 'homeboy/resource-cleanup-intent/v1';
 const cleanupIntents = new Set(['none', 'external', 'manual', 'pipeline']);
 const homeboyBin = process.env.HOMEBOY_BIN || 'homeboy';
 
@@ -244,8 +242,6 @@ function lintLifecycleCleanup(rel, rig) {
   const cleanup = lifecycleCleanupPolicy(rig);
 
   if (cleanup) {
-    validateHomeboyCleanupIntentContract(rel, cleanup);
-
     if (!cleanupIntents.has(cleanup.intent)) {
       failures.push(`${rel}: lifecycle.cleanup.intent must be one of ${[...cleanupIntents].join(', ')}`);
     }
@@ -262,73 +258,6 @@ function lintLifecycleCleanup(rel, rig) {
   }
 
   failures.push(`${rel}: rigs with declared resources and empty or missing pipeline.down must declare lifecycle.cleanup intent`);
-}
-
-function cleanupContractForRigPolicy(rel, cleanup) {
-  const owner = typeof cleanup.intent === 'string' ? cleanup.intent : '';
-  const reason = typeof cleanup.reason === 'string' ? cleanup.reason : '';
-  const metadata = {
-    owner,
-    declared_by: rel,
-    reason,
-  };
-  const contract = {
-    schema: cleanupIntentContractSchema,
-    intent: cleanup.intent === 'pipeline' ? 'apply' : 'dry_run',
-    ownership: {
-      dry_run: metadata,
-    },
-  };
-
-  if (cleanup.intent === 'pipeline') {
-    contract.ownership.apply = metadata;
-  }
-
-  return contract;
-}
-
-function validateHomeboyCleanupIntentContract(rel, cleanup) {
-  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'homeboy-rigs-cleanup-intent-'));
-  const contractFile = join(temporaryDirectory, 'cleanup-intent.json');
-
-  try {
-    writeFileSync(contractFile, `${JSON.stringify(cleanupContractForRigPolicy(rel, cleanup), null, 2)}\n`);
-    const result = spawnSync(homeboyBin, ['contract', 'validate', cleanupIntentContractSchema, '--file', contractFile], {
-      encoding: 'utf8',
-    });
-
-    if (result.error) {
-      failures.push(`${rel}: failed to run Homeboy cleanup intent contract validator: ${result.error.message}`);
-      return;
-    }
-
-    if (result.status === 0) {
-      return;
-    }
-
-    failures.push(`${rel}: lifecycle.cleanup failed Homeboy cleanup intent contract validation: ${formatHomeboyValidationFailure(result)}`);
-  } finally {
-    rmSync(temporaryDirectory, { recursive: true, force: true });
-  }
-}
-
-function formatHomeboyValidationFailure(result) {
-  const output = `${result.stdout || ''}\n${result.stderr || ''}`.trim();
-
-  if (!output) {
-    return `validator exited with status ${result.status}`;
-  }
-
-  try {
-    const payload = JSON.parse(output);
-    const details = payload.error?.details || {};
-    const path = details.path || details.field;
-    const error = details.error || payload.error?.message;
-
-    return [path, error].filter(Boolean).join(': ') || output;
-  } catch {
-    return output;
-  }
 }
 
 function lintSharedPaths(rel, rig) {

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -37,51 +37,15 @@ if (command !== 'contract' || subcommand !== 'validate') {
 }
 
 const isFuzzWorkload = first === '--file' && third === 'homeboy/fuzz-workload/v1';
-const isCleanupIntent = first === 'homeboy/resource-cleanup-intent/v1' && second === '--file';
-const file = isFuzzWorkload ? second : third;
-const schema = isFuzzWorkload ? third : first;
+const file = second;
+const schema = third;
 
-if (!isFuzzWorkload && !isCleanupIntent) {
+if (!isFuzzWorkload) {
   console.error(\`unexpected homeboy args: ${'${process.argv.slice(2).join(" ")}'}\`);
   process.exit(64);
 }
 
 const payload = JSON.parse(readFileSync(file, 'utf8'));
-
-function fail(path, error) {
-  console.log(JSON.stringify({
-    success: false,
-    error: {
-      code: 'validation.invalid_json',
-      message: 'Contract validation failed',
-      details: { path, error, schema, valid: false },
-    },
-  }));
-  process.exit(1);
-}
-
-if (isCleanupIntent) {
-  if (payload.schema !== 'homeboy/resource-cleanup-intent/v1') {
-    fail('schema', 'unexpected schema');
-  }
-  if (!['dry_run', 'apply'].includes(payload.intent)) {
-    fail('intent', 'unknown cleanup intent');
-  }
-  if (!payload.ownership?.dry_run?.owner?.trim()) {
-    fail('ownership.dry_run.owner', 'must not be blank');
-  }
-  if (!payload.ownership?.dry_run?.declared_by?.trim()) {
-    fail('ownership.dry_run.declared_by', 'must not be blank');
-  }
-  if (payload.ownership.dry_run.reason !== undefined && !payload.ownership.dry_run.reason.trim()) {
-    fail('ownership.dry_run.reason', 'must not be blank');
-  }
-  if (payload.intent === 'apply' && !payload.ownership?.apply?.owner?.trim()) {
-    fail('ownership.apply', 'apply cleanup intent requires explicit apply ownership metadata');
-  }
-  console.log(JSON.stringify({ success: true, data: { file, schema, valid: true } }));
-  process.exit(0);
-}
 
 const workload = payload;
 if (workload.schema !== 'homeboy/fuzz-workload/v1') {
@@ -417,7 +381,7 @@ test('accepts explicit cleanup policy for rigs with resources and empty down lif
   assert.doesNotMatch(result.stderr, /declared resources and empty or missing pipeline\.down/);
 });
 
-test('validates cleanup policy metadata through the Homeboy cleanup intent contract', () => {
+test('validates cleanup policy metadata without runtime cleanup proof', () => {
   const directory = createRigPackage({
     rig: {
       lifecycle: {
@@ -435,8 +399,7 @@ test('validates cleanup policy metadata through the Homeboy cleanup intent contr
   const result = runLint(directory);
 
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /lifecycle\.cleanup failed Homeboy cleanup intent contract validation/);
-  assert.match(result.stderr, /ownership\.dry_run\.reason: must not be blank/);
+  assert.match(result.stderr, /lifecycle\.cleanup\.reason must explain the cleanup boundary/);
 });
 
 test('rejects invalid explicit cleanup policy', () => {

--- a/shared/stable-workload-lab-command-planner.mjs
+++ b/shared/stable-workload-lab-command-planner.mjs
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -6,6 +7,12 @@ export function emitStableWorkloadLabCommands(config, argv = process.argv.slice(
   const scriptDir = path.dirname(fileURLToPath(config.moduleUrl));
   const packageRoot = path.join(scriptDir, '..');
   const manifestPath = path.join(packageRoot, 'manifests/stable-workloads.json');
+  const coreMode = corePlannerMode(argv);
+
+  if (coreMode && maybeEmitCoreStablePlan(config, manifestPath, argv, stdout, coreMode)) {
+    return;
+  }
+
   const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
 
   const options = parseArgs(argv, config, stdout);
@@ -100,6 +107,8 @@ export function emitStableWorkloadLabCommands(config, argv = process.argv.slice(
     profile_id: manifest.profile_id,
     rig_id: config.rigId,
     local_execution: false,
+    planner: 'homeboy-rigs-local-compat',
+    migration_target: 'homeboy fuzz stable-plan',
     run_id_prefix: runIdPrefix,
     run_commands: runCommands,
     compare_commands: compareCommands,
@@ -151,6 +160,9 @@ function parseArgs(argv, config, stdout) {
       case '--detach-after-handoff':
         parsed.detachAfterHandoff = true;
         break;
+      case '--prefer-core-planner':
+      case '--use-core-planner':
+        break;
       case '--hotspot-limit':
         parsed.hotspotLimit = Number.parseInt(readValue(arg), 10);
         break;
@@ -192,6 +204,55 @@ function parseArgs(argv, config, stdout) {
   }
 
   return parsed;
+}
+
+function corePlannerMode(argv) {
+  if (argv.includes('--use-core-planner')) {
+    return 'required';
+  }
+  if (argv.includes('--prefer-core-planner')) {
+    return 'preferred';
+  }
+  return '';
+}
+
+function maybeEmitCoreStablePlan(config, manifestPath, argv, stdout, mode) {
+  const homeboyBin = process.env.HOMEBOY_BIN || 'homeboy';
+  const strippedArgs = argv.filter((arg) => !['--prefer-core-planner', '--use-core-planner'].includes(arg));
+  const help = spawnSync(homeboyBin, ['fuzz', 'help', 'stable-plan'], { encoding: 'utf8' });
+
+  if (help.status !== 0) {
+    if (mode === 'required') {
+      throw new Error('Homeboy core stable planner is unavailable; expected `homeboy fuzz stable-plan`');
+    }
+    return false;
+  }
+
+  const result = spawnSync(homeboyBin, [
+    'fuzz',
+    'stable-plan',
+    '--manifest',
+    manifestPath,
+    '--component',
+    config.component,
+    '--rig',
+    config.rigId,
+    ...strippedArgs,
+  ], { encoding: 'utf8' });
+
+  if (result.stdout) {
+    stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+  return true;
 }
 
 function selectedContracts(contracts, stableIds) {
@@ -245,4 +306,6 @@ function printHelp(config, stdout) {
   stdout.write(`  --limit <n>                  Run-history limit for refs/compare. Default: 50.\n`);
   stdout.write(`  --hotspot-limit <n>          Hotspot compare row limit. Default: 20.\n`);
   stdout.write(`  --json                       Emit structured JSON instead of shell commands.\n`);
+  stdout.write(`  --prefer-core-planner        Use homeboy fuzz stable-plan when available; otherwise use the rig-local migration planner.\n`);
+  stdout.write(`  --use-core-planner           Require homeboy fuzz stable-plan and fail if the installed Homeboy does not expose it.\n`);
 }

--- a/shared/stable-workload-lab-command-planner.test.mjs
+++ b/shared/stable-workload-lab-command-planner.test.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { chmodSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { pathToFileURL } from 'node:url';
+import { emitStableWorkloadLabCommands } from './stable-workload-lab-command-planner.mjs';
+
+function writeJson(file, value) {
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function createPackage() {
+  const root = mkdtempSync(path.join(tmpdir(), 'homeboy-rigs-stable-plan-'));
+  const packageRoot = path.join(root, 'Vendor', 'product');
+  const toolsRoot = path.join(packageRoot, 'tools');
+  const manifestRoot = path.join(packageRoot, 'manifests');
+  mkdirSync(toolsRoot, { recursive: true });
+  mkdirSync(manifestRoot, { recursive: true });
+  writeFileSync(path.join(toolsRoot, 'stable-workload-lab-commands.mjs'), '');
+  writeJson(path.join(manifestRoot, 'stable-workloads.json'), {
+    profile_id: 'stable-profile',
+    contracts: [
+      {
+        id: 'stable-contract',
+        entry_workloads: ['stable-workload'],
+      },
+    ],
+  });
+  return { moduleUrl: pathToFileURL(path.join(toolsRoot, 'stable-workload-lab-commands.mjs')).href };
+}
+
+function createHomeboyWithoutStablePlan() {
+  const root = mkdtempSync(path.join(tmpdir(), 'homeboy-rigs-homeboy-'));
+  const bin = path.join(root, 'homeboy');
+  writeFileSync(bin, `#!/usr/bin/env node
+if (process.argv.slice(2).join(' ') === 'fuzz help stable-plan') {
+  console.error("error: unrecognized subcommand 'stable-plan'");
+  process.exit(2);
+}
+console.error('unexpected homeboy call');
+process.exit(64);
+`);
+  chmodSync(bin, 0o755);
+  return bin;
+}
+
+test('prefer-core-planner falls back to rig-local migration planner when core command is unavailable', () => {
+  const previousHomeboyBin = process.env.HOMEBOY_BIN;
+  process.env.HOMEBOY_BIN = createHomeboyWithoutStablePlan();
+  const writes = [];
+
+  try {
+    emitStableWorkloadLabCommands({
+      ...createPackage(),
+      productLabel: 'Product',
+      component: 'product',
+      rigId: 'product-rig',
+      schema: 'homeboy-rigs/product-stable-lab-command-plan/v1',
+      defaultRunIdPrefix: 'product-stable',
+    }, ['--prefer-core-planner', '--json', '--run-id-prefix', 'stable-proof'], {
+      write: (value) => writes.push(value),
+    });
+  } finally {
+    if (previousHomeboyBin === undefined) {
+      delete process.env.HOMEBOY_BIN;
+    } else {
+      process.env.HOMEBOY_BIN = previousHomeboyBin;
+    }
+  }
+
+  const payload = JSON.parse(writes.join(''));
+  assert.equal(payload.planner, 'homeboy-rigs-local-compat');
+  assert.equal(payload.migration_target, 'homeboy fuzz stable-plan');
+  assert.deepEqual(payload.run_commands[0].command.slice(0, 4), ['homeboy', 'fuzz', 'run', '--lab-only']);
+});

--- a/woocommerce/woocommerce/README.md
+++ b/woocommerce/woocommerce/README.md
@@ -272,6 +272,7 @@ Generate the Lab-only command plan without executing any workload:
 
 ```bash
 node woocommerce/woocommerce/tools/stable-workload-lab-commands.mjs \
+  --prefer-core-planner \
   --runner LAB_RUNNER_ID \
   --artifact-root ARTIFACT_ROOT \
   --run-id-prefix woo-stable-YYYYMMDD \
@@ -282,6 +283,7 @@ For a focused proof, pass one or more stable IDs:
 
 ```bash
 node woocommerce/woocommerce/tools/stable-workload-lab-commands.mjs \
+  --prefer-core-planner \
   --stable-id rest-db-query-profile,store-api-product-browse \
   --runner LAB_RUNNER_ID \
   --artifact-root ARTIFACT_ROOT \
@@ -295,6 +297,9 @@ generated `homeboy runs refs`, `homeboy runs compare`, and `homeboy runs
 hotspots --baseline-run BASELINE_RUN_ID --candidate-run CANDIDATE_RUN_ID`
 commands to compare persisted evidence over time. Keep reviewer-facing proof in
 Homeboy run/artifact refs; local paths and local-only URLs are not proof.
+When the installed Homeboy includes `homeboy fuzz stable-plan`, `--prefer-core-planner`
+delegates planning to core; otherwise the rig-local migration planner emits the
+same Lab-only command surface.
 
 Each Woo fuzz manifest declares the WP Codebox fixture contract in metadata:
 `wp-codebox` runtime, disposable WordPress scope, WooCommerce component, and


### PR DESCRIPTION
## Summary
- Remove rig-local execution of the Homeboy cleanup intent contract from package linting while retaining static metadata validation.
- Document runtime cleanup proof as owned by Homeboy `rig_resource_lifecycle_index` artifacts.
- Add stable workload planner migration flags so wrappers can prefer or require the core planner when released.

## Verification
- `node --test --test-name-pattern "cleanup|prefer-core-planner" scripts/lint-rig-packages.test.mjs shared/stable-workload-lab-command-planner.test.mjs`
- `node Automattic/jetpack/tools/stable-workload-lab-commands.mjs --prefer-core-planner --json --run-id-prefix verify-jetpack`
- `node woocommerce/woocommerce/tools/stable-workload-lab-commands.mjs --prefer-core-planner --json --run-id-prefix verify-woo`

## Known environment issue
- Full local lint still depends on a missing `HOMEBOY_WORDPRESS_HELPER_MANIFEST` target in this machine environment.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** gpt-5.5 via OpenCode
- **Used for:** Rigs cleanup, migration seam implementation, tests, and verification orchestration.