### PR TITLE
Expand Gutenberg Block Notes convergence corpus

### DIFF
--- a/WordPress/gutenberg/bench/notes-multi-author-convergence.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-multi-author-convergence.trace.mjs
@@ -1,0 +1,274 @@
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { wpCodeboxBrowserArtifacts } from '../shared/wp-codebox/artifacts.mjs';
+import { runWpCodeboxRecipe } from '../shared/wp-codebox/recipe.mjs';
+
+const componentPath = process.env.HOMEBOY_COMPONENT_PATH;
+const resultsFile = process.env.HOMEBOY_TRACE_RESULTS_FILE;
+const artifactDir = process.env.HOMEBOY_TRACE_ARTIFACT_DIR || path.join( tmpdir(), 'gutenberg-notes-multi-author-artifacts' );
+const wpVersion = process.env.HOMEBOY_GUTENBERG_NOTES_WP_VERSION || '7.0';
+const actorCount = 12;
+
+if ( ! componentPath || ! resultsFile ) {
+	throw new Error( 'HOMEBOY_COMPONENT_PATH and HOMEBOY_TRACE_RESULTS_FILE are required' );
+}
+
+const workDir = await mkdtemp( path.join( tmpdir(), 'gutenberg-notes-multi-author.' ) );
+const fixturePluginDir = path.join( workDir, 'gutenberg-notes-multi-author-fixture' );
+const recipeFile = path.join( workDir, 'recipe.json' );
+const outputFile = path.join( artifactDir, 'wp-codebox-output.json' );
+const codeboxArtifacts = path.join( artifactDir, 'wp-codebox-artifacts' );
+const startedAt = performance.now();
+const timeline = [];
+
+const event = ( source, name, data = {} ) => timeline.push( {
+	t_ms: Math.round( performance.now() - startedAt ),
+	source,
+	event: name,
+	data,
+} );
+
+const readJson = async ( file ) => existsSync( file ) ? JSON.parse( await readFile( file, 'utf8' ) ) : null;
+const actorName = ( index ) => `author-${ String( index + 1 ).padStart( 2, '0' ) }`;
+
+function actorExpression( index ) {
+	const actor = actorName( index );
+	const targetText = `Multi-author anchor ${ String( index + 1 ).padStart( 2, '0' ) }.`;
+	const noteText = `Multi-author note ${ String( index + 1 ).padStart( 2, '0' ) }.`;
+	return `
+const actor = ${ JSON.stringify( actor ) };
+const actorIndex = ${ index };
+const targetText = ${ JSON.stringify( targetText ) };
+const noteText = ${ JSON.stringify( noteText ) };
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const waitFor = async (predicate, label, timeout = 30000) => {
+	const deadline = performance.now() + timeout;
+	while (performance.now() < deadline) {
+		const value = await predicate();
+		if (value) return value;
+		await sleep(100);
+	}
+	throw new Error(actor + ' timed out waiting for ' + label);
+};
+await waitFor(() => document.body?.classList.contains('block-editor-page'), 'editor shell');
+await waitFor(() => window.wp?.data?.select('core/block-editor')?.getBlocks?.().length === ${ actorCount }, 'twelve saved blocks');
+const editorSelect = window.wp.data.select('core/editor');
+const postId = editorSelect.getCurrentPostId();
+const blockSelect = window.wp.data.select('core/block-editor');
+const blockDispatch = window.wp.data.dispatch('core/block-editor');
+const initialBlocks = blockSelect.getBlocks();
+const target = initialBlocks.find((block) => String(block.attributes?.content || '').includes(targetText));
+if (!target) throw new Error(actor + ' could not find ' + targetText);
+
+if (actorIndex === 8) {
+	blockDispatch.updateBlockAttributes(initialBlocks[0].clientId, { content: actor + ' unrelated dirty text' });
+}
+if (actorIndex === 9) {
+	blockDispatch.insertBlock(window.wp.blocks.createBlock('core/paragraph', { content: actor + ' unsaved structural edit' }), 0);
+}
+
+const coreDispatch = window.wp.data.dispatch('core');
+const rootNote = await coreDispatch.saveEntityRecord('root', 'comment', {
+	post: postId,
+	content: noteText,
+	type: 'note',
+	status: 'hold',
+	parent: 0,
+}, { throwOnError: true });
+const liveTarget = blockSelect.getBlock(target.clientId);
+blockDispatch.updateBlockAttributes(target.clientId, {
+	metadata: { ...liveTarget.attributes.metadata, noteId: [rootNote.id] },
+});
+const { unlock } = window.wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/core-data'
+);
+const persist = unlock(window.wp.data.dispatch('core')).persistEntityBlockAttributes;
+const persistAttachment = (attributes) => persist('postType', editorSelect.getCurrentPostType(), postId, {
+	record: editorSelect.getCurrentPost(),
+	blockPath: [actorIndex],
+	isMatch: (candidate) => candidate.name === target.name && String(candidate.attributes?.content || '').includes(targetText),
+	matchCount: 1,
+	matchIndex: 0,
+	blockCount: blockSelect.getBlocks().length,
+	blockName: target.name,
+	attributes,
+});
+if (!await persistAttachment((savedAttributes) => ({
+	metadata: { ...savedAttributes.metadata, noteId: [...new Set([...(Array.isArray(savedAttributes.metadata?.noteId) ? savedAttributes.metadata.noteId : []), rootNote.id])] },
+}))) {
+	throw new Error(actor + ' targeted attachment persistence returned false');
+}
+
+const reachBarrier = async (stage) => {
+	const response = await fetch('/wp-json/homeboy-gutenberg-notes/v1/barrier', {
+		method: 'POST',
+		credentials: 'include',
+		headers: { 'Content-Type': 'application/json', 'X-WP-Nonce': window.wpApiSettings?.nonce || '' },
+		body: JSON.stringify({ actor, stage }),
+	});
+	if (!response.ok) throw new Error(actor + ' barrier POST failed: HTTP ' + response.status);
+	await waitFor(async () => {
+		const state = await fetch('/wp-json/homeboy-gutenberg-notes/v1/barrier?stage=' + encodeURIComponent(stage), { credentials: 'include' }).then((result) => result.json());
+		return state.count === ${ actorCount };
+	}, stage + ' barrier', 45000);
+};
+
+await reachBarrier('attachments');
+if (actorIndex === 9) {
+	await coreDispatch.saveEntityRecord('root', 'comment', { id: rootNote.id, status: 'approved' }, { throwOnError: true });
+	await coreDispatch.saveEntityRecord('root', 'comment', { post: postId, content: '', type: 'note', status: 'approved', parent: rootNote.id, meta: { _wp_note_status: 'resolved' } }, { throwOnError: true });
+	await coreDispatch.saveEntityRecord('root', 'comment', { id: rootNote.id, status: 'hold' }, { throwOnError: true });
+	await coreDispatch.saveEntityRecord('root', 'comment', { post: postId, content: 'Reopened by ' + actor, type: 'note', status: 'hold', parent: rootNote.id, meta: { _wp_note_status: 'reopen' } }, { throwOnError: true });
+}
+if (actorIndex === 10) {
+	await coreDispatch.saveEntityRecord('root', 'comment', { post: postId, content: 'Reply from ' + actor, type: 'note', status: 'hold', parent: rootNote.id }, { throwOnError: true });
+}
+if (actorIndex === 11) {
+	await coreDispatch.deleteEntityRecord('root', 'comment', rootNote.id, undefined, { throwOnError: true });
+	if (!await persistAttachment((savedAttributes) => ({
+		metadata: { ...savedAttributes.metadata, noteId: (Array.isArray(savedAttributes.metadata?.noteId) ? savedAttributes.metadata.noteId : []).filter((id) => Number(id) !== Number(rootNote.id)) },
+	}))) {
+		throw new Error(actor + ' targeted deletion persistence returned false');
+	}
+}
+await reachBarrier('lifecycle');
+await sleep(1500);
+
+const post = await window.wp.apiFetch({ path: '/wp/v2/posts/' + postId + '?context=edit&_fields=id,content,meta' });
+const comments = await window.wp.apiFetch({ path: '/wp/v2/comments?post=' + postId + '&type=note&status=all&per_page=100&context=edit' });
+const persistedBlocks = window.wp.blocks.parse(post.content?.raw || post.content?.rendered || '');
+const rootNotes = comments.filter((comment) => Number(comment.parent) === 0);
+for (let noteIndex = 0; noteIndex < ${ actorCount - 1 }; noteIndex++) {
+	const expectedText = 'Multi-author note ' + String(noteIndex + 1).padStart(2, '0') + '.';
+	const expectedAnchor = 'Multi-author anchor ' + String(noteIndex + 1).padStart(2, '0') + '.';
+	const note = rootNotes.find((comment) => String(comment.content?.raw || comment.content?.rendered || '').includes(expectedText));
+	const block = persistedBlocks.find((candidate) => String(candidate.attributes?.content || '').includes(expectedAnchor));
+	const ids = Array.isArray(block?.attributes?.metadata?.noteId) ? block.attributes.metadata.noteId.map(Number) : [];
+	if (!note || !ids.includes(Number(note.id))) {
+		throw new Error(actor + ' observed missing attachment for ' + expectedText + '; root notes=' + rootNotes.length + '; attached=' + ids.join(','));
+	}
+}
+const deletedAnchor = persistedBlocks.find((candidate) => String(candidate.attributes?.content || '').includes('Multi-author anchor 12.'));
+if ((deletedAnchor?.attributes?.metadata?.noteId || []).length !== 0) throw new Error(actor + ' observed deleted note attachment');
+if (String(post.content?.raw || '').includes('unrelated dirty text') || String(post.content?.raw || '').includes('unsaved structural edit')) throw new Error(actor + ' observed unrelated dirty state persisted');
+if (!comments.some((comment) => String(comment.meta?._wp_note_status || '') === 'resolved')) throw new Error(actor + ' did not observe resolve history');
+if (!comments.some((comment) => String(comment.meta?._wp_note_status || '') === 'reopen')) throw new Error(actor + ' did not observe reopen history');
+if (!comments.some((comment) => String(comment.content?.raw || comment.content?.rendered || '').includes('Reply from author-11'))) throw new Error(actor + ' did not observe reply history');
+return true;`;
+}
+
+try {
+	await mkdir( fixturePluginDir, { recursive: true } );
+	await mkdir( artifactDir, { recursive: true } );
+	await mkdir( path.dirname( resultsFile ), { recursive: true } );
+	await writeFile( path.join( fixturePluginDir, 'fixture.php' ), `<?php
+/** Plugin Name: Gutenberg Notes Multi-Author Fixture */
+function homeboy_notes_multi_author_post_id() {
+	$post = get_page_by_path( 'homeboy-notes-multi-author', OBJECT, 'post' );
+	if ( $post ) return (int) $post->ID;
+	$content = array();
+	for ( $index = 1; $index <= ${ actorCount }; $index++ ) {
+		$content[] = '<!-- wp:paragraph --><p>Multi-author anchor ' . str_pad( (string) $index, 2, '0', STR_PAD_LEFT ) . '.</p><!-- /wp:paragraph -->';
+	}
+	return (int) wp_insert_post( array( 'post_type' => 'post', 'post_status' => 'draft', 'post_title' => 'Multi-Author Note Convergence', 'post_name' => 'homeboy-notes-multi-author', 'post_content' => implode( "\n\n", $content ), 'post_author' => 1 ) );
+}
+add_action( 'init', function () {
+	update_option( 'wp_collaboration_enabled', '1' );
+	$supports = get_all_post_type_supports( 'post' );
+	$editor_supports = array( 'notes' => true );
+	if ( is_array( $supports['editor'] ) && isset( $supports['editor'][0] ) && is_array( $supports['editor'][0] ) ) $editor_supports = array_merge( $editor_supports, $supports['editor'][0] );
+	add_post_type_support( 'post', 'editor', $editor_supports );
+	homeboy_notes_multi_author_post_id();
+} );
+add_action( 'rest_api_init', function () {
+	register_rest_route( 'homeboy-gutenberg-notes/v1', '/barrier', array(
+		array( 'methods' => 'POST', 'permission_callback' => function () { return current_user_can( 'edit_posts' ); }, 'callback' => function ( WP_REST_Request $request ) {
+			$actor = sanitize_key( $request->get_param( 'actor' ) );
+			$stage = sanitize_key( $request->get_param( 'stage' ) );
+			if ( ! $actor || ! in_array( $stage, array( 'attachments', 'lifecycle' ), true ) ) return new WP_Error( 'invalid_barrier', 'Invalid barrier input.', array( 'status' => 400 ) );
+			update_option( 'homeboy_notes_barrier_' . $stage . '_' . $actor, 1, false );
+			return rest_ensure_response( array( 'arrived' => true ) );
+		} ),
+		array( 'methods' => 'GET', 'permission_callback' => function () { return current_user_can( 'edit_posts' ); }, 'callback' => function ( WP_REST_Request $request ) {
+			$stage = sanitize_key( $request->get_param( 'stage' ) );
+			$count = 0;
+			for ( $index = 1; $index <= ${ actorCount }; $index++ ) $count += (int) (bool) get_option( 'homeboy_notes_barrier_' . $stage . '_author-' . str_pad( (string) $index, 2, '0', STR_PAD_LEFT ) );
+			return rest_ensure_response( array( 'count' => $count ) );
+		} ),
+	) );
+} );
+add_action( 'admin_init', function () {
+	global $pagenow;
+	if ( empty( $_GET['homeboy_notes_multi_author'] ) || 'post.php' === $pagenow ) return;
+	wp_safe_redirect( add_query_arg( array( 'post' => homeboy_notes_multi_author_post_id(), 'action' => 'edit', 'homeboy_notes_multi_author' => 1 ), admin_url( 'post.php' ) ) );
+	exit;
+} );
+` );
+
+	const fixtureUsers = Array.from( { length: actorCount }, ( _, index ) => ( { name: actorName( index ), username: `notes-${ actorName( index ) }`, role: 'editor' } ) );
+	const userSessions = fixtureUsers.map( ( user ) => ( { name: `${ user.name }-session`, user: user.name } ) );
+	const browserActors = fixtureUsers.map( ( user ) => ( { name: user.name, userSession: `${ user.name }-session` } ) );
+	const scenario = {
+		schema: 'wp-codebox/browser-multi-actor-scenario/v1',
+		url: '/wp-admin/?homeboy_notes_multi_author=1',
+		seed: process.env.HOMEBOY_SEED || 'gutenberg-79020-twelve-authors',
+		stepTimeoutMs: 120000,
+		actors: browserActors,
+		actions: browserActors.map( ( actor, index ) => ( { id: `${ actor.name }-lifecycle`, actor: actor.name, step: { kind: 'evaluate', expression: actorExpression( index ) } } ) ),
+	};
+	const recipe = {
+		schema: 'wp-codebox/workspace-recipe/v1',
+		runtime: { wp: wpVersion, blueprint: { steps: [
+			{ step: 'activatePlugin', pluginPath: '/wordpress/wp-content/plugins/gutenberg/gutenberg.php' },
+			{ step: 'activatePlugin', pluginPath: '/wordpress/wp-content/plugins/gutenberg-notes-multi-author-fixture/fixture.php' },
+		] } },
+		inputs: {
+			extra_plugins: [
+				{ source: componentPath, slug: 'gutenberg', pluginFile: 'gutenberg/gutenberg.php', activate: true },
+				{ source: fixturePluginDir, slug: 'gutenberg-notes-multi-author-fixture', pluginFile: 'gutenberg-notes-multi-author-fixture/fixture.php', activate: true },
+			],
+			fixtureUsers,
+			userSessions,
+			browserActors,
+		},
+		workflow: { steps: [ { command: 'wordpress.browser-scenario', args: [ `scenario-json=${ JSON.stringify( scenario ) }` ] } ] },
+		artifacts: { directory: codeboxArtifacts },
+	};
+
+	event( 'scenario', 'start', { actor_count: actorCount, component_path: componentPath, issue: 'https://github.com/WordPress/gutenberg/pull/79020' } );
+	await writeFile( recipeFile, `${ JSON.stringify( recipe, null, 2 ) }\n` );
+	const result = await runWpCodeboxRecipe( { recipeFile, artifactsDir: codeboxArtifacts, outputFile, event } );
+	const output = JSON.parse( result.stdout );
+	const files = wpCodeboxBrowserArtifacts( output, [ 'multi-actor-scenario-summary.json', 'multi-actor-events.json', 'multi-actor-network.json', 'multi-actor-replay.json' ] );
+	const summary = await readJson( files[ 'multi-actor-scenario-summary.json' ] );
+	const finalState = summary?.scenario?.finalState || 'failed';
+	const observedActors = Object.keys( summary?.actors || {} );
+	const pass = finalState === 'completed' && observedActors.length === actorCount;
+	const traceResult = {
+		component_id: process.env.HOMEBOY_COMPONENT_ID || 'gutenberg',
+		scenario_id: 'notes-multi-author-convergence',
+		status: pass ? 'pass' : 'fail',
+		summary: `${ observedActors.length } independently authenticated actors completed with final state ${ finalState }.` ,
+		timeline,
+		assertions: [
+			{ id: 'twelve-authenticated-authors', status: observedActors.length === actorCount ? 'pass' : 'fail', message: `Captured ${ observedActors.length } actor evidence records.` },
+			{ id: 'cross-session-note-convergence', status: finalState === 'completed' ? 'pass' : 'fail', message: `Every actor observed the same persisted attachments and lifecycle history=${ finalState === 'completed' }.` },
+		],
+		artifacts: [
+			{ label: 'WP Codebox output', path: path.relative( artifactDir, outputFile ) },
+			...Object.entries( files ).filter( ( [ , file ] ) => file && existsSync( file ) ).map( ( [ label, file ] ) => ( { label, path: path.relative( artifactDir, file ) } ) ),
+		],
+	};
+	await writeFile( resultsFile, `${ JSON.stringify( traceResult, null, 2 ) }\n` );
+	process.exitCode = pass ? 0 : 1;
+} catch ( error ) {
+	await mkdir( path.dirname( resultsFile ), { recursive: true } );
+	await writeFile( resultsFile, `${ JSON.stringify( { component_id: process.env.HOMEBOY_COMPONENT_ID || 'gutenberg', scenario_id: 'notes-multi-author-convergence', status: 'fail', summary: error instanceof Error ? error.message : String( error ), timeline, assertions: [ { id: 'trace-workload-completed', status: 'fail', message: error instanceof Error ? error.message : String( error ) } ], artifacts: existsSync( outputFile ) ? [ { label: 'WP Codebox output', path: path.relative( artifactDir, outputFile ) } ] : [] }, null, 2 ) }\n` );
+	throw error;
+} finally {
+	await rm( workDir, { recursive: true, force: true } );
+}

--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -667,6 +667,44 @@ const createNoteOnBlock = async (block, text) => {
 	await waitFor(() => document.body.textContent.includes(text), 'created live note thread ' + text);
 	return waitFor(() => getBlockNoteIds().find((id) => !beforeIds.has(id)), 'new live note id in edited block metadata');
 };
+const createConcurrentNoteRepair = async (block, text) => {
+	const coreDispatch = window.wp.data.dispatch('core');
+	const editorSelect = window.wp.data.select('core/editor');
+	const liveBlock = window.wp.data.select('core/block-editor').getBlock(block.clientId);
+	const savedNote = await coreDispatch.saveEntityRecord('root', 'comment', {
+		post: editorSelect.getCurrentPostId(),
+		content: text,
+		status: 'hold',
+		type: 'note',
+		parent: 0,
+	}, { throwOnError: true });
+	const existingIds = Array.isArray(liveBlock.attributes.metadata?.noteId) ? liveBlock.attributes.metadata.noteId : [liveBlock.attributes.metadata?.noteId].filter(Boolean);
+	const noteIds = [...new Set([...existingIds, savedNote.id])];
+	window.wp.data.dispatch('core/block-editor').updateBlockAttributes(liveBlock.clientId, { metadata: { ...liveBlock.attributes.metadata, noteId: noteIds } });
+	const { unlock } = window.wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+		'@wordpress/core-data'
+	);
+	const repair = unlock(window.wp.data.dispatch('core')).persistEntityBlockAttributes(
+		'postType',
+		editorSelect.getCurrentPostType(),
+		editorSelect.getCurrentPostId(),
+		{
+			record: editorSelect.getCurrentPost(),
+			blockPath: [0],
+			isMatch: (candidate) => candidate.name === liveBlock.name && getBlockText(candidate) === getBlockText(liveBlock),
+			matchCount: 1,
+			matchIndex: 0,
+			blockCount: 1,
+			blockName: liveBlock.name,
+			attributes: (savedAttributes) => {
+				const savedIds = Array.isArray(savedAttributes.metadata?.noteId) ? savedAttributes.metadata.noteId : [savedAttributes.metadata?.noteId].filter(Boolean);
+				return { metadata: { ...savedAttributes.metadata, noteId: [...new Set([...savedIds, ...noteIds])] } };
+			},
+		}
+	);
+	return { noteId: savedNote.id, repair };
+};
 const findRichTextEditable = (block) => {
 	const selector = '[data-block="' + block.clientId + '"][contenteditable="true"], [data-block="' + block.clientId + '"] [contenteditable="true"]';
 	return getEditorDocuments().map((editorDocument) => editorDocument.querySelector(selector)).find((editable) => editable?.textContent?.includes('note anchor'));
@@ -968,10 +1006,11 @@ const collectConcurrentNoteRepairsCase = async () => {
 	const target = getTargetBlock(caseId);
 	const firstNoteId = await createNoteOnBlock(target, 'Homeboy held repair note');
 	await waitFor(() => actorTimeline.some((entry) => entry.event === 'request-held' && entry.data.route === 'post-rest'), 'first targeted repair hold');
-	const secondCreation = createNoteOnBlock(target, 'Homeboy overlapping repair note');
+	const secondCreation = await createConcurrentNoteRepair(target, 'Homeboy overlapping repair note');
 	await waitFor(() => getBlockNoteIds().length === 2, 'second local note attachment while first repair is held');
 	releaseHeldRequest();
-	const secondNoteId = await secondCreation;
+	await secondCreation.repair;
+	const secondNoteId = secondCreation.noteId;
 	await waitForPersistedNoteIds(item.post_id, [firstNoteId, secondNoteId]);
 	const reloaded = await collectReloadedEditorState(caseId, item.post_id, secondNoteId, '');
 	const heldAndReleased = actorTimeline.some((entry) => entry.event === 'request-held') && actorTimeline.some((entry) => entry.event === 'request-released');
@@ -990,10 +1029,9 @@ const collectInlinePendingEditCase = async () => {
 	await waitFor(() => getBlockText(getTargetBlock(caseId)) === dirtyText, 'pending inline dirty edit');
 	releaseHeldRequest();
 	const surfacedFailure = await waitFor(() => (window.wp.data.select('core/notices')?.getNotices?.() || []).some((notice) => String(notice.content || '').includes('selected text changed')), 'stale inline selection notice');
-	const noteId = await waitFor(async () => {
-		const response = await originalFetch('/wp-json/wp/v2/comments?post=' + encodeURIComponent(item.post_id) + '&type=note&status=all&per_page=100', { credentials: 'include' });
-		const notes = await response.json();
-		return notes.find((note) => String(note.content?.rendered || '').includes(noteText))?.id;
+	const noteId = await waitFor(() => {
+		const notes = window.wp.data.select('core').getEntityRecords('root', 'comment', { post: item.post_id, type: 'note', status: 'all', per_page: -1 }) || [];
+		return notes.find((note) => String(note.content?.rendered || note.content?.raw || note.content || '').includes(noteText))?.id;
 	}, 'created stale inline note entity');
 	const persistedContent = await getPostContent(item.post_id);
 	const reloaded = await collectReloadedEditorState(caseId, item.post_id, noteId, dirtyText);

--- a/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
+++ b/WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs
@@ -12,7 +12,7 @@ const scenarioId = process.env.HOMEBOY_TRACE_SCENARIO || 'notes-unsaved-attachme
 const resultsFile = process.env.HOMEBOY_TRACE_RESULTS_FILE;
 const artifactDir = process.env.HOMEBOY_TRACE_ARTIFACT_DIR || path.join( tmpdir(), 'gutenberg-notes-unsaved-attachment-artifacts' );
 const wpVersion = process.env.HOMEBOY_GUTENBERG_NOTES_WP_VERSION || process.env.HOMEBOY_SETTINGS_GUTENBERG_NOTES_WP_VERSION || '7.0';
-const knownCases = new Set( [ 'orphan', 'saved-anchor', 'live-create', 'dirty-live-create', 'dirty-sibling-live-create', 'dirty-structural-live-create', 'nested-live-create', 'double-live-create', 'inline-range-live-create', 'no-saved-match', 'ambiguous-contentless', 'empty-saved-content', 'store-coherence', 'repair-sync-race', 'crdt-peer-lineage', 'matrix' ] );
+const knownCases = new Set( [ 'orphan', 'saved-anchor', 'live-create', 'dirty-live-create', 'dirty-sibling-live-create', 'dirty-structural-live-create', 'nested-live-create', 'double-live-create', 'inline-range-live-create', 'no-saved-match', 'ambiguous-contentless', 'empty-saved-content', 'store-coherence', 'repair-sync-race', 'crdt-peer-lineage', 'repair-failure-recovery', 'concurrent-note-repairs', 'inline-pending-edit', 'matrix' ] );
 const profileCase = process.env.HOMEBOY_TRACE_PROFILE || process.env.HOMEBOY_PROFILE || '';
 const targetCase = process.env.HOMEBOY_GUTENBERG_NOTES_CASE || process.env.HOMEBOY_SETTINGS_GUTENBERG_NOTES_CASE || ( knownCases.has( profileCase ) ? profileCase : 'orphan' );
 const probeDuration = process.env.HOMEBOY_GUTENBERG_NOTES_PROBE_DURATION || '12s';
@@ -205,6 +205,9 @@ function homeboy_gutenberg_notes_fixture_state() {
 	$store_coherence_post_id = homeboy_gutenberg_notes_create_post( 'homeboy-notes-store-coherence', 'Homeboy Notes Store Coherence' );
 	$repair_sync_race_post_id = homeboy_gutenberg_notes_create_post( 'homeboy-notes-repair-sync-race', 'Homeboy Notes Repair Sync Race' );
 	$crdt_peer_lineage_post_id = homeboy_gutenberg_notes_create_post( 'homeboy-notes-crdt-peer-lineage', 'Homeboy Notes CRDT Peer Lineage' );
+	$repair_failure_recovery_post_id = homeboy_gutenberg_notes_create_post( 'homeboy-notes-repair-failure-recovery', 'Homeboy Notes Repair Failure Recovery' );
+	$concurrent_note_repairs_post_id = homeboy_gutenberg_notes_create_post( 'homeboy-notes-concurrent-note-repairs', 'Homeboy Notes Concurrent Repairs' );
+	$inline_pending_edit_post_id = homeboy_gutenberg_notes_create_post( 'homeboy-notes-inline-pending-edit', 'Homeboy Notes Inline Pending Edit' );
 
 	$state = array(
 		'orphan' => array(
@@ -258,6 +261,9 @@ function homeboy_gutenberg_notes_fixture_state() {
 		'store-coherence' => array( 'post_id' => $store_coherence_post_id, 'note_id' => 0, 'expected_orphan' => false ),
 		'repair-sync-race' => array( 'post_id' => $repair_sync_race_post_id, 'note_id' => 0, 'expected_orphan' => false ),
 		'crdt-peer-lineage' => array( 'post_id' => $crdt_peer_lineage_post_id, 'note_id' => 0, 'expected_orphan' => false ),
+		'repair-failure-recovery' => array( 'post_id' => $repair_failure_recovery_post_id, 'note_id' => 0, 'expected_orphan' => false ),
+		'concurrent-note-repairs' => array( 'post_id' => $concurrent_note_repairs_post_id, 'note_id' => 0, 'expected_orphan' => false ),
+		'inline-pending-edit' => array( 'post_id' => $inline_pending_edit_post_id, 'note_id' => 0, 'expected_orphan' => false ),
 	);
 
 	update_option( 'homeboy_gutenberg_notes_fixture_state', $state, false );
@@ -329,6 +335,10 @@ const currentCase = new URL(location.href).searchParams.get('homeboy_notes_case'
 const observedRequests = [];
 const actorTimeline = [];
 const actorEvent = (actor, event, data = {}) => actorTimeline.push({ t_ms: Math.round(performance.now()), actor, event, data });
+let releaseHeldRequest;
+const heldRequest = new Promise((resolve) => { releaseHeldRequest = resolve; });
+let heldRepairCount = 0;
+let forcedRepairFailurePending = currentCase === 'repair-failure-recovery';
 const originalFetch = window.fetch.bind(window);
 window.fetch = async (input, init = {}) => {
 	const request = input instanceof Request ? input : null;
@@ -337,7 +347,7 @@ window.fetch = async (input, init = {}) => {
 	const rawBody = typeof init.body === 'string' ? init.body : '';
 	let payload = null;
 	try { payload = rawBody ? JSON.parse(rawBody) : null; } catch (error) {}
-	const route = url.includes('/wp-sync/v1/save') ? 'sync-save' : url.includes('/wp-json/wp/v2/posts/') ? 'post-rest' : 'other';
+	const route = url.includes('/wp-sync/v1/save') ? 'sync-save' : url.includes('/wp-json/wp/v2/posts/') ? 'post-rest' : url.includes('/wp-json/wp/v2/comments') ? 'comment-rest' : 'other';
 	const payloadKeys = Object.keys(payload || {}).sort();
 	const semantics = {
 		has_crdt_document: typeof payload?.meta?._crdt_document === 'string' || typeof payload?.doc === 'string',
@@ -354,8 +364,22 @@ window.fetch = async (input, init = {}) => {
 		actorEvent('parent', 'request-delayed', { route, delay_ms: raceDelay, seed });
 		await sleep(raceDelay);
 	}
+	const holdConcurrentRepair = currentCase === 'concurrent-note-repairs' && route === 'post-rest' && semantics.is_targeted_repair && heldRepairCount++ === 0;
+	const holdPendingComment = currentCase === 'inline-pending-edit' && route === 'comment-rest' && method === 'POST';
+	if (holdConcurrentRepair || holdPendingComment) {
+		actorEvent('parent', 'request-held', { route, semantics });
+		await heldRequest;
+		actorEvent('parent', 'request-released', { route, semantics });
+	}
 	actorEvent('parent', 'request-start', { route, method, semantics });
 	try {
+		if (forcedRepairFailurePending && route === 'post-rest' && semantics.is_targeted_repair) {
+			forcedRepairFailurePending = false;
+			const response = new Response(JSON.stringify({ code: 'forced_attachment_failure', message: 'Forced attachment repair failure.' }), { status: 500, headers: { 'Content-Type': 'application/json' } });
+			observedRequests.push({ t_ms: Math.round(performance.now()), url, method, status: response.status, route, semantics, body: rawBody.slice(0, 500), forced_failure: true });
+			actorEvent('parent', 'request-finish', { route, method, status: response.status, semantics, forced_failure: true });
+			return response;
+		}
 		const response = await originalFetch(input, init);
 		observedRequests.push({ t_ms: Math.round(performance.now()), url, method, status: response.status, route, semantics, body: rawBody.slice(0, 500) });
 		actorEvent('parent', 'request-finish', { route, method, status: response.status, semantics });
@@ -667,7 +691,7 @@ const selectRichTextRange = (editable) => {
 	}
 	throw new Error('Could not select rich-text note anchor range');
 };
-const createNoteOnRichTextRange = async (block, text) => {
+const beginNoteOnRichTextRange = async (block, text) => {
 	const beforeIds = new Set(getBlockNoteIds());
 	const editable = await waitFor(() => findRichTextEditable(block), 'rich-text note anchor editable');
 	if (selectRichTextRange(editable) !== 'note anchor') throw new Error('Rich-text range selection did not match note anchor');
@@ -689,6 +713,10 @@ const createNoteOnRichTextRange = async (block, text) => {
 	setFieldValue(textarea, text);
 	const addButton = await waitForAddNoteButton();
 	addButton.click();
+	return beforeIds;
+};
+const createNoteOnRichTextRange = async (block, text) => {
+	const beforeIds = await beginNoteOnRichTextRange(block, text);
 	await waitFor(() => document.body.textContent.includes(text), 'created rich-text range note thread ' + text);
 	const noteId = await waitFor(() => getBlockNoteIds().find((id) => !beforeIds.has(id)), 'new rich-text range note id in block metadata');
 	await waitFor(() => getCoreNoteMarkers().some((marker) => marker.clientId === block.clientId && Number(marker.attributes?.['data-id']) === Number(noteId)), 'core/note rich-text marker for note ' + noteId);
@@ -920,6 +948,57 @@ const collectCrdtPeerLineageCase = async () => {
 	iframe.remove();
 	return { caseId, postId: item.post_id, noteId, parentBlockCount, parentText, peer, passed: peer.noteIds.includes(noteId) && peer.attachmentCount === 1 && peer.blockCount === parentBlockCount && peer.blockTexts.join('\\n') === parentText, actorTimeline: [...actorTimeline], observedRequests: observedRequests.filter((request) => request.route === 'post-rest' || request.route === 'sync-save') };
 };
+const collectRepairFailureRecoveryCase = async () => {
+	const caseId = 'repair-failure-recovery';
+	const item = fixtureState[caseId];
+	await waitForEditorReady(caseId);
+	const target = getTargetBlock(caseId);
+	const firstNoteId = await createNoteOnBlock(target, 'Homeboy failed repair note');
+	const surfacedFailure = await waitFor(() => (window.wp.data.select('core/notices')?.getNotices?.() || []).some((notice) => String(notice.content || '').includes('Forced attachment repair failure')), 'failed repair notice');
+	const secondNoteId = await createNoteOnBlock(target, 'Homeboy repair recovery note');
+	await waitForPersistedNoteIds(item.post_id, [firstNoteId, secondNoteId]);
+	const reloaded = await collectReloadedEditorState(caseId, item.post_id, secondNoteId, '');
+	const forcedFailure = postRequests(item.post_id).some((request) => request.forced_failure);
+	return { caseId, postId: item.post_id, noteIds: [firstNoteId, secondNoteId], surfacedFailure: !!surfacedFailure, forcedFailure, ...reloaded, passed: !!surfacedFailure && forcedFailure && reloaded.reloadedBlockNoteIds.includes(firstNoteId) && reloaded.reloadedBlockNoteIds.includes(secondNoteId), actorTimeline: [...actorTimeline], observedRequests: postRequests(item.post_id) };
+};
+const collectConcurrentNoteRepairsCase = async () => {
+	const caseId = 'concurrent-note-repairs';
+	const item = fixtureState[caseId];
+	await waitForEditorReady(caseId);
+	const target = getTargetBlock(caseId);
+	const firstNoteId = await createNoteOnBlock(target, 'Homeboy held repair note');
+	await waitFor(() => actorTimeline.some((entry) => entry.event === 'request-held' && entry.data.route === 'post-rest'), 'first targeted repair hold');
+	const secondCreation = createNoteOnBlock(target, 'Homeboy overlapping repair note');
+	await waitFor(() => getBlockNoteIds().length === 2, 'second local note attachment while first repair is held');
+	releaseHeldRequest();
+	const secondNoteId = await secondCreation;
+	await waitForPersistedNoteIds(item.post_id, [firstNoteId, secondNoteId]);
+	const reloaded = await collectReloadedEditorState(caseId, item.post_id, secondNoteId, '');
+	const heldAndReleased = actorTimeline.some((entry) => entry.event === 'request-held') && actorTimeline.some((entry) => entry.event === 'request-released');
+	return { caseId, postId: item.post_id, noteIds: [firstNoteId, secondNoteId], heldAndReleased, ...reloaded, passed: heldAndReleased && reloaded.reloadedBlockNoteIds.includes(firstNoteId) && reloaded.reloadedBlockNoteIds.includes(secondNoteId), actorTimeline: [...actorTimeline], observedRequests: postRequests(item.post_id) };
+};
+const collectInlinePendingEditCase = async () => {
+	const caseId = 'inline-pending-edit';
+	const item = fixtureState[caseId];
+	await waitForEditorReady(caseId);
+	const target = getTargetBlock(caseId);
+	const noteText = 'Homeboy stale inline range note';
+	await beginNoteOnRichTextRange(target, noteText);
+	await waitFor(() => actorTimeline.some((entry) => entry.event === 'request-held' && entry.data.route === 'comment-rest'), 'pending note comment hold');
+	const dirtyText = 'Homeboy text changed while note creation was pending.';
+	window.wp.data.dispatch('core/block-editor').updateBlockAttributes(target.clientId, { content: dirtyText });
+	await waitFor(() => getBlockText(getTargetBlock(caseId)) === dirtyText, 'pending inline dirty edit');
+	releaseHeldRequest();
+	const surfacedFailure = await waitFor(() => (window.wp.data.select('core/notices')?.getNotices?.() || []).some((notice) => String(notice.content || '').includes('selected text changed')), 'stale inline selection notice');
+	const noteId = await waitFor(async () => {
+		const response = await originalFetch('/wp-json/wp/v2/comments?post=' + encodeURIComponent(item.post_id) + '&type=note&status=all&per_page=100', { credentials: 'include' });
+		const notes = await response.json();
+		return notes.find((note) => String(note.content?.rendered || '').includes(noteText))?.id;
+	}, 'created stale inline note entity');
+	const persistedContent = await getPostContent(item.post_id);
+	const reloaded = await collectReloadedEditorState(caseId, item.post_id, noteId, dirtyText);
+	return { caseId, postId: item.post_id, noteId, dirtyText, surfacedFailure: !!surfacedFailure, persistedContent, ...reloaded, logicalOrphan: !reloaded.reloadedHasNoteId, passed: !!surfacedFailure && !contentHasNoteId(persistedContent, noteId) && !persistedContent.includes(dirtyText) && !reloaded.reloadedHasNoteId && !reloaded.reloadedHasCoreNoteMarker && !reloaded.reloadedHasDirtyText, actorTimeline: [...actorTimeline], observedRequests: observedRequests.filter((request) => request.route === 'comment-rest' || request.route === 'post-rest') };
+};
 const collectCase = async (caseId) => {
 	const item = fixtureState[caseId];
 	if (!item) {
@@ -937,6 +1016,9 @@ const collectCase = async (caseId) => {
 	if (caseId === 'store-coherence') return collectStoreCoherenceCase();
 	if (caseId === 'repair-sync-race') return collectRepairSyncRaceCase();
 	if (caseId === 'crdt-peer-lineage') return collectCrdtPeerLineageCase();
+	if (caseId === 'repair-failure-recovery') return collectRepairFailureRecoveryCase();
+	if (caseId === 'concurrent-note-repairs') return collectConcurrentNoteRepairsCase();
+	if (caseId === 'inline-pending-edit') return collectInlinePendingEditCase();
 	return collectBlockAttachment(caseId, item, Number(item.note_id));
 };
 const results = [await collectCase(currentCase)];

--- a/WordPress/gutenberg/fuzz/gutenberg-notes-attachment-corpus.json
+++ b/WordPress/gutenberg/fuzz/gutenberg-notes-attachment-corpus.json
@@ -26,9 +26,10 @@
     "crdt-peer-lineage-reload",
     "failed-repair-recovery",
     "concurrent-note-repair-ordering",
-    "inline-pending-edit-safe-refusal"
+    "inline-pending-edit-safe-refusal",
+    "twelve-authenticated-author-convergence"
   ],
-  "case_budget": 18,
+  "case_budget": 19,
   "duration_budget_seconds": 2700,
   "metadata": {
     "kind": "gutenberg-browser-fuzz",
@@ -36,7 +37,7 @@
     "source_issue": "github_issue:WordPress/gutenberg#72717",
     "readiness": {
       "level": "executable",
-      "coverage_contract": "The checked-in corpus builds the exact Gutenberg checkout, executes eighteen Block Notes attachment and persistence cases in disposable WP Codebox browser runtimes, proves plugin bundle provenance, captures actor and request timelines, and emits replayable case-level evidence."
+      "coverage_contract": "The checked-in corpus builds the exact Gutenberg checkout, executes nineteen Block Notes attachment and persistence cases in disposable WP Codebox browser runtimes, proves plugin bundle provenance, captures actor and request timelines, and emits replayable case-level evidence."
     },
     "corpus_cases": [
       { "id": "orphan", "operation": "missing-anchor-load", "invariant": "A note whose ID is absent from block metadata is classified as detached." },
@@ -56,7 +57,8 @@
       { "id": "crdt-peer-lineage", "operation": "crdt-peer-lineage-reload", "invariant": "A second same-origin editor peer reloads persisted CRDT lineage without duplicate blocks or text and retains the attachment." },
       { "id": "repair-failure-recovery", "operation": "failed-repair-recovery", "invariant": "A failed targeted repair is surfaced and a later repair recovers both durable note attachments without a full editor save." },
       { "id": "concurrent-note-repairs", "operation": "concurrent-note-repair-ordering", "invariant": "A second note created while the first targeted repair is held preserves both IDs after queued persistence and reload." },
-      { "id": "inline-pending-edit", "operation": "inline-pending-edit-safe-refusal", "invariant": "Changing selected rich text while comment creation is pending refuses stale offsets without persisting a wrong marker or the dirty edit." }
+      { "id": "inline-pending-edit", "operation": "inline-pending-edit-safe-refusal", "invariant": "Changing selected rich text while comment creation is pending refuses stale offsets without persisting a wrong marker or the dirty edit." },
+      { "id": "multi-author-convergence", "operation": "twelve-authenticated-author-convergence", "invariant": "Twelve independently authenticated editors converge on all surviving note attachments, lifecycle history, and saved content without persisting unrelated dirty state." }
     ]
   },
   "target": {
@@ -96,7 +98,8 @@
         "crdt-peer-lineage-reload",
         "failed-repair-recovery",
         "concurrent-note-repair-ordering",
-        "inline-pending-edit-safe-refusal"
+        "inline-pending-edit-safe-refusal",
+        "twelve-authenticated-author-convergence"
       ],
       "artifacts": [
         { "name": "case_log", "path": "case-log.jsonl", "required": true, "metadata": { "semantic_key": "fuzz.case_log" } },
@@ -109,7 +112,7 @@
     }
   ],
   "limits": {
-    "max_cases": 18,
+    "max_cases": 19,
     "max_duration_seconds": 2700
   },
   "coverage": {
@@ -136,7 +139,8 @@
       "crdt-peer-lineage-reload",
       "failed-repair-recovery",
       "concurrent-note-repair-ordering",
-      "inline-pending-edit-safe-refusal"
+      "inline-pending-edit-safe-refusal",
+      "twelve-authenticated-author-convergence"
     ]
   },
   "artifacts": {

--- a/WordPress/gutenberg/fuzz/gutenberg-notes-attachment-corpus.json
+++ b/WordPress/gutenberg/fuzz/gutenberg-notes-attachment-corpus.json
@@ -23,9 +23,12 @@
     "empty-saved-content-unsaved-note",
     "store-coherence-before-dependent-operation",
     "repair-sync-order-race",
-    "crdt-peer-lineage-reload"
+    "crdt-peer-lineage-reload",
+    "failed-repair-recovery",
+    "concurrent-note-repair-ordering",
+    "inline-pending-edit-safe-refusal"
   ],
-  "case_budget": 15,
+  "case_budget": 18,
   "duration_budget_seconds": 2700,
   "metadata": {
     "kind": "gutenberg-browser-fuzz",
@@ -33,7 +36,7 @@
     "source_issue": "github_issue:WordPress/gutenberg#72717",
     "readiness": {
       "level": "executable",
-      "coverage_contract": "The checked-in corpus builds the exact Gutenberg checkout, executes fifteen Block Notes attachment and persistence cases in disposable WP Codebox browser runtimes, proves plugin bundle provenance, captures actor and request timelines, and emits replayable case-level evidence."
+      "coverage_contract": "The checked-in corpus builds the exact Gutenberg checkout, executes eighteen Block Notes attachment and persistence cases in disposable WP Codebox browser runtimes, proves plugin bundle provenance, captures actor and request timelines, and emits replayable case-level evidence."
     },
     "corpus_cases": [
       { "id": "orphan", "operation": "missing-anchor-load", "invariant": "A note whose ID is absent from block metadata is classified as detached." },
@@ -50,7 +53,10 @@
       { "id": "empty-saved-content", "operation": "empty-saved-content-unsaved-note", "invariant": "An empty saved document plus an unsaved inserted note target produces no parse error or unintended full editor save." },
       { "id": "store-coherence", "operation": "store-coherence-before-dependent-operation", "invariant": "Block-editor and editor stores agree on the repaired attachment before a dependent second note operation." },
       { "id": "repair-sync-race", "operation": "repair-sync-order-race", "invariant": "Seeded REST and wp-sync request ordering converges with every created note ID attached." },
-      { "id": "crdt-peer-lineage", "operation": "crdt-peer-lineage-reload", "invariant": "A second same-origin editor peer reloads persisted CRDT lineage without duplicate blocks or text and retains the attachment." }
+      { "id": "crdt-peer-lineage", "operation": "crdt-peer-lineage-reload", "invariant": "A second same-origin editor peer reloads persisted CRDT lineage without duplicate blocks or text and retains the attachment." },
+      { "id": "repair-failure-recovery", "operation": "failed-repair-recovery", "invariant": "A failed targeted repair is surfaced and a later repair recovers both durable note attachments without a full editor save." },
+      { "id": "concurrent-note-repairs", "operation": "concurrent-note-repair-ordering", "invariant": "A second note created while the first targeted repair is held preserves both IDs after queued persistence and reload." },
+      { "id": "inline-pending-edit", "operation": "inline-pending-edit-safe-refusal", "invariant": "Changing selected rich text while comment creation is pending refuses stale offsets without persisting a wrong marker or the dirty edit." }
     ]
   },
   "target": {
@@ -87,7 +93,10 @@
         "empty-saved-content-unsaved-note",
         "store-coherence-before-dependent-operation",
         "repair-sync-order-race",
-        "crdt-peer-lineage-reload"
+        "crdt-peer-lineage-reload",
+        "failed-repair-recovery",
+        "concurrent-note-repair-ordering",
+        "inline-pending-edit-safe-refusal"
       ],
       "artifacts": [
         { "name": "case_log", "path": "case-log.jsonl", "required": true, "metadata": { "semantic_key": "fuzz.case_log" } },
@@ -100,7 +109,7 @@
     }
   ],
   "limits": {
-    "max_cases": 15,
+    "max_cases": 18,
     "max_duration_seconds": 2700
   },
   "coverage": {
@@ -124,7 +133,10 @@
       "empty-saved-content-unsaved-note",
       "store-coherence-before-dependent-operation",
       "repair-sync-order-race",
-      "crdt-peer-lineage-reload"
+      "crdt-peer-lineage-reload",
+      "failed-repair-recovery",
+      "concurrent-note-repair-ordering",
+      "inline-pending-edit-safe-refusal"
     ]
   },
   "artifacts": {

--- a/WordPress/gutenberg/fuzz/gutenberg-notes-unsaved-attachment.mjs
+++ b/WordPress/gutenberg/fuzz/gutenberg-notes-unsaved-attachment.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 const packageRoot = path.resolve( path.dirname( fileURLToPath( import.meta.url ) ), '..' );
 const tracePath = path.join( packageRoot, 'bench/notes-unsaved-attachment.trace.mjs' );
+const multiAuthorTracePath = path.join( packageRoot, 'bench/notes-multi-author-convergence.trace.mjs' );
 const artifactsDir = process.env.HOMEBOY_FUZZ_ARTIFACTS_DIR || path.join( packageRoot, 'artifacts/fuzz/notes-unsaved-attachment' );
 const resultsFile = process.env.HOMEBOY_FUZZ_RESULTS_FILE || path.join( artifactsDir, 'results.json' );
 const runId = process.env.HOMEBOY_FUZZ_RUN_ID || `gutenberg-notes-${ Date.now() }`;
@@ -34,6 +35,7 @@ const corpus = [
 	[ 'repair-failure-recovery', 'failed-repair-recovery' ],
 	[ 'concurrent-note-repairs', 'concurrent-note-repair-ordering' ],
 	[ 'inline-pending-edit', 'inline-pending-edit-safe-refusal' ],
+	[ 'multi-author-convergence', 'twelve-authenticated-author-convergence' ],
 ];
 
 await mkdir( artifactsDir, { recursive: true } );
@@ -99,7 +101,7 @@ const buildProvenance = {
 function runTrace( caseId, resultFile, caseArtifactsDir ) {
 	return new Promise( ( resolve ) => {
 		const started = performance.now();
-		const child = spawn( process.execPath, [ tracePath ], {
+		const child = spawn( process.execPath, [ caseId === 'multi-author-convergence' ? multiAuthorTracePath : tracePath ], {
 			cwd: packageRoot,
 			env: {
 				...process.env,

--- a/WordPress/gutenberg/fuzz/gutenberg-notes-unsaved-attachment.mjs
+++ b/WordPress/gutenberg/fuzz/gutenberg-notes-unsaved-attachment.mjs
@@ -31,6 +31,9 @@ const corpus = [
 	[ 'store-coherence', 'store-coherence-before-dependent-operation' ],
 	[ 'repair-sync-race', 'repair-sync-order-race' ],
 	[ 'crdt-peer-lineage', 'crdt-peer-lineage-reload' ],
+	[ 'repair-failure-recovery', 'failed-repair-recovery' ],
+	[ 'concurrent-note-repairs', 'concurrent-note-repair-ordering' ],
+	[ 'inline-pending-edit', 'inline-pending-edit-safe-refusal' ],
 ];
 
 await mkdir( artifactsDir, { recursive: true } );

--- a/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
+++ b/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
@@ -24,6 +24,7 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
   const workload = readJson('fuzz/gutenberg-notes-attachment-corpus.json');
   const runnerSource = readFileSync(path.join(root, 'fuzz/gutenberg-notes-unsaved-attachment.mjs'), 'utf8');
   const traceSource = readFileSync(path.join(root, 'bench/notes-unsaved-attachment.trace.mjs'), 'utf8');
+  const multiAuthorTraceSource = readFileSync(path.join(root, 'bench/notes-multi-author-convergence.trace.mjs'), 'utf8');
   const browserScriptStart = traceSource.indexOf('const browserScript = `') + 'const browserScript = `'.length;
   const browserScriptEnd = traceSource.indexOf('`;\n\ntry {', browserScriptStart);
   const browserScriptTemplate = traceSource.slice(browserScriptStart, browserScriptEnd);
@@ -53,6 +54,7 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
     'repair-failure-recovery',
     'concurrent-note-repairs',
     'inline-pending-edit',
+    'multi-author-convergence',
   ];
 
   assert.deepEqual(inventoryRig.components.gutenberg.extensions.nodejs, {});
@@ -91,6 +93,12 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
   assert.match(traceSource, /repair-failure-recovery/);
   assert.match(traceSource, /concurrent-note-repairs/);
   assert.match(traceSource, /inline-pending-edit/);
+  assert.match(multiAuthorTraceSource, /wordpress\.browser-scenario/);
+  assert.match(multiAuthorTraceSource, /actorCount = 12/);
+  assert.match(multiAuthorTraceSource, /fixtureUsers/);
+  assert.match(multiAuthorTraceSource, /userSessions/);
+  assert.match(multiAuthorTraceSource, /browserActors/);
+  assert.match(multiAuthorTraceSource, /cross-session-note-convergence/);
   assert.match(traceSource, /actorTimeline/);
   assert.match(traceSource, /HOMEBOY_SEED/);
   assert.doesNotThrow(() => new AsyncFunction(browserScript));

--- a/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
+++ b/WordPress/gutenberg/tools/fuzz-coverage.test.mjs
@@ -50,6 +50,9 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
     'store-coherence',
     'repair-sync-race',
     'crdt-peer-lineage',
+    'repair-failure-recovery',
+    'concurrent-note-repairs',
+    'inline-pending-edit',
   ];
 
   assert.deepEqual(inventoryRig.components.gutenberg.extensions.nodejs, {});
@@ -85,6 +88,9 @@ test('Block Notes fuzz rig owns its complete adversarial corpus', () => {
   assert.match(traceSource, /store-coherence/);
   assert.match(traceSource, /repair-sync-race/);
   assert.match(traceSource, /crdt-peer-lineage/);
+  assert.match(traceSource, /repair-failure-recovery/);
+  assert.match(traceSource, /concurrent-note-repairs/);
+  assert.match(traceSource, /inline-pending-edit/);
   assert.match(traceSource, /actorTimeline/);
   assert.match(traceSource, /HOMEBOY_SEED/);
   assert.doesNotThrow(() => new AsyncFunction(browserScript));


### PR DESCRIPTION
## Summary

- expand the Block Notes adversarial corpus from 15 to 19 cases
- cover failed repair recovery, overlapping repairs, and stale inline selections
- add a dedicated 12-author scenario with independently authenticated editor contexts
- coordinate attachment and lifecycle phases through server-backed barriers
- verify surviving and deleted attachments, resolve/reopen history, replies, and unsaved dirty-state boundaries from every actor

Consumer: WordPress/gutenberg#79020.
Runtime prerequisite: Automattic/wp-codebox#1948.

## Verification

- `node --test WordPress/gutenberg/tools/fuzz-coverage.test.mjs`
- `node --check WordPress/gutenberg/bench/notes-multi-author-convergence.trace.mjs`
- `node --check WordPress/gutenberg/bench/notes-unsaved-attachment.trace.mjs`
- `node --check WordPress/gutenberg/fuzz/gutenberg-notes-unsaved-attachment.mjs`
- `git diff --check origin/main...HEAD`

## Runtime status

The isolated WP Codebox prerequisite built successfully in Lab as run `wp-codebox-1946-lab-hydrate` at SHA `9fbd9e30`. The 12-author Gutenberg run did not start because Homeboy refused to rotate a stale shared Lab daemon while two unrelated jobs were active. No runtime convergence claim is made yet.