### PR TITLE
Fix Playground bench workload spec

### DIFF
--- a/WordPress/wordpress-playground/rigs/playground-cli-diagnostics/rig.json
+++ b/WordPress/wordpress-playground/rigs/playground-cli-diagnostics/rig.json
@@ -26,7 +26,9 @@
   },
   "bench_workloads": {
     "nodejs": [
-      "${package.root}/bench/playground-cli-runphp-errors.bench.mjs"
+      {
+        "path": "${package.root}/bench/playground-cli-runphp-errors.bench.mjs"
+      }
     ]
   },
   "pipeline": {


### PR DESCRIPTION
Fixes #672

## Verification
- `homeboy rig lint WordPress/wordpress-playground --id playground-cli-diagnostics`
- `HOMEBOY_WORDPRESS_HELPER_MANIFEST=/Users/chubes/Developer/homeboy-extensions/wordpress/lib/helper-manifest.js node scripts/lint-rig-packages.mjs WordPress/wordpress-playground`
- `HOMEBOY_WORDPRESS_HELPER_MANIFEST=/Users/chubes/Developer/homeboy-extensions/wordpress/lib/helper-manifest.js node scripts/lint-rig-packages.mjs`

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** opencode general subagent (GPT 5.5), orchestrated by Franklin (Claude claude-fable-5)
- **Used for:** Implemented audited rig fixes/dedup; human reviews every line.