### PR TITLE
Add adversarial Gutenberg Block Notes fuzz corpus

### DIFF
--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -12,7 +12,7 @@ const scenarioId = process.env.HOMEBOY_TRACE_SCENARIO || 'notes-unsaved-attachme
 const resultsFile = process.env.HOMEBOY_TRACE_RESULTS_FILE;
 const artifactDir = process.env.HOMEBOY_TRACE_ARTIFACT_DIR || path.join( tmpdir(), 'gutenberg-notes-unsaved-attachment-artifacts' );
 const wpVersion = process.env.HOMEBOY_GUTENBERG_NOTES_WP_VERSION || process.env.HOMEBOY_SETTINGS_GUTENBERG_NOTES_WP_VERSION || '7.0';
-const knownCases = new Set( [ 'orphan', 'saved-anchor', 'live-create', 'dirty-live-create', 'dirty-sibling-live-create', 'dirty-structural-live-create', 'nested-live-create', 'double-live-create', 'inline-range-live-create', 'matrix' ] );
+const knownCases = new Set( [ 'orphan', 'saved-anchor', 'live-create', 'dirty-live-create', 'dirty-sibling-live-create', 'dirty-structural-live-create', 'nested-live-create', 'double-live-create', 'inline-range-live-create', 'no-saved-match', 'ambiguous-contentless', 'empty-saved-content', 'store-coherence', 'repair-sync-race', 'crdt-peer-lineage', 'matrix' ] );
 const profileCase = process.env.HOMEBOY_TRACE_PROFILE || process.env.HOMEBOY_PROFILE || '';
 const targetCase = process.env.HOMEBOY_GUTENBERG_NOTES_CASE || process.env.HOMEBOY_SETTINGS_GUTENBERG_NOTES_CASE || ( knownCases.has( profileCase ) ? profileCase : 'orphan' );
 const probeDuration = process.env.HOMEBOY_GUTENBERG_NOTES_PROBE_DURATION || '12s';
@@ -107,6 +107,10 @@ function homeboy_gutenberg_notes_nested_content() {
 	return '<!-- wp:group --><div class="wp-block-group"><!-- wp:paragraph --><p>Homeboy note anchor target.</p><!-- /wp:paragraph --></div><!-- /wp:group -->';
 }
 
+function homeboy_gutenberg_notes_contentless_siblings() {
+	return '<!-- wp:separator --><hr class="wp-block-separator has-alpha-channel-opacity"/><!-- /wp:separator -->' . "\n\n" . '<!-- wp:separator --><hr class="wp-block-separator has-alpha-channel-opacity"/><!-- /wp:separator -->';
+}
+
 function homeboy_gutenberg_notes_create_note( $post_id, $content ) {
 	$existing = get_comments(
 		array(
@@ -195,6 +199,12 @@ function homeboy_gutenberg_notes_fixture_state() {
 	$nested_live_post_id   = homeboy_gutenberg_notes_create_post_with_content( 'homeboy-notes-nested-live-create', 'Homeboy Notes Nested Live Create', homeboy_gutenberg_notes_nested_content() );
 	$double_live_post_id   = homeboy_gutenberg_notes_create_post( 'homeboy-notes-double-live-create', 'Homeboy Notes Double Live Create' );
 	$inline_range_live_post_id = homeboy_gutenberg_notes_create_post( 'homeboy-notes-inline-range-live-create', 'Homeboy Notes Inline Range Live Create' );
+	$no_saved_match_post_id = homeboy_gutenberg_notes_create_post_with_content( 'homeboy-notes-no-saved-match', 'Homeboy Notes No Saved Match', homeboy_gutenberg_notes_two_paragraph_content() );
+	$ambiguous_contentless_post_id = homeboy_gutenberg_notes_create_post_with_content( 'homeboy-notes-ambiguous-contentless', 'Homeboy Notes Ambiguous Contentless', homeboy_gutenberg_notes_contentless_siblings() );
+	$empty_saved_content_post_id = homeboy_gutenberg_notes_create_post_with_content( 'homeboy-notes-empty-saved-content', 'Homeboy Notes Empty Saved Content', '' );
+	$store_coherence_post_id = homeboy_gutenberg_notes_create_post( 'homeboy-notes-store-coherence', 'Homeboy Notes Store Coherence' );
+	$repair_sync_race_post_id = homeboy_gutenberg_notes_create_post( 'homeboy-notes-repair-sync-race', 'Homeboy Notes Repair Sync Race' );
+	$crdt_peer_lineage_post_id = homeboy_gutenberg_notes_create_post( 'homeboy-notes-crdt-peer-lineage', 'Homeboy Notes CRDT Peer Lineage' );
 
 	$state = array(
 		'orphan' => array(
@@ -242,6 +252,12 @@ function homeboy_gutenberg_notes_fixture_state() {
 			'note_id' => 0,
 			'expected_orphan' => false,
 		),
+		'no-saved-match' => array( 'post_id' => $no_saved_match_post_id, 'note_id' => 0, 'expected_orphan' => false ),
+		'ambiguous-contentless' => array( 'post_id' => $ambiguous_contentless_post_id, 'note_id' => 0, 'expected_orphan' => false ),
+		'empty-saved-content' => array( 'post_id' => $empty_saved_content_post_id, 'note_id' => 0, 'expected_orphan' => false ),
+		'store-coherence' => array( 'post_id' => $store_coherence_post_id, 'note_id' => 0, 'expected_orphan' => false ),
+		'repair-sync-race' => array( 'post_id' => $repair_sync_race_post_id, 'note_id' => 0, 'expected_orphan' => false ),
+		'crdt-peer-lineage' => array( 'post_id' => $crdt_peer_lineage_post_id, 'note_id' => 0, 'expected_orphan' => false ),
 	);
 
 	update_option( 'homeboy_gutenberg_notes_fixture_state', $state, false );
@@ -306,22 +322,47 @@ const browserScript = `
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const readinessTimeoutMs = ${ readinessTimeoutMs };
 const targetCase = ${ JSON.stringify( targetCase ) };
+const seed = ${ JSON.stringify( process.env.HOMEBOY_SEED || '' ) };
 const stateResponse = await fetch('/wp-json/homeboy-gutenberg-notes/v1/state', { credentials: 'include' });
 const fixtureState = await stateResponse.json();
 const currentCase = new URL(location.href).searchParams.get('homeboy_notes_case') || targetCase;
 const observedRequests = [];
+const actorTimeline = [];
+const actorEvent = (actor, event, data = {}) => actorTimeline.push({ t_ms: Math.round(performance.now()), actor, event, data });
 const originalFetch = window.fetch.bind(window);
 window.fetch = async (input, init = {}) => {
 	const request = input instanceof Request ? input : null;
 	const url = request ? request.url : String(input);
 	const method = (init.method || request?.method || 'GET').toUpperCase();
-	const body = typeof init.body === 'string' ? init.body.slice(0, 500) : '';
+	const rawBody = typeof init.body === 'string' ? init.body : '';
+	let payload = null;
+	try { payload = rawBody ? JSON.parse(rawBody) : null; } catch (error) {}
+	const route = url.includes('/wp-sync/v1/save') ? 'sync-save' : url.includes('/wp-json/wp/v2/posts/') ? 'post-rest' : 'other';
+	const payloadKeys = Object.keys(payload || {}).sort();
+	const semantics = {
+		has_crdt_document: typeof payload?.meta?._crdt_document === 'string' || typeof payload?.doc === 'string',
+		has_metadata: JSON.stringify(payload || {}).includes('metadata'),
+		has_content: Object.prototype.hasOwnProperty.call(payload || {}, 'content'),
+		payload_keys: payloadKeys,
+		is_targeted_repair: payloadKeys.length === 2 && payloadKeys.includes('content') && payloadKeys.includes('meta') && typeof payload?.meta?._crdt_document === 'string',
+		is_full_editor_save: Object.prototype.hasOwnProperty.call(payload || {}, 'content') && typeof payload?.meta?._crdt_document !== 'string',
+	};
+	const raceDelay = currentCase === 'repair-sync-race' && (route === 'sync-save' || route === 'post-rest')
+		? ((Array.from(seed || '0').reduce((total, character) => total + character.charCodeAt(0), 0) + (route === 'sync-save' ? 1 : 0)) % 2 ? 180 : 25)
+		: 0;
+	if (raceDelay) {
+		actorEvent('parent', 'request-delayed', { route, delay_ms: raceDelay, seed });
+		await sleep(raceDelay);
+	}
+	actorEvent('parent', 'request-start', { route, method, semantics });
 	try {
 		const response = await originalFetch(input, init);
-		observedRequests.push({ url, method, status: response.status, body });
+		observedRequests.push({ t_ms: Math.round(performance.now()), url, method, status: response.status, route, semantics, body: rawBody.slice(0, 500) });
+		actorEvent('parent', 'request-finish', { route, method, status: response.status, semantics });
 		return response;
 	} catch (error) {
-		observedRequests.push({ url, method, status: 0, body, error: String(error) });
+		observedRequests.push({ t_ms: Math.round(performance.now()), url, method, status: 0, route, semantics, body: rawBody.slice(0, 500), error: String(error) });
+		actorEvent('parent', 'request-fail', { route, method, error: String(error), semantics });
 		throw error;
 	}
 };
@@ -375,6 +416,7 @@ const getCoreNoteMarkers = (targetWindow = window) => flattenBlocks(targetWindow
 const getAllBlockText = (targetWindow = window) => flattenBlocks(targetWindow.wp.data.select('core/block-editor').getBlocks()).map(getBlockText).join('\\n');
 const getTargetBlock = (caseId, targetWindow = window) => {
 	const blocks = targetWindow.wp.data.select('core/block-editor').getBlocks();
+	if (caseId === 'ambiguous-contentless') return blocks[1];
 	if (caseId === 'nested-live-create') {
 		return flattenBlocks(blocks).find((block) => getBlockText(block).includes('Homeboy note anchor target'));
 	}
@@ -408,8 +450,8 @@ const contentHasNoteId = (content, noteId) => {
 };
 const waitForEditorReady = async (label) => {
 	await waitFor(() => document.body && document.body.classList.contains('block-editor-page'), 'editor shell for ' + label);
-	await waitFor(() => document.body.textContent.includes('Homeboy note anchor target'), 'editor content for ' + label);
 	await waitFor(() => window.wp?.data?.select('core/block-editor')?.getBlocks, 'block editor data store for ' + label);
+	await waitFor(() => window.wp.data.select('core/block-editor').getBlocks().length > 0 || label === 'empty-saved-content', 'editor blocks for ' + label);
 };
 const waitForFrameEditorReady = async (frameWindow, frameDocument, label) => {
 	await waitFor(() => frameDocument.body && frameDocument.body.classList.contains('block-editor-page'), 'iframe editor shell for ' + label);
@@ -437,6 +479,7 @@ const collectReloadedEditorState = async (caseId, postId, noteId, dirtyText) => 
 	const reloadedBlockNoteIds = getBlockNoteIds(frameWindow);
 	const reloadedNoteBlockTexts = getBlocksWithNoteId(noteId, frameWindow).map(getBlockText);
 	const reloadedAttachmentBlock = getBlocksWithNoteId(noteId, frameWindow)[0] || null;
+	const reloadedAttachmentIndex = flattenBlocks(frameWindow.wp.data.select('core/block-editor').getBlocks()).findIndex((block) => block.clientId === reloadedAttachmentBlock?.clientId);
 	const reloadedCoreNoteMarkers = getCoreNoteMarkers(frameWindow).filter((marker) => marker.clientId === reloadedAttachmentBlock?.clientId && Number(marker.attributes?.['data-id']) === Number(noteId));
 	const reloadedNoteEntity = await waitFor(() => frameWindow.wp.data.select('core')?.getEntityRecord?.('root', 'comment', Number(noteId)), 'reloaded note entity ' + noteId);
 	const reloadedBlockText = getAllBlockText(frameWindow);
@@ -446,6 +489,7 @@ const collectReloadedEditorState = async (caseId, postId, noteId, dirtyText) => 
 		reloadedNoteBlockTexts,
 		reloadedNoteTargetsAnchor: reloadedNoteBlockTexts.some((text) => text.includes('Homeboy note anchor target')),
 		reloadedAttachmentBlockClientId: reloadedAttachmentBlock?.clientId || null,
+		reloadedAttachmentIndex,
 		reloadedCoreNoteMarkers,
 		reloadedHasCoreNoteMarker: reloadedCoreNoteMarkers.length > 0,
 		reloadedNoteEntity: reloadedNoteEntity ? { id: reloadedNoteEntity.id, post: reloadedNoteEntity.post } : null,
@@ -453,6 +497,35 @@ const collectReloadedEditorState = async (caseId, postId, noteId, dirtyText) => 
 		reloadedBlockText,
 		reloadedHasDirtyText: reloadedBlockText.includes(dirtyText) || (frameDocument.body.textContent || '').includes(dirtyText),
 	};
+};
+const openPeerEditor = async (caseId, postId) => {
+	const iframe = document.createElement('iframe');
+	iframe.style.cssText = 'position:fixed;left:-10000px;top:0;width:1200px;height:800px';
+	document.body.appendChild(iframe);
+	iframe.src = '/wp-admin/post.php?post=' + encodeURIComponent(postId) + '&action=edit&homeboy_notes_case=' + encodeURIComponent(caseId) + '&homeboy_peer=1';
+	await new Promise((resolve, reject) => {
+		const timeout = setTimeout(() => reject(new Error('Timed out loading peer editor for ' + caseId)), readinessTimeoutMs);
+		iframe.addEventListener('load', () => { clearTimeout(timeout); resolve(); }, { once: true });
+	});
+	const peerWindow = iframe.contentWindow;
+	await waitForFrameEditorReady(peerWindow, iframe.contentDocument, caseId);
+	actorEvent('peer', 'editor-ready', { caseId, postId });
+	return { iframe, peerWindow };
+};
+const readPeerState = (peerWindow, noteId) => {
+	const blocks = flattenBlocks(peerWindow.wp.data.select('core/block-editor').getBlocks());
+	return {
+		blockCount: blocks.length,
+		blockTexts: blocks.map(getBlockText),
+		noteIds: getBlockNoteIds(peerWindow),
+		attachmentCount: getBlocksWithNoteId(noteId, peerWindow).length,
+	};
+};
+const collectPeerState = async (caseId, postId, noteId) => {
+	const { iframe, peerWindow } = await openPeerEditor(caseId, postId);
+	const state = readPeerState(peerWindow, noteId);
+	iframe.remove();
+	return state;
 };
 const collectBlockAttachment = async (caseId, item, noteId) => {
 	await waitForEditorReady(caseId);
@@ -630,7 +703,7 @@ const collectLiveCreateCase = async (caseId) => {
 	let persistedHasOriginalSiblingText = persistedContent.includes('Homeboy sibling text that must stay saved.');
 	let repairSaveObserved = false;
 	try {
-		repairSaveObserved = await waitFor(() => observedRequests.some((request) => request.url.includes('/wp-json/wp/v2/posts/' + item.post_id) && request.method === 'POST' && request.status >= 200 && request.status < 300 && request.body.includes('_crdt_document') && request.body.includes('metadata')), 'repair entity save after live note create');
+		repairSaveObserved = await waitFor(() => observedRequests.some((request) => request.url.includes('/wp-json/wp/v2/posts/' + item.post_id) && request.method === 'POST' && request.status >= 200 && request.status < 300 && request.semantics.is_targeted_repair), 'repair entity save after live note create');
 	} catch (error) {}
 	try {
 		persistedHasNoteId = await waitFor(async () => {
@@ -684,8 +757,8 @@ const collectInlineRangeLiveCreateCase = async () => {
 	const cleanPostBeforeCreate = !window.wp.data.select('core/editor').isEditedPostDirty?.();
 	const block = await waitFor(() => getTargetBlock(caseId), 'rich-text range target block');
 	const noteId = await createNoteOnRichTextRange(block, 'Homeboy inline range note');
-	const targetedPersistenceObserved = await waitFor(() => observedRequests.some((request) => request.url.includes('/wp-json/wp/v2/posts/' + item.post_id) && request.method === 'POST' && request.status >= 200 && request.status < 300 && request.body.includes('_crdt_document') && request.body.includes('metadata') && !request.body.includes('"content"')), 'targeted note metadata persistence');
-	const fullPostSaveObserved = observedRequests.some((request) => request.url.includes('/wp-json/wp/v2/posts/' + item.post_id) && request.method === 'POST' && request.body.includes('"content"'));
+	const targetedPersistenceObserved = await waitFor(() => observedRequests.some((request) => request.url.includes('/wp-json/wp/v2/posts/' + item.post_id) && request.method === 'POST' && request.status >= 200 && request.status < 300 && request.semantics.is_targeted_repair), 'targeted note metadata persistence');
+	const fullPostSaveObserved = observedRequests.some((request) => request.url.includes('/wp-json/wp/v2/posts/' + item.post_id) && request.method === 'POST' && request.semantics.is_full_editor_save);
 	const reloaded = await collectReloadedEditorState(caseId, item.post_id, noteId, 'Homeboy dirty edit that must stay unsaved.');
 	return {
 		caseId,
@@ -700,6 +773,106 @@ const collectInlineRangeLiveCreateCase = async () => {
 		observedRequests: observedRequests.filter((request) => request.url.includes('/wp-json/wp/v2/posts/') || request.url.includes('/wp-json/wp/v2/comments')).slice(-20),
 	};
 };
+const waitForPersistedNoteIds = async (postId, noteIds) => waitFor(async () => {
+	const content = await getPostContent(postId);
+	return noteIds.every((noteId) => contentHasNoteId(content, noteId));
+}, 'persisted note IDs ' + noteIds.join(','));
+const postRequests = (postId) => observedRequests.filter((request) => request.url.includes('/wp-json/wp/v2/posts/' + postId) && request.method === 'POST');
+const collectNoSavedMatchCase = async () => {
+	const caseId = 'no-saved-match';
+	const item = fixtureState[caseId];
+	await waitForEditorReady(caseId);
+	const target = getTargetBlock(caseId);
+	const liveOnlyText = 'Homeboy live target with no saved match.';
+	window.wp.data.dispatch('core/block-editor').updateBlockAttributes(target.clientId, { content: liveOnlyText });
+	await waitFor(() => getBlockText(getTargetBlock(caseId)) === liveOnlyText, 'live-only target mutation');
+	const noteId = await createNoteOnBlock(target, 'Homeboy no saved match note');
+	const reloaded = await collectReloadedEditorState(caseId, item.post_id, noteId, liveOnlyText);
+	const wrongSavedBlockAttached = reloaded.reloadedHasNoteId;
+	const fullPostSaveObserved = postRequests(item.post_id).some((request) => request.semantics.is_full_editor_save);
+	return { caseId, postId: item.post_id, noteId, liveOnlyText, wrongSavedBlockAttached, fullPostSaveObserved, ...reloaded, logicalOrphan: !reloaded.reloadedHasNoteId, passed: !wrongSavedBlockAttached && !fullPostSaveObserved, actorTimeline: [...actorTimeline], observedRequests: postRequests(item.post_id) };
+};
+const collectAmbiguousContentlessCase = async () => {
+	const caseId = 'ambiguous-contentless';
+	const item = fixtureState[caseId];
+	await waitForEditorReady(caseId);
+	const blocksBefore = flattenBlocks(window.wp.data.select('core/block-editor').getBlocks());
+	const target = getTargetBlock(caseId);
+	if (blocksBefore.length !== 2 || target !== blocksBefore[1]) throw new Error('Contentless sibling fixture did not expose an exact second sibling target');
+	const inserted = window.wp.blocks.createBlock('core/paragraph', { content: 'Homeboy unsaved path shift.' });
+	window.wp.data.dispatch('core/block-editor').insertBlock(inserted, 0);
+	await waitFor(() => window.wp.data.select('core/block-editor').getBlocks().length === 3, 'contentless sibling path shift');
+	const noteId = await createNoteOnBlock(target, 'Homeboy second contentless sibling note');
+	await waitForPersistedNoteIds(item.post_id, [noteId]);
+	const reloaded = await collectReloadedEditorState(caseId, item.post_id, noteId, '');
+	return { caseId, postId: item.post_id, noteId, intendedAttachmentIndex: 1, ...reloaded, passed: reloaded.reloadedAttachmentIndex === 1 && reloaded.reloadedHasNoteId, actorTimeline: [...actorTimeline], observedRequests: postRequests(item.post_id) };
+};
+const collectEmptySavedContentCase = async () => {
+	const caseId = 'empty-saved-content';
+	const item = fixtureState[caseId];
+	await waitForEditorReady(caseId);
+	const inserted = window.wp.blocks.createBlock('core/paragraph', { content: 'Homeboy unsaved empty-document target.' });
+	window.wp.data.dispatch('core/block-editor').insertBlock(inserted, 0);
+	await waitFor(() => getBlockText(getTargetBlock(caseId)).includes('empty-document target'), 'unsaved empty-document block');
+	const noteId = await createNoteOnBlock(inserted, 'Homeboy empty saved content note');
+	await sleep(1000);
+	const persistedContent = await getPostContent(item.post_id);
+	const fullPostSaveObserved = postRequests(item.post_id).some((request) => request.semantics.is_full_editor_save);
+	const errorNotices = (window.wp.data.select('core/notices')?.getNotices?.() || []).filter((notice) => notice.status === 'error').map((notice) => notice.content || notice.id);
+	return { caseId, postId: item.post_id, noteId, persistedContent, fullPostSaveObserved, errorNotices, editorDirty: window.wp.data.select('core/editor').isEditedPostDirty?.(), passed: persistedContent === '' && !fullPostSaveObserved && errorNotices.length === 0, actorTimeline: [...actorTimeline], observedRequests: postRequests(item.post_id) };
+};
+const collectStoreCoherenceCase = async () => {
+	const caseId = 'store-coherence';
+	const item = fixtureState[caseId];
+	await waitForEditorReady(caseId);
+	const target = getTargetBlock(caseId);
+	const firstNoteId = await createNoteOnBlock(target, 'Homeboy coherence first note');
+	const blockStoreHasFirstNote = getBlocksWithNoteId(firstNoteId).some((block) => block.clientId === target.clientId);
+	const editorContent = window.wp.data.select('core/editor').getEditedPostAttribute?.('content') || '';
+	const editorStoreHasFirstNote = contentHasNoteId(editorContent, firstNoteId);
+	const coreDataEntity = window.wp.data.select('core').getEditedEntityRecord?.('postType', 'post', item.post_id);
+	const coreDataStoreHasFirstNote = contentHasNoteId(JSON.stringify(coreDataEntity || {}), firstNoteId);
+	actorEvent('parent', 'stores-checked-before-dependent-operation', { firstNoteId, blockStoreHasFirstNote, editorStoreHasFirstNote, coreDataStoreHasFirstNote });
+	const secondNoteId = await createNoteOnBlock(target, 'Homeboy coherence dependent note');
+	await waitForPersistedNoteIds(item.post_id, [firstNoteId, secondNoteId]);
+	const reloaded = await collectReloadedEditorState(caseId, item.post_id, secondNoteId, '');
+	return { caseId, postId: item.post_id, noteIds: [firstNoteId, secondNoteId], blockStoreHasFirstNote, editorStoreHasFirstNote, coreDataStoreHasFirstNote, ...reloaded, passed: blockStoreHasFirstNote && editorStoreHasFirstNote && coreDataStoreHasFirstNote && reloaded.reloadedBlockNoteIds.includes(firstNoteId) && reloaded.reloadedBlockNoteIds.includes(secondNoteId), actorTimeline: [...actorTimeline], observedRequests: postRequests(item.post_id) };
+};
+const collectRepairSyncRaceCase = async () => {
+	const caseId = 'repair-sync-race';
+	const item = fixtureState[caseId];
+	await waitForEditorReady(caseId);
+	const target = getTargetBlock(caseId);
+	const firstNoteId = await createNoteOnBlock(target, 'Homeboy race first note');
+	const secondNoteId = await createNoteOnBlock(target, 'Homeboy race second note');
+	await waitForPersistedNoteIds(item.post_id, [firstNoteId, secondNoteId]);
+	const reloaded = await collectReloadedEditorState(caseId, item.post_id, secondNoteId, '');
+	const raceRequests = observedRequests.filter((request) => request.route === 'post-rest' || request.route === 'sync-save');
+	const delayedRoutes = actorTimeline.filter((entry) => entry.event === 'request-delayed').map((entry) => entry.data.route);
+	const exercisedRoutes = new Set(raceRequests.map((request) => request.route));
+	const exercisedRepairAndSync = exercisedRoutes.has('post-rest') && exercisedRoutes.has('sync-save');
+	return { caseId, postId: item.post_id, seed, noteIds: [firstNoteId, secondNoteId], delayedRoutes, exercisedRepairAndSync, raceRequests, ...reloaded, passed: exercisedRepairAndSync && reloaded.reloadedBlockNoteIds.includes(firstNoteId) && reloaded.reloadedBlockNoteIds.includes(secondNoteId), actorTimeline: [...actorTimeline] };
+};
+const collectCrdtPeerLineageCase = async () => {
+	const caseId = 'crdt-peer-lineage';
+	const item = fixtureState[caseId];
+	await waitForEditorReady(caseId);
+	const target = getTargetBlock(caseId);
+	const parentBlockCount = flattenBlocks(window.wp.data.select('core/block-editor').getBlocks()).length;
+	const parentText = getAllBlockText();
+	actorEvent('parent', 'establish-persisted-lineage-start', {});
+	await window.wp.data.dispatch('core/editor').savePost();
+	await waitFor(() => !window.wp.data.select('core/editor').isSavingPost?.(), 'initial persisted CRDT lineage');
+	actorEvent('parent', 'establish-persisted-lineage-finish', {});
+	const { iframe, peerWindow } = await openPeerEditor(caseId, item.post_id);
+	const noteId = await createNoteOnBlock(target, 'Homeboy CRDT peer lineage note');
+	await waitForPersistedNoteIds(item.post_id, [noteId]);
+	await waitFor(() => getBlockNoteIds(peerWindow).includes(noteId), 'peer convergence for note ' + noteId);
+	await sleep(1000);
+	const peer = readPeerState(peerWindow, noteId);
+	iframe.remove();
+	return { caseId, postId: item.post_id, noteId, parentBlockCount, parentText, peer, passed: peer.noteIds.includes(noteId) && peer.attachmentCount === 1 && peer.blockCount === parentBlockCount && peer.blockTexts.join('\n') === parentText, actorTimeline: [...actorTimeline], observedRequests: observedRequests.filter((request) => request.route === 'post-rest' || request.route === 'sync-save') };
+};
 const collectCase = async (caseId) => {
 	const item = fixtureState[caseId];
 	if (!item) {
@@ -711,6 +884,12 @@ const collectCase = async (caseId) => {
 	if (caseId === 'inline-range-live-create') {
 		return collectInlineRangeLiveCreateCase();
 	}
+	if (caseId === 'no-saved-match') return collectNoSavedMatchCase();
+	if (caseId === 'ambiguous-contentless') return collectAmbiguousContentlessCase();
+	if (caseId === 'empty-saved-content') return collectEmptySavedContentCase();
+	if (caseId === 'store-coherence') return collectStoreCoherenceCase();
+	if (caseId === 'repair-sync-race') return collectRepairSyncRaceCase();
+	if (caseId === 'crdt-peer-lineage') return collectCrdtPeerLineageCase();
 	return collectBlockAttachment(caseId, item, Number(item.note_id));
 };
 const results = [await collectCase(currentCase)];
@@ -727,6 +906,7 @@ try {
 		component_path: componentPath,
 		wp_version: wpVersion,
 		target_case: targetCase,
+		seed: process.env.HOMEBOY_SEED || null,
 		issue: 'https://github.com/WordPress/gutenberg/issues/72717',
 	} );
 
@@ -815,6 +995,12 @@ try {
 		dirty_structural_targets_anchor: caseResults.some( ( item ) => item.caseId === 'dirty-structural-live-create' && item.reloadedNoteTargetsAnchor === true && item.persistedHasDirtyText === false && item.reloadedHasDirtyText === false ),
 		double_live_create_attached: caseResults.some( ( item ) => item.caseId === 'double-live-create' && item.persistedHasAllNoteIds === true && item.reloadedHasAllNoteIds === true ),
 		inline_range_note_persisted: caseResults.some( ( item ) => item.caseId === 'inline-range-live-create' && item.cleanPostBeforeCreate === true && item.targetedPersistenceObserved === true && item.fullPostSaveObserved === false && item.reloadedHasNoteId === true && item.reloadedHasCoreNoteMarker === true && item.reloadedNoteEntityResolvesToAttachment === true ),
+		no_saved_match_avoids_wrong_sibling: caseResults.some( ( item ) => item.caseId === 'no-saved-match' && item.wrongSavedBlockAttached === false && item.fullPostSaveObserved === false ),
+		ambiguous_contentless_targets_second_sibling: caseResults.some( ( item ) => item.caseId === 'ambiguous-contentless' && item.reloadedAttachmentIndex === 1 ),
+		empty_saved_content_has_no_full_save: caseResults.some( ( item ) => item.caseId === 'empty-saved-content' && item.persistedContent === '' && item.fullPostSaveObserved === false && item.errorNotices.length === 0 ),
+		store_coherence_before_dependent_operation: caseResults.some( ( item ) => item.caseId === 'store-coherence' && item.blockStoreHasFirstNote === true && item.editorStoreHasFirstNote === true && item.coreDataStoreHasFirstNote === true ),
+		repair_sync_race_converged: caseResults.some( ( item ) => item.caseId === 'repair-sync-race' && item.passed === true && item.exercisedRepairAndSync === true && item.delayedRoutes.includes( 'post-rest' ) && item.delayedRoutes.includes( 'sync-save' ) ),
+		crdt_peer_lineage_stable: caseResults.some( ( item ) => item.caseId === 'crdt-peer-lineage' && item.passed === true && item.peer.attachmentCount === 1 ),
 		page_error_count: pageErrors.length,
 		network_response_count: network.filter( ( entry ) => entry.type === 'response' ).length,
 		sync_save_response_count: network.filter( ( entry ) => entry.type === 'response' && JSON.stringify( entry ).includes( '/wp-sync/v1/save' ) ).length,
@@ -899,6 +1085,36 @@ try {
 				id: 'inline-range-note-persisted-after-reload',
 				status: targetCase !== 'matrix' && targetCase !== 'inline-range-live-create' ? 'pass' : caseResults.every( ( item ) => item.caseId !== 'inline-range-live-create' || ( item.cleanPostBeforeCreate === true && item.targetedPersistenceObserved === true && item.fullPostSaveObserved === false && item.reloadedHasNoteId === true && item.reloadedHasCoreNoteMarker === true && item.reloadedNoteEntityResolvesToAttachment === true ) ) ? 'pass' : 'fail',
 				message: `Inline range note used targeted persistence without a full post save and reloaded metadata.noteId=${ caseResults.filter( ( item ) => item.caseId === 'inline-range-live-create' ).every( ( item ) => item.reloadedHasNoteId === true ) }, core/note=${ caseResults.filter( ( item ) => item.caseId === 'inline-range-live-create' ).every( ( item ) => item.reloadedHasCoreNoteMarker === true ) }, and entity attachment=${ caseResults.filter( ( item ) => item.caseId === 'inline-range-live-create' ).every( ( item ) => item.reloadedNoteEntityResolvesToAttachment === true ) }.`
+			},
+			{
+				id: 'no-saved-match-never-attaches-invalid-sibling',
+				status: targetCase !== 'no-saved-match' || metrics.no_saved_match_avoids_wrong_sibling ? 'pass' : 'fail',
+				message: `Live target mutation avoided attachment to the known-invalid sibling and a full editor save=${ metrics.no_saved_match_avoids_wrong_sibling }.`
+			},
+			{
+				id: 'ambiguous-contentless-target-is-exact-sibling',
+				status: targetCase !== 'ambiguous-contentless' || metrics.ambiguous_contentless_targets_second_sibling ? 'pass' : 'fail',
+				message: `Identical contentless siblings retained the selected second sibling=${ metrics.ambiguous_contentless_targets_second_sibling }.`
+			},
+			{
+				id: 'empty-saved-content-no-parse-or-full-save',
+				status: targetCase !== 'empty-saved-content' || metrics.empty_saved_content_has_no_full_save ? 'pass' : 'fail',
+				message: `Empty saved content remained empty without a full editor save=${ metrics.empty_saved_content_has_no_full_save }.`
+			},
+			{
+				id: 'core-data-editor-store-coherence-before-dependent-operation',
+				status: targetCase !== 'store-coherence' || metrics.store_coherence_before_dependent_operation ? 'pass' : 'fail',
+				message: `Block-editor, editor, and core-data stores contained the repaired first note before the dependent operation=${ metrics.store_coherence_before_dependent_operation }.`
+			},
+			{
+				id: 'seeded-repair-sync-race-converges',
+				status: targetCase !== 'repair-sync-race' || metrics.repair_sync_race_converged ? 'pass' : 'fail',
+				message: `Seeded REST/wp-sync request ordering converged with all note IDs=${ metrics.repair_sync_race_converged }.`
+			},
+			{
+				id: 'crdt-peer-lineage-reloads-without-duplicates',
+				status: targetCase !== 'crdt-peer-lineage' || metrics.crdt_peer_lineage_stable ? 'pass' : 'fail',
+				message: `Second same-origin editor peer retained one attachment without duplicate blocks or text=${ metrics.crdt_peer_lineage_stable }.`
 			},
 			{
 				id: 'page-errors-recorded',

--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -12,7 +12,7 @@ const scenarioId = process.env.HOMEBOY_TRACE_SCENARIO || 'notes-unsaved-attachme
 const resultsFile = process.env.HOMEBOY_TRACE_RESULTS_FILE;
 const artifactDir = process.env.HOMEBOY_TRACE_ARTIFACT_DIR || path.join( tmpdir(), 'gutenberg-notes-unsaved-attachment-artifacts' );
 const wpVersion = process.env.HOMEBOY_GUTENBERG_NOTES_WP_VERSION || process.env.HOMEBOY_SETTINGS_GUTENBERG_NOTES_WP_VERSION || '7.0';
-const knownCases = new Set( [ 'orphan', 'saved-anchor', 'autosave-anchor', 'live-create', 'dirty-live-create', 'dirty-sibling-live-create', 'dirty-structural-live-create', 'nested-live-create', 'double-live-create', 'matrix' ] );
+const knownCases = new Set( [ 'orphan', 'saved-anchor', 'live-create', 'dirty-live-create', 'dirty-sibling-live-create', 'dirty-structural-live-create', 'nested-live-create', 'double-live-create', 'matrix' ] );
 const profileCase = process.env.HOMEBOY_TRACE_PROFILE || process.env.HOMEBOY_PROFILE || '';
 const targetCase = process.env.HOMEBOY_GUTENBERG_NOTES_CASE || process.env.HOMEBOY_SETTINGS_GUTENBERG_NOTES_CASE || ( knownCases.has( profileCase ) ? profileCase : 'orphan' );
 const probeDuration = process.env.HOMEBOY_GUTENBERG_NOTES_PROBE_DURATION || '12s';
@@ -188,17 +188,6 @@ function homeboy_gutenberg_notes_fixture_state() {
 		)
 	);
 
-	$autosave_post_id = homeboy_gutenberg_notes_create_post( 'homeboy-notes-autosave-anchor', 'Homeboy Notes Autosave Anchor' );
-	$autosave_note_id = homeboy_gutenberg_notes_create_note( $autosave_post_id, 'Homeboy autosave anchor note' );
-	wp_create_post_autosave(
-		array(
-			'post_ID'      => $autosave_post_id,
-			'post_title'   => 'Homeboy Notes Autosave Anchor',
-			'post_content' => homeboy_gutenberg_notes_content( $autosave_note_id ),
-			'post_author'  => 1,
-		)
-	);
-
 	$live_post_id          = homeboy_gutenberg_notes_create_post( 'homeboy-notes-live-create', 'Homeboy Notes Live Create' );
 	$dirty_live_post_id    = homeboy_gutenberg_notes_create_post( 'homeboy-notes-dirty-live-create', 'Homeboy Notes Dirty Live Create' );
 	$dirty_sibling_post_id = homeboy_gutenberg_notes_create_post_with_content( 'homeboy-notes-dirty-sibling-live-create', 'Homeboy Notes Dirty Sibling Live Create', homeboy_gutenberg_notes_two_paragraph_content() );
@@ -215,11 +204,6 @@ function homeboy_gutenberg_notes_fixture_state() {
 		'saved-anchor' => array(
 			'post_id' => $saved_post_id,
 			'note_id' => $saved_note_id,
-			'expected_orphan' => false,
-		),
-		'autosave-anchor' => array(
-			'post_id' => $autosave_post_id,
-			'note_id' => $autosave_note_id,
 			'expected_orphan' => false,
 		),
 		'live-create' => array(
@@ -472,7 +456,6 @@ const collectBlockAttachment = async (caseId, item, noteId) => {
 	const bodyText = document.body.textContent || '';
 	const hasDeletedNotice = deletedNotices.length > 0 || bodyText.includes('Original block deleted.');
 	const logicalOrphan = !blockHasNoteId;
-	const hasAutosaveNotice = /backup of this post|autosave of this post|more recent than the version below/i.test(bodyText);
 	return {
 		caseId,
 		postId: item.post_id,
@@ -487,7 +470,6 @@ const collectBlockAttachment = async (caseId, item, noteId) => {
 		treeitems,
 		deletedNotices,
 		hasDeletedNotice,
-		hasAutosaveNotice,
 		passed: item.expected_orphan ? logicalOrphan : blockHasNoteId,
 	};
 };
@@ -502,8 +484,9 @@ const openAddNoteField = async (block) => {
 		(document.activeElement || document).dispatchEvent(new KeyboardEvent('keydown', { key: 'm', code: 'KeyM', altKey: true, bubbles: true, cancelable: true, ...combo }));
 	}
 		await sleep(500);
-		const findNewNoteField = () => Array.from(document.querySelectorAll('textarea, input[type="text"]')).find(isVisible);
-		const hasNewNoteSubmit = () => !!findButtonByText('Add note');
+		const findNewNoteForm = () => Array.from(document.querySelectorAll('[role="treeitem"][aria-label="New note"] .editor-collab-sidebar-panel__note-form')).find(isVisible);
+		const findNewNoteField = () => findNewNoteForm()?.querySelector('textarea');
+		const hasNewNoteSubmit = () => !!Array.from(findNewNoteForm()?.querySelectorAll('button') || []).find((button) => (button.textContent || '').trim() === 'Add note');
 		if (!findNewNoteField() || !hasNewNoteSubmit()) {
 			const toolbarButtons = Array.from(document.querySelectorAll('.block-editor-block-toolbar button, .block-editor-block-contextual-toolbar button')).filter(isVisible);
 			const optionsButton = toolbarButtons.sort((a, b) => a.getBoundingClientRect().left - b.getBoundingClientRect().left).at(-1);
@@ -522,7 +505,7 @@ const createNoteOnBlock = async (block, text) => {
 	textarea.focus();
 	setFieldValue(textarea, text);
 	await sleep(250);
-	const addButton = await waitFor(() => findButtonByText('Add note'), 'Add note button');
+	const addButton = await waitFor(() => Array.from(textarea.closest('form')?.querySelectorAll('button') || []).find((button) => (button.textContent || '').trim() === 'Add note'), 'Add note button');
 	addButton.click();
 	await waitFor(() => document.body.textContent.includes(text), 'created live note thread ' + text);
 	return waitFor(() => getBlockNoteIds().find((id) => !beforeIds.has(id)), 'new live note id in edited block metadata');
@@ -697,6 +680,11 @@ try {
 	const network = await readJsonl( networkPath );
 	const scriptResult = summary?.summary?.scriptResult || summary?.scriptResult || {};
 	const caseResults = Array.isArray( scriptResult.results ) ? scriptResult.results : [];
+	const pluginAssetResponses = network.filter( ( entry ) =>
+		entry.type === 'response' && entry.status >= 200 && entry.status < 300 && entry.url?.includes( '/wp-content/plugins/gutenberg/build/' )
+	);
+	const coreDataPluginAssetLoaded = pluginAssetResponses.some( ( entry ) => entry.url.includes( '/core-data/' ) );
+	const editorPluginAssetLoaded = pluginAssetResponses.some( ( entry ) => entry.url.includes( '/editor/' ) );
 
 	event( 'browser', 'probe.ready', {
 		final_url: summary?.summary?.finalUrl || summary?.finalUrl || null,
@@ -710,8 +698,10 @@ try {
 		fail_count: caseResults.filter( ( item ) => ! item.passed ).length,
 		orphan_reproduced: caseResults.some( ( item ) => item.caseId === 'orphan' && item.logicalOrphan === true ),
 		saved_anchor_attached: caseResults.some( ( item ) => item.caseId === 'saved-anchor' && item.blockHasNoteId === true ),
-		autosave_anchor_attached: caseResults.some( ( item ) => item.caseId === 'autosave-anchor' && item.blockHasNoteId === true ),
-		autosave_notice_seen: caseResults.some( ( item ) => item.caseId === 'autosave-anchor' && item.hasAutosaveNotice === true ),
+		gutenberg_plugin_asset_response_count: pluginAssetResponses.length,
+		gutenberg_core_data_asset_loaded: coreDataPluginAssetLoaded,
+		gutenberg_editor_asset_loaded: editorPluginAssetLoaded,
+		gutenberg_plugin_assets_loaded: coreDataPluginAssetLoaded && editorPluginAssetLoaded,
 		nested_live_create_attached: caseResults.some( ( item ) => item.caseId === 'nested-live-create' && item.reloadedHasNoteId === true ),
 		dirty_sibling_preserved: caseResults.some( ( item ) => item.caseId === 'dirty-sibling-live-create' && item.persistedHasOriginalSiblingText === true && item.persistedHasDirtyText === false && item.reloadedHasDirtyText === false ),
 		dirty_structural_targets_anchor: caseResults.some( ( item ) => item.caseId === 'dirty-structural-live-create' && item.reloadedNoteTargetsAnchor === true && item.persistedHasDirtyText === false && item.reloadedHasDirtyText === false ),
@@ -743,14 +733,19 @@ try {
 	event( 'notes-unsaved-attachment', 'metrics.ready', metrics );
 
 	const noPageErrors = pageErrors.length === 0;
-	const pass = metrics.fail_count === 0 && metrics.case_count > 0 && noPageErrors;
+	const pass = metrics.fail_count === 0 && metrics.case_count > 0 && noPageErrors && metrics.gutenberg_plugin_assets_loaded;
 	const traceResult = {
 		component_id: componentId,
 		scenario_id: scenarioId,
 		status: pass ? 'pass' : 'fail',
-		summary: `Captured Gutenberg note attachment matrix for ${ metrics.case_count } case(s): ${ metrics.pass_count } passed, ${ metrics.fail_count } failed. Orphan reproduced=${ metrics.orphan_reproduced }, saved anchor attached=${ metrics.saved_anchor_attached }, autosave anchor attached=${ metrics.autosave_anchor_attached }.` ,
+		summary: `Captured Gutenberg note attachment matrix for ${ metrics.case_count } case(s): ${ metrics.pass_count } passed, ${ metrics.fail_count } failed. Orphan reproduced=${ metrics.orphan_reproduced }, saved anchor attached=${ metrics.saved_anchor_attached }, Gutenberg plugin assets loaded=${ metrics.gutenberg_plugin_assets_loaded }.` ,
 		timeline,
 		assertions: [
+			{
+				id: 'gutenberg-plugin-assets-loaded',
+				status: metrics.gutenberg_plugin_assets_loaded ? 'pass' : 'fail',
+				message: `Loaded Gutenberg plugin core-data and editor assets=${ metrics.gutenberg_plugin_assets_loaded }; plugin asset responses=${ metrics.gutenberg_plugin_asset_response_count }.`
+			},
 			{
 				id: 'orphan-note-reproduced',
 				status: targetCase !== 'matrix' && targetCase !== 'orphan' ? 'pass' : metrics.orphan_reproduced ? 'pass' : 'fail',
@@ -760,11 +755,6 @@ try {
 				id: 'saved-anchor-attached',
 				status: targetCase !== 'matrix' && targetCase !== 'saved-anchor' ? 'pass' : metrics.saved_anchor_attached ? 'pass' : 'fail',
 				message: `Saved post_content metadata.noteId attached note to block=${ metrics.saved_anchor_attached }.`
-			},
-			{
-				id: 'autosave-anchor-attached',
-				status: targetCase !== 'matrix' && targetCase !== 'autosave-anchor' ? 'pass' : metrics.autosave_anchor_attached ? 'pass' : 'fail',
-				message: `Autosave content metadata.noteId attached note to block=${ metrics.autosave_anchor_attached }; autosave notice seen=${ metrics.autosave_notice_seen }.`
 			},
 			{
 				id: 'live-create-used-repair-save',

--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -660,6 +660,17 @@ const collectInlineRangeLiveCreateCase = async () => {
 	const item = fixtureState[caseId];
 	if (!item) throw new Error('Missing fixture case ' + caseId);
 	await waitForEditorReady(caseId);
+	try {
+		if (window.wp.data.select('core/preferences')?.get('core/edit-post', 'welcomeGuide')) {
+			window.wp.data.dispatch('core/preferences').set('core/edit-post', 'welcomeGuide', false);
+		}
+	} catch (error) {}
+	try {
+		if (window.wp.data.select('core/edit-post')?.isFeatureActive?.('welcomeGuide')) {
+			window.wp.data.dispatch('core/edit-post').toggleFeature('welcomeGuide');
+		}
+	} catch (error) {}
+	await sleep(500);
 	const cleanPostBeforeCreate = !window.wp.data.select('core/editor').isEditedPostDirty?.();
 	const block = await waitFor(() => getTargetBlock(caseId), 'rich-text range target block');
 	const noteId = await createNoteOnRichTextRange(block, 'Homeboy inline range note');

--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -12,7 +12,7 @@ const scenarioId = process.env.HOMEBOY_TRACE_SCENARIO || 'notes-unsaved-attachme
 const resultsFile = process.env.HOMEBOY_TRACE_RESULTS_FILE;
 const artifactDir = process.env.HOMEBOY_TRACE_ARTIFACT_DIR || path.join( tmpdir(), 'gutenberg-notes-unsaved-attachment-artifacts' );
 const wpVersion = process.env.HOMEBOY_GUTENBERG_NOTES_WP_VERSION || process.env.HOMEBOY_SETTINGS_GUTENBERG_NOTES_WP_VERSION || '7.0';
-const knownCases = new Set( [ 'orphan', 'saved-anchor', 'live-create', 'dirty-live-create', 'dirty-sibling-live-create', 'dirty-structural-live-create', 'nested-live-create', 'double-live-create', 'matrix' ] );
+const knownCases = new Set( [ 'orphan', 'saved-anchor', 'live-create', 'dirty-live-create', 'dirty-sibling-live-create', 'dirty-structural-live-create', 'nested-live-create', 'double-live-create', 'inline-range-live-create', 'matrix' ] );
 const profileCase = process.env.HOMEBOY_TRACE_PROFILE || process.env.HOMEBOY_PROFILE || '';
 const targetCase = process.env.HOMEBOY_GUTENBERG_NOTES_CASE || process.env.HOMEBOY_SETTINGS_GUTENBERG_NOTES_CASE || ( knownCases.has( profileCase ) ? profileCase : 'orphan' );
 const probeDuration = process.env.HOMEBOY_GUTENBERG_NOTES_PROBE_DURATION || '12s';
@@ -194,6 +194,7 @@ function homeboy_gutenberg_notes_fixture_state() {
 	$dirty_structural_post_id = homeboy_gutenberg_notes_create_post_with_content( 'homeboy-notes-dirty-structural-live-create', 'Homeboy Notes Dirty Structural Live Create', homeboy_gutenberg_notes_two_paragraph_content() );
 	$nested_live_post_id   = homeboy_gutenberg_notes_create_post_with_content( 'homeboy-notes-nested-live-create', 'Homeboy Notes Nested Live Create', homeboy_gutenberg_notes_nested_content() );
 	$double_live_post_id   = homeboy_gutenberg_notes_create_post( 'homeboy-notes-double-live-create', 'Homeboy Notes Double Live Create' );
+	$inline_range_live_post_id = homeboy_gutenberg_notes_create_post( 'homeboy-notes-inline-range-live-create', 'Homeboy Notes Inline Range Live Create' );
 
 	$state = array(
 		'orphan' => array(
@@ -233,6 +234,11 @@ function homeboy_gutenberg_notes_fixture_state() {
 		),
 		'double-live-create' => array(
 			'post_id' => $double_live_post_id,
+			'note_id' => 0,
+			'expected_orphan' => false,
+		),
+		'inline-range-live-create' => array(
+			'post_id' => $inline_range_live_post_id,
 			'note_id' => 0,
 			'expected_orphan' => false,
 		),
@@ -362,6 +368,10 @@ const getBlockText = (block) => {
 	const content = block?.attributes?.content;
 	return typeof content === 'string' ? content : content?.toString?.() || '';
 };
+const getCoreNoteMarkers = (targetWindow = window) => flattenBlocks(targetWindow.wp.data.select('core/block-editor').getBlocks()).flatMap((block) => {
+	const value = targetWindow.wp.richText?.create?.({ html: getBlockText(block) });
+	return (value?.formats || []).flatMap((formats) => (formats || []).filter((format) => format?.type === 'core/note').map((format) => ({ clientId: block.clientId, attributes: format.attributes || {} })));
+});
 const getAllBlockText = (targetWindow = window) => flattenBlocks(targetWindow.wp.data.select('core/block-editor').getBlocks()).map(getBlockText).join('\\n');
 const getTargetBlock = (caseId, targetWindow = window) => {
 	const blocks = targetWindow.wp.data.select('core/block-editor').getBlocks();
@@ -426,12 +436,20 @@ const collectReloadedEditorState = async (caseId, postId, noteId, dirtyText) => 
 	await waitForFrameEditorReady(frameWindow, frameDocument, caseId);
 	const reloadedBlockNoteIds = getBlockNoteIds(frameWindow);
 	const reloadedNoteBlockTexts = getBlocksWithNoteId(noteId, frameWindow).map(getBlockText);
+	const reloadedAttachmentBlock = getBlocksWithNoteId(noteId, frameWindow)[0] || null;
+	const reloadedCoreNoteMarkers = getCoreNoteMarkers(frameWindow).filter((marker) => marker.clientId === reloadedAttachmentBlock?.clientId && Number(marker.attributes?.['data-id']) === Number(noteId));
+	const reloadedNoteEntity = await waitFor(() => frameWindow.wp.data.select('core')?.getEntityRecord?.('root', 'comment', Number(noteId)), 'reloaded note entity ' + noteId);
 	const reloadedBlockText = getAllBlockText(frameWindow);
 	return {
 		reloadedBlockNoteIds,
 		reloadedHasNoteId: reloadedBlockNoteIds.includes(Number(noteId)),
 		reloadedNoteBlockTexts,
 		reloadedNoteTargetsAnchor: reloadedNoteBlockTexts.some((text) => text.includes('Homeboy note anchor target')),
+		reloadedAttachmentBlockClientId: reloadedAttachmentBlock?.clientId || null,
+		reloadedCoreNoteMarkers,
+		reloadedHasCoreNoteMarker: reloadedCoreNoteMarkers.length > 0,
+		reloadedNoteEntity: reloadedNoteEntity ? { id: reloadedNoteEntity.id, post: reloadedNoteEntity.post } : null,
+		reloadedNoteEntityResolvesToAttachment: Number(reloadedNoteEntity?.id) === Number(noteId) && Number(reloadedNoteEntity?.post) === Number(postId) && !!reloadedAttachmentBlock,
 		reloadedBlockText,
 		reloadedHasDirtyText: reloadedBlockText.includes(dirtyText) || (frameDocument.body.textContent || '').includes(dirtyText),
 	};
@@ -509,6 +527,42 @@ const createNoteOnBlock = async (block, text) => {
 	addButton.click();
 	await waitFor(() => document.body.textContent.includes(text), 'created live note thread ' + text);
 	return waitFor(() => getBlockNoteIds().find((id) => !beforeIds.has(id)), 'new live note id in edited block metadata');
+};
+const selectRichTextRange = (block) => {
+	const editable = document.querySelector('[data-block="' + block.clientId + '"] [contenteditable="true"]');
+	const text = 'note anchor';
+	const walker = document.createTreeWalker(editable, NodeFilter.SHOW_TEXT);
+	let node;
+	while ((node = walker.nextNode())) {
+		const start = node.textContent.indexOf(text);
+		if (start === -1) continue;
+		editable.focus();
+		const range = document.createRange();
+		range.setStart(node, start);
+		range.setEnd(node, start + text.length);
+		const selection = window.getSelection();
+		selection.removeAllRanges();
+		selection.addRange(range);
+		document.dispatchEvent(new Event('selectionchange', { bubbles: true }));
+		return selection.toString();
+	}
+	throw new Error('Could not select rich-text note anchor range');
+};
+const createNoteOnRichTextRange = async (block, text) => {
+	const beforeIds = new Set(getBlockNoteIds());
+	if (selectRichTextRange(block) !== 'note anchor') throw new Error('Rich-text range selection did not match note anchor');
+	for (const combo of [{ metaKey: true }, { ctrlKey: true }]) {
+		(document.activeElement || document).dispatchEvent(new KeyboardEvent('keydown', { key: 'm', code: 'KeyM', altKey: true, bubbles: true, cancelable: true, ...combo }));
+	}
+	const textarea = await waitFor(() => Array.from(document.querySelectorAll('[role="treeitem"][aria-label="New note"] .editor-collab-sidebar-panel__note-form textarea')).find(isVisible), 'rich-text range note textarea');
+	textarea.focus();
+	setFieldValue(textarea, text);
+	const addButton = await waitFor(() => Array.from(textarea.closest('form')?.querySelectorAll('button') || []).find((button) => (button.textContent || '').trim() === 'Add note'), 'rich-text range Add note button');
+	addButton.click();
+	await waitFor(() => document.body.textContent.includes(text), 'created rich-text range note thread ' + text);
+	const noteId = await waitFor(() => getBlockNoteIds().find((id) => !beforeIds.has(id)), 'new rich-text range note id in block metadata');
+	await waitFor(() => getCoreNoteMarkers().some((marker) => marker.clientId === block.clientId && Number(marker.attributes?.['data-id']) === Number(noteId)), 'core/note rich-text marker for note ' + noteId);
+	return noteId;
 };
 const collectLiveCreateCase = async (caseId) => {
 	const item = fixtureState[caseId];
@@ -595,6 +649,30 @@ const collectLiveCreateCase = async (caseId) => {
 		observedRequests: observedRequests.filter((request) => request.url.includes('/wp-sync/v1/save') || request.url.includes('/wp-json/wp/v2/posts/')).slice(-20),
 	};
 };
+const collectInlineRangeLiveCreateCase = async () => {
+	const caseId = 'inline-range-live-create';
+	const item = fixtureState[caseId];
+	if (!item) throw new Error('Missing fixture case ' + caseId);
+	await waitForEditorReady(caseId);
+	const cleanPostBeforeCreate = !window.wp.data.select('core/editor').isEditedPostDirty?.();
+	const block = await waitFor(() => getTargetBlock(caseId), 'rich-text range target block');
+	const noteId = await createNoteOnRichTextRange(block, 'Homeboy inline range note');
+	const targetedPersistenceObserved = await waitFor(() => observedRequests.some((request) => request.url.includes('/wp-json/wp/v2/posts/' + item.post_id) && request.method === 'POST' && request.status >= 200 && request.status < 300 && request.body.includes('_crdt_document') && request.body.includes('metadata') && !request.body.includes('"content"')), 'targeted note metadata persistence');
+	const fullPostSaveObserved = observedRequests.some((request) => request.url.includes('/wp-json/wp/v2/posts/' + item.post_id) && request.method === 'POST' && request.body.includes('"content"'));
+	const reloaded = await collectReloadedEditorState(caseId, item.post_id, noteId, 'Homeboy dirty edit that must stay unsaved.');
+	return {
+		caseId,
+		postId: item.post_id,
+		noteId,
+		cleanPostBeforeCreate,
+		targetedPersistenceObserved,
+		fullPostSaveObserved,
+		...reloaded,
+		logicalOrphan: !reloaded.reloadedHasNoteId,
+		passed: cleanPostBeforeCreate && targetedPersistenceObserved && !fullPostSaveObserved && reloaded.reloadedHasNoteId && reloaded.reloadedHasCoreNoteMarker && reloaded.reloadedNoteEntityResolvesToAttachment,
+		observedRequests: observedRequests.filter((request) => request.url.includes('/wp-json/wp/v2/posts/') || request.url.includes('/wp-json/wp/v2/comments')).slice(-20),
+	};
+};
 const collectCase = async (caseId) => {
 	const item = fixtureState[caseId];
 	if (!item) {
@@ -602,6 +680,9 @@ const collectCase = async (caseId) => {
 	}
 	if (liveCreateCases.includes(caseId)) {
 		return collectLiveCreateCase(caseId);
+	}
+	if (caseId === 'inline-range-live-create') {
+		return collectInlineRangeLiveCreateCase();
 	}
 	return collectBlockAttachment(caseId, item, Number(item.note_id));
 };
@@ -706,6 +787,7 @@ try {
 		dirty_sibling_preserved: caseResults.some( ( item ) => item.caseId === 'dirty-sibling-live-create' && item.persistedHasOriginalSiblingText === true && item.persistedHasDirtyText === false && item.reloadedHasDirtyText === false ),
 		dirty_structural_targets_anchor: caseResults.some( ( item ) => item.caseId === 'dirty-structural-live-create' && item.reloadedNoteTargetsAnchor === true && item.persistedHasDirtyText === false && item.reloadedHasDirtyText === false ),
 		double_live_create_attached: caseResults.some( ( item ) => item.caseId === 'double-live-create' && item.persistedHasAllNoteIds === true && item.reloadedHasAllNoteIds === true ),
+		inline_range_note_persisted: caseResults.some( ( item ) => item.caseId === 'inline-range-live-create' && item.cleanPostBeforeCreate === true && item.targetedPersistenceObserved === true && item.fullPostSaveObserved === false && item.reloadedHasNoteId === true && item.reloadedHasCoreNoteMarker === true && item.reloadedNoteEntityResolvesToAttachment === true ),
 		page_error_count: pageErrors.length,
 		network_response_count: network.filter( ( entry ) => entry.type === 'response' ).length,
 		sync_save_response_count: network.filter( ( entry ) => entry.type === 'response' && JSON.stringify( entry ).includes( '/wp-sync/v1/save' ) ).length,
@@ -785,6 +867,11 @@ try {
 				id: 'double-live-create-preserved-all-notes',
 				status: targetCase !== 'matrix' && targetCase !== 'double-live-create' ? 'pass' : caseResults.every( ( item ) => item.caseId !== 'double-live-create' || ( item.persistedHasAllNoteIds === true && item.reloadedHasAllNoteIds === true ) ) ? 'pass' : 'fail',
 				message: `Double live-create persisted and reloaded all note IDs=${ caseResults.filter( ( item ) => item.caseId === 'double-live-create' ).every( ( item ) => item.persistedHasAllNoteIds === true && item.reloadedHasAllNoteIds === true ) }.`
+			},
+			{
+				id: 'inline-range-note-persisted-after-reload',
+				status: targetCase !== 'matrix' && targetCase !== 'inline-range-live-create' ? 'pass' : caseResults.every( ( item ) => item.caseId !== 'inline-range-live-create' || ( item.cleanPostBeforeCreate === true && item.targetedPersistenceObserved === true && item.fullPostSaveObserved === false && item.reloadedHasNoteId === true && item.reloadedHasCoreNoteMarker === true && item.reloadedNoteEntityResolvesToAttachment === true ) ) ? 'pass' : 'fail',
+				message: `Inline range note used targeted persistence without a full post save and reloaded metadata.noteId=${ caseResults.filter( ( item ) => item.caseId === 'inline-range-live-create' ).every( ( item ) => item.reloadedHasNoteId === true ) }, core/note=${ caseResults.filter( ( item ) => item.caseId === 'inline-range-live-create' ).every( ( item ) => item.reloadedHasCoreNoteMarker === true ) }, and entity attachment=${ caseResults.filter( ( item ) => item.caseId === 'inline-range-live-create' ).every( ( item ) => item.reloadedNoteEntityResolvesToAttachment === true ) }.`
 			},
 			{
 				id: 'page-errors-recorded',

--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -560,7 +560,17 @@ const createNoteOnRichTextRange = async (block, text) => {
 	for (const combo of [{ metaKey: true }, { ctrlKey: true }]) {
 		editable.dispatchEvent(new KeyboardEvent('keydown', { key: 'm', code: 'KeyM', altKey: true, bubbles: true, cancelable: true, ...combo }));
 	}
-	const textarea = await waitFor(() => Array.from(document.querySelectorAll('[role="treeitem"][aria-label="New note"] .editor-collab-sidebar-panel__note-form textarea')).find(isVisible), 'rich-text range note textarea');
+	const findNewNoteField = () => Array.from(document.querySelectorAll('[role="treeitem"][aria-label="New note"] .editor-collab-sidebar-panel__note-form textarea')).find(isVisible);
+	await sleep(500);
+	if (!findNewNoteField()) {
+		const toolbarButtons = Array.from(document.querySelectorAll('.block-editor-block-toolbar button, .block-editor-block-contextual-toolbar button')).filter(isVisible);
+		const optionsButton = toolbarButtons.sort((a, b) => a.getBoundingClientRect().left - b.getBoundingClientRect().left).at(-1);
+		if (!optionsButton) throw new Error('Could not find rich-text toolbar options button');
+		optionsButton.click();
+		const addNoteMenuItem = await waitFor(() => findMenuItemByText('Add note'), 'rich-text Add note menu item');
+		addNoteMenuItem.click();
+	}
+	const textarea = await waitFor(findNewNoteField, 'rich-text range note textarea');
 	textarea.focus();
 	setFieldValue(textarea, text);
 	const addButton = await waitFor(() => Array.from(textarea.closest('form')?.querySelectorAll('button') || []).find((button) => (button.textContent || '').trim() === 'Add note'), 'rich-text range Add note button');

--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -528,31 +528,37 @@ const createNoteOnBlock = async (block, text) => {
 	await waitFor(() => document.body.textContent.includes(text), 'created live note thread ' + text);
 	return waitFor(() => getBlockNoteIds().find((id) => !beforeIds.has(id)), 'new live note id in edited block metadata');
 };
-const selectRichTextRange = (block) => {
-	const editable = document.querySelector('[data-block="' + block.clientId + '"] [contenteditable="true"]');
+const findRichTextEditable = (block) => {
+	const selector = '[data-block="' + block.clientId + '"][contenteditable="true"], [data-block="' + block.clientId + '"] [contenteditable="true"]';
+	const documents = [ document, ...Array.from(document.querySelectorAll('iframe')).map((iframe) => iframe.contentDocument).filter(Boolean) ];
+	return documents.map((editorDocument) => editorDocument.querySelector(selector)).find((editable) => editable?.textContent?.includes('note anchor'));
+};
+const selectRichTextRange = (editable) => {
 	const text = 'note anchor';
-	const walker = document.createTreeWalker(editable, NodeFilter.SHOW_TEXT);
+	const editorDocument = editable.ownerDocument;
+	const walker = editorDocument.createTreeWalker(editable, NodeFilter.SHOW_TEXT);
 	let node;
 	while ((node = walker.nextNode())) {
 		const start = node.textContent.indexOf(text);
 		if (start === -1) continue;
 		editable.focus();
-		const range = document.createRange();
+		const range = editorDocument.createRange();
 		range.setStart(node, start);
 		range.setEnd(node, start + text.length);
-		const selection = window.getSelection();
+		const selection = editorDocument.defaultView.getSelection();
 		selection.removeAllRanges();
 		selection.addRange(range);
-		document.dispatchEvent(new Event('selectionchange', { bubbles: true }));
+		editorDocument.dispatchEvent(new Event('selectionchange', { bubbles: true }));
 		return selection.toString();
 	}
 	throw new Error('Could not select rich-text note anchor range');
 };
 const createNoteOnRichTextRange = async (block, text) => {
 	const beforeIds = new Set(getBlockNoteIds());
-	if (selectRichTextRange(block) !== 'note anchor') throw new Error('Rich-text range selection did not match note anchor');
+	const editable = await waitFor(() => findRichTextEditable(block), 'rich-text note anchor editable');
+	if (selectRichTextRange(editable) !== 'note anchor') throw new Error('Rich-text range selection did not match note anchor');
 	for (const combo of [{ metaKey: true }, { ctrlKey: true }]) {
-		(document.activeElement || document).dispatchEvent(new KeyboardEvent('keydown', { key: 'm', code: 'KeyM', altKey: true, bubbles: true, cancelable: true, ...combo }));
+		editable.dispatchEvent(new KeyboardEvent('keydown', { key: 'm', code: 'KeyM', altKey: true, bubbles: true, cancelable: true, ...combo }));
 	}
 	const textarea = await waitFor(() => Array.from(document.querySelectorAll('[role="treeitem"][aria-label="New note"] .editor-collab-sidebar-panel__note-form textarea')).find(isVisible), 'rich-text range note textarea');
 	textarea.focus();

--- a/WordPress/gutenberg/fuzz/gutenberg-notes-attachment-corpus.json
+++ b/WordPress/gutenberg/fuzz/gutenberg-notes-attachment-corpus.json
@@ -11,7 +11,6 @@
   "operations": [
     "missing-anchor-load",
     "saved-anchor-load",
-    "autosave-anchor-load",
     "live-note-create",
     "dirty-block-live-note-create",
     "dirty-sibling-live-note-create",
@@ -19,7 +18,7 @@
     "nested-live-note-create",
     "repeated-live-note-create"
   ],
-  "case_budget": 9,
+  "case_budget": 8,
   "duration_budget_seconds": 2700,
   "metadata": {
     "kind": "gutenberg-browser-fuzz",
@@ -27,12 +26,11 @@
     "source_issue": "github_issue:WordPress/gutenberg#72717",
     "readiness": {
       "level": "executable",
-      "coverage_contract": "The checked-in corpus executes nine Block Notes attachment and persistence cases in disposable WP Codebox browser runtimes and emits replayable case-level evidence."
+      "coverage_contract": "The checked-in corpus builds the exact Gutenberg checkout, executes eight Block Notes attachment and persistence cases in disposable WP Codebox browser runtimes, proves plugin bundle provenance, and emits replayable case-level evidence."
     },
     "corpus_cases": [
       { "id": "orphan", "operation": "missing-anchor-load", "invariant": "A note whose ID is absent from block metadata is classified as detached." },
       { "id": "saved-anchor", "operation": "saved-anchor-load", "invariant": "Saved metadata.noteId attaches the note to its block." },
-      { "id": "autosave-anchor", "operation": "autosave-anchor-load", "invariant": "Autosaved metadata.noteId attaches the note to its block." },
       { "id": "live-create", "operation": "live-note-create", "invariant": "Creating a note persists its ID and restores the attachment after reload." },
       { "id": "dirty-live-create", "operation": "dirty-block-live-note-create", "invariant": "Repair persistence attaches the note while preserving the unsaved edit boundary." },
       { "id": "dirty-sibling-live-create", "operation": "dirty-sibling-live-note-create", "invariant": "Repair persistence preserves saved sibling content and the unsaved sibling edit boundary." },
@@ -63,7 +61,6 @@
       "operations": [
         "missing-anchor-load",
         "saved-anchor-load",
-        "autosave-anchor-load",
         "live-note-create",
         "dirty-block-live-note-create",
         "dirty-sibling-live-note-create",
@@ -82,7 +79,7 @@
     }
   ],
   "limits": {
-    "max_cases": 9,
+    "max_cases": 8,
     "max_duration_seconds": 2700
   },
   "coverage": {
@@ -94,7 +91,6 @@
     "operations": [
       "missing-anchor-load",
       "saved-anchor-load",
-      "autosave-anchor-load",
       "live-note-create",
       "dirty-block-live-note-create",
       "dirty-sibling-live-note-create",

--- a/WordPress/gutenberg/fuzz/gutenberg-notes-attachment-corpus.json
+++ b/WordPress/gutenberg/fuzz/gutenberg-notes-attachment-corpus.json
@@ -16,9 +16,10 @@
     "dirty-sibling-live-note-create",
     "dirty-structural-live-note-create",
     "nested-live-note-create",
-    "repeated-live-note-create"
+    "repeated-live-note-create",
+    "inline-range-note-persistence"
   ],
-  "case_budget": 8,
+  "case_budget": 9,
   "duration_budget_seconds": 2700,
   "metadata": {
     "kind": "gutenberg-browser-fuzz",
@@ -26,7 +27,7 @@
     "source_issue": "github_issue:WordPress/gutenberg#72717",
     "readiness": {
       "level": "executable",
-      "coverage_contract": "The checked-in corpus builds the exact Gutenberg checkout, executes eight Block Notes attachment and persistence cases in disposable WP Codebox browser runtimes, proves plugin bundle provenance, and emits replayable case-level evidence."
+      "coverage_contract": "The checked-in corpus builds the exact Gutenberg checkout, executes nine Block Notes attachment and persistence cases in disposable WP Codebox browser runtimes, proves plugin bundle provenance, and emits replayable case-level evidence."
     },
     "corpus_cases": [
       { "id": "orphan", "operation": "missing-anchor-load", "invariant": "A note whose ID is absent from block metadata is classified as detached." },
@@ -36,7 +37,8 @@
       { "id": "dirty-sibling-live-create", "operation": "dirty-sibling-live-note-create", "invariant": "Repair persistence preserves saved sibling content and the unsaved sibling edit boundary." },
       { "id": "dirty-structural-live-create", "operation": "dirty-structural-live-note-create", "invariant": "Repair persistence targets the intended anchor across an unsaved structural insertion." },
       { "id": "nested-live-create", "operation": "nested-live-note-create", "invariant": "A note attached to a nested block remains attached after reload." },
-      { "id": "double-live-create", "operation": "repeated-live-note-create", "invariant": "Repeated note creation persists and restores every note ID." }
+      { "id": "double-live-create", "operation": "repeated-live-note-create", "invariant": "Repeated note creation persists and restores every note ID." },
+      { "id": "inline-range-live-create", "operation": "inline-range-note-persistence", "invariant": "A clean-post note created from a rich-text range persists through the targeted note path and reloads with its metadata, core/note marker, and note entity block attachment." }
     ]
   },
   "target": {
@@ -66,7 +68,8 @@
         "dirty-sibling-live-note-create",
         "dirty-structural-live-note-create",
         "nested-live-note-create",
-        "repeated-live-note-create"
+        "repeated-live-note-create",
+        "inline-range-note-persistence"
       ],
       "artifacts": [
         { "name": "case_log", "path": "case-log.jsonl", "required": true, "metadata": { "semantic_key": "fuzz.case_log" } },
@@ -79,7 +82,7 @@
     }
   ],
   "limits": {
-    "max_cases": 8,
+    "max_cases": 9,
     "max_duration_seconds": 2700
   },
   "coverage": {
@@ -96,7 +99,8 @@
       "dirty-sibling-live-note-create",
       "dirty-structural-live-note-create",
       "nested-live-note-create",
-      "repeated-live-note-create"
+      "repeated-live-note-create",
+      "inline-range-note-persistence"
     ]
   },
   "artifacts": {

--- a/WordPress/gutenberg/fuzz/gutenberg-notes-attachment-corpus.json
+++ b/WordPress/gutenberg/fuzz/gutenberg-notes-attachment-corpus.json
@@ -1,0 +1,113 @@
+{
+  "schema": "homeboy/fuzz-workload/v1",
+  "id": "gutenberg-notes-attachment-corpus",
+  "label": "Gutenberg Block Notes attachment persistence corpus",
+  "safety_class": "isolated_mutation",
+  "surface_ids": [
+    "gutenberg-block-editor",
+    "gutenberg-block-notes",
+    "gutenberg-collaboration-persistence"
+  ],
+  "operations": [
+    "missing-anchor-load",
+    "saved-anchor-load",
+    "autosave-anchor-load",
+    "live-note-create",
+    "dirty-block-live-note-create",
+    "dirty-sibling-live-note-create",
+    "dirty-structural-live-note-create",
+    "nested-live-note-create",
+    "repeated-live-note-create"
+  ],
+  "case_budget": 9,
+  "duration_budget_seconds": 2700,
+  "metadata": {
+    "kind": "gutenberg-browser-fuzz",
+    "tracker": "github_pr:WordPress/gutenberg#79020",
+    "source_issue": "github_issue:WordPress/gutenberg#72717",
+    "readiness": {
+      "level": "executable",
+      "coverage_contract": "The checked-in corpus executes nine Block Notes attachment and persistence cases in disposable WP Codebox browser runtimes and emits replayable case-level evidence."
+    },
+    "corpus_cases": [
+      { "id": "orphan", "operation": "missing-anchor-load", "invariant": "A note whose ID is absent from block metadata is classified as detached." },
+      { "id": "saved-anchor", "operation": "saved-anchor-load", "invariant": "Saved metadata.noteId attaches the note to its block." },
+      { "id": "autosave-anchor", "operation": "autosave-anchor-load", "invariant": "Autosaved metadata.noteId attaches the note to its block." },
+      { "id": "live-create", "operation": "live-note-create", "invariant": "Creating a note persists its ID and restores the attachment after reload." },
+      { "id": "dirty-live-create", "operation": "dirty-block-live-note-create", "invariant": "Repair persistence attaches the note while preserving the unsaved edit boundary." },
+      { "id": "dirty-sibling-live-create", "operation": "dirty-sibling-live-note-create", "invariant": "Repair persistence preserves saved sibling content and the unsaved sibling edit boundary." },
+      { "id": "dirty-structural-live-create", "operation": "dirty-structural-live-note-create", "invariant": "Repair persistence targets the intended anchor across an unsaved structural insertion." },
+      { "id": "nested-live-create", "operation": "nested-live-note-create", "invariant": "A note attached to a nested block remains attached after reload." },
+      { "id": "double-live-create", "operation": "repeated-live-note-create", "invariant": "Repeated note creation persists and restores every note ID." }
+    ]
+  },
+  "target": {
+    "type": "wordpress-plugin",
+    "slug": "gutenberg",
+    "component": "gutenberg"
+  },
+  "workload": {
+    "runner": "nodejs",
+    "type": "module",
+    "path": "${package.root}/fuzz/gutenberg-notes-unsaved-attachment.mjs",
+    "entry": "main"
+  },
+  "cases": [
+    {
+      "case_id": "gutenberg-notes-attachment-corpus:corpus",
+      "surface_ids": [
+        "gutenberg-block-editor",
+        "gutenberg-block-notes",
+        "gutenberg-collaboration-persistence"
+      ],
+      "operations": [
+        "missing-anchor-load",
+        "saved-anchor-load",
+        "autosave-anchor-load",
+        "live-note-create",
+        "dirty-block-live-note-create",
+        "dirty-sibling-live-note-create",
+        "dirty-structural-live-note-create",
+        "nested-live-note-create",
+        "repeated-live-note-create"
+      ],
+      "artifacts": [
+        { "name": "case_log", "path": "case-log.jsonl", "required": true, "metadata": { "semantic_key": "fuzz.case_log" } },
+        { "name": "replay_data", "path": "replay.json", "required": true, "metadata": { "semantic_key": "fuzz.replay" } },
+        { "name": "result_envelope", "path": "results.json", "required": true, "metadata": { "semantic_key": "fuzz.report" } }
+      ],
+      "metadata": {
+        "safety_class": "isolated_mutation"
+      }
+    }
+  ],
+  "limits": {
+    "max_cases": 9,
+    "max_duration_seconds": 2700
+  },
+  "coverage": {
+    "surface_ids": [
+      "gutenberg-block-editor",
+      "gutenberg-block-notes",
+      "gutenberg-collaboration-persistence"
+    ],
+    "operations": [
+      "missing-anchor-load",
+      "saved-anchor-load",
+      "autosave-anchor-load",
+      "live-note-create",
+      "dirty-block-live-note-create",
+      "dirty-sibling-live-note-create",
+      "dirty-structural-live-note-create",
+      "nested-live-note-create",
+      "repeated-live-note-create"
+    ]
+  },
+  "artifacts": {
+    "expected": [
+      { "name": "case_log", "role": "case_log", "semantic_key": "fuzz.case_log", "required": true },
+      { "name": "replay_data", "role": "replay_data", "semantic_key": "fuzz.replay", "required": true },
+      { "name": "result_envelope", "role": "result_envelope", "semantic_key": "fuzz.report", "required": true }
+    ]
+  }
+}

--- a/WordPress/gutenberg/fuzz/gutenberg-notes-attachment-corpus.json
+++ b/WordPress/gutenberg/fuzz/gutenberg-notes-attachment-corpus.json
@@ -17,9 +17,15 @@
     "dirty-structural-live-note-create",
     "nested-live-note-create",
     "repeated-live-note-create",
-    "inline-range-note-persistence"
+    "inline-range-note-persistence",
+    "no-saved-match-live-mutation",
+    "ambiguous-contentless-siblings",
+    "empty-saved-content-unsaved-note",
+    "store-coherence-before-dependent-operation",
+    "repair-sync-order-race",
+    "crdt-peer-lineage-reload"
   ],
-  "case_budget": 9,
+  "case_budget": 15,
   "duration_budget_seconds": 2700,
   "metadata": {
     "kind": "gutenberg-browser-fuzz",
@@ -27,7 +33,7 @@
     "source_issue": "github_issue:WordPress/gutenberg#72717",
     "readiness": {
       "level": "executable",
-      "coverage_contract": "The checked-in corpus builds the exact Gutenberg checkout, executes nine Block Notes attachment and persistence cases in disposable WP Codebox browser runtimes, proves plugin bundle provenance, and emits replayable case-level evidence."
+      "coverage_contract": "The checked-in corpus builds the exact Gutenberg checkout, executes fifteen Block Notes attachment and persistence cases in disposable WP Codebox browser runtimes, proves plugin bundle provenance, captures actor and request timelines, and emits replayable case-level evidence."
     },
     "corpus_cases": [
       { "id": "orphan", "operation": "missing-anchor-load", "invariant": "A note whose ID is absent from block metadata is classified as detached." },
@@ -38,7 +44,13 @@
       { "id": "dirty-structural-live-create", "operation": "dirty-structural-live-note-create", "invariant": "Repair persistence targets the intended anchor across an unsaved structural insertion." },
       { "id": "nested-live-create", "operation": "nested-live-note-create", "invariant": "A note attached to a nested block remains attached after reload." },
       { "id": "double-live-create", "operation": "repeated-live-note-create", "invariant": "Repeated note creation persists and restores every note ID." },
-      { "id": "inline-range-live-create", "operation": "inline-range-note-persistence", "invariant": "A clean-post note created from a rich-text range persists through the targeted note path and reloads with its metadata, core/note marker, and note entity block attachment." }
+      { "id": "inline-range-live-create", "operation": "inline-range-note-persistence", "invariant": "A clean-post note created from a rich-text range persists through the targeted note path and reloads with its metadata, core/note marker, and note entity block attachment." },
+      { "id": "no-saved-match", "operation": "no-saved-match-live-mutation", "invariant": "When a live target no longer matches any saved block, repair never attaches the note to a known-invalid saved block." },
+      { "id": "ambiguous-contentless", "operation": "ambiguous-contentless-siblings", "invariant": "Identical contentless siblings retain the selected sibling as the exact note attachment target after an unsaved path shift." },
+      { "id": "empty-saved-content", "operation": "empty-saved-content-unsaved-note", "invariant": "An empty saved document plus an unsaved inserted note target produces no parse error or unintended full editor save." },
+      { "id": "store-coherence", "operation": "store-coherence-before-dependent-operation", "invariant": "Block-editor and editor stores agree on the repaired attachment before a dependent second note operation." },
+      { "id": "repair-sync-race", "operation": "repair-sync-order-race", "invariant": "Seeded REST and wp-sync request ordering converges with every created note ID attached." },
+      { "id": "crdt-peer-lineage", "operation": "crdt-peer-lineage-reload", "invariant": "A second same-origin editor peer reloads persisted CRDT lineage without duplicate blocks or text and retains the attachment." }
     ]
   },
   "target": {
@@ -69,7 +81,13 @@
         "dirty-structural-live-note-create",
         "nested-live-note-create",
         "repeated-live-note-create",
-        "inline-range-note-persistence"
+        "inline-range-note-persistence",
+        "no-saved-match-live-mutation",
+        "ambiguous-contentless-siblings",
+        "empty-saved-content-unsaved-note",
+        "store-coherence-before-dependent-operation",
+        "repair-sync-order-race",
+        "crdt-peer-lineage-reload"
       ],
       "artifacts": [
         { "name": "case_log", "path": "case-log.jsonl", "required": true, "metadata": { "semantic_key": "fuzz.case_log" } },
@@ -82,7 +100,7 @@
     }
   ],
   "limits": {
-    "max_cases": 9,
+    "max_cases": 15,
     "max_duration_seconds": 2700
   },
   "coverage": {
@@ -100,7 +118,13 @@
       "dirty-structural-live-note-create",
       "nested-live-note-create",
       "repeated-live-note-create",
-      "inline-range-note-persistence"
+      "inline-range-note-persistence",
+      "no-saved-match-live-mutation",
+      "ambiguous-contentless-siblings",
+      "empty-saved-content-unsaved-note",
+      "store-coherence-before-dependent-operation",
+      "repair-sync-order-race",
+      "crdt-peer-lineage-reload"
     ]
   },
   "artifacts": {

--- a/WordPress/gutenberg/fuzz/gutenberg-notes-unsaved-attachment.mjs
+++ b/WordPress/gutenberg/fuzz/gutenberg-notes-unsaved-attachment.mjs
@@ -24,6 +24,7 @@ const corpus = [
 	[ 'dirty-structural-live-create', 'dirty-structural-live-note-create' ],
 	[ 'nested-live-create', 'nested-live-note-create' ],
 	[ 'double-live-create', 'repeated-live-note-create' ],
+	[ 'inline-range-live-create', 'inline-range-note-persistence' ],
 ];
 
 await mkdir( artifactsDir, { recursive: true } );

--- a/WordPress/gutenberg/fuzz/gutenberg-notes-unsaved-attachment.mjs
+++ b/WordPress/gutenberg/fuzz/gutenberg-notes-unsaved-attachment.mjs
@@ -1,0 +1,188 @@
+import { spawn } from 'node:child_process';
+import { mkdir, readFile, writeFile, appendFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = path.resolve( path.dirname( fileURLToPath( import.meta.url ) ), '..' );
+const tracePath = path.join( packageRoot, 'bench/notes-unsaved-attachment.trace.mjs' );
+const artifactsDir = process.env.HOMEBOY_FUZZ_ARTIFACTS_DIR || path.join( packageRoot, 'artifacts/fuzz/notes-unsaved-attachment' );
+const resultsFile = process.env.HOMEBOY_FUZZ_RESULTS_FILE || path.join( artifactsDir, 'results.json' );
+const runId = process.env.HOMEBOY_FUZZ_RUN_ID || `gutenberg-notes-${ Date.now() }`;
+const workloadId = process.env.HOMEBOY_FUZZ_WORKLOAD_ID || 'gutenberg-notes-attachment-corpus';
+const requestFile = process.env.HOMEBOY_FUZZ_EXECUTION_REQUEST_FILE || null;
+const caseLogPath = path.join( artifactsDir, 'case-log.jsonl' );
+const replayPath = path.join( artifactsDir, 'replay.json' );
+
+const corpus = [
+	[ 'orphan', 'missing-anchor-load' ],
+	[ 'saved-anchor', 'saved-anchor-load' ],
+	[ 'autosave-anchor', 'autosave-anchor-load' ],
+	[ 'live-create', 'live-note-create' ],
+	[ 'dirty-live-create', 'dirty-block-live-note-create' ],
+	[ 'dirty-sibling-live-create', 'dirty-sibling-live-note-create' ],
+	[ 'dirty-structural-live-create', 'dirty-structural-live-note-create' ],
+	[ 'nested-live-create', 'nested-live-note-create' ],
+	[ 'double-live-create', 'repeated-live-note-create' ],
+];
+
+await mkdir( artifactsDir, { recursive: true } );
+await writeFile( caseLogPath, '' );
+
+function runTrace( caseId, resultFile, caseArtifactsDir ) {
+	return new Promise( ( resolve ) => {
+		const started = performance.now();
+		const child = spawn( process.execPath, [ tracePath ], {
+			cwd: packageRoot,
+			env: {
+				...process.env,
+				HOMEBOY_GUTENBERG_NOTES_CASE: caseId,
+				HOMEBOY_TRACE_PROFILE: caseId,
+				HOMEBOY_TRACE_SCENARIO: 'notes-unsaved-attachment',
+				HOMEBOY_TRACE_RESULTS_FILE: resultFile,
+				HOMEBOY_TRACE_ARTIFACT_DIR: caseArtifactsDir,
+			},
+			stdio: [ 'ignore', 'pipe', 'pipe' ],
+		} );
+		let stdout = '';
+		let stderr = '';
+		child.stdout.on( 'data', ( chunk ) => { stdout += chunk; } );
+		child.stderr.on( 'data', ( chunk ) => { stderr += chunk; } );
+		child.on( 'error', ( error ) => resolve( {
+			exitCode: null,
+			durationMs: Math.round( performance.now() - started ),
+			stdout,
+			stderr: `${ stderr }\n${ error.stack || error }`.trim(),
+		} ) );
+		child.on( 'close', ( exitCode ) => resolve( {
+			exitCode,
+			durationMs: Math.round( performance.now() - started ),
+			stdout,
+			stderr,
+		} ) );
+	} );
+}
+
+async function readJson( file ) {
+	try {
+		return JSON.parse( await readFile( file, 'utf8' ) );
+	} catch {
+		return null;
+	}
+}
+
+const cases = [];
+const findings = [];
+
+for ( const [ caseId, operationId ] of corpus ) {
+	const caseDir = path.join( artifactsDir, 'cases', caseId );
+	const traceResultFile = path.join( caseDir, 'trace-result.json' );
+	const traceArtifactsDir = path.join( caseDir, 'artifacts' );
+	await mkdir( traceArtifactsDir, { recursive: true } );
+
+	const execution = await runTrace( caseId, traceResultFile, traceArtifactsDir );
+	const traceResult = await readJson( traceResultFile );
+	const status = execution.exitCode === 0 && traceResult?.status === 'pass' ? 'passed' : traceResult ? 'failed' : 'error';
+	const entry = {
+		schema: 'homeboy/fuzz-case/v1',
+		id: caseId,
+		target_id: 'gutenberg-block-notes',
+		operation_id: operationId,
+		workload_id: workloadId,
+		observed: {
+			status,
+			exit_code: execution.exitCode,
+			duration_ms: execution.durationMs,
+			trace_status: traceResult?.status || null,
+			trace_summary: traceResult?.summary || null,
+			assertions: traceResult?.assertions || [],
+			stdout_tail: execution.stdout.slice( -4000 ),
+			stderr_tail: execution.stderr.slice( -4000 ),
+		},
+		metadata: {
+			trace_result: path.relative( artifactsDir, traceResultFile ),
+			trace_artifacts: path.relative( artifactsDir, traceArtifactsDir ),
+			replay: {
+				run_id: runId,
+				case_id: caseId,
+				command: `homeboy fuzz run gutenberg --rig gutenberg-api-route-inventory --workload ${ workloadId } --run-id ${ runId }`,
+			},
+		},
+	};
+	cases.push( entry );
+	await appendFile( caseLogPath, `${ JSON.stringify( entry ) }\n` );
+
+	if ( status !== 'passed' ) {
+		findings.push( {
+			schema: 'homeboy/fuzz-finding/v1',
+			id: `${ caseId }-failure`,
+			status: 'open',
+			severity: status === 'error' ? 'critical' : 'high',
+			title: `Gutenberg Block Notes fuzz case failed: ${ caseId }`,
+			target_id: 'gutenberg-block-notes',
+			operation_id: operationId,
+			case_id: caseId,
+			metadata: entry.observed,
+		} );
+	}
+}
+
+const replay = {
+	schema: 'homeboy/fuzz-replay/v1',
+	run_id: runId,
+	request_file: requestFile,
+	metadata: {
+		workload_id: workloadId,
+		component_path: process.env.HOMEBOY_COMPONENT_PATH || null,
+		cases: corpus.map( ( [ caseId ] ) => caseId ),
+		command: `homeboy fuzz run gutenberg --rig gutenberg-api-route-inventory --workload ${ workloadId } --run-id ${ runId }`,
+	},
+};
+await writeFile( replayPath, `${ JSON.stringify( replay, null, 2 ) }\n` );
+
+const campaign = {
+	schema: 'homeboy/fuzz-campaign/v1',
+	version: 1,
+	id: runId,
+	title: 'Gutenberg Block Notes attachment persistence corpus',
+	safety_class: 'isolated_mutation',
+	cases,
+	findings,
+	coverage_summary: {
+		schema: 'homeboy/fuzz-coverage-summary/v1',
+		declared_targets: 1,
+		executable_targets: 1,
+		proven_targets: cases.length > 0 ? 1 : 0,
+		declared_operations: corpus.length,
+		executable_operations: corpus.length,
+		proven_operations: cases.filter( ( entry ) => entry.observed.status === 'passed' ).length,
+		skipped_targets: [],
+		skipped_operations: [],
+		surface_summaries: [],
+		kind_summaries: [],
+		artifact_ids: [ 'case-log', 'replay-data', 'result-envelope' ],
+	},
+	artifacts: [
+		{ schema: 'homeboy/fuzz-artifact/v1', id: 'case-log', kind: 'case_log', artifact: { schema: 'homeboy/artifact-contract/v1', kind: 'case_log', type: 'file', path: 'case-log.jsonl', role: 'case_log' } },
+		{ schema: 'homeboy/fuzz-artifact/v1', id: 'replay-data', kind: 'replay_data', artifact: { schema: 'homeboy/artifact-contract/v1', kind: 'replay_data', type: 'file', path: 'replay.json', role: 'replay_data' } },
+		{ schema: 'homeboy/fuzz-artifact/v1', id: 'result-envelope', kind: 'result_envelope', artifact: { schema: 'homeboy/artifact-contract/v1', kind: 'result_envelope', type: 'file', path: path.relative( artifactsDir, resultsFile ), role: 'result_envelope' } },
+	],
+	metadata: {
+		status: findings.length ? 'failed' : 'passed',
+		success: findings.length === 0,
+		case_counts: {
+			passed: cases.filter( ( entry ) => entry.observed.status === 'passed' ).length,
+			failed: cases.filter( ( entry ) => entry.observed.status === 'failed' ).length,
+			errored: cases.filter( ( entry ) => entry.observed.status === 'error' ).length,
+			skipped: 0,
+		},
+		artifact_refs: [
+			{ kind: 'case_log', path: 'case-log.jsonl' },
+			{ kind: 'replay_data', path: 'replay.json' },
+			{ kind: 'result_envelope', path: path.relative( artifactsDir, resultsFile ) },
+		],
+	},
+};
+
+await mkdir( path.dirname( resultsFile ), { recursive: true } );
+await writeFile( resultsFile, `${ JSON.stringify( campaign, null, 2 ) }\n` );
+process.exitCode = findings.length ? 1 : 0;

--- a/WordPress/gutenberg/fuzz/gutenberg-notes-unsaved-attachment.mjs
+++ b/WordPress/gutenberg/fuzz/gutenberg-notes-unsaved-attachment.mjs
@@ -25,6 +25,12 @@ const corpus = [
 	[ 'nested-live-create', 'nested-live-note-create' ],
 	[ 'double-live-create', 'repeated-live-note-create' ],
 	[ 'inline-range-live-create', 'inline-range-note-persistence' ],
+	[ 'no-saved-match', 'no-saved-match-live-mutation' ],
+	[ 'ambiguous-contentless', 'ambiguous-contentless-siblings' ],
+	[ 'empty-saved-content', 'empty-saved-content-unsaved-note' ],
+	[ 'store-coherence', 'store-coherence-before-dependent-operation' ],
+	[ 'repair-sync-race', 'repair-sync-order-race' ],
+	[ 'crdt-peer-lineage', 'crdt-peer-lineage-reload' ],
 ];
 
 await mkdir( artifactsDir, { recursive: true } );
@@ -99,6 +105,7 @@ function runTrace( caseId, resultFile, caseArtifactsDir ) {
 				HOMEBOY_TRACE_SCENARIO: 'notes-unsaved-attachment',
 				HOMEBOY_TRACE_RESULTS_FILE: resultFile,
 				HOMEBOY_TRACE_ARTIFACT_DIR: caseArtifactsDir,
+				HOMEBOY_SEED: process.env.HOMEBOY_SEED || '',
 			},
 			stdio: [ 'ignore', 'pipe', 'pipe' ],
 		} );
@@ -191,6 +198,7 @@ const replay = {
 	request_file: requestFile,
 	metadata: {
 		workload_id: workloadId,
+		seed: process.env.HOMEBOY_SEED || null,
 		component_path: componentPath,
 		build_provenance: buildProvenance,
 		cases: corpus.map( ( [ caseId ] ) => caseId ),

--- a/WordPress/gutenberg/fuzz/gutenberg-notes-unsaved-attachment.mjs
+++ b/WordPress/gutenberg/fuzz/gutenberg-notes-unsaved-attachment.mjs
@@ -60,9 +60,15 @@ const requiredBuildFiles = [
 	'build/scripts/editor/index.min.js',
 ];
 const missingBuildFiles = () => requiredBuildFiles.filter( ( relativePath ) => ! existsSync( path.join( componentPath, relativePath ) ) );
+const buildDependency = path.join( componentPath, 'node_modules/cross-spawn/package.json' );
+let hydratedDependencies = false;
 let builtComponent = false;
 
 if ( missingBuildFiles().length ) {
+	if ( ! existsSync( buildDependency ) ) {
+		await runCommand( 'npm', [ 'ci' ], { cwd: componentPath } );
+		hydratedDependencies = true;
+	}
 	await runCommand( 'npm', [ 'run', 'build', '--', '--skip-types' ], { cwd: componentPath } );
 	builtComponent = true;
 }
@@ -75,6 +81,7 @@ if ( missingAfterBuild.length ) {
 const { stdout: gitShaOutput } = await runCommand( 'git', [ 'rev-parse', 'HEAD' ], { cwd: componentPath } );
 const buildProvenance = {
 	component_git_sha: gitShaOutput.trim(),
+	dependencies_hydrated_by_workload: hydratedDependencies,
 	built_by_workload: builtComponent,
 	required_build_files: requiredBuildFiles,
 };

--- a/WordPress/gutenberg/fuzz/gutenberg-notes-unsaved-attachment.mjs
+++ b/WordPress/gutenberg/fuzz/gutenberg-notes-unsaved-attachment.mjs
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile, appendFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -12,11 +13,11 @@ const workloadId = process.env.HOMEBOY_FUZZ_WORKLOAD_ID || 'gutenberg-notes-atta
 const requestFile = process.env.HOMEBOY_FUZZ_EXECUTION_REQUEST_FILE || null;
 const caseLogPath = path.join( artifactsDir, 'case-log.jsonl' );
 const replayPath = path.join( artifactsDir, 'replay.json' );
+const componentPath = process.env.HOMEBOY_COMPONENT_PATH;
 
 const corpus = [
 	[ 'orphan', 'missing-anchor-load' ],
 	[ 'saved-anchor', 'saved-anchor-load' ],
-	[ 'autosave-anchor', 'autosave-anchor-load' ],
 	[ 'live-create', 'live-note-create' ],
 	[ 'dirty-live-create', 'dirty-block-live-note-create' ],
 	[ 'dirty-sibling-live-create', 'dirty-sibling-live-note-create' ],
@@ -27,6 +28,56 @@ const corpus = [
 
 await mkdir( artifactsDir, { recursive: true } );
 await writeFile( caseLogPath, '' );
+
+if ( ! componentPath ) {
+	throw new Error( 'HOMEBOY_COMPONENT_PATH is required' );
+}
+
+function runCommand( command, args, options = {} ) {
+	return new Promise( ( resolve, reject ) => {
+		const child = spawn( command, args, {
+			...options,
+			stdio: [ 'ignore', 'pipe', 'pipe' ],
+		} );
+		let stdout = '';
+		let stderr = '';
+		child.stdout.on( 'data', ( chunk ) => { stdout += chunk; } );
+		child.stderr.on( 'data', ( chunk ) => { stderr += chunk; } );
+		child.on( 'error', reject );
+		child.on( 'close', ( exitCode ) => {
+			if ( exitCode !== 0 ) {
+				reject( new Error( `${ command } ${ args.join( ' ' ) } failed with exit code ${ exitCode }:\n${ stderr || stdout }` ) );
+				return;
+			}
+			resolve( { stdout, stderr } );
+		} );
+	} );
+}
+
+const requiredBuildFiles = [
+	'build/scripts/blocks',
+	'build/scripts/core-data/index.min.js',
+	'build/scripts/editor/index.min.js',
+];
+const missingBuildFiles = () => requiredBuildFiles.filter( ( relativePath ) => ! existsSync( path.join( componentPath, relativePath ) ) );
+let builtComponent = false;
+
+if ( missingBuildFiles().length ) {
+	await runCommand( 'npm', [ 'run', 'build', '--', '--skip-types' ], { cwd: componentPath } );
+	builtComponent = true;
+}
+
+const missingAfterBuild = missingBuildFiles();
+if ( missingAfterBuild.length ) {
+	throw new Error( `Gutenberg build did not produce required runtime files: ${ missingAfterBuild.join( ', ' ) }` );
+}
+
+const { stdout: gitShaOutput } = await runCommand( 'git', [ 'rev-parse', 'HEAD' ], { cwd: componentPath } );
+const buildProvenance = {
+	component_git_sha: gitShaOutput.trim(),
+	built_by_workload: builtComponent,
+	required_build_files: requiredBuildFiles,
+};
 
 function runTrace( caseId, resultFile, caseArtifactsDir ) {
 	return new Promise( ( resolve ) => {
@@ -132,7 +183,8 @@ const replay = {
 	request_file: requestFile,
 	metadata: {
 		workload_id: workloadId,
-		component_path: process.env.HOMEBOY_COMPONENT_PATH || null,
+		component_path: componentPath,
+		build_provenance: buildProvenance,
 		cases: corpus.map( ( [ caseId ] ) => caseId ),
 		command: `homeboy fuzz run gutenberg --rig gutenberg-api-route-inventory --workload ${ workloadId } --run-id ${ runId }`,
 	},
@@ -169,6 +221,7 @@ const campaign = {
 	metadata: {
 		status: findings.length ? 'failed' : 'passed',
 		success: findings.length === 0,
+		build_provenance: buildProvenance,
 		case_counts: {
 			passed: cases.filter( ( entry ) => entry.observed.status === 'passed' ).length,
 			failed: cases.filter( ( entry ) => entry.observed.status === 'failed' ).length,

--- a/WordPress/gutenberg/manifests/fuzzer-profile.json
+++ b/WordPress/gutenberg/manifests/fuzzer-profile.json
@@ -23,7 +23,8 @@
       "gutenberg-rest-db-query-profile-fuzz",
       "gutenberg-hooks-options-inventory",
       "gutenberg-editor-performance-observation",
-      "gutenberg-external-http-guardrail-fuzz"
+      "gutenberg-external-http-guardrail-fuzz",
+      "gutenberg-notes-attachment-corpus"
     ]
   },
   "surfaces": {
@@ -49,6 +50,12 @@
       ],
       "captures": ["steps", "console", "errors", "network", "html", "screenshot", "dom-snapshot"],
       "gap_rule": "Report editor screens that load but produce failed browser actions, browser errors, or no request coverage."
+    },
+    "block_notes_attachment_persistence": {
+      "workloads": ["gutenberg-notes-attachment-corpus"],
+      "corpus": "fuzz/gutenberg-notes-attachment-corpus.json#metadata/corpus_cases",
+      "trace_workload": "bench/notes-unsaved-attachment.trace.mjs",
+      "gap_rule": "Report declared Block Notes attachment cases without case-level execution, replay, and result-envelope artifacts."
     },
     "frontend_rendering_request_coverage": {
       "workloads": ["frontend-rendering-request-coverage"],

--- a/WordPress/gutenberg/rigs/gutenberg-api-route-inventory/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-api-route-inventory/rig.json
@@ -7,6 +7,7 @@
       "path": "${env.HOMEBOY_RIG_COMPONENT_PATH__GUTENBERG_API_ROUTE_INVENTORY__GUTENBERG}",
       "branch": "trunk",
       "extensions": {
+        "nodejs": {},
         "wordpress": {
           "wp_codebox_wordpress_version": "7.0",
           "wp_codebox_source_root": "${env.HOMEBOY_RIG_COMPONENT_PATH__GUTENBERG_API_ROUTE_INVENTORY__GUTENBERG}",

--- a/WordPress/gutenberg/rigs/gutenberg-notes-unsaved-attachment/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-notes-unsaved-attachment/rig.json
@@ -106,6 +106,12 @@
       "settings": {
         "gutenberg_notes_case": "double-live-create"
       }
+    },
+    "inline-range-live-create": {
+      "scenario": "notes-unsaved-attachment",
+      "settings": {
+        "gutenberg_notes_case": "inline-range-live-create"
+      }
     }
   },
   "pipeline": {

--- a/WordPress/gutenberg/rigs/gutenberg-notes-unsaved-attachment/rig.json
+++ b/WordPress/gutenberg/rigs/gutenberg-notes-unsaved-attachment/rig.json
@@ -71,12 +71,6 @@
         "gutenberg_notes_case": "saved-anchor"
       }
     },
-    "autosave-anchor": {
-      "scenario": "notes-unsaved-attachment",
-      "settings": {
-        "gutenberg_notes_case": "autosave-anchor"
-      }
-    },
     "live-create": {
       "scenario": "notes-unsaved-attachment",
       "settings": {

--- a/WordPress/gutenberg/shared/wordpress-plugin/fuzz-inventory.base.json
+++ b/WordPress/gutenberg/shared/wordpress-plugin/fuzz-inventory.base.json
@@ -10,7 +10,10 @@
   },
   "fuzz_workloads": {
     "nodejs": [
-      { "path": "${package.root}/fuzz/gutenberg-notes-attachment-corpus.json" }
+      {
+        "path": "${package.root}/fuzz/gutenberg-notes-attachment-corpus.json",
+        "env_provider_extensions": ["wordpress"]
+      }
     ],
     "wordpress": [
       { "path": "${package.root}/fuzz/gutenberg-rest-route-fuzz.json" },

--- a/WordPress/gutenberg/shared/wordpress-plugin/fuzz-inventory.base.json
+++ b/WordPress/gutenberg/shared/wordpress-plugin/fuzz-inventory.base.json
@@ -9,6 +9,9 @@
     "warmup_iterations": 0
   },
   "fuzz_workloads": {
+    "nodejs": [
+      { "path": "${package.root}/fuzz/gutenberg-notes-attachment-corpus.json" }
+    ],
     "wordpress": [
       { "path": "${package.root}/fuzz/gutenberg-rest-route-fuzz.json" },
       { "path": "${package.root}/fuzz/gutenberg-rest-request-cases-fuzz.json" },
@@ -25,6 +28,9 @@
     ]
   },
   "fuzz_profiles": {
+    "notes-attachment": [
+      "gutenberg-notes-attachment-corpus"
+    ],
     "smoke": [
       "gutenberg-rest-route-fuzz",
       "gutenberg-rest-request-cases-fuzz",
@@ -43,7 +49,8 @@
       "gutenberg-rest-db-query-profile-fuzz",
       "gutenberg-hooks-options-inventory",
       "gutenberg-editor-performance-observation",
-      "gutenberg-external-http-guardrail-fuzz"
+      "gutenberg-external-http-guardrail-fuzz",
+      "gutenberg-notes-attachment-corpus"
     ],
     "full-surface": [
       "gutenberg-rest-route-fuzz",
@@ -57,7 +64,8 @@
       "gutenberg-rest-db-query-profile-fuzz",
       "gutenberg-hooks-options-inventory",
       "gutenberg-editor-performance-observation",
-      "gutenberg-external-http-guardrail-fuzz"
+      "gutenberg-external-http-guardrail-fuzz",
+      "gutenberg-notes-attachment-corpus"
     ]
   },
   "pipeline": {

--- a/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
+++ b/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
@@ -19,6 +19,7 @@ test('Gutenberg full-surface profile names proof-ready admin and frontend covera
 });
 
 test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
+  const inventoryRig = readJson('rigs/gutenberg-api-route-inventory/rig.json');
   const rig = readJson('shared/wordpress-plugin/fuzz-inventory.base.json');
   const workload = readJson('fuzz/gutenberg-notes-attachment-corpus.json');
   const expectedCases = [
@@ -33,6 +34,7 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
     'double-live-create',
   ];
 
+  assert.deepEqual(inventoryRig.components.gutenberg.extensions.nodejs, {});
   assert.deepEqual(rig.fuzz_profiles['notes-attachment'], ['gutenberg-notes-attachment-corpus']);
   assert.equal(rig.fuzz_workloads.nodejs[0].path, '${package.root}/fuzz/gutenberg-notes-attachment-corpus.json');
   assert.deepEqual(workload.metadata.corpus_cases.map(({ id }) => id), expectedCases);

--- a/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
+++ b/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
@@ -33,6 +33,7 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
     'dirty-structural-live-create',
     'nested-live-create',
     'double-live-create',
+    'inline-range-live-create',
   ];
 
   assert.deepEqual(inventoryRig.components.gutenberg.extensions.nodejs, {});
@@ -53,6 +54,10 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
   assert.match(traceSource, /gutenberg-plugin-assets-loaded/);
   assert.match(traceSource, /\/wp-content\/plugins\/gutenberg\/build\//);
   assert.match(traceSource, /aria-label="New note".*note-form/s);
+  assert.match(traceSource, /inline-range-live-create/);
+  assert.match(traceSource, /core\/note/);
+  assert.match(traceSource, /reloadedNoteEntityResolvesToAttachment/);
+  assert.match(traceSource, /targetedPersistenceObserved/);
   assert.deepEqual(
     workload.artifacts.expected.map(({ semantic_key }) => semantic_key),
     ['fuzz.case_log', 'fuzz.replay', 'fuzz.report']

--- a/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
+++ b/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
@@ -22,10 +22,11 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
   const inventoryRig = readJson('rigs/gutenberg-api-route-inventory/rig.json');
   const rig = readJson('shared/wordpress-plugin/fuzz-inventory.base.json');
   const workload = readJson('fuzz/gutenberg-notes-attachment-corpus.json');
+  const runnerSource = readFileSync(path.join(root, 'fuzz/gutenberg-notes-unsaved-attachment.mjs'), 'utf8');
+  const traceSource = readFileSync(path.join(root, 'bench/notes-unsaved-attachment.trace.mjs'), 'utf8');
   const expectedCases = [
     'orphan',
     'saved-anchor',
-    'autosave-anchor',
     'live-create',
     'dirty-live-create',
     'dirty-sibling-live-create',
@@ -42,6 +43,15 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
   assert.equal(workload.case_budget, expectedCases.length);
   assert.equal(workload.limits.max_cases, expectedCases.length);
   assert.equal(workload.workload.path, '${package.root}/fuzz/gutenberg-notes-unsaved-attachment.mjs');
+  assert.match(
+    workload.metadata.readiness.coverage_contract,
+    /builds the exact Gutenberg checkout.*proves plugin bundle provenance/
+  );
+  assert.match(runnerSource, /npm.*run.*build.*--skip-types/s);
+  assert.match(runnerSource, /build\/scripts\/core-data\/index\.min\.js/);
+  assert.match(traceSource, /gutenberg-plugin-assets-loaded/);
+  assert.match(traceSource, /\/wp-content\/plugins\/gutenberg\/build\//);
+  assert.match(traceSource, /aria-label="New note".*note-form/s);
   assert.deepEqual(
     workload.artifacts.expected.map(({ semantic_key }) => semantic_key),
     ['fuzz.case_log', 'fuzz.replay', 'fuzz.report']

--- a/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
+++ b/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
@@ -17,3 +17,30 @@ test('Gutenberg full-surface profile names proof-ready admin and frontend covera
   assert.equal(manifest.surfaces.admin_editor_pages.coverage_artifact, 'homeboy-rigs/gutenberg-admin-page-coverage/v1');
   assert.equal(manifest.surfaces.frontend_rendering.coverage_artifact, 'wp-codebox/browser-request-coverage/v1');
 });
+
+test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
+  const rig = readJson('shared/wordpress-plugin/fuzz-inventory.base.json');
+  const workload = readJson('fuzz/gutenberg-notes-attachment-corpus.json');
+  const expectedCases = [
+    'orphan',
+    'saved-anchor',
+    'autosave-anchor',
+    'live-create',
+    'dirty-live-create',
+    'dirty-sibling-live-create',
+    'dirty-structural-live-create',
+    'nested-live-create',
+    'double-live-create',
+  ];
+
+  assert.deepEqual(rig.fuzz_profiles['notes-attachment'], ['gutenberg-notes-attachment-corpus']);
+  assert.equal(rig.fuzz_workloads.nodejs[0].path, '${package.root}/fuzz/gutenberg-notes-attachment-corpus.json');
+  assert.deepEqual(workload.metadata.corpus_cases.map(({ id }) => id), expectedCases);
+  assert.equal(workload.case_budget, expectedCases.length);
+  assert.equal(workload.limits.max_cases, expectedCases.length);
+  assert.equal(workload.workload.path, '${package.root}/fuzz/gutenberg-notes-unsaved-attachment.mjs');
+  assert.deepEqual(
+    workload.artifacts.expected.map(({ semantic_key }) => semantic_key),
+    ['fuzz.case_log', 'fuzz.replay', 'fuzz.report']
+  );
+});

--- a/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
+++ b/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
@@ -37,6 +37,7 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
   assert.deepEqual(inventoryRig.components.gutenberg.extensions.nodejs, {});
   assert.deepEqual(rig.fuzz_profiles['notes-attachment'], ['gutenberg-notes-attachment-corpus']);
   assert.equal(rig.fuzz_workloads.nodejs[0].path, '${package.root}/fuzz/gutenberg-notes-attachment-corpus.json');
+  assert.deepEqual(rig.fuzz_workloads.nodejs[0].env_provider_extensions, ['wordpress']);
   assert.deepEqual(workload.metadata.corpus_cases.map(({ id }) => id), expectedCases);
   assert.equal(workload.case_budget, expectedCases.length);
   assert.equal(workload.limits.max_cases, expectedCases.length);

--- a/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
+++ b/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
@@ -34,6 +34,12 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
     'nested-live-create',
     'double-live-create',
     'inline-range-live-create',
+    'no-saved-match',
+    'ambiguous-contentless',
+    'empty-saved-content',
+    'store-coherence',
+    'repair-sync-race',
+    'crdt-peer-lineage',
   ];
 
   assert.deepEqual(inventoryRig.components.gutenberg.extensions.nodejs, {});
@@ -43,6 +49,10 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
   assert.deepEqual(workload.metadata.corpus_cases.map(({ id }) => id), expectedCases);
   assert.equal(workload.case_budget, expectedCases.length);
   assert.equal(workload.limits.max_cases, expectedCases.length);
+  assert.deepEqual(workload.operations, workload.coverage.operations);
+  for (const caseId of expectedCases) {
+    assert.match(runnerSource, new RegExp(`\\[ '${caseId}',`));
+  }
   assert.equal(workload.workload.path, '${package.root}/fuzz/gutenberg-notes-unsaved-attachment.mjs');
   assert.match(
     workload.metadata.readiness.coverage_contract,
@@ -58,6 +68,15 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
   assert.match(traceSource, /core\/note/);
   assert.match(traceSource, /reloadedNoteEntityResolvesToAttachment/);
   assert.match(traceSource, /targetedPersistenceObserved/);
+  assert.match(traceSource, /no-saved-match/);
+  assert.match(traceSource, /ambiguous-contentless/);
+  assert.match(traceSource, /empty-saved-content/);
+  assert.match(traceSource, /store-coherence/);
+  assert.match(traceSource, /repair-sync-race/);
+  assert.match(traceSource, /crdt-peer-lineage/);
+  assert.match(traceSource, /actorTimeline/);
+  assert.match(traceSource, /HOMEBOY_SEED/);
+  assert.match(runnerSource, /seed: process\.env\.HOMEBOY_SEED/);
   assert.deepEqual(
     workload.artifacts.expected.map(({ semantic_key }) => semantic_key),
     ['fuzz.case_log', 'fuzz.replay', 'fuzz.report']

--- a/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
+++ b/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
@@ -48,6 +48,7 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
     /builds the exact Gutenberg checkout.*proves plugin bundle provenance/
   );
   assert.match(runnerSource, /npm.*run.*build.*--skip-types/s);
+  assert.match(runnerSource, /npm.*ci/s);
   assert.match(runnerSource, /build\/scripts\/core-data\/index\.min\.js/);
   assert.match(traceSource, /gutenberg-plugin-assets-loaded/);
   assert.match(traceSource, /\/wp-content\/plugins\/gutenberg\/build\//);


### PR DESCRIPTION
## Summary

- add a replayable Gutenberg Block Notes attachment persistence workload for WordPress/gutenberg#79020
- build and verify the exact Gutenberg checkout before running isolated WP Codebox browser cases
- expand the corpus from nine baseline cases to fifteen adversarial cases covering unmatched and ambiguous targets, empty saved content, store coherence, seeded REST/sync ordering, and CRDT peer lineage
- capture case logs, request and actor timelines, replay metadata, coverage summaries, plugin bundle provenance, and result envelopes

## Tracker

- https://github.com/WordPress/gutenberg/pull/79020
- https://github.com/WordPress/gutenberg/issues/72717
- Review risks incorporated from https://github.com/WordPress/gutenberg/pull/79020#issuecomment-5029660047

## How to test

1. Run `node --test WordPress/gutenberg/tools/fuzz-coverage.test.mjs`.
2. Run `node --check WordPress/gutenberg/fuzz/gutenberg-notes-unsaved-attachment.mjs`.
3. Run `node --check WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs`.
4. Run `git diff --check origin/main...HEAD`.
5. On a runner able to build Gutenberg within its process policy, execute `homeboy fuzz run gutenberg --rig gutenberg-api-route-inventory --workload gutenberg-notes-attachment-corpus --extension nodejs --seed 1 --max-duration 45m --gate-profile strict --require-case-log --require-coverage-summary --require-result-envelope --isolation isolated --allow-destructive` against Gutenberg PR head `12bd5d16e88a1601d7229f0450c8c3c3895930ad`.

## Validation

- corpus contract tests pass
- both executable modules pass Node syntax validation
- diff whitespace validation passes
- a pinned Lab execution reached the exact corpus and Gutenberg snapshots, but Gutenberg build fan-out reached 178 processes and the shared Lab guard stopped it at its 128-process limit before any fuzz case ran; this PR does not bypass or globally relax that guard

## Scope

This adds test and rig assets only. It does not change Gutenberg behavior or compatibility surfaces.