### PR TITLE
Add JSON output for rig lint

### DIFF
--- a/scripts/lint-rig-packages.mjs
+++ b/scripts/lint-rig-packages.mjs
@@ -6,6 +6,7 @@ import { basename, dirname, isAbsolute, join, normalize, relative, resolve } fro
 import { pathToFileURL } from 'node:url';
 
 const args = process.argv.slice(2);
+const jsonOutput = args.includes('--json');
 const strictFuzzReadiness = args.includes('--strict-fuzz-readiness');
 const rootArg = args.find((arg) => !arg.startsWith('--'));
 const root = rootArg ? resolve(process.cwd(), rootArg) : process.cwd();
@@ -727,6 +728,10 @@ function reportFailures() {
     return;
   }
 
+  if (jsonOutput) {
+    reportJsonAndExit(1);
+  }
+
   console.error('Rig package lint failed:');
   for (const failure of failures) {
     console.error(`- ${failure}`);
@@ -743,6 +748,25 @@ function reportWarnings() {
   for (const warning of warnings) {
     console.warn(`- ${warning}`);
   }
+}
+
+function lintResult() {
+  return {
+    ok: failures.length === 0,
+    rig_count: rigFiles.length,
+    fuzz_workload_count: fuzzWorkloadFiles.length,
+    portable_source_count: portableSourceFiles.length,
+    php_syntax_file_count: phpFiles.length,
+    warning_count: warnings.length,
+    error_count: failures.length,
+    warnings: [...warnings],
+    errors: [...failures],
+  };
+}
+
+function reportJsonAndExit(status = failures.length === 0 ? 0 : 1) {
+  console.log(JSON.stringify(lintResult()));
+  process.exit(status);
 }
 
 function lintFuzzManifestValidators() {
@@ -769,6 +793,10 @@ lintFuzzManifestValidators();
 reportFailures();
 
 if (!hasPhp()) {
+  if (jsonOutput) {
+    warnings.push(`PHP not found; skipped syntax checks for ${phpFiles.length} PHP file(s).`);
+    reportJsonAndExit(0);
+  }
   reportWarnings();
   console.warn(`PHP not found; skipped syntax checks for ${phpFiles.length} PHP file(s).`);
   process.exit(0);
@@ -777,6 +805,10 @@ if (!hasPhp()) {
 phpFiles.forEach(lintPhp);
 
 reportFailures();
+
+if (jsonOutput) {
+  reportJsonAndExit(0);
+}
 
 reportWarnings();
 

--- a/scripts/lint-rig-packages.test.mjs
+++ b/scripts/lint-rig-packages.test.mjs
@@ -129,8 +129,8 @@ function fuzzWorkload(overrides = {}) {
   };
 }
 
-function runLint(directory, env = {}) {
-  return spawnSync(process.execPath, [script, directory], {
+function runLint(directory, env = {}, args = []) {
+  return spawnSync(process.execPath, [script, ...args, directory], {
     encoding: 'utf8',
     env: {
       ...process.env,
@@ -139,6 +139,11 @@ function runLint(directory, env = {}) {
       ...env,
     },
   });
+}
+
+function parseJsonOutput(result) {
+  assert.equal(result.stderr, '');
+  return JSON.parse(result.stdout);
 }
 
 test('accepts generic declared fuzz workloads', () => {
@@ -153,12 +158,47 @@ test('accepts generic declared fuzz workloads', () => {
   assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
 });
 
+test('emits structured JSON for passing lint results', () => {
+  const directory = createRigPackage({
+    fuzzWorkloads: {
+      'generic-fuzz': fuzzWorkload(),
+    },
+  });
+
+  const result = runLint(directory, {}, ['--json']);
+  const payload = parseJsonOutput(result);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.rig_count, 1);
+  assert.equal(payload.fuzz_workload_count, 1);
+  assert.equal(payload.portable_source_count, 4);
+  assert.equal(payload.php_syntax_file_count, 0);
+  assert.equal(payload.warning_count, payload.warnings.length);
+  assert.equal(payload.error_count, 0);
+  assert.deepEqual(payload.errors, []);
+});
+
 test('rejects missing declared fuzz workload files', () => {
   const directory = createRigPackage();
   const result = runLint(directory);
 
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /declares missing file/);
+});
+
+test('emits structured JSON for failing lint results', () => {
+  const directory = createRigPackage();
+  const result = runLint(directory, {}, ['--json']);
+  const payload = parseJsonOutput(result);
+
+  assert.notEqual(result.status, 0);
+  assert.equal(payload.ok, false);
+  assert.equal(payload.rig_count, 1);
+  assert.equal(payload.fuzz_workload_count, 0);
+  assert.equal(payload.warning_count, payload.warnings.length);
+  assert.equal(payload.error_count, payload.errors.length);
+  assert.match(payload.errors.join('\n'), /declares missing file/);
 });
 
 test('accepts registry-backed components with portable path settings', () => {


### PR DESCRIPTION
## Summary
- Add `--json` output to `scripts/lint-rig-packages.mjs` with stable lint result fields for orchestration.
- Preserve default human-readable output and existing exit code semantics.
- Add focused JSON success and failure coverage using existing fixture helpers.

## Tests
- `HOMEBOY_WORDPRESS_HELPER_MANIFEST=/Users/chubes/Developer/homeboy-extensions/wordpress/lib/helper-manifest.js node --test scripts/lint-rig-packages.test.mjs`
- `HOMEBOY_WORDPRESS_HELPER_MANIFEST=/Users/chubes/Developer/homeboy-extensions/wordpress/lib/helper-manifest.js node scripts/lint-rig-packages.mjs --json`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Added and verified structured JSON output for rig lint orchestration.