### PR TITLE
Remove brittle rig test deadweight

### DIFF
--- a/Automattic/jetpack/tools/fuzz-workload-validator.test.mjs
+++ b/Automattic/jetpack/tools/fuzz-workload-validator.test.mjs
@@ -19,7 +19,6 @@ test('rejects executable readiness with optional artifacts', () => {
         },
       ],
       artifacts: { expected: [{ name: 'report', path: 'report.json', required: true }] },
-    }, { file: 'jetpack-fuzz.json' }),
-    /executable Jetpack readiness requires case artifact report to be required/
+    }, { file: 'jetpack-fuzz.json' })
   );
 });

--- a/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
+++ b/Automattic/jetpack/tools/validate-fuzz-manifests.mjs
@@ -23,7 +23,6 @@ const browserRig = readMaterializedRig(packageRoot, 'rigs/jetpack-browser-covera
 const fullSurfaceCoverage = readJson(packageRoot, 'manifests/full-surface-coverage.json');
 const restRouteCoverage = readJson(packageRoot, 'manifests/rest-route-coverage.json');
 const stableWorkloads = readJson(packageRoot, 'manifests/stable-workloads.json');
-const legacyLabCommandGeneratorKey = 'lab_' + 'command_generator';
 const generatedRestCases = readJson(packageRoot, 'bench/generated-rest-request-cases.workload.json');
 const dbInventory = readJson(packageRoot, 'bench/db-inventory.workload.json');
 const fuzzManifests = collectFuzzManifests(packageRoot);
@@ -64,11 +63,8 @@ const expectedStableWorkloadIds = new Set([
 
 assertFullSurfaceCoverageManifest(fullSurfaceCoverage, { file: 'Jetpack full-surface coverage' });
 assert.equal(fuzzManifests.length, expectedFuzzIds.size, 'expected one Jetpack fuzz manifest per declared API fuzz workload');
-assert.equal(apiRig.bench_workloads, undefined, 'Jetpack fuzz coverage must not use bench_workloads as a fallback');
-assert.equal(apiRig.bench_profiles, undefined, 'Jetpack fuzz coverage must not use bench_profiles as a fallback');
 assert.equal(stableWorkloads.schema, 'homeboy-rigs/jetpack-stable-workloads/v1', 'Jetpack stable workload schema drifted');
 assert.equal(stableWorkloads.rig, 'rigs/jetpack-api-route-inventory/rig.json', 'Jetpack stable workloads must target API inventory rig');
-assert.equal(stableWorkloads[legacyLabCommandGeneratorKey], undefined, 'Jetpack stable workload planning must use homeboy fuzz stable-plan directly');
 
 const declaredIds = declaredFuzzIds(apiRig);
 const benchWorkloadIds = declaredBenchWorkloadIds(apiRig);

--- a/WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs
+++ b/WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs
@@ -51,7 +51,7 @@ test( 'Core frontend/content/media fuzz workloads declare posts, pages, users, m
 	assert.ok( mediaUsers.artifacts.expected.every( ( artifact ) => artifact.required === true ) );
 } );
 
-test( 'Core fuzz rig and full-surface profile include admin and frontend coverage with no bench fallback', () => {
+test( 'Core fuzz rig and full-surface profile include admin and frontend coverage', () => {
 	const rig = readJson( 'rigs', 'wordpress-core-fuzz-coverage', 'rig.json' );
 	const manifest = readJson( 'manifests', 'full-surface-coverage.json' );
 	const workloadPaths = rig.fuzz_workloads.wordpress.map( ( entry ) => entry.path );
@@ -61,8 +61,6 @@ test( 'Core fuzz rig and full-surface profile include admin and frontend coverag
 	assert.ok( workloadPaths.some( ( entry ) => entry.includes( 'fuzz/frontend-rendering-request-coverage.json' ) ) );
 	assert.ok( allProfiles.includes( 'admin-page-coverage' ) );
 	assert.ok( allProfiles.includes( 'frontend-rendering-request-coverage' ) );
-	assert.ok( ! rig.bench_workloads );
-	assert.ok( ! rig.bench_profiles );
 	assertFullSurfaceCoverageManifest( manifest, { file: 'WordPress Core full-surface coverage' } );
 	assert.ok( manifest.coverage_profiles[ 'full-surface' ].includes( 'frontend-rendering-request-coverage' ) );
 } );

--- a/scripts/fuzz-manifest-helpers.test.mjs
+++ b/scripts/fuzz-manifest-helpers.test.mjs
@@ -100,8 +100,7 @@ test('assertGenericFuzzManifest rejects runner commands when intent is required'
       declaredIds: new Set(['product-fuzz']),
       targetSlug: 'product',
       requireRunnerNeutralIntent: true,
-    }),
-    /requires runner-neutral case intent/
+    })
   );
 });
 
@@ -112,8 +111,7 @@ test('assertGenericFuzzManifest rejects fuzz workloads that leak into bench path
       declaredIds: new Set(['product-fuzz']),
       benchWorkloadIds: new Set(['product-fuzz']),
       targetSlug: 'product',
-    }),
-    /must not appear in bench_workloads/
+    })
   );
 });
 
@@ -197,8 +195,7 @@ test('assertGenericFuzzManifest can require readiness metadata', () => {
       declaredIds: new Set(['product-fuzz']),
       targetSlug: 'product',
       requireReadinessMetadata: true,
-    }),
-    /requires metadata.readiness/
+    })
   );
 });
 
@@ -250,10 +247,8 @@ test('reviewer-facing fuzz refs accept durable refs and reject placeholders/loca
   assert.equal(normalizeReviewerFacingFuzzRef('homeboy://run/product-fuzz/artifact/report').status, 'normalized');
   assert.throws(
     () => assertReviewerFacingFuzzRef('<artifact-ref>', 'proof ref'),
-    /Invalid argument 'artifact-ref'/
   );
   assert.throws(
     () => assertReviewerFacingFuzzRef('artifact:./report.json', 'proof ref'),
-    /Invalid argument 'artifact-ref'/
   );
 });

--- a/scripts/product-full-surface-matrix.test.mjs
+++ b/scripts/product-full-surface-matrix.test.mjs
@@ -83,7 +83,6 @@ test('product full-surface manifests keep product-owned matrix contracts', () =>
     assertFullSurfaceCoverageManifest(manifest, { file: productManifest.product });
     assert.equal(manifest.property, productManifest.product);
     assert.equal(manifest.execution_claim_policy, 'product_manifest_only_no_runner_support_claim');
-    assert.equal(manifest.requires_primitives, undefined, `${productManifest.product} must not own generic primitive requirements`);
     assert.ok(matrix && typeof matrix === 'object' && !Array.isArray(matrix), `${productManifest.product} requires product_surface_matrix`);
 
     assertStringArray(matrix.taxonomy, productManifest.taxonomy, `${productManifest.product} taxonomy`);
@@ -102,9 +101,8 @@ test('product matrix readiness is wired to explicit upstream contract ids', () =
 
     assert.ok(contracts && typeof contracts === 'object' && !Array.isArray(contracts), `${productManifest.product} requires upstream_contracts`);
     assert.deepEqual(contracts.contract_ids, upstreamContractIds, `${productManifest.product} upstream contract ids drifted`);
-    assert.equal(contracts.source_prs.wp_codebox, 'Automattic/wp-codebox#1634,#1635,#1636');
-    assert.equal(contracts.source_prs.homeboy, 'Extra-Chill/homeboy#6941,#6942,#6943');
-    assert.equal(contracts.source_prs.homeboy_extensions, 'Extra-Chill/homeboy-extensions#2016,#2017,#2018');
+    assert.ok(contracts.source_prs && typeof contracts.source_prs === 'object' && !Array.isArray(contracts.source_prs), `${productManifest.product} upstream source PRs must be recorded`);
+    assertStringMap(contracts.source_prs, `${productManifest.product} upstream source PRs`);
 
     assert.ok(readiness && typeof readiness === 'object' && !Array.isArray(readiness), `${productManifest.product} requires readiness_contract`);
     assert.equal(readiness.schema, 'homeboy-rigs/product-surface-readiness-contract/v1');

--- a/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
+++ b/woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs
@@ -222,7 +222,6 @@ test('REST DB query profile consumes generated request case artifacts with caps'
 
   assert.equal(profilerSteps.length, 1);
   for (const step of profilerSteps) {
-    assert.equal(step.rest_request_cases, undefined, `${step.type} must not fall back to hard-coded route cases`);
     assert.equal(step.rest_request_cases_source.type, 'artifact');
     assert.equal(step.rest_request_cases_source.schema, 'homeboy/wordpress-rest-request-cases/v1');
     assert.deepEqual(step.rest_request_cases_source.artifact_globs, ['generated-rest-request-cases/*.json']);

--- a/woocommerce/woocommerce/manifests/scale-profiles.test.mjs
+++ b/woocommerce/woocommerce/manifests/scale-profiles.test.mjs
@@ -102,11 +102,3 @@ test('Woo scale profile dimensions cover the requested production scale surfaces
   assert.ok(dimensionsByProfile.get('woo-admin-list-table-scale').has('admin-list-table-scale'));
   assert.ok(dimensionsByProfile.get('woo-rest-pagination-search-filter-scale').has('rest-collection-scale'));
 });
-
-test('Woo profiles do not embed generic generation steps or proof claims', () => {
-  const serialized = JSON.stringify(manifest);
-  assert.equal(serialized.includes('benchmark_proof'), false, 'scale profiles must not claim benchmark proof');
-  assert.equal(serialized.includes('fuzz_proof'), false, 'scale profiles must not claim fuzz proof');
-  assert.equal(serialized.includes('generation_step'), false, 'scale profiles must not implement generic generation');
-  assert.equal(serialized.includes('generator'), false, 'scale profiles must not declare a generic generator');
-});

--- a/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
+++ b/woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
@@ -166,12 +166,9 @@ function assertDeclaredOrExternalDiscoveryWorkload(workloadId, context) {
 }
 
 function assertStableWorkloadContracts(manifest) {
-  const legacyLabCommandGeneratorKey = 'lab_' + 'command_generator';
-
   assert.equal(manifest.schema, 'homeboy-rigs/woocommerce-stable-workloads/v1', 'stable workloads schema drifted');
   assert.equal(manifest.profile_id, 'woo-profiling-stabilization', 'stable workloads profile id drifted');
   assert.equal(manifest.rig, 'rigs/woocommerce-performance/rig.json', 'stable workloads rig ref drifted');
-  assert.equal(manifest[legacyLabCommandGeneratorKey], undefined, 'stable workloads must use homeboy fuzz stable-plan directly');
   assert.deepEqual(manifest.comparison_commands, ['homeboy runs refs', 'homeboy runs compare', 'homeboy runs hotspots'], 'stable workload comparison command surface drifted');
 
   const expectedIds = new Set([
@@ -609,10 +606,8 @@ function assertAggressiveIsolatedCampaignContract(campaign) {
   assert.ok(campaign.command_plan?.plan_items?.request_aggressive_isolated_firehose?.required_flags?.includes('--require-result-envelope'), 'aggressive command plan manifest must require core result-envelope planning');
   assert.ok(campaign.command_plan?.plan_items?.request_aggressive_isolated_firehose?.extension_args?.includes('--hbex-aggressive-isolated-mode'), 'aggressive command plan manifest must declare HBEX aggressive mode handoff args');
   assert.ok(campaign.command_plan?.plan_items?.collect_reviewer_facing_artifact_refs?.command_argv?.includes('$planned_artifact_semantic_keys'), 'aggressive command plan manifest must declare semantic artifact ref collection');
-  assert.equal(campaign.command_plan?.plan_items?.request_aggressive_isolated_firehose?.command_argv, undefined, 'aggressive workload requests must not carry manifest-owned homeboy fuzz run argv arrays');
   assert.ok(Array.isArray(rig.fuzz_profiles?.[campaign.profile_id]) && rig.fuzz_profiles[campaign.profile_id].length > 0, 'aggressive firehose must declare planned fuzz workload ids');
   assert.equal(rig.fuzz_profile_metadata?.[campaign.profile_id]?.campaign_manifest, 'manifests/aggressive-isolated-fuzz-campaign.json', 'aggressive profile metadata must link the campaign manifest');
-  assert.equal(rig.fuzz_profile_metadata?.[campaign.profile_id]?.command_plan_generator, undefined, 'aggressive profile metadata must not link a rig-owned command generator');
   assert.equal(rig.fuzz_profile_metadata?.[campaign.profile_id]?.homeboy_fuzz_profile, campaign.profile_id, 'aggressive profile metadata Homeboy profile drifted');
   assert.equal(rig.fuzz_profile_metadata?.[campaign.profile_id]?.hbex_fuzz_profile, campaign.profile_id, 'aggressive profile metadata HBEX profile drifted');
   assert.equal(rig.fuzz_profile_metadata?.[campaign.profile_id]?.codebox_fuzz_profile, 'woocommerce-aggressive-isolated-firehose', 'aggressive profile metadata Codebox profile drifted');


### PR DESCRIPTION
## Summary
- Remove brittle exact wording and historical PR ID expectations from rig tests while preserving structural validation.
- Delete absence-only legacy key checks that do not protect shipped behavior.
- Keep readiness, contract ID, artifact, safety, and product surface coverage assertions intact.

## Tests
- HOMEBOY_WORDPRESS_HELPER_MANIFEST=/Users/chubes/Developer/homeboy-extensions/wordpress/lib/helper-manifest.js node --test scripts/fuzz-manifest-helpers.test.mjs scripts/product-full-surface-matrix.test.mjs scripts/lint-rig-packages.test.mjs
- HOMEBOY_WORDPRESS_HELPER_MANIFEST=/Users/chubes/Developer/homeboy-extensions/wordpress/lib/helper-manifest.js node --test WordPress/wordpress-develop/fuzz/core-fuzz-contracts.test.mjs Automattic/jetpack/tools/fuzz-workload-validator.test.mjs woocommerce/woocommerce/manifests/full-surface-coverage.test.mjs woocommerce/woocommerce/manifests/scale-profiles.test.mjs
- HOMEBOY_WORDPRESS_HELPER_MANIFEST=/Users/chubes/Developer/homeboy-extensions/wordpress/lib/helper-manifest.js node Automattic/jetpack/tools/validate-fuzz-manifests.mjs
- HOMEBOY_WORDPRESS_HELPER_MANIFEST=/Users/chubes/Developer/homeboy-extensions/wordpress/lib/helper-manifest.js node woocommerce/woocommerce/tools/validate-fuzz-manifests.mjs
- HOMEBOY_WORDPRESS_HELPER_MANIFEST=/Users/chubes/Developer/homeboy-extensions/wordpress/lib/helper-manifest.js node WordPress/wordpress-develop/tools/validate-fuzz-manifests.mjs

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Drafted and verified the rig test deadweight cleanup.