### PR TITLE
Fix Jetpack owner mismatch fixture

### DIFF
--- a/Automattic/jetpack/bench/jetpack-connection-owner-mismatch.php
+++ b/Automattic/jetpack/bench/jetpack-connection-owner-mismatch.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Jetpack local connection-owner mismatch fixture.
+ *
+ * This models the stale local owner shape without contacting WordPress.com.
+ */
+return function (): array {
+	$option_names = array( 'jetpack_options', 'jetpack_private_options', 'jetpack_active_modules' );
+	$missing      = new stdClass();
+	$snapshot     = array();
+	foreach ( $option_names as $option_name ) {
+		$value                    = get_option( $option_name, $missing );
+		$snapshot[ $option_name ] = array(
+			'present'    => $value !== $missing,
+			'value'      => $value === $missing ? null : $value,
+			'value_hash' => $value === $missing ? null : hash( 'sha256', wp_json_encode( $value ) ),
+		);
+	}
+
+	$previous_user_id = get_current_user_id();
+	$owner_id         = 0;
+	$manager          = new \Automattic\Jetpack\Connection\Manager( 'jetpack' );
+	$failure          = null;
+	$cleanup_errors   = array();
+	$result           = array();
+
+	try {
+		$owner_id = wp_insert_user(
+			array(
+				'user_login' => 'hb-jp-owner-' . substr( str_replace( '-', '', wp_generate_uuid4() ), 0, 20 ),
+				'user_pass'  => wp_generate_password( 32, true, true ),
+				'role'       => 'administrator',
+			)
+		);
+		if ( is_wp_error( $owner_id ) ) {
+			throw new RuntimeException( $owner_id->get_error_message() );
+		}
+
+		// Jetpack validates this local token shape before identifying the owner.
+		Jetpack_Options::update_option( 'id', 11206186 );
+		Jetpack_Options::update_option( 'blog_token', 'fixture.blog.token' );
+		Jetpack_Options::update_option( 'master_user', $owner_id );
+		Jetpack_Options::update_option( 'user_tokens', array( $owner_id => 'fixture.owner.' . $owner_id ) );
+		$manager->reset_connection_status();
+
+		$fixture_snapshot = array();
+		foreach ( $option_names as $option_name ) {
+			$value                           = get_option( $option_name, $missing );
+			$fixture_snapshot[ $option_name ] = array(
+				'present'    => $value !== $missing,
+				'value_hash' => $value === $missing ? null : hash( 'sha256', wp_json_encode( $value ) ),
+			);
+		}
+		$module_before  = get_option( 'jetpack_active_modules', array() );
+		$health_tests   = new \Automattic\Jetpack\Connection\Connection_Health_Tests();
+		$healthy_result = $health_tests->run_test( 'test__master_user_can_manage_options' );
+		$owner          = get_userdata( $owner_id );
+		if ( ! $owner instanceof WP_User ) {
+			throw new RuntimeException( 'Jetpack connection-owner fixture user could not be loaded.' );
+		}
+		$owner->set_role( 'subscriber' );
+		$drift_result = $health_tests->run_test( 'test__master_user_can_manage_options' );
+		$module_after = get_option( 'jetpack_active_modules', array() );
+
+		$result = array(
+			'schema' => 'homeboy-rigs/jetpack-connection-owner-mismatch/v1',
+			'anchor' => array(
+				'github_issue' => 'https://github.com/chubes4/homeboy-rigs/issues/693',
+				'zendesk_ticket' => '11206186',
+			),
+			'fixture' => array(
+				'connection_owner_id' => $manager->get_connection_owner_id(),
+				'owner_role_before_drift' => 'administrator',
+				'owner_role_after_drift' => 'subscriber',
+				'owner_lost_manage_options' => ! user_can( $owner_id, 'manage_options' ),
+				'has_connected_owner' => $manager->has_connected_owner(),
+				'is_user_connected'  => $manager->is_user_connected( $owner_id ),
+				'is_site_connected'  => $manager->is_connected(),
+			),
+			'health' => array(
+				'test' => 'test__master_user_can_manage_options',
+				'before_drift_pass' => $healthy_result['pass'] ?? null,
+				'after_drift_pass' => $drift_result['pass'] ?? null,
+			),
+			'module_state' => array(
+				'before_hash' => hash( 'sha256', wp_json_encode( $module_before ) ),
+				'after_hash'  => hash( 'sha256', wp_json_encode( $module_after ) ),
+				'changed'     => $module_before !== $module_after,
+			),
+			'connection_option_snapshots' => array(
+				'before_drift' => array_map(
+					static fn ( $entry ) => array(
+						'present'    => $entry['present'],
+						'value_hash' => $entry['value_hash'],
+					),
+					$snapshot
+				),
+				'after_drift_and_health_evaluation' => $fixture_snapshot,
+			),
+			'network_calls' => array(
+				'allowed' => false,
+				'performed' => false,
+			),
+			'scope' => array(
+				'local_proof' => 'connection owner capability drift does not mutate jetpack_active_modules',
+				'remote_proof' => 'WPCOM JetpackConnectionHealthTest::test_test_rest_api_endpoint_with_user_token_if_blog_owner_doesnt_match_remote_connection_owner',
+				'remote_diagnostic' => 'connection_owner_mismatch',
+			),
+		);
+		if (
+			$owner_id !== $result['fixture']['connection_owner_id'] ||
+			! $result['fixture']['owner_lost_manage_options'] ||
+			! $result['fixture']['has_connected_owner'] ||
+			! $result['fixture']['is_user_connected'] ||
+			! $result['fixture']['is_site_connected'] ||
+			true !== $result['health']['before_drift_pass'] ||
+			false !== $result['health']['after_drift_pass'] ||
+			$result['module_state']['changed']
+		) {
+			throw new RuntimeException( 'Jetpack connection-owner mismatch fixture did not produce the expected local health state.' );
+		}
+	} catch ( Throwable $error ) {
+		$failure = $error;
+	} finally {
+		foreach ( $snapshot as $option_name => $entry ) {
+			$restored = $entry['present']
+				? update_option( $option_name, $entry['value'] ) || get_option( $option_name ) === $entry['value']
+				: delete_option( $option_name ) || get_option( $option_name, $missing ) === $missing;
+			if ( ! $restored ) {
+				$cleanup_errors[] = "option:$option_name";
+			}
+		}
+		$manager->reset_connection_status();
+		if ( ! function_exists( 'wp_delete_user' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/user.php';
+		}
+		if ( $owner_id > 0 && ! wp_delete_user( $owner_id ) ) {
+			$cleanup_errors[] = 'fixture_owner';
+		}
+		wp_set_current_user( $previous_user_id );
+
+		$after_snapshot = array();
+		foreach ( $option_names as $option_name ) {
+			$value                         = get_option( $option_name, $missing );
+			$after_snapshot[ $option_name ] = array(
+				'present'    => $value !== $missing,
+				'value_hash' => $value === $missing ? null : hash( 'sha256', wp_json_encode( $value ) ),
+			);
+		}
+		$result['cleanup'] = array(
+			'options_restored' => $after_snapshot === array_map(
+				static fn ( $entry ) => array(
+					'present'    => $entry['present'],
+					'value_hash' => $entry['value_hash'],
+				),
+				$snapshot
+			),
+			'fixture_owner_deleted' => $owner_id <= 0 || ! get_user_by( 'id', $owner_id ),
+			'errors' => $cleanup_errors,
+		);
+		$result['connection_option_snapshots']['after_restoration'] = $after_snapshot;
+	}
+
+	if ( $failure instanceof Throwable ) {
+		throw $failure;
+	}
+	if ( ! empty( $cleanup_errors ) || empty( $result['cleanup']['options_restored'] ) || empty( $result['cleanup']['fixture_owner_deleted'] ) ) {
+		throw new RuntimeException( 'Jetpack connection-owner mismatch fixture cleanup failed.' );
+	}
+
+	return array(
+		'metrics' => array(
+			'health_passed_before_owner_drift' => true === $result['health']['before_drift_pass'],
+			'health_failed_after_owner_drift' => false === $result['health']['after_drift_pass'],
+			'module_state_changed' => $result['module_state']['changed'],
+			'cleanup_passed' => true,
+		),
+		'metadata' => array(
+			'runner' => 'wp-codebox',
+			'workload' => 'jetpack-connection-owner-mismatch',
+			'coverage_shape' => 'healthy local Jetpack connection owner downgraded to subscriber and evaluated without outbound requests',
+		),
+		'artifacts' => array(
+			'connection_owner_mismatch' => $result,
+		),
+		'result' => $result,
+	);
+};

--- a/Automattic/jetpack/fuzz/jetpack-connected-disconnected-fixtures.json
+++ b/Automattic/jetpack/fuzz/jetpack-connected-disconnected-fixtures.json
@@ -1,179 +1,57 @@
 {
   "schema": "homeboy/fuzz-workload/v1",
   "id": "jetpack-connected-disconnected-fixtures",
-  "label": "Jetpack connected and disconnected fixture coverage",
+  "label": "Jetpack local connection-owner mismatch fixture",
   "safety_class": "isolated_mutation",
   "surface_ids": [
     "jetpack-connection",
     "jetpack-modules",
-    "jetpack-sync",
-    "wordpress-options"
+    "wordpress-options",
+    "wordpress-users"
   ],
   "operations": [
-    "local-placeholder-connected-fixture-state",
-    "disconnected-fixture-state",
-    "token-placeholder-serialization",
-    "skip-reason-classification"
+    "local-connection-owner-capability-drift",
+    "connection-health-evaluation",
+    "module-state-no-change-evidence",
+    "fixture-state-restoration"
   ],
-  "case_budget": 80,
-  "duration_budget_seconds": 900,
+  "case_budget": 1,
+  "duration_budget_seconds": 300,
   "metadata": {
     "kind": "wordpress-plugin-fuzz",
     "wordpress_runner": "wp-codebox",
-    "workload_path": "${package.root}/manifests/full-surface-coverage.json",
+    "workload_path": "${package.root}/bench/jetpack-connection-owner-mismatch.php",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report",
-    "fixture_states": [
-      "connected",
-      "disconnected"
-    ],
-    "fixture_state_contract": {
-      "connected": {
-        "description": "Synthetic local connected-site shape with placeholder blog/user IDs and fake token material only. This is not true WP.com connected-state support.",
-        "required_options": [
-          "jetpack_options",
-          "jetpack_private_options",
-          "jetpack_active_modules"
-        ],
-        "expected_connection_state": "locally_connected_without_wpcom_sandbox",
-        "allowed_secret_values": [
-          "__JETPACK_FAKE_BLOG_TOKEN__",
-          "__JETPACK_FAKE_USER_TOKEN__"
-        ],
-        "expected_skip_reasons": [
-          "credential_unavailable",
-          "external_service_required"
-        ],
-        "network_calls_allowed": false
-      },
-      "disconnected": {
-        "description": "Clean local disconnected-site shape with connection options absent or reset to empty defaults.",
-        "required_absent_options": [
-          "jetpack_private_options.blog_token",
-          "jetpack_private_options.user_tokens"
-        ],
-        "expected_connection_state": "disconnected_without_wpcom_sandbox",
-        "expected_skip_reasons": [
-          "connection_required",
-          "disconnected_expected"
-        ],
-        "network_calls_allowed": false
-      }
+    "anchor": {
+      "github_issue": "https://github.com/chubes4/homeboy-rigs/issues/693",
+      "zendesk_ticket": "11206186"
     },
-    "fake_token_policy": {
+    "fixture": {
+      "runtime": "wp-codebox",
+      "scope": "disposable-wordpress",
+      "connection": "local-placeholder-only",
+      "network_calls_allowed": false,
       "real_wpcom_credentials_allowed": false,
-      "real_tokens_allowed": false,
-      "placeholder_tokens_only": true,
-      "redact_token_fields": [
-        "blog_token",
-        "user_token",
-        "token",
-        "secret",
-        "access_token"
-      ],
-      "redaction_placeholder": "[redacted:jetpack-fixture-token]",
-      "artifact_must_not_contain_patterns": [
-        "Bearer ",
-        "token_secret",
-        "oauth_token_secret",
-        "public-api.wordpress.com/rest/v1.1/me"
-      ]
-    },
-    "wpcom_sandbox_blockers": [
-      "No WP.com OAuth application, sandbox blog, or service account is provisioned for this fixture lane.",
-      "Connected behavior that requires public-api.wordpress.com must be reported as a skip, not exercised with live credentials.",
-      "The Jetpack external HTTP guardrail owns network blocking proof for this lane."
-    ],
-    "connected_remote_state_contract": {
-      "level": "blocked_until_provisioned",
-      "required_provisioning": [
-        "wpcom_oauth_app",
-        "wpcom_sandbox_blog",
-        "wpcom_service_account"
-      ],
-      "exact_equivalent_allowed": true,
-      "guessed_support_allowed": false,
-      "local_placeholder_state_is_remote_support": false,
-      "blocker_reason_code": "provisioned_connected_state_required"
-    },
-    "module_availability_expectations": {
-      "available_in_both_states": [
-        "shortcodes",
-        "markdown",
-        "widget-visibility"
-      ],
-      "connected_fixture_may_enable": [
-        "stats",
-        "publicize",
-        "related-posts",
-        "protect"
-      ],
-      "requires_connected_or_wpcom_service": [
-        "stats",
-        "publicize",
-        "protect"
-      ],
-      "unavailable_reason": "credential_unavailable"
-    },
-    "reset_contract": {
-      "snapshot_before_mutation": true,
-      "restore_original_values": true,
-      "rollback_required": false,
-      "reset_after_each_state": true,
-      "option_patterns": [
-        "jetpack_options",
-        "jetpack_private_options",
-        "jetpack_active_modules",
-        "jetpack_sync_settings_*"
-      ],
-      "transient_patterns": [
-        "jetpack_%",
-        "jp_%"
-      ],
-      "failure_policy": "fail_if_fixture_state_leaks_after_assert"
-    },
-    "mutation_policy": "upstream_disposable_destructive_contract",
-    "artifact_expectations": {
-      "required": [
-        "connected_fixture_rows",
-        "disconnected_fixture_rows",
-        "token_placeholder_serialization",
-        "skip_reason_rows",
-        "fixture_reset_rows",
-        "redaction_rows"
-      ],
-      "optional": [
-        "module_state_diffs",
-        "sync_queue_diffs"
-      ]
-    },
-    "proof_artifact_expectations": {
-      "connection_fixture_matrix": [
-        "state",
-        "connection_state",
-        "option_snapshot_hash",
-        "module_expectations",
-        "skip_reasons"
-      ],
-      "connection_skip_reasons": [
-        "state",
-        "surface",
-        "reason_code",
-        "blocked_by_wpcom_sandbox"
-      ],
-      "connection_reset_report": [
-        "state",
-        "restored_options",
-        "restored_transients",
-        "leaked_keys",
-        "passed"
-      ]
+      "placeholder_tokens_only": true
     },
     "readiness": {
       "level": "executable",
-      "coverage_contract": "Jetpack local placeholder connected and disconnected fixture states using placeholder tokens, redaction checks, skip-reason classification, and fixture reset artifacts. True WP.com connected-state behavior is blocked until explicit OAuth app, sandbox blog, service account, or exact equivalent provisioning exists.",
+      "coverage_contract": "Creates a temporary local administrator owner with placeholder Jetpack tokens, proves the owner health check passes, downgrades that owner to subscriber, proves the health check fails without changing jetpack_active_modules, and restores all fixture state.",
       "upstream_blockers": [
-        "Reviewer-facing fuzz run artifacts are required before this workload can be marked proven."
+        "True WordPress.com connection behavior requires provisioned credentials and remains outside this local fixture."
+      ],
+      "mutation": {
+        "safety_boundary": "Mutates only local WP Codebox state and restores it before returning.",
+        "rollback_required": true,
+        "rollback_artifacts": [
+          "connection_owner_mismatch"
+        ]
+      }
+    },
+    "artifact_expectations": {
+      "required": [
+        "connection_owner_mismatch"
       ]
     }
   },
@@ -184,9 +62,9 @@
   },
   "workload": {
     "runner": "wp-codebox",
-    "type": "generic",
-    "path": "${package.root}/manifests/full-surface-coverage.json",
-    "entry": "jetpack-connected-disconnected-fixtures"
+    "type": "php",
+    "path": "${package.root}/bench/jetpack-connection-owner-mismatch.php",
+    "entry": "jetpack-connection-owner-mismatch"
   },
   "cases": [
     {
@@ -194,88 +72,26 @@
       "surface_ids": [
         "jetpack-connection",
         "jetpack-modules",
-        "jetpack-sync",
-        "wordpress-options"
+        "wordpress-options",
+        "wordpress-users"
       ],
       "operations": [
-          "local-placeholder-connected-fixture-state",
-        "disconnected-fixture-state",
-        "token-placeholder-serialization",
-        "skip-reason-classification"
+        "local-connection-owner-capability-drift",
+        "connection-health-evaluation",
+        "module-state-no-change-evidence",
+        "fixture-state-restoration"
       ],
       "inputs": {
-        "states": [
-          "connected",
-          "disconnected"
-        ],
-        "fixture_states": [
-          "connected",
-          "disconnected"
-        ],
-        "explicit_fixture_states": {
-          "connected": "synthetic_placeholder_connection_without_wpcom_sandbox",
-          "disconnected": "clean_local_disconnect_without_wpcom_sandbox"
-        },
         "connection_options": [
           "jetpack_options",
           "jetpack_private_options",
-          "jetpack_active_modules",
-          "jetpack_sync_settings_sync_wait_time"
+          "jetpack_active_modules"
         ],
-        "fixture_options": [
-          "jetpack_options",
-          "jetpack_private_options",
-          "jetpack_active_modules",
-          "jetpack_sync_settings_*"
-        ],
-        "redact_option_fields": [
-          "blog_token",
-          "user_token",
-          "token",
-          "secret",
-          "access_token"
-        ],
-        "allowed_fake_tokens": [
-          "__JETPACK_FAKE_BLOG_TOKEN__",
-          "__JETPACK_FAKE_USER_TOKEN__"
-        ],
-        "real_wpcom_credentials_allowed": false,
-        "real_tokens_allowed": false,
+        "owner_role_before_drift": "administrator",
+        "owner_role_after_drift": "subscriber",
         "network_calls_allowed": false,
-        "wpcom_sandbox_required": false,
-        "connected_remote_state_provisioning_required": true,
-        "guessed_connected_state_support_allowed": false,
-        "secret_placeholders_only": true,
-        "restore_original_values": true,
-        "reset_after_each_state": true,
-        "rollback_required": false,
-        "module_availability_expectations": {
-          "available_in_both_states": [
-            "shortcodes",
-            "markdown",
-            "widget-visibility"
-          ],
-          "connected_fixture_may_enable": [
-            "stats",
-            "publicize",
-            "related-posts",
-            "protect"
-          ],
-          "requires_connected_or_wpcom_service": [
-            "stats",
-            "publicize",
-            "protect"
-          ]
-        },
-        "skip_reason_codes": [
-          "credential_unavailable",
-          "external_service_required",
-          "connection_required",
-          "disconnected_expected",
-          "connected_required",
-          "destructive_action",
-          "unsupported_fixture"
-        ]
+        "real_wpcom_credentials_allowed": false,
+        "restore_original_values": true
       },
       "phases": {
         "setup": [
@@ -288,14 +104,10 @@
         ],
         "action": [
           {
-            "command": "wordpress.fuzz-plugin-connection-fixtures",
+            "command": "wordpress.run-workload",
             "args": [
-              "states=connected,disconnected",
-              "secret_placeholders_only=true",
-              "restore_original_values=true",
-              "rollback_required=false",
-              "connected_remote_state_provisioning_required=true",
-              "classify_skips=true"
+              "path=${package.root}/bench/jetpack-connection-owner-mismatch.php",
+              "type=php"
             ]
           }
         ],
@@ -303,79 +115,68 @@
           {
             "command": "wordpress.collect-workload-result",
             "args": [
-              "artifact=connection_fixture_matrix"
+              "artifact=connection_owner_mismatch"
             ]
           }
         ]
       },
       "artifacts": [
         {
-          "name": "connection_fixture_matrix",
-          "path": "jetpack-connected-disconnected-fixtures/connection_fixture_matrix.json",
+          "name": "connection_owner_mismatch",
+          "path": "jetpack-connected-disconnected-fixtures/connection_owner_mismatch.json",
           "required": true,
           "metadata": {
             "semantic_key": "fuzz.report"
           }
-        },
-        {
-          "name": "connection_skip_reasons",
-          "path": "jetpack-connected-disconnected-fixtures/connection_skip_reasons.json",
-          "required": true,
-          "metadata": {
-            "semantic_key": "fuzz.skip_reasons"
-          }
-        },
-        {
-          "name": "connection_fixture_reset_report",
-          "path": "jetpack-connected-disconnected-fixtures/connection_fixture_reset_report.json",
-          "required": true,
-          "metadata": {
-            "semantic_key": "fuzz.fixture_reset_report"
-          }
         }
       ],
       "metadata": {
-        "safety_class": "isolated_mutation",
-        "mutation_policy": "upstream_disposable_destructive_contract"
+        "safety_class": "isolated_mutation"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": {
+          "activation": "jetpack/jetpack.php"
+        },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/jetpack-connection-owner-mismatch.php",
+          "type": "php",
+          "entry": "jetpack-connection-owner-mismatch"
+        },
+        "collect": [
+          {
+            "artifact": "connection_owner_mismatch"
+          }
+        ]
       }
     }
   ],
   "limits": {
-    "max_cases": 80,
-    "max_duration_seconds": 900
+    "max_cases": 1,
+    "max_duration_seconds": 300
   },
   "coverage": {
     "surface_ids": [
       "jetpack-connection",
       "jetpack-modules",
-      "jetpack-sync",
-      "wordpress-options"
+      "wordpress-options",
+      "wordpress-users"
     ],
     "operations": [
-      "local-placeholder-connected-fixture-state",
-      "disconnected-fixture-state",
-      "token-placeholder-serialization",
-      "skip-reason-classification"
+      "local-connection-owner-capability-drift",
+      "connection-health-evaluation",
+      "module-state-no-change-evidence",
+      "fixture-state-restoration"
     ]
   },
   "artifacts": {
     "expected": [
       {
-        "name": "connection_fixture_matrix",
+        "name": "connection_owner_mismatch",
         "role": "fuzz_report",
         "semantic_key": "fuzz.report",
-        "required": true
-      },
-      {
-        "name": "connection_skip_reasons",
-        "role": "safety_report",
-        "semantic_key": "fuzz.skip_reasons",
-        "required": true
-      },
-      {
-        "name": "connection_fixture_reset_report",
-        "role": "fixture_reset_report",
-        "semantic_key": "fuzz.fixture_reset_report",
         "required": true
       }
     ]


### PR DESCRIPTION
## Summary

- replace the non-executable coverage declaration with a real WP Codebox PHP workload
- create a placeholder-only local Jetpack owner, then downgrade it from administrator to subscriber
- assert the owner health test changes from passing to failing without mutating `jetpack_active_modules`
- restore all touched options and remove the temporary user before returning

Closes #693.

Depends on the production readiness repair in Extra-Chill/homeboy-extensions#2365.

## Evidence

`homeboy-lab` run `jetpack-owner-drift-gh-693-v8` passed with WP Codebox 0.13.1:

- health before drift: `true`
- health after drift: `false`
- module hashes before and after evaluation: `4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945`
- module state changed: `false`
- options restored: `true`
- fixture owner deleted: `true`
- network calls performed: `false`

This proves local owner capability drift and the health evaluation do not themselves mutate active module state. It does not claim to reproduce remote WordPress.com owner identity divergence or the reported module deletion.

Reproduce against a Jetpack checkout with the rig branch installed:

```sh
homeboy fuzz jetpack --runner homeboy-lab --rig jetpack-api-route-inventory --workload jetpack-connected-disconnected-fixtures --run-id jetpack-owner-drift-review --gate-profile evidence --allow-destructive --isolation isolated run
```

## Validation

- `php -l Automattic/jetpack/bench/jetpack-connection-owner-mismatch.php`
- `homeboy rig lint Automattic/jetpack --all`
- `node scripts/test-contracts.mjs --scope=wordpress-rigs` (18 passing)
- `git diff --check`

## AI Assistance

OpenAI `gpt-5.6-sol` through OpenCode implemented the executable fixture, manifest repair, evidence analysis, and PR draft. Chris Huber reviewed the diff and remains responsible for the change.