### PR TITLE
Simplify the Stripe ECE trace workload setup

### DIFF
--- a/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
+++ b/woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs
@@ -22,7 +22,6 @@ const componentPath = process.env.HOMEBOY_COMPONENT_PATH;
 const componentId = process.env.HOMEBOY_COMPONENT_ID || 'woocommerce-gateway-stripe';
 const scenarioId = process.env.HOMEBOY_TRACE_SCENARIO || DEFAULT_ECE_SCENARIO_ID;
 const scenario = eceProductPageScenario(scenarioId);
-const resultsFile = process.env.HOMEBOY_TRACE_RESULTS_FILE;
 const artifactDir = process.env.HOMEBOY_TRACE_ARTIFACT_DIR || path.join(tmpdir(), 'wc-stripe-ece-waterfall-artifacts');
 const woocommercePath = process.env.HOMEBOY_WC_STRIPE_WOOCOMMERCE_PATH
   || process.env.HOMEBOY_RIG_COMPONENT_PATH__WOOCOMMERCE_STRIPE_ECE_PRODUCT_PAGE__WOOCOMMERCE;
@@ -49,9 +48,6 @@ const fixtureBootstrapPath = fileURLToPath(new URL('./fixture-bootstrap.php', im
 if (!componentPath) {
   throw new Error('HOMEBOY_COMPONENT_PATH is required');
 }
-if (!resultsFile) {
-  throw new Error('HOMEBOY_TRACE_RESULTS_FILE is required');
-}
 if (!traceHelperDir) {
   throw new Error('HOMEBOY_TRACE_HELPER_DIR is required');
 }
@@ -71,16 +67,14 @@ const fixtureBootstrapSource = (await readFile(fixtureBootstrapPath, 'utf8'))
 const requestedAcceptedPaymentMethods = csvToJsonArray(acceptedPaymentMethods);
 
 process.env.HOMEBOY_TRACE_ARTIFACT_DIR ||= artifactDir;
-const { createTraceReporter } = await import(pathToFileURL(path.join(traceHelperDir, 'timeline.mjs')).href);
-const trace = createTraceReporter({
+const { createTraceWorkload } = await import(pathToFileURL(path.join(traceHelperDir, 'timeline.mjs')).href);
+const trace = createTraceWorkload({
   componentId,
   scenarioId,
-  resultsFile,
 });
 trace.recorder.timestampMs = () => Math.round(performance.now() - trace.recorder.start);
 
 await mkdir(artifactDir, { recursive: true });
-await mkdir(path.dirname(resultsFile), { recursive: true });
 
 const workDir = await mkdtemp(path.join(tmpdir(), 'wc-stripe-ece-waterfall.'));
 const setupFile = path.join(workDir, 'setup.php');


### PR DESCRIPTION
## Summary
Remove rig-owned result-path setup now provided by the generic Homeboy Extensions trace workload helper.

## What changed
- Use createTraceWorkload for the Stripe ECE profile and delete redundant result-file validation and directory creation.

## How to test
1. Run `node --check woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-waterfall.trace.mjs`; expect The trace workload parses..
2. Run `node --test woocommerce/woocommerce-gateway-stripe/bench/ece-product-page-profile.test.mjs`; expect All 33 profile tests pass..
3. Run `node scripts/lint-rig-packages.mjs`; expect Rig package lint passes with only an existing optional-artifact warning..

## Compatibility
Uses the existing Homeboy Extensions trace helper contract and preserves workload output. Broader issue #658 prep and Studio/fuzz extraction remain open.

## Evidence
- Base unchanged since verification: main remains at 0030e56914c6df3ecce90295545defad54482851.
- Reviewer-resolvable source evidence: https://github.com/chubes4/homeboy-rigs/issues/658
- Verified finalization base: main at 0030e56914c6df3ecce90295545defad54482851
- profile-tests: Passed
- rig-lint: Passed
- syntax: Passed

## AI assistance
- **AI assistance:** Yes
- **Tool(s):** OpenCode
- **Model:** openai/gpt-5.6-sol
- **Used for:** Verified the available upstream trace primitive and prepared the safe downstream simplification with Chris.

## Source relationships
- Relates to chubes4/homeboy-rigs#658
