### PR TITLE
Harden Gutenberg note editor automation

### DIFF
--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -604,7 +604,19 @@ const openAddNoteField = async (block) => {
 		const addNoteMenuItem = await waitFor(() => findMenuItemByText('Add note'), 'Add note menu item');
 		addNoteMenuItem.click();
 	}
-	return waitFor(findNewNoteField, 'new note textarea');
+	try {
+		return await waitFor(findNewNoteField, 'new note textarea');
+	} catch (error) {
+		const candidates = getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('textarea, input, [contenteditable="true"]'))).filter(isVisible).map((field) => ({
+			tag: field.tagName,
+			placeholder: field.getAttribute('placeholder'),
+			dataPlaceholder: field.getAttribute('data-placeholder'),
+			ariaLabel: field.getAttribute('aria-label'),
+			role: field.getAttribute('role'),
+			className: field.className,
+		}));
+		throw new Error(error.message + '; visible editor fields=' + JSON.stringify(candidates.slice(0, 30)));
+	}
 };
 const createNoteOnBlock = async (block, text) => {
 	const beforeIds = new Set(getBlockNoteIds());

--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -596,13 +596,13 @@ const collectBlockAttachment = async (caseId, item, noteId) => {
 	};
 };
 const openAddNoteField = async (block) => {
-	const existingFields = new Set(getNoteFieldCandidates());
 	window.wp.data.dispatch('core/block-editor').selectBlock(block.clientId);
 	const blockElement = document.querySelector('[data-block="' + block.clientId + '"]');
 	blockElement?.scrollIntoView({ block: 'center' });
 	blockElement?.focus();
 	blockElement?.click();
 	await sleep(250);
+	const existingFields = new Set(getNoteFieldCandidates());
 	for (const combo of [{ metaKey: true }, { ctrlKey: true }]) {
 		(document.activeElement || document).dispatchEvent(new KeyboardEvent('keydown', { key: 'm', code: 'KeyM', altKey: true, bubbles: true, cancelable: true, ...combo }));
 	}

--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -575,9 +575,8 @@ const openAddNoteField = async (block) => {
 		(document.activeElement || document).dispatchEvent(new KeyboardEvent('keydown', { key: 'm', code: 'KeyM', altKey: true, bubbles: true, cancelable: true, ...combo }));
 	}
 		await sleep(500);
-		const findNewNoteForm = () => Array.from(document.querySelectorAll('.editor-collab-sidebar-panel__note-form')).find((form) => isVisible(form) && form.querySelector('textarea'));
-		const findNewNoteField = () => findNewNoteForm()?.querySelector('textarea');
-		const hasNewNoteSubmit = () => !!Array.from(findNewNoteForm()?.querySelectorAll('button') || []).find((button) => (button.textContent || '').trim() === 'Add note');
+		const findNewNoteField = () => Array.from(document.querySelectorAll('textarea')).find((textarea) => isVisible(textarea) && (textarea.getAttribute('placeholder') || '').startsWith('Add a note'));
+		const hasNewNoteSubmit = () => isVisible(findButtonByText('Add note'));
 		if (!findNewNoteField() || !hasNewNoteSubmit()) {
 			const toolbarButtons = Array.from(document.querySelectorAll('.block-editor-block-toolbar button, .block-editor-block-contextual-toolbar button')).filter(isVisible);
 			const optionsButton = toolbarButtons.sort((a, b) => a.getBoundingClientRect().left - b.getBoundingClientRect().left).at(-1);
@@ -596,7 +595,7 @@ const createNoteOnBlock = async (block, text) => {
 	textarea.focus();
 	setFieldValue(textarea, text);
 	await sleep(250);
-	const addButton = await waitFor(() => Array.from(textarea.closest('form')?.querySelectorAll('button') || []).find((button) => (button.textContent || '').trim() === 'Add note'), 'Add note button');
+	const addButton = await waitFor(() => isVisible(findButtonByText('Add note')) && findButtonByText('Add note'), 'Add note button');
 	addButton.click();
 	await waitFor(() => document.body.textContent.includes(text), 'created live note thread ' + text);
 	return waitFor(() => getBlockNoteIds().find((id) => !beforeIds.has(id)), 'new live note id in edited block metadata');
@@ -633,7 +632,7 @@ const createNoteOnRichTextRange = async (block, text) => {
 	for (const combo of [{ metaKey: true }, { ctrlKey: true }]) {
 		editable.dispatchEvent(new KeyboardEvent('keydown', { key: 'm', code: 'KeyM', altKey: true, bubbles: true, cancelable: true, ...combo }));
 	}
-	const findNewNoteField = () => Array.from(document.querySelectorAll('.editor-collab-sidebar-panel__note-form textarea')).find(isVisible);
+	const findNewNoteField = () => Array.from(document.querySelectorAll('textarea')).find((textarea) => isVisible(textarea) && (textarea.getAttribute('placeholder') || '').startsWith('Add a note'));
 	await sleep(500);
 	if (!findNewNoteField()) {
 		const toolbarButtons = Array.from(document.querySelectorAll('.block-editor-block-toolbar button, .block-editor-block-contextual-toolbar button')).filter(isVisible);
@@ -646,7 +645,7 @@ const createNoteOnRichTextRange = async (block, text) => {
 	const textarea = await waitFor(findNewNoteField, 'rich-text range note textarea');
 	textarea.focus();
 	setFieldValue(textarea, text);
-	const addButton = await waitFor(() => Array.from(textarea.closest('form')?.querySelectorAll('button') || []).find((button) => (button.textContent || '').trim() === 'Add note'), 'rich-text range Add note button');
+	const addButton = await waitFor(() => isVisible(findButtonByText('Add note')) && findButtonByText('Add note'), 'rich-text range Add note button');
 	addButton.click();
 	await waitFor(() => document.body.textContent.includes(text), 'created rich-text range note thread ' + text);
 	const noteId = await waitFor(() => getBlockNoteIds().find((id) => !beforeIds.has(id)), 'new rich-text range note id in block metadata');

--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -377,22 +377,24 @@ const waitFor = async (predicate, label) => {
 	}
 	throw new Error('Timed out waiting for ' + label);
 };
-const findButtonByText = (text) => Array.from(document.querySelectorAll('button')).find((button) => (button.textContent || '').trim() === text);
+const getEditorDocuments = () => [ document, ...Array.from(document.querySelectorAll('iframe')).map((iframe) => iframe.contentDocument).filter(Boolean) ];
+const findButtonByText = (text) => getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('button'))).find((button) => (button.textContent || '').trim() === text);
 const isVisible = (node) => {
 	const rect = node?.getBoundingClientRect?.();
 	return !!rect && rect.width > 0 && rect.height > 0;
 };
-const findMenuItemByText = (text) => Array.from(document.querySelectorAll('[role="menuitem"], button')).find((node) => (node.textContent || '').trim().startsWith(text) && isVisible(node));
+const findMenuItemByText = (text) => getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('[role="menuitem"], button'))).find((node) => (node.textContent || '').trim().startsWith(text) && isVisible(node));
 const setFieldValue = (field, value) => {
-	const prototype = field instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+	const ownerWindow = field.ownerDocument.defaultView;
+	const prototype = field instanceof ownerWindow.HTMLTextAreaElement ? ownerWindow.HTMLTextAreaElement.prototype : ownerWindow.HTMLInputElement.prototype;
 	const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
 	if (setter) {
 		setter.call(field, value);
 	} else {
 		field.value = value;
 	}
-	field.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: value }));
-	field.dispatchEvent(new Event('change', { bubbles: true }));
+	field.dispatchEvent(new ownerWindow.InputEvent('input', { bubbles: true, inputType: 'insertText', data: value }));
+	field.dispatchEvent(new ownerWindow.Event('change', { bubbles: true }));
 };
 const flattenBlocks = (blocks) => blocks.flatMap((block) => [block, ...flattenBlocks(block.innerBlocks || [])]);
 const liveCreateCases = [ 'live-create', 'dirty-live-create', 'dirty-sibling-live-create', 'dirty-structural-live-create', 'nested-live-create', 'double-live-create' ];
@@ -575,10 +577,10 @@ const openAddNoteField = async (block) => {
 		(document.activeElement || document).dispatchEvent(new KeyboardEvent('keydown', { key: 'm', code: 'KeyM', altKey: true, bubbles: true, cancelable: true, ...combo }));
 	}
 		await sleep(500);
-		const findNewNoteField = () => Array.from(document.querySelectorAll('textarea')).find((textarea) => isVisible(textarea) && (textarea.getAttribute('placeholder') || '').startsWith('Add a note'));
+		const findNewNoteField = () => getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('textarea'))).find((textarea) => isVisible(textarea) && (textarea.getAttribute('placeholder') || '').startsWith('Add a note'));
 		const hasNewNoteSubmit = () => isVisible(findButtonByText('Add note'));
 		if (!findNewNoteField() || !hasNewNoteSubmit()) {
-			const toolbarButtons = Array.from(document.querySelectorAll('.block-editor-block-toolbar button, .block-editor-block-contextual-toolbar button')).filter(isVisible);
+			const toolbarButtons = getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('.block-editor-block-toolbar button, .block-editor-block-contextual-toolbar button'))).filter(isVisible);
 			const optionsButton = toolbarButtons.sort((a, b) => a.getBoundingClientRect().left - b.getBoundingClientRect().left).at(-1);
 			if (!optionsButton) {
 			throw new Error('Could not find block toolbar options button; toolbar buttons=' + toolbarButtons.map((button) => button.getAttribute('aria-label') || button.textContent || '').join(', '));
@@ -602,8 +604,7 @@ const createNoteOnBlock = async (block, text) => {
 };
 const findRichTextEditable = (block) => {
 	const selector = '[data-block="' + block.clientId + '"][contenteditable="true"], [data-block="' + block.clientId + '"] [contenteditable="true"]';
-	const documents = [ document, ...Array.from(document.querySelectorAll('iframe')).map((iframe) => iframe.contentDocument).filter(Boolean) ];
-	return documents.map((editorDocument) => editorDocument.querySelector(selector)).find((editable) => editable?.textContent?.includes('note anchor'));
+	return getEditorDocuments().map((editorDocument) => editorDocument.querySelector(selector)).find((editable) => editable?.textContent?.includes('note anchor'));
 };
 const selectRichTextRange = (editable) => {
 	const text = 'note anchor';
@@ -632,10 +633,10 @@ const createNoteOnRichTextRange = async (block, text) => {
 	for (const combo of [{ metaKey: true }, { ctrlKey: true }]) {
 		editable.dispatchEvent(new KeyboardEvent('keydown', { key: 'm', code: 'KeyM', altKey: true, bubbles: true, cancelable: true, ...combo }));
 	}
-	const findNewNoteField = () => Array.from(document.querySelectorAll('textarea')).find((textarea) => isVisible(textarea) && (textarea.getAttribute('placeholder') || '').startsWith('Add a note'));
+	const findNewNoteField = () => getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('textarea'))).find((textarea) => isVisible(textarea) && (textarea.getAttribute('placeholder') || '').startsWith('Add a note'));
 	await sleep(500);
 	if (!findNewNoteField()) {
-		const toolbarButtons = Array.from(document.querySelectorAll('.block-editor-block-toolbar button, .block-editor-block-contextual-toolbar button')).filter(isVisible);
+		const toolbarButtons = getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('.block-editor-block-toolbar button, .block-editor-block-contextual-toolbar button'))).filter(isVisible);
 		const optionsButton = toolbarButtons.sort((a, b) => a.getBoundingClientRect().left - b.getBoundingClientRect().left).at(-1);
 		if (!optionsButton) throw new Error('Could not find rich-text toolbar options button');
 		optionsButton.click();

--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -575,7 +575,7 @@ const openAddNoteField = async (block) => {
 		(document.activeElement || document).dispatchEvent(new KeyboardEvent('keydown', { key: 'm', code: 'KeyM', altKey: true, bubbles: true, cancelable: true, ...combo }));
 	}
 		await sleep(500);
-		const findNewNoteForm = () => Array.from(document.querySelectorAll('[role="treeitem"][aria-label="New note"] .editor-collab-sidebar-panel__note-form')).find(isVisible);
+		const findNewNoteForm = () => Array.from(document.querySelectorAll('.editor-collab-sidebar-panel__note-form')).find((form) => isVisible(form) && form.querySelector('textarea'));
 		const findNewNoteField = () => findNewNoteForm()?.querySelector('textarea');
 		const hasNewNoteSubmit = () => !!Array.from(findNewNoteForm()?.querySelectorAll('button') || []).find((button) => (button.textContent || '').trim() === 'Add note');
 		if (!findNewNoteField() || !hasNewNoteSubmit()) {
@@ -633,7 +633,7 @@ const createNoteOnRichTextRange = async (block, text) => {
 	for (const combo of [{ metaKey: true }, { ctrlKey: true }]) {
 		editable.dispatchEvent(new KeyboardEvent('keydown', { key: 'm', code: 'KeyM', altKey: true, bubbles: true, cancelable: true, ...combo }));
 	}
-	const findNewNoteField = () => Array.from(document.querySelectorAll('[role="treeitem"][aria-label="New note"] .editor-collab-sidebar-panel__note-form textarea')).find(isVisible);
+	const findNewNoteField = () => Array.from(document.querySelectorAll('.editor-collab-sidebar-panel__note-form textarea')).find(isVisible);
 	await sleep(500);
 	if (!findNewNoteField()) {
 		const toolbarButtons = Array.from(document.querySelectorAll('.block-editor-block-toolbar button, .block-editor-block-contextual-toolbar button')).filter(isVisible);

--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -377,7 +377,13 @@ const waitFor = async (predicate, label) => {
 	}
 	throw new Error('Timed out waiting for ' + label);
 };
-const getEditorDocuments = () => [ document, ...Array.from(document.querySelectorAll('iframe')).map((iframe) => iframe.contentDocument).filter(Boolean) ];
+const getEditorDocuments = () => {
+	const documents = [ document ];
+	for (let index = 0; index < documents.length; index++) {
+		documents.push(...Array.from(documents[index].querySelectorAll('iframe')).map((iframe) => iframe.contentDocument).filter((frameDocument) => frameDocument && !documents.includes(frameDocument)));
+	}
+	return documents;
+};
 const findButtonByText = (text) => getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('button'))).find((button) => (button.textContent || '').trim() === text);
 const isVisible = (node) => {
 	const rect = node?.getBoundingClientRect?.();
@@ -386,6 +392,12 @@ const isVisible = (node) => {
 const findMenuItemByText = (text) => getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('[role="menuitem"], button'))).find((node) => (node.textContent || '').trim().startsWith(text) && isVisible(node));
 const setFieldValue = (field, value) => {
 	const ownerWindow = field.ownerDocument.defaultView;
+	if (field.isContentEditable) {
+		field.textContent = value;
+		field.dispatchEvent(new ownerWindow.InputEvent('input', { bubbles: true, inputType: 'insertText', data: value }));
+		field.dispatchEvent(new ownerWindow.Event('change', { bubbles: true }));
+		return;
+	}
 	const prototype = field instanceof ownerWindow.HTMLTextAreaElement ? ownerWindow.HTMLTextAreaElement.prototype : ownerWindow.HTMLInputElement.prototype;
 	const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
 	if (setter) {
@@ -397,6 +409,10 @@ const setFieldValue = (field, value) => {
 	field.dispatchEvent(new ownerWindow.Event('change', { bubbles: true }));
 };
 const flattenBlocks = (blocks) => blocks.flatMap((block) => [block, ...flattenBlocks(block.innerBlocks || [])]);
+const findNewNoteField = () => getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('textarea, input, [contenteditable="true"]'))).find((field) => {
+	const prompt = field.getAttribute('placeholder') || field.getAttribute('data-placeholder') || field.getAttribute('aria-label') || '';
+	return isVisible(field) && prompt.startsWith('Add a note');
+});
 const liveCreateCases = [ 'live-create', 'dirty-live-create', 'dirty-sibling-live-create', 'dirty-structural-live-create', 'nested-live-create', 'double-live-create' ];
 const getBlockNoteIds = (targetWindow = window) => flattenBlocks(targetWindow.wp.data.select('core/block-editor').getBlocks()).flatMap((block) => {
 	const noteId = block?.attributes?.metadata?.noteId;
@@ -577,7 +593,6 @@ const openAddNoteField = async (block) => {
 		(document.activeElement || document).dispatchEvent(new KeyboardEvent('keydown', { key: 'm', code: 'KeyM', altKey: true, bubbles: true, cancelable: true, ...combo }));
 	}
 		await sleep(500);
-		const findNewNoteField = () => getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('textarea'))).find((textarea) => isVisible(textarea) && (textarea.getAttribute('placeholder') || '').startsWith('Add a note'));
 		const hasNewNoteSubmit = () => isVisible(findButtonByText('Add note'));
 		if (!findNewNoteField() || !hasNewNoteSubmit()) {
 			const toolbarButtons = getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('.block-editor-block-toolbar button, .block-editor-block-contextual-toolbar button'))).filter(isVisible);
@@ -633,7 +648,6 @@ const createNoteOnRichTextRange = async (block, text) => {
 	for (const combo of [{ metaKey: true }, { ctrlKey: true }]) {
 		editable.dispatchEvent(new KeyboardEvent('keydown', { key: 'm', code: 'KeyM', altKey: true, bubbles: true, cancelable: true, ...combo }));
 	}
-	const findNewNoteField = () => getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('textarea'))).find((textarea) => isVisible(textarea) && (textarea.getAttribute('placeholder') || '').startsWith('Add a note'));
 	await sleep(500);
 	if (!findNewNoteField()) {
 		const toolbarButtons = getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('.block-editor-block-toolbar button, .block-editor-block-contextual-toolbar button'))).filter(isVisible);

--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -409,9 +409,10 @@ const setFieldValue = (field, value) => {
 	field.dispatchEvent(new ownerWindow.Event('change', { bubbles: true }));
 };
 const flattenBlocks = (blocks) => blocks.flatMap((block) => [block, ...flattenBlocks(block.innerBlocks || [])]);
-const findNewNoteField = () => getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('textarea, input, [contenteditable="true"]'))).find((field) => {
+const getNoteFieldCandidates = () => getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('textarea, input, [contenteditable], [role="textbox"]')));
+const findNewNoteField = (existingFields) => getNoteFieldCandidates().find((field) => {
 	const prompt = field.getAttribute('placeholder') || field.getAttribute('data-placeholder') || field.getAttribute('aria-label') || '';
-	return isVisible(field) && prompt.startsWith('Add a note');
+	return isVisible(field) && (prompt.startsWith('Add a note') || (existingFields && !existingFields.has(field) && field.getAttribute('role') === 'textbox'));
 });
 const liveCreateCases = [ 'live-create', 'dirty-live-create', 'dirty-sibling-live-create', 'dirty-structural-live-create', 'nested-live-create', 'double-live-create' ];
 const getBlockNoteIds = (targetWindow = window) => flattenBlocks(targetWindow.wp.data.select('core/block-editor').getBlocks()).flatMap((block) => {
@@ -583,6 +584,7 @@ const collectBlockAttachment = async (caseId, item, noteId) => {
 	};
 };
 const openAddNoteField = async (block) => {
+	const existingFields = new Set(getNoteFieldCandidates());
 	window.wp.data.dispatch('core/block-editor').selectBlock(block.clientId);
 	const blockElement = document.querySelector('[data-block="' + block.clientId + '"]');
 	blockElement?.scrollIntoView({ block: 'center' });
@@ -594,7 +596,7 @@ const openAddNoteField = async (block) => {
 	}
 		await sleep(500);
 		const hasNewNoteSubmit = () => isVisible(findButtonByText('Add note'));
-		if (!findNewNoteField() || !hasNewNoteSubmit()) {
+		if (!findNewNoteField(existingFields) || !hasNewNoteSubmit()) {
 			const toolbarButtons = getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('.block-editor-block-toolbar button, .block-editor-block-contextual-toolbar button'))).filter(isVisible);
 			const optionsButton = toolbarButtons.sort((a, b) => a.getBoundingClientRect().left - b.getBoundingClientRect().left).at(-1);
 			if (!optionsButton) {
@@ -605,9 +607,9 @@ const openAddNoteField = async (block) => {
 		addNoteMenuItem.click();
 	}
 	try {
-		return await waitFor(findNewNoteField, 'new note textarea');
+		return await waitFor(() => findNewNoteField(existingFields), 'new note textarea');
 	} catch (error) {
-		const candidates = getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('textarea, input, [contenteditable="true"]'))).filter(isVisible).map((field) => ({
+		const candidates = getNoteFieldCandidates().filter(isVisible).map((field) => ({
 			tag: field.tagName,
 			placeholder: field.getAttribute('placeholder'),
 			dataPlaceholder: field.getAttribute('data-placeholder'),
@@ -657,11 +659,12 @@ const createNoteOnRichTextRange = async (block, text) => {
 	const beforeIds = new Set(getBlockNoteIds());
 	const editable = await waitFor(() => findRichTextEditable(block), 'rich-text note anchor editable');
 	if (selectRichTextRange(editable) !== 'note anchor') throw new Error('Rich-text range selection did not match note anchor');
+	const existingFields = new Set(getNoteFieldCandidates());
 	for (const combo of [{ metaKey: true }, { ctrlKey: true }]) {
 		editable.dispatchEvent(new KeyboardEvent('keydown', { key: 'm', code: 'KeyM', altKey: true, bubbles: true, cancelable: true, ...combo }));
 	}
 	await sleep(500);
-	if (!findNewNoteField()) {
+	if (!findNewNoteField(existingFields)) {
 		const toolbarButtons = getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('.block-editor-block-toolbar button, .block-editor-block-contextual-toolbar button'))).filter(isVisible);
 		const optionsButton = toolbarButtons.sort((a, b) => a.getBoundingClientRect().left - b.getBoundingClientRect().left).at(-1);
 		if (!optionsButton) throw new Error('Could not find rich-text toolbar options button');
@@ -669,7 +672,7 @@ const createNoteOnRichTextRange = async (block, text) => {
 		const addNoteMenuItem = await waitFor(() => findMenuItemByText('Add note'), 'rich-text Add note menu item');
 		addNoteMenuItem.click();
 	}
-	const textarea = await waitFor(findNewNoteField, 'rich-text range note textarea');
+	const textarea = await waitFor(() => findNewNoteField(existingFields), 'rich-text range note textarea');
 	textarea.focus();
 	setFieldValue(textarea, text);
 	const addButton = await waitFor(() => isVisible(findButtonByText('Add note')) && findButtonByText('Add note'), 'rich-text range Add note button');

--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -390,6 +390,18 @@ const isVisible = (node) => {
 	return !!rect && rect.width > 0 && rect.height > 0;
 };
 const findMenuItemByText = (text) => getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('[role="menuitem"], button'))).find((node) => (node.textContent || '').trim().startsWith(text) && isVisible(node));
+const waitForAddNoteButton = async () => {
+	try {
+		return await waitFor(() => isVisible(findButtonByText('Add note')) && findButtonByText('Add note'), 'Add note button');
+	} catch (error) {
+		const buttons = getEditorDocuments().flatMap((editorDocument) => Array.from(editorDocument.querySelectorAll('button'))).filter(isVisible).map((button) => ({
+			text: (button.textContent || '').trim(),
+			ariaLabel: button.getAttribute('aria-label'),
+			disabled: button.disabled,
+		}));
+		throw new Error(error.message + '; visible buttons=' + JSON.stringify(buttons.slice(-30)));
+	}
+};
 const setFieldValue = (field, value) => {
 	const ownerWindow = field.ownerDocument.defaultView;
 	if (field.isContentEditable) {
@@ -626,7 +638,7 @@ const createNoteOnBlock = async (block, text) => {
 	textarea.focus();
 	setFieldValue(textarea, text);
 	await sleep(250);
-	const addButton = await waitFor(() => isVisible(findButtonByText('Add note')) && findButtonByText('Add note'), 'Add note button');
+	const addButton = await waitForAddNoteButton();
 	addButton.click();
 	await waitFor(() => document.body.textContent.includes(text), 'created live note thread ' + text);
 	return waitFor(() => getBlockNoteIds().find((id) => !beforeIds.has(id)), 'new live note id in edited block metadata');
@@ -675,7 +687,7 @@ const createNoteOnRichTextRange = async (block, text) => {
 	const textarea = await waitFor(() => findNewNoteField(existingFields), 'rich-text range note textarea');
 	textarea.focus();
 	setFieldValue(textarea, text);
-	const addButton = await waitFor(() => isVisible(findButtonByText('Add note')) && findButtonByText('Add note'), 'rich-text range Add note button');
+	const addButton = await waitForAddNoteButton();
 	addButton.click();
 	await waitFor(() => document.body.textContent.includes(text), 'created rich-text range note thread ' + text);
 	const noteId = await waitFor(() => getBlockNoteIds().find((id) => !beforeIds.has(id)), 'new rich-text range note id in block metadata');

--- a/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
+++ b/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
@@ -74,6 +74,7 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
   assert.match(traceSource, /gutenberg-plugin-assets-loaded/);
   assert.match(traceSource, /\/wp-content\/plugins\/gutenberg\/build\//);
   assert.match(traceSource, /contenteditable.*data-placeholder.*Add a note/s);
+  assert.match(traceSource, /existingFields && !existingFields\.has\(field\)/);
   assert.match(traceSource, /inline-range-live-create/);
   assert.match(traceSource, /core\/note/);
   assert.match(traceSource, /reloadedNoteEntityResolvesToAttachment/);

--- a/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
+++ b/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
@@ -73,7 +73,7 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
   assert.match(runnerSource, /build\/scripts\/core-data\/index\.min\.js/);
   assert.match(traceSource, /gutenberg-plugin-assets-loaded/);
   assert.match(traceSource, /\/wp-content\/plugins\/gutenberg\/build\//);
-  assert.match(traceSource, /aria-label="New note".*note-form/s);
+  assert.match(traceSource, /editor-collab-sidebar-panel__note-form.*textarea/s);
   assert.match(traceSource, /inline-range-live-create/);
   assert.match(traceSource, /core\/note/);
   assert.match(traceSource, /reloadedNoteEntityResolvesToAttachment/);

--- a/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
+++ b/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
@@ -73,7 +73,7 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
   assert.match(runnerSource, /build\/scripts\/core-data\/index\.min\.js/);
   assert.match(traceSource, /gutenberg-plugin-assets-loaded/);
   assert.match(traceSource, /\/wp-content\/plugins\/gutenberg\/build\//);
-  assert.match(traceSource, /textarea.*placeholder.*Add a note/s);
+  assert.match(traceSource, /contenteditable.*data-placeholder.*Add a note/s);
   assert.match(traceSource, /inline-range-live-create/);
   assert.match(traceSource, /core\/note/);
   assert.match(traceSource, /reloadedNoteEntityResolvesToAttachment/);

--- a/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
+++ b/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
@@ -73,7 +73,7 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
   assert.match(runnerSource, /build\/scripts\/core-data\/index\.min\.js/);
   assert.match(traceSource, /gutenberg-plugin-assets-loaded/);
   assert.match(traceSource, /\/wp-content\/plugins\/gutenberg\/build\//);
-  assert.match(traceSource, /editor-collab-sidebar-panel__note-form.*textarea/s);
+  assert.match(traceSource, /textarea.*placeholder.*Add a note/s);
   assert.match(traceSource, /inline-range-live-create/);
   assert.match(traceSource, /core\/note/);
   assert.match(traceSource, /reloadedNoteEntityResolvesToAttachment/);


### PR DESCRIPTION
## Summary
- discover note controls across nested same-origin editor frames
- identify the newly opened role=textbox composer by lifecycle instead of unstable classes or labels
- dispatch input events in the field owner realm and report bounded DOM diagnostics on timeout

## Verification
- `node --test WordPress/gutenberg/tools/fuzz-coverage.test.mjs`
- `node --check WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs`
- `git diff --check`
- Lab representative `live-create`: pass
- Lab `dirty-sibling-live-create`: pass after baseline fix
- Exact Gutenberg PR #79020 head `12bd5d16e88a1601d7229f0450c8c3c3895930ad`, final 15-case run `gutenberg-79020-fifteen-case-final-r12`: 11 passed, 4 behavioral findings, 0 harness errors