### PR TITLE
Update Gutenberg note form selectors

### DIFF
--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -575,7 +575,7 @@ const openAddNoteField = async (block) => {
 		(document.activeElement || document).dispatchEvent(new KeyboardEvent('keydown', { key: 'm', code: 'KeyM', altKey: true, bubbles: true, cancelable: true, ...combo }));
 	}
 		await sleep(500);
-		const findNewNoteForm = () => Array.from(document.querySelectorAll('[role="treeitem"][aria-label="New note"] .editor-collab-sidebar-panel__note-form')).find(isVisible);
+		const findNewNoteForm = () => Array.from(document.querySelectorAll('.editor-collab-sidebar-panel__note-form')).find((form) => isVisible(form) && form.querySelector('textarea'));
 		const findNewNoteField = () => findNewNoteForm()?.querySelector('textarea');
 		const hasNewNoteSubmit = () => !!Array.from(findNewNoteForm()?.querySelectorAll('button') || []).find((button) => (button.textContent || '').trim() === 'Add note');
 		if (!findNewNoteField() || !hasNewNoteSubmit()) {
@@ -633,7 +633,7 @@ const createNoteOnRichTextRange = async (block, text) => {
 	for (const combo of [{ metaKey: true }, { ctrlKey: true }]) {
 		editable.dispatchEvent(new KeyboardEvent('keydown', { key: 'm', code: 'KeyM', altKey: true, bubbles: true, cancelable: true, ...combo }));
 	}
-	const findNewNoteField = () => Array.from(document.querySelectorAll('[role="treeitem"][aria-label="New note"] .editor-collab-sidebar-panel__note-form textarea')).find(isVisible);
+	const findNewNoteField = () => Array.from(document.querySelectorAll('.editor-collab-sidebar-panel__note-form textarea')).find(isVisible);
 	await sleep(500);
 	if (!findNewNoteField()) {
 		const toolbarButtons = Array.from(document.querySelectorAll('.block-editor-block-toolbar button, .block-editor-block-contextual-toolbar button')).filter(isVisible);

--- a/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
+++ b/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
@@ -73,7 +73,7 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
   assert.match(runnerSource, /build\/scripts\/core-data\/index\.min\.js/);
   assert.match(traceSource, /gutenberg-plugin-assets-loaded/);
   assert.match(traceSource, /\/wp-content\/plugins\/gutenberg\/build\//);
-  assert.match(traceSource, /aria-label="New note".*note-form/s);
+  assert.match(traceSource, /editor-collab-sidebar-panel__note-form.*textarea/s);
   assert.match(traceSource, /inline-range-live-create/);
   assert.match(traceSource, /core\/note/);
   assert.match(traceSource, /reloadedNoteEntityResolvesToAttachment/);


### PR DESCRIPTION
## Summary
- locate the visible Gutenberg note form without requiring obsolete treeitem ancestry
- use the same current form selector for block and rich-text note creation paths

## Evidence
Lab run `gutenberg-79020-fifteen-case-expanded-20260721-r8` passed the two static attachment cases. All 13 note-creation cases reached Gutenberg but timed out waiting for the textarea after opening Add note because the form no longer matched `[role="treeitem"][aria-label="New note"] ...`.

## How to test
1. Run `node --test WordPress/gutenberg/tools/fuzz-coverage.test.mjs`.
2. Run `node --check WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs`.
3. Confirm `git diff --check` passes.

## Compatibility
No workload contract changes. Selection remains scoped to a visible Gutenberg collaboration note form containing a textarea.