### PR TITLE
Deduplicate rig arrays with extends directives

### DIFF
--- a/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
+++ b/Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json
@@ -38,74 +38,19 @@
   "fuzz": {
     "default_component": "jetpack"
   },
-  "fuzz_workloads": {
-    "wordpress": [
-      { "path": "${package.root}/fuzz/jetpack-rest-route-inventory.json" },
-      { "path": "${package.root}/fuzz/generated-rest-request-cases.json" },
-      { "path": "${package.root}/fuzz/rest-db-query-profile.json" },
-      { "path": "${package.root}/fuzz/db-inventory.json" },
-      { "path": "${package.root}/fuzz/jetpack-admin-page-coverage.json" },
-      { "path": "${package.root}/fuzz/jetpack-module-state-matrix.json" },
-      { "path": "${package.root}/fuzz/jetpack-module-option-table-inventory.json" },
-      { "path": "${package.root}/fuzz/jetpack-options-matrix.json" },
-      { "path": "${package.root}/fuzz/jetpack-sync-queue-coverage.json" },
-      { "path": "${package.root}/fuzz/jetpack-cron-sync-actions.json" },
-      { "path": "${package.root}/fuzz/jetpack-connected-disconnected-fixtures.json" },
-      { "path": "${package.root}/fuzz/jetpack-public-module-frontend-coverage.json" },
-      { "path": "${package.root}/fuzz/jetpack-performance-observation.json" },
-      { "path": "${package.root}/fuzz/jetpack-external-http-guardrail.json" }
-    ]
-  },
-  "fuzz_profiles": {
-    "smoke": [
-      "jetpack-rest-route-inventory",
-      "generated-rest-request-cases",
-      "rest-db-query-profile",
-      "db-inventory"
-    ],
-    "fuzzer": [
-      "jetpack-rest-route-inventory",
-      "generated-rest-request-cases",
-      "rest-db-query-profile",
-      "db-inventory",
-      "jetpack-admin-page-coverage",
-      "jetpack-module-state-matrix",
-      "jetpack-module-option-table-inventory",
-      "jetpack-options-matrix",
-      "jetpack-sync-queue-coverage",
-      "jetpack-cron-sync-actions",
-      "jetpack-connected-disconnected-fixtures",
-      "jetpack-public-module-frontend-coverage",
-      "jetpack-performance-observation",
-      "jetpack-external-http-guardrail"
-    ],
-    "full-surface": [
-      "jetpack-rest-route-inventory",
-      "generated-rest-request-cases",
-      "rest-db-query-profile",
-      "db-inventory",
-      "jetpack-admin-page-coverage",
-      "jetpack-module-state-matrix",
-      "jetpack-module-option-table-inventory",
-      "jetpack-options-matrix",
-      "jetpack-sync-queue-coverage",
-      "jetpack-cron-sync-actions",
-      "jetpack-connected-disconnected-fixtures",
-      "jetpack-public-module-frontend-coverage",
-      "jetpack-performance-observation",
-      "jetpack-external-http-guardrail"
-    ]
-  },
   "pipeline": {
-    "check": [
-      {
-        "kind": "requirement",
-        "label": "Jetpack plugin checkout exists",
-        "file": "${components.jetpack.path}/jetpack.php",
-        "component": "jetpack",
-        "component_path_contains": "jetpack",
-        "remediation": "Pass homeboy bench --path /path/to/jetpack/projects/plugins/jetpack or update components.jetpack.path before running jetpack-api-route-inventory."
-      }
-    ]
+    "check": {
+      "$merge_by": "label",
+      "entries": [
+        {
+          "kind": "requirement",
+          "label": "Jetpack plugin checkout exists",
+          "file": "${components.jetpack.path}/jetpack.php",
+          "component": "jetpack",
+          "component_path_contains": "jetpack",
+          "remediation": "Pass homeboy bench --path /path/to/jetpack/projects/plugins/jetpack or update components.jetpack.path before running jetpack-api-route-inventory."
+        }
+      ]
+    }
   }
 }

--- a/Automattic/jetpack/rigs/jetpack-browser-coverage/rig.json
+++ b/Automattic/jetpack/rigs/jetpack-browser-coverage/rig.json
@@ -20,27 +20,5 @@
   },
   "trace": {
     "default_component": "jetpack"
-  },
-  "trace_workloads": {
-    "nodejs": [
-      {
-        "path": "${package.root}/bench/jetpack-browser-coverage.trace.mjs"
-      }
-    ]
-  },
-  "trace_profiles": {
-    "smoke": ["jetpack-browser-coverage"],
-    "full-surface": ["jetpack-browser-coverage"]
-  },
-  "pipeline": {
-    "check": [
-      {
-        "kind": "requirement",
-        "label": "Jetpack plugin checkout exists",
-        "file": "${components.jetpack.path}/jetpack.php",
-        "component": "jetpack",
-        "component_path_contains": "jetpack"
-      }
-    ]
   }
 }

--- a/Automattic/jetpack/shared/wordpress-plugin/browser-coverage.base.json
+++ b/Automattic/jetpack/shared/wordpress-plugin/browser-coverage.base.json
@@ -14,7 +14,27 @@
       }
     }
   },
+  "trace_workloads": {
+    "nodejs": [
+      {
+        "path": "${package.root}/bench/jetpack-browser-coverage.trace.mjs"
+      }
+    ]
+  },
+  "trace_profiles": {
+    "smoke": ["jetpack-browser-coverage"],
+    "full-surface": ["jetpack-browser-coverage"]
+  },
   "pipeline": {
+    "check": [
+      {
+        "kind": "requirement",
+        "label": "Jetpack plugin checkout exists",
+        "file": "${components.jetpack.path}/jetpack.php",
+        "component": "jetpack",
+        "component_path_contains": "jetpack"
+      }
+    ],
     "down": []
   }
 }

--- a/Automattic/jetpack/shared/wordpress-plugin/fuzz-inventory.base.json
+++ b/Automattic/jetpack/shared/wordpress-plugin/fuzz-inventory.base.json
@@ -3,7 +3,74 @@
   "bench": {
     "warmup_iterations": 0
   },
+  "fuzz_workloads": {
+    "wordpress": [
+      { "path": "${package.root}/fuzz/jetpack-rest-route-inventory.json" },
+      { "path": "${package.root}/fuzz/generated-rest-request-cases.json" },
+      { "path": "${package.root}/fuzz/rest-db-query-profile.json" },
+      { "path": "${package.root}/fuzz/db-inventory.json" },
+      { "path": "${package.root}/fuzz/jetpack-admin-page-coverage.json" },
+      { "path": "${package.root}/fuzz/jetpack-module-state-matrix.json" },
+      { "path": "${package.root}/fuzz/jetpack-module-option-table-inventory.json" },
+      { "path": "${package.root}/fuzz/jetpack-options-matrix.json" },
+      { "path": "${package.root}/fuzz/jetpack-sync-queue-coverage.json" },
+      { "path": "${package.root}/fuzz/jetpack-cron-sync-actions.json" },
+      { "path": "${package.root}/fuzz/jetpack-connected-disconnected-fixtures.json" },
+      { "path": "${package.root}/fuzz/jetpack-public-module-frontend-coverage.json" },
+      { "path": "${package.root}/fuzz/jetpack-performance-observation.json" },
+      { "path": "${package.root}/fuzz/jetpack-external-http-guardrail.json" }
+    ]
+  },
+  "fuzz_profiles": {
+    "smoke": [
+      "jetpack-rest-route-inventory",
+      "generated-rest-request-cases",
+      "rest-db-query-profile",
+      "db-inventory"
+    ],
+    "fuzzer": [
+      "jetpack-rest-route-inventory",
+      "generated-rest-request-cases",
+      "rest-db-query-profile",
+      "db-inventory",
+      "jetpack-admin-page-coverage",
+      "jetpack-module-state-matrix",
+      "jetpack-module-option-table-inventory",
+      "jetpack-options-matrix",
+      "jetpack-sync-queue-coverage",
+      "jetpack-cron-sync-actions",
+      "jetpack-connected-disconnected-fixtures",
+      "jetpack-public-module-frontend-coverage",
+      "jetpack-performance-observation",
+      "jetpack-external-http-guardrail"
+    ],
+    "full-surface": [
+      "jetpack-rest-route-inventory",
+      "generated-rest-request-cases",
+      "rest-db-query-profile",
+      "db-inventory",
+      "jetpack-admin-page-coverage",
+      "jetpack-module-state-matrix",
+      "jetpack-module-option-table-inventory",
+      "jetpack-options-matrix",
+      "jetpack-sync-queue-coverage",
+      "jetpack-cron-sync-actions",
+      "jetpack-connected-disconnected-fixtures",
+      "jetpack-public-module-frontend-coverage",
+      "jetpack-performance-observation",
+      "jetpack-external-http-guardrail"
+    ]
+  },
   "pipeline": {
+    "check": [
+      {
+        "kind": "requirement",
+        "label": "Jetpack plugin checkout exists",
+        "file": "${components.jetpack.path}/jetpack.php",
+        "component": "jetpack",
+        "component_path_contains": "jetpack"
+      }
+    ],
     "down": []
   }
 }

--- a/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
+++ b/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
@@ -11,14 +11,15 @@ import {
   declaredBenchWorkloadIds,
   declaredFuzzIds,
   fuzzManifestHasExecutableArtifactContract,
+  readMaterializedRig,
   readJson,
 } from '../../../scripts/fuzz-manifest-helpers.mjs';
 import { assertJetpackFuzzManifestReadinessContract } from './fuzz-workload-validator.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
-const apiRig = readJson(packageRoot, 'rigs/jetpack-api-route-inventory/rig.json');
-const browserRig = readJson(packageRoot, 'rigs/jetpack-browser-coverage/rig.json');
+const apiRig = readMaterializedRig(packageRoot, 'rigs/jetpack-api-route-inventory/rig.json');
+const browserRig = readMaterializedRig(packageRoot, 'rigs/jetpack-browser-coverage/rig.json');
 const fullSurfaceCoverage = readJson(packageRoot, 'manifests/full-surface-coverage.json');
 const restRouteCoverage = readJson(packageRoot, 'manifests/rest-route-coverage.json');
 const stableWorkloads = readJson(packageRoot, 'manifests/stable-workloads.json');

--- a/WordPress/gutenberg/rigs/gutenberg-api-route-inventory/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-api-route-inventory/rig.json
@@ -29,68 +29,19 @@
   "fuzz": {
     "default_component": "gutenberg"
   },
-  "fuzz_workloads": {
-    "wordpress": [
-      { "path": "${package.root}/fuzz/gutenberg-rest-route-fuzz.json" },
-      { "path": "${package.root}/fuzz/gutenberg-rest-request-cases-fuzz.json" },
-      { "path": "${package.root}/fuzz/gutenberg-admin-page-coverage.json" },
-      { "path": "${package.root}/fuzz/block-editor-browser-coverage.json" },
-      { "path": "${package.root}/fuzz/site-editor-browser-coverage.json" },
-      { "path": "${package.root}/fuzz/block-rendering-coverage.json" },
-      { "path": "${package.root}/fuzz/frontend-rendering-request-coverage.json" },
-      { "path": "${package.root}/fuzz/gutenberg-db-inventory-fuzz.json" },
-      { "path": "${package.root}/fuzz/gutenberg-rest-db-query-profile-fuzz.json" },
-      { "path": "${package.root}/fuzz/gutenberg-hooks-options-inventory.json" },
-      { "path": "${package.root}/fuzz/gutenberg-editor-performance-observation.json" },
-      { "path": "${package.root}/fuzz/gutenberg-external-http-guardrail-fuzz.json" }
-    ]
-  },
-  "fuzz_profiles": {
-    "smoke": [
-      "gutenberg-rest-route-fuzz",
-      "gutenberg-rest-request-cases-fuzz",
-      "gutenberg-admin-page-coverage",
-      "block-editor-browser-coverage"
-    ],
-    "fuzzer": [
-      "gutenberg-rest-route-fuzz",
-      "gutenberg-rest-request-cases-fuzz",
-      "gutenberg-admin-page-coverage",
-      "block-editor-browser-coverage",
-      "site-editor-browser-coverage",
-      "block-rendering-coverage",
-      "frontend-rendering-request-coverage",
-      "gutenberg-db-inventory-fuzz",
-      "gutenberg-rest-db-query-profile-fuzz",
-      "gutenberg-hooks-options-inventory",
-      "gutenberg-editor-performance-observation",
-      "gutenberg-external-http-guardrail-fuzz"
-    ],
-    "full-surface": [
-      "gutenberg-rest-route-fuzz",
-      "gutenberg-rest-request-cases-fuzz",
-      "gutenberg-admin-page-coverage",
-      "block-editor-browser-coverage",
-      "site-editor-browser-coverage",
-      "block-rendering-coverage",
-      "frontend-rendering-request-coverage",
-      "gutenberg-db-inventory-fuzz",
-      "gutenberg-rest-db-query-profile-fuzz",
-      "gutenberg-hooks-options-inventory",
-      "gutenberg-editor-performance-observation",
-      "gutenberg-external-http-guardrail-fuzz"
-    ]
-  },
   "pipeline": {
-    "check": [
-      {
-        "kind": "requirement",
-        "label": "Gutenberg checkout exists",
-        "file": "${components.gutenberg.path}/gutenberg.php",
-        "component": "gutenberg",
-        "component_path_contains": "gutenberg",
-        "remediation": "Pass homeboy bench --path /path/to/gutenberg or update components.gutenberg.path before running gutenberg-api-route-inventory."
-      }
-    ]
+    "check": {
+      "$merge_by": "label",
+      "entries": [
+        {
+          "kind": "requirement",
+          "label": "Gutenberg checkout exists",
+          "file": "${components.gutenberg.path}/gutenberg.php",
+          "component": "gutenberg",
+          "component_path_contains": "gutenberg",
+          "remediation": "Pass homeboy bench --path /path/to/gutenberg or update components.gutenberg.path before running gutenberg-api-route-inventory."
+        }
+      ]
+    }
   }
 }

--- a/WordPress/gutenberg/rigs/gutenberg-browser-coverage/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-browser-coverage/rig.json
@@ -18,28 +18,5 @@
   },
   "trace": {
     "default_component": "gutenberg"
-  },
-  "trace_workloads": {
-    "nodejs": [
-      {
-        "path": "${package.root}/bench/gutenberg-browser-coverage.trace.mjs"
-      }
-    ]
-  },
-  "trace_profiles": {
-    "smoke": ["gutenberg-browser-coverage"],
-    "fuzzer": ["gutenberg-browser-coverage"],
-    "full-surface": ["gutenberg-browser-coverage"]
-  },
-  "pipeline": {
-    "check": [
-      {
-        "kind": "requirement",
-        "label": "Gutenberg checkout exists",
-        "file": "${components.gutenberg.path}/gutenberg.php",
-        "component": "gutenberg",
-        "component_path_contains": "gutenberg"
-      }
-    ]
   }
 }

--- a/WordPress/gutenberg/shared/wordpress-plugin/browser-coverage.base.json
+++ b/WordPress/gutenberg/shared/wordpress-plugin/browser-coverage.base.json
@@ -14,7 +14,28 @@
       }
     }
   },
+  "trace_workloads": {
+    "nodejs": [
+      {
+        "path": "${package.root}/bench/gutenberg-browser-coverage.trace.mjs"
+      }
+    ]
+  },
+  "trace_profiles": {
+    "smoke": ["gutenberg-browser-coverage"],
+    "fuzzer": ["gutenberg-browser-coverage"],
+    "full-surface": ["gutenberg-browser-coverage"]
+  },
   "pipeline": {
+    "check": [
+      {
+        "kind": "requirement",
+        "label": "Gutenberg checkout exists",
+        "file": "${components.gutenberg.path}/gutenberg.php",
+        "component": "gutenberg",
+        "component_path_contains": "gutenberg"
+      }
+    ],
     "down": []
   }
 }

--- a/WordPress/gutenberg/shared/wordpress-plugin/fuzz-inventory.base.json
+++ b/WordPress/gutenberg/shared/wordpress-plugin/fuzz-inventory.base.json
@@ -3,7 +3,68 @@
   "bench": {
     "warmup_iterations": 0
   },
+  "fuzz_workloads": {
+    "wordpress": [
+      { "path": "${package.root}/fuzz/gutenberg-rest-route-fuzz.json" },
+      { "path": "${package.root}/fuzz/gutenberg-rest-request-cases-fuzz.json" },
+      { "path": "${package.root}/fuzz/gutenberg-admin-page-coverage.json" },
+      { "path": "${package.root}/fuzz/block-editor-browser-coverage.json" },
+      { "path": "${package.root}/fuzz/site-editor-browser-coverage.json" },
+      { "path": "${package.root}/fuzz/block-rendering-coverage.json" },
+      { "path": "${package.root}/fuzz/frontend-rendering-request-coverage.json" },
+      { "path": "${package.root}/fuzz/gutenberg-db-inventory-fuzz.json" },
+      { "path": "${package.root}/fuzz/gutenberg-rest-db-query-profile-fuzz.json" },
+      { "path": "${package.root}/fuzz/gutenberg-hooks-options-inventory.json" },
+      { "path": "${package.root}/fuzz/gutenberg-editor-performance-observation.json" },
+      { "path": "${package.root}/fuzz/gutenberg-external-http-guardrail-fuzz.json" }
+    ]
+  },
+  "fuzz_profiles": {
+    "smoke": [
+      "gutenberg-rest-route-fuzz",
+      "gutenberg-rest-request-cases-fuzz",
+      "gutenberg-admin-page-coverage",
+      "block-editor-browser-coverage"
+    ],
+    "fuzzer": [
+      "gutenberg-rest-route-fuzz",
+      "gutenberg-rest-request-cases-fuzz",
+      "gutenberg-admin-page-coverage",
+      "block-editor-browser-coverage",
+      "site-editor-browser-coverage",
+      "block-rendering-coverage",
+      "frontend-rendering-request-coverage",
+      "gutenberg-db-inventory-fuzz",
+      "gutenberg-rest-db-query-profile-fuzz",
+      "gutenberg-hooks-options-inventory",
+      "gutenberg-editor-performance-observation",
+      "gutenberg-external-http-guardrail-fuzz"
+    ],
+    "full-surface": [
+      "gutenberg-rest-route-fuzz",
+      "gutenberg-rest-request-cases-fuzz",
+      "gutenberg-admin-page-coverage",
+      "block-editor-browser-coverage",
+      "site-editor-browser-coverage",
+      "block-rendering-coverage",
+      "frontend-rendering-request-coverage",
+      "gutenberg-db-inventory-fuzz",
+      "gutenberg-rest-db-query-profile-fuzz",
+      "gutenberg-hooks-options-inventory",
+      "gutenberg-editor-performance-observation",
+      "gutenberg-external-http-guardrail-fuzz"
+    ]
+  },
   "pipeline": {
+    "check": [
+      {
+        "kind": "requirement",
+        "label": "Gutenberg checkout exists",
+        "file": "${components.gutenberg.path}/gutenberg.php",
+        "component": "gutenberg",
+        "component_path_contains": "gutenberg"
+      }
+    ],
     "down": []
   }
 }

--- a/WordPress/gutenberg/tools/validate-fuzz-manifests.mjs
+++ b/WordPress/gutenberg/tools/validate-fuzz-manifests.mjs
@@ -9,12 +9,13 @@ import {
   declaredBenchProfileIds,
   declaredBenchWorkloadIds,
   declaredFuzzIds,
+  readMaterializedRig,
   readJson,
 } from '../../../scripts/fuzz-manifest-helpers.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');
-const rig = readJson(packageRoot, 'rigs/gutenberg-api-route-inventory/rig.json');
+const rig = readMaterializedRig(packageRoot, 'rigs/gutenberg-api-route-inventory/rig.json');
 
 const declaredIds = declaredFuzzIds(rig);
 const benchWorkloadIds = declaredBenchWorkloadIds(rig);

--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -14,6 +14,103 @@ export function readJson(root, ...parts) {
   return JSON.parse(readFileSync(path.join(root, ...parts), 'utf8'));
 }
 
+export function readMaterializedRig(root, ...parts) {
+  const file = path.join(root, ...parts);
+  return materializeRigSpec(file, JSON.parse(readFileSync(file, 'utf8')));
+}
+
+function materializeRigSpec(file, rig, seen = new Set()) {
+  const extendPath = typeof rig.extends === 'string' ? rig.extends.trim() : '';
+  if (!extendPath) {
+    return rig;
+  }
+
+  const parentFile = path.resolve(path.dirname(file), extendPath);
+  if (seen.has(parentFile)) {
+    throw new Error(`${file}: rig extends cycle includes ${parentFile}`);
+  }
+
+  seen.add(parentFile);
+  const parentRig = JSON.parse(readFileSync(parentFile, 'utf8'));
+  const materializedParent = materializeRigSpec(parentFile, parentRig, seen);
+  seen.delete(parentFile);
+
+  return deepMergeRigSpec(materializedParent, rig);
+}
+
+function deepMergeRigSpec(parent, child) {
+  if (Array.isArray(parent) && isArrayMergeDirective(child)) {
+    return applyArrayMergeDirective(parent, child);
+  }
+
+  if (!parent || typeof parent !== 'object' || Array.isArray(parent)) {
+    return child;
+  }
+
+  if (!child || typeof child !== 'object' || Array.isArray(child)) {
+    return child;
+  }
+
+  const merged = { ...parent };
+  for (const [key, value] of Object.entries(child)) {
+    if (key === 'extends') {
+      continue;
+    }
+
+    const parentValue = merged[key];
+    merged[key] = parentValue && value && shouldRecurseMerge(parentValue, value)
+      ? deepMergeRigSpec(parentValue, value)
+      : value;
+  }
+
+  return merged;
+}
+
+function shouldRecurseMerge(parentValue, childValue) {
+  if (Array.isArray(parentValue) && isArrayMergeDirective(childValue)) {
+    return true;
+  }
+
+  return typeof parentValue === 'object'
+    && typeof childValue === 'object'
+    && !Array.isArray(parentValue)
+    && !Array.isArray(childValue);
+}
+
+function isArrayMergeDirective(value) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    && (Object.hasOwn(value, '$append') || Object.hasOwn(value, '$merge_by'));
+}
+
+function applyArrayMergeDirective(parent, directive) {
+  if (Object.hasOwn(directive, '$append')) {
+    return [...parent, ...asDirectiveEntries(directive.$append)];
+  }
+
+  const key = typeof directive.$merge_by === 'string' ? directive.$merge_by.trim() : '';
+  const entries = asDirectiveEntries(directive.entries);
+  if (!key) {
+    return directive;
+  }
+
+  const merged = [...parent];
+  for (const entry of entries) {
+    const entryKey = entry && typeof entry === 'object' && !Array.isArray(entry) ? entry[key] : undefined;
+    const index = merged.findIndex((candidate) => candidate && typeof candidate === 'object' && !Array.isArray(candidate) && candidate[key] === entryKey);
+    if (entryKey === undefined || index === -1) {
+      merged.push(entry);
+      continue;
+    }
+    merged[index] = deepMergeRigSpec(merged[index], entry);
+  }
+
+  return merged;
+}
+
+function asDirectiveEntries(value) {
+  return Array.isArray(value) ? value : [];
+}
+
 export function workloadIdFromPath(workloadPath) {
   return path.basename(workloadPath)
     .replace(/\.workload\.json$/, '')

--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -207,6 +207,10 @@ function materializeRigSpec(file, rig, seen = new Set()) {
 }
 
 function deepMergeRigSpec(parent, child) {
+  if (Array.isArray(parent) && isArrayMergeDirective(child)) {
+    return applyArrayMergeDirective(parent, child);
+  }
+
   if (!parent || typeof parent !== 'object' || Array.isArray(parent)) {
     return child;
   }
@@ -222,16 +226,56 @@ function deepMergeRigSpec(parent, child) {
     }
 
     const parentValue = merged[key];
-    merged[key] = parentValue && value
-      && typeof parentValue === 'object'
-      && typeof value === 'object'
-      && !Array.isArray(parentValue)
-      && !Array.isArray(value)
+    merged[key] = parentValue && value && shouldRecurseMerge(parentValue, value)
       ? deepMergeRigSpec(parentValue, value)
       : value;
   }
 
   return merged;
+}
+
+function shouldRecurseMerge(parentValue, childValue) {
+  if (Array.isArray(parentValue) && isArrayMergeDirective(childValue)) {
+    return true;
+  }
+
+  return typeof parentValue === 'object'
+    && typeof childValue === 'object'
+    && !Array.isArray(parentValue)
+    && !Array.isArray(childValue);
+}
+
+function isArrayMergeDirective(value) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    && (Object.hasOwn(value, '$append') || Object.hasOwn(value, '$merge_by'));
+}
+
+function applyArrayMergeDirective(parent, directive) {
+  if (Object.hasOwn(directive, '$append')) {
+    return [...parent, ...asDirectiveEntries(directive.$append)];
+  }
+
+  const key = typeof directive.$merge_by === 'string' ? directive.$merge_by.trim() : '';
+  const entries = asDirectiveEntries(directive.entries);
+  if (!key) {
+    return directive;
+  }
+
+  const merged = [...parent];
+  for (const entry of entries) {
+    const entryKey = entry && typeof entry === 'object' && !Array.isArray(entry) ? entry[key] : undefined;
+    const index = merged.findIndex((candidate) => candidate && typeof candidate === 'object' && !Array.isArray(candidate) && candidate[key] === entryKey);
+    if (entryKey === undefined || index === -1) {
+      merged.push(entry);
+      continue;
+    }
+    merged[index] = deepMergeRigSpec(merged[index], entry);
+  }
+  return merged;
+}
+
+function asDirectiveEntries(value) {
+  return Array.isArray(value) ? value : [];
 }
 
 function hasDeclaredResources(resources) {

--- a/woocommerce/woocommerce/rigs/woocommerce-browser-coverage/rig.json
+++ b/woocommerce/woocommerce/rigs/woocommerce-browser-coverage/rig.json
@@ -19,32 +19,16 @@
   "trace": {
     "default_component": "woocommerce"
   },
-  "trace_workloads": {
-    "nodejs": [
-      {
-        "path": "${package.root}/bench/woocommerce-browser-coverage.trace.mjs"
-      }
-    ]
-  },
-  "trace_profiles": {
-    "smoke": ["woocommerce-browser-coverage"],
-    "full-surface": ["woocommerce-browser-coverage"]
-  },
   "pipeline": {
-    "check": [
-      {
-        "kind": "requirement",
-        "label": "WooCommerce plugin checkout exists",
-        "file": "${components.woocommerce.path}/woocommerce.php",
-        "component": "woocommerce",
-        "component_path_contains": "woocommerce"
-      },
-      {
-        "kind": "command",
-        "label": "WooCommerce admin assets are built",
-        "command": "bash \"${package.root}/tools/check-admin-assets.sh\" \"${components.woocommerce.path}\"",
-        "remediation": "Use a packaged WooCommerce plugin checkout or build the WooCommerce admin assets before running woocommerce-browser-coverage."
-      }
-    ]
+    "check": {
+      "$append": [
+        {
+          "kind": "command",
+          "label": "WooCommerce admin assets are built",
+          "command": "bash \"${package.root}/tools/check-admin-assets.sh\" \"${components.woocommerce.path}\"",
+          "remediation": "Use a packaged WooCommerce plugin checkout or build the WooCommerce admin assets before running woocommerce-browser-coverage."
+        }
+      ]
+    }
   }
 }

--- a/woocommerce/woocommerce/shared/wordpress-plugin/browser-coverage.base.json
+++ b/woocommerce/woocommerce/shared/wordpress-plugin/browser-coverage.base.json
@@ -14,7 +14,27 @@
       }
     }
   },
+  "trace_workloads": {
+    "nodejs": [
+      {
+        "path": "${package.root}/bench/woocommerce-browser-coverage.trace.mjs"
+      }
+    ]
+  },
+  "trace_profiles": {
+    "smoke": ["woocommerce-browser-coverage"],
+    "full-surface": ["woocommerce-browser-coverage"]
+  },
   "pipeline": {
+    "check": [
+      {
+        "kind": "requirement",
+        "label": "WooCommerce plugin checkout exists",
+        "file": "${components.woocommerce.path}/woocommerce.php",
+        "component": "woocommerce",
+        "component_path_contains": "woocommerce"
+      }
+    ],
     "down": []
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to Extra-Chill/homeboy#7563 and Extra-Chill/homeboy#7547 for chubes4/homeboy-rigs.

- Confirmed no rig package currently needs a declared `homeboy-rig-package.json` lint ignore list.
- Moved common browser-coverage and fuzz-inventory arrays into the shared package bases introduced by #661.
- Updated repo-local rig materializers/validators so CI understands the new `$append` and `$merge_by` array directives.

Related: Extra-Chill/homeboy#7563, Extra-Chill/homeboy#7547, chubes4/homeboy-rigs#518.

## Ignore declarations

Core now only structurally ignores `.git` and `.homeboy`; package-specific ignores belong in `homeboy-rig-package.json` as `lint_ignore_directories`.

| Package | Needed declared ignores | Change |
| --- | --- | --- |
| Automattic/jetpack | None found (`.claude`, `.datamachine`, `.opencode`, `.sampleplugin`, `node_modules`, `vendor` absent) | No manifest added |
| Automattic/studio | None found | No manifest added |
| WordPress/gutenberg | None found | No manifest added |
| WordPress/wordpress-develop | None found | No manifest added |
| WordPress/wordpress-playground | None found | No manifest added |
| woocommerce/woocommerce | None found | No manifest added |
| woocommerce/woocommerce-gateway-stripe | None found | No manifest added |
| chubes4/isolated-block-editor | None found | No manifest added |

## Extends dedup LOC

| Area | Files | Added | Removed | Net |
| --- | --- | ---: | ---: | ---: |
| Jetpack browser coverage | `Automattic/jetpack/rigs/jetpack-browser-coverage/rig.json`, `Automattic/jetpack/shared/wordpress-plugin/browser-coverage.base.json` | 20 | 22 | -2 |
| Jetpack fuzz inventory | `Automattic/jetpack/rigs/jetpack-api-route-inventory/rig.json`, `Automattic/jetpack/shared/wordpress-plugin/fuzz-inventory.base.json` | 80 | 68 | +12 |
| Gutenberg browser coverage | `WordPress/gutenberg/rigs/gutenberg-browser-coverage/rig.json`, `WordPress/gutenberg/shared/wordpress-plugin/browser-coverage.base.json` | 21 | 23 | -2 |
| Gutenberg fuzz inventory | `WordPress/gutenberg/rigs/gutenberg-api-route-inventory/rig.json`, `WordPress/gutenberg/shared/wordpress-plugin/fuzz-inventory.base.json` | 74 | 62 | +12 |
| WooCommerce browser coverage | `woocommerce/woocommerce/rigs/woocommerce-browser-coverage/rig.json`, `woocommerce/woocommerce/shared/wordpress-plugin/browser-coverage.base.json` | 30 | 26 | +4 |
| Repo materializers/validators | `scripts/lint-rig-packages.mjs`, `scripts/fuzz-manifest-helpers.mjs`, package validators | 151 | 8 | +143 |

The net LOC increase is mostly the repo-local materializer support for the new core directives. The affected child rigs now inherit workload/profile/check arrays from their package bases and use `$merge_by`/`$append` for child-owned entries.

## Verification

- `node scripts/lint-rig-packages.mjs .` passed with existing warning: `woocommerce/woocommerce/fuzz/codebox-fuzz-suite-contract.json: executable fuzz readiness has optional artifact(s): codebox_fuzz_suite_result`.
- `node --test scripts/product-full-surface-matrix.test.mjs` passed.
- `HOMEBOY_WORDPRESS_HELPER_MANIFEST=/Users/chubes/Developer/homeboy-extensions/wordpress/lib/helper-manifest.js node --test scripts/test-homeboy-wordpress-helper-manifest.mjs` passed.
- `git diff --check` passed.
- `homeboy --version`: `homeboy 0.281.2+354282127480`.
- `homeboy rig lint Automattic/jetpack --all`, `homeboy rig lint WordPress/gutenberg --all`, and `homeboy rig lint woocommerce/woocommerce --all` passed, proving the installed Homeboy supports the directive materialization used here.
- Stable-key JSON comparison passed for materialized output before/after against `origin/main` for 5 rigs: Jetpack API inventory, Jetpack browser coverage, Gutenberg API inventory, Gutenberg browser coverage, WooCommerce browser coverage.

## Verification limits

- The semantic comparison covers materialized rig JSON only. It does not run live WP Codebox/browser/fuzz workloads.
- No package lint manifests were added because the current package roots do not contain the package-specific ignored directories named in Extra-Chill/homeboy#7563.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT-5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Declared package lint ignores and deepened extends-based dedup; Chris reviews and owns the change.
