### PR TITLE
Prune redundant rig materializer tests

### DIFF
--- a/scripts/fuzz-manifest-helpers.mjs
+++ b/scripts/fuzz-manifest-helpers.mjs
@@ -292,16 +292,6 @@ export function assertRequiredFuzzProofContracts(manifest, {
   }
 }
 
-function collectRequiredArtifactNames(manifest) {
-  return new Set([
-    ...(manifest.cases || []).flatMap((runnerCase) => runnerCase.artifacts || []),
-    ...(manifest.artifacts?.expected || []),
-  ]
-    .filter((artifact) => artifact?.required === true)
-    .map((artifact) => artifact?.name)
-    .filter(Boolean));
-}
-
 function assertStringArray(value, label) {
   assert.ok(Array.isArray(value), `${label} must be an array`);
   assert.ok(value.length > 0, `${label} must not be empty`);

--- a/scripts/fuzz-manifest-helpers.test.mjs
+++ b/scripts/fuzz-manifest-helpers.test.mjs
@@ -4,12 +4,10 @@ import {
   assertFuzzProofBundle,
   assertGenericFuzzManifest,
   assertReviewerFacingFuzzRef,
-  declaredFuzzIds,
   fullSurfaceRequiredArtifactIds,
   fuzzManifestHasExecutableArtifactContract,
   fuzzProofBundleFields,
   normalizeReviewerFacingFuzzRef,
-  workloadIdFromPath,
 } from './fuzz-manifest-helpers.mjs';
 
 function fuzzManifest(overrides = {}) {
@@ -51,23 +49,6 @@ function fuzzManifest(overrides = {}) {
     ...overrides,
   };
 }
-
-test('workloadIdFromPath strips supported workload suffixes', () => {
-  assert.equal(workloadIdFromPath('${package.root}/fuzz/product-fuzz.json'), 'product-fuzz');
-  assert.equal(workloadIdFromPath('${package.root}/bench/product-fuzz.workload.json'), 'product-fuzz');
-  assert.equal(workloadIdFromPath('${package.root}/bench/product-fuzz.php'), 'product-fuzz');
-});
-
-test('declaredFuzzIds accepts object and string workload declarations', () => {
-  assert.deepEqual(declaredFuzzIds({
-    fuzz_workloads: {
-      wordpress: [
-        { path: '${package.root}/fuzz/product-fuzz.json' },
-        '${package.root}/fuzz/other-fuzz.json',
-      ],
-    },
-  }), new Set(['product-fuzz', 'other-fuzz']));
-});
 
 test('assertGenericFuzzManifest accepts a linked generic fuzz workload contract', () => {
   const runnerCase = assertGenericFuzzManifest(fuzzManifest(), {


### PR DESCRIPTION
## Summary
- Prune helper-only workload id/declaration tests now covered by lint JSON outcomes.
- Remove an unused private required-artifact helper.
- Preserve lint JSON coverage for inherited array directive materialization.

## Tests
- HOMEBOY_WORDPRESS_HELPER_MANIFEST=/Users/chubes/Developer/homeboy-extensions/wordpress/lib/helper-manifest.js node --test scripts/lint-rig-packages.test.mjs scripts/fuzz-manifest-helpers.test.mjs
- HOMEBOY_WORDPRESS_HELPER_MANIFEST=/Users/chubes/Developer/homeboy-extensions/wordpress/lib/helper-manifest.js node scripts/lint-rig-packages.mjs --json

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.5
- **Used for:** Pruned redundant rig materializer tests after JSON lint coverage.