### PR TITLE
Fix Gutenberg fuzz browser script generation

### DIFF
--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -871,7 +871,7 @@ const collectCrdtPeerLineageCase = async () => {
 	await sleep(1000);
 	const peer = readPeerState(peerWindow, noteId);
 	iframe.remove();
-	return { caseId, postId: item.post_id, noteId, parentBlockCount, parentText, peer, passed: peer.noteIds.includes(noteId) && peer.attachmentCount === 1 && peer.blockCount === parentBlockCount && peer.blockTexts.join('\n') === parentText, actorTimeline: [...actorTimeline], observedRequests: observedRequests.filter((request) => request.route === 'post-rest' || request.route === 'sync-save') };
+	return { caseId, postId: item.post_id, noteId, parentBlockCount, parentText, peer, passed: peer.noteIds.includes(noteId) && peer.attachmentCount === 1 && peer.blockCount === parentBlockCount && peer.blockTexts.join('\\n') === parentText, actorTimeline: [...actorTimeline], observedRequests: observedRequests.filter((request) => request.route === 'post-rest' || request.route === 'sync-save') };
 };
 const collectCase = async (caseId) => {
 	const item = fixtureState[caseId];

--- a/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
+++ b/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
@@ -24,6 +24,16 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
   const workload = readJson('fuzz/gutenberg-notes-attachment-corpus.json');
   const runnerSource = readFileSync(path.join(root, 'fuzz/gutenberg-notes-unsaved-attachment.mjs'), 'utf8');
   const traceSource = readFileSync(path.join(root, 'bench/notes-unsaved-attachment.trace.mjs'), 'utf8');
+  const browserScriptStart = traceSource.indexOf('const browserScript = `') + 'const browserScript = `'.length;
+  const browserScriptEnd = traceSource.indexOf('`;\n\ntry {', browserScriptStart);
+  const browserScriptTemplate = traceSource.slice(browserScriptStart, browserScriptEnd);
+  const browserScript = Function(
+    'readinessTimeoutMs',
+    'targetCase',
+    'process',
+    `return \`${browserScriptTemplate}\``
+  )(20000, 'orphan', { env: { HOMEBOY_SEED: '1' } });
+  const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
   const expectedCases = [
     'orphan',
     'saved-anchor',
@@ -76,6 +86,7 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
   assert.match(traceSource, /crdt-peer-lineage/);
   assert.match(traceSource, /actorTimeline/);
   assert.match(traceSource, /HOMEBOY_SEED/);
+  assert.doesNotThrow(() => new AsyncFunction(browserScript));
   assert.match(runnerSource, /seed: process\.env\.HOMEBOY_SEED/);
   assert.deepEqual(
     workload.artifacts.expected.map(({ semantic_key }) => semantic_key),


### PR DESCRIPTION
## Summary
- preserve the newline escape inside the generated CRDT peer browser script
- compile the generated async browser workload in corpus contract tests

## Evidence
Lab run `gutenberg-79020-fifteen-case-expanded-20260721-r6` reached all 15 cases but each WP Codebox browser probe failed while constructing the generated script with `SyntaxError: Invalid or unexpected token`. `node --check` pinpointed the literal newline emitted by `peer.blockTexts.join`.

## How to test
1. Run `node --test WordPress/gutenberg/tools/fuzz-coverage.test.mjs`.
2. Run `node --check WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs`.
3. Confirm `git diff --check` passes.

## Compatibility
No extension or workload contract changes. The existing browser workload now compiles as intended.