### PR TITLE
Make Gutenberg rig package self-contained

### DIFF
--- a/WordPress/gutenberg/bench/gutenberg-browser-coverage.trace.mjs
+++ b/WordPress/gutenberg/bench/gutenberg-browser-coverage.trace.mjs
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { runBrowserCoverageTrace } from '../../../shared/wp-codebox/browser-coverage-trace.mjs';
+import { runBrowserCoverageTrace } from '../shared/wp-codebox/browser-coverage-trace.mjs';
 
 const componentPath = process.env.HOMEBOY_COMPONENT_PATH;
 const scenarioRoot = new URL( '../browser-scenarios/', import.meta.url ).pathname;

--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -3,8 +3,8 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { wpCodeboxBrowserArtifacts } from '../../../shared/wp-codebox/artifacts.mjs';
-import { runWpCodeboxRecipe } from '../../../shared/wp-codebox/recipe.mjs';
+import { wpCodeboxBrowserArtifacts } from '../shared/wp-codebox/artifacts.mjs';
+import { runWpCodeboxRecipe } from '../shared/wp-codebox/recipe.mjs';
 
 const componentPath = process.env.HOMEBOY_COMPONENT_PATH;
 const componentId = process.env.HOMEBOY_COMPONENT_ID || 'gutenberg';

--- a/WordPress/gutenberg/bench/pattern-preview-assets.trace.mjs
+++ b/WordPress/gutenberg/bench/pattern-preview-assets.trace.mjs
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { runWpCodeboxRecipe } from '../../../shared/wp-codebox/recipe.mjs';
+import { runWpCodeboxRecipe } from '../shared/wp-codebox/recipe.mjs';
 
 const componentPath = process.env.HOMEBOY_COMPONENT_PATH;
 const componentId = process.env.HOMEBOY_COMPONENT_ID || 'gutenberg';

--- a/WordPress/gutenberg/scripts/fuzz-manifest-helpers.mjs
+++ b/WordPress/gutenberg/scripts/fuzz-manifest-helpers.mjs
@@ -1,0 +1,1 @@
+../../../scripts/fuzz-manifest-helpers.mjs

--- a/WordPress/gutenberg/shared/wordpress-helper-loader.mjs
+++ b/WordPress/gutenberg/shared/wordpress-helper-loader.mjs
@@ -1,0 +1,1 @@
+../../../shared/wordpress-helper-loader.mjs

--- a/WordPress/gutenberg/shared/wp-codebox
+++ b/WordPress/gutenberg/shared/wp-codebox
@@ -1,0 +1,1 @@
+../../../shared/wp-codebox

--- a/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
+++ b/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { assertFullSurfaceCoverageManifest } from '../../../scripts/fuzz-manifest-helpers.mjs';
+import { assertFullSurfaceCoverageManifest } from '../scripts/fuzz-manifest-helpers.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.join(__dirname, '..');

--- a/WordPress/gutenberg/tools/validate-fuzz-manifests.mjs
+++ b/WordPress/gutenberg/tools/validate-fuzz-manifests.mjs
@@ -11,7 +11,7 @@ import {
   declaredFuzzIds,
   readMaterializedRig,
   readJson,
-} from '../../../scripts/fuzz-manifest-helpers.mjs';
+} from '../scripts/fuzz-manifest-helpers.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageRoot = path.join(__dirname, '..');


### PR DESCRIPTION
## Summary
- route Gutenberg trace imports through package-local shared paths
- include generic WP Codebox and WordPress helper modules through dereferenced package links
- include the fuzz manifest helper so package validation also works after isolated materialization

Discovered while fuzzing WordPress/gutenberg#79020 on Homeboy Lab.

## How to test
1. Create a dereferenced archive with `tar -h -cf /tmp/gutenberg-rig.tar WordPress/gutenberg` and extract it outside the checkout.
2. Import `shared/wp-codebox/artifacts.mjs`, `shared/wp-codebox/recipe.mjs`, and `shared/wp-codebox/browser-coverage-trace.mjs` from the extracted package.
3. Run `node --test tools/fuzz-coverage.test.mjs` with `HOMEBOY_WORDPRESS_HELPER_MANIFEST` pointing to the WordPress extension helper manifest.
4. Run `node tools/validate-fuzz-manifests.mjs` with the same manifest and confirm all 12 manifests validate.

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode with openai/gpt-5.6-sol
- **Used for:** Diagnosed isolated package import failures, implemented package-local dependency links, and verified dereferenced archive behavior. Chris reviewed and owns the change.