### PR TITLE
Make Jetpack module-state fuzz coverage executable

### DIFF
--- a/Automattic/jetpack/bench/jetpack-module-state-matrix.php
+++ b/Automattic/jetpack/bench/jetpack-module-state-matrix.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Jetpack local module-state fixture.
+ *
+ * Exercises local module toggles and connection-owner health only. The HTTP
+ * interceptor makes any accidental remote request fail inside the disposable
+ * Codebox runtime.
+ */
+return function (): array {
+	$option_names = array( 'jetpack_active_modules', 'jetpack_options', 'jetpack_private_options', 'jetpack_sync_settings' );
+	$missing      = new stdClass();
+	$snapshot     = array();
+	$describe     = static function ( $value, $missing ): array {
+		$present = $value !== $missing;
+		return array(
+			'present'     => $present,
+			'value_hash'  => $present ? hash( 'sha256', wp_json_encode( $value ) ) : null,
+			'value_type'  => $present ? gettype( $value ) : 'missing',
+			'value_keys'  => $present && is_array( $value ) ? array_values( array_map( 'strval', array_keys( $value ) ) ) : array(),
+			'value_count' => $present && is_countable( $value ) ? count( $value ) : null,
+		);
+	};
+	$describe_setting_value = static function ( $option_name, $value ) {
+		if ( 'jetpack_sync_settings' === $option_name ) {
+			return $value;
+		}
+		if ( ! is_array( $value ) ) {
+			return null;
+		}
+		return array(
+			'id'              => $value['id'] ?? null,
+			'master_user'     => $value['master_user'] ?? null,
+			'blog_token'      => array_key_exists( 'blog_token', $value ) ? '[redacted]' : null,
+			'user_token_count' => isset( $value['user_tokens'] ) && is_array( $value['user_tokens'] ) ? count( $value['user_tokens'] ) : 0,
+		);
+	};
+	foreach ( $option_names as $option_name ) {
+		$value                    = get_option( $option_name, $missing );
+		$snapshot[ $option_name ] = array(
+			'value'    => $value === $missing ? null : $value,
+			'describe' => $describe( $value, $missing ),
+		);
+	}
+
+	$previous_user_id = get_current_user_id();
+	$owner_id         = 0;
+	$network_calls    = array();
+	$cleanup_errors   = array();
+	$result           = array();
+	$failure          = null;
+	$manager          = new \Automattic\Jetpack\Connection\Manager( 'jetpack' );
+	$block_http       = static function ( $preempt, $args, $url ) use ( &$network_calls ) {
+		$network_calls[] = esc_url_raw( $url );
+		return new WP_Error( 'homeboy_jetpack_module_state_network_blocked', 'Outbound HTTP is blocked by the local module-state fixture.' );
+	};
+
+	add_filter( 'pre_http_request', $block_http, 10, 3 );
+	try {
+		$owner_id = wp_insert_user(
+			array(
+				'user_login' => 'hb-jp-module-owner-' . substr( str_replace( '-', '', wp_generate_uuid4() ), 0, 16 ),
+				'user_pass'  => wp_generate_password( 32, true, true ),
+				'role'       => 'administrator',
+			)
+		);
+		if ( is_wp_error( $owner_id ) ) {
+			throw new RuntimeException( $owner_id->get_error_message() );
+		}
+
+		// Keep the fixture representative without using a real WordPress.com identity.
+		if ( ! \Jetpack::update_active_modules( array( 'markdown', 'shortcodes' ) ) ) {
+			throw new RuntimeException( 'Jetpack module-state fixture could not seed active modules.' );
+		}
+		Jetpack_Options::update_option( 'id', 6950001 );
+		Jetpack_Options::update_option( 'blog_token', 'fixture.module-state.blog-token' );
+		Jetpack_Options::update_option( 'master_user', $owner_id );
+		Jetpack_Options::update_option( 'user_tokens', array( $owner_id => 'fixture.module-state.owner-token' ) );
+		update_option( 'jetpack_sync_settings', array( 'full_sync' => 'fixture-disabled', 'sent' => false ) );
+		$manager->reset_connection_status();
+
+		$fixture_before = array();
+		foreach ( $option_names as $option_name ) {
+			$fixture_before[ $option_name ] = $describe( get_option( $option_name, $missing ), $missing );
+		}
+		$module_before = get_option( 'jetpack_active_modules', array() );
+		$settings_before = array();
+		foreach ( array( 'jetpack_options', 'jetpack_private_options', 'jetpack_sync_settings' ) as $option_name ) {
+			$value                         = get_option( $option_name, $missing );
+			$settings_before[ $option_name ] = array_merge(
+				$fixture_before[ $option_name ],
+				array( 'value' => $describe_setting_value( $option_name, $value ) )
+			);
+		}
+		$health_tests   = new \Automattic\Jetpack\Connection\Connection_Health_Tests();
+		$healthy_result = $health_tests->run_test( 'test__master_user_can_manage_options' );
+
+		$available_modules = \Jetpack::get_available_modules();
+		$toggle_candidates = array_values( array_diff( array_intersect( array( 'contact-form', 'markdown', 'shortcodes' ), $available_modules ), $module_before ) );
+		if ( empty( $toggle_candidates ) ) {
+			throw new RuntimeException( 'No local Jetpack module toggle candidate is available.' );
+		}
+		$toggle_module = $toggle_candidates[0];
+		\Jetpack::activate_module( $toggle_module, false, false );
+		$active_after_activation = \Jetpack::is_module_active( $toggle_module );
+		\Jetpack::deactivate_module( $toggle_module );
+		$active_after_deactivation = \Jetpack::is_module_active( $toggle_module );
+		$module_after = get_option( 'jetpack_active_modules', array() );
+
+		$owner = get_userdata( $owner_id );
+		if ( ! $owner instanceof WP_User ) {
+			throw new RuntimeException( 'Jetpack module-state fixture owner could not be loaded.' );
+		}
+		$owner->set_role( 'subscriber' );
+		$unhealthy_result = $health_tests->run_test( 'test__master_user_can_manage_options' );
+		$settings_after = array();
+		foreach ( array_keys( $settings_before ) as $option_name ) {
+			$value                        = get_option( $option_name, $missing );
+			$settings_after[ $option_name ] = array_merge(
+				$describe( $value, $missing ),
+				array( 'value' => $describe_setting_value( $option_name, $value ) )
+			);
+		}
+
+		$result = array(
+			'schema' => 'homeboy-rigs/jetpack-module-state-matrix/v1',
+			'fixture' => array(
+				'module_seed' => array( 'markdown', 'shortcodes' ),
+				'placeholder_connection_owner_id' => $owner_id,
+				'connection' => 'local-placeholder-only',
+			),
+			'module_state' => array(
+				'before_value' => $module_before,
+				'before_hash' => hash( 'sha256', wp_json_encode( $module_before ) ),
+				'after_value' => $module_after,
+				'after_hash' => hash( 'sha256', wp_json_encode( $module_after ) ),
+				'toggle_module' => $toggle_module,
+				'active_after_activation' => $active_after_activation,
+				'active_after_deactivation' => $active_after_deactivation,
+			),
+			'settings_state' => array(
+				'before' => $settings_before,
+				'after' => $settings_after,
+			),
+			'owner_health' => array(
+				'test' => 'test__master_user_can_manage_options',
+				'before_role_drift_pass' => $healthy_result['pass'] ?? null,
+				'after_role_drift_pass' => $unhealthy_result['pass'] ?? null,
+			),
+			'remote_connection_dependent_behavior' => array(
+				'classification' => 'provisioned_connected_state_required',
+				'executed' => false,
+				'reason' => 'This workload uses placeholder-only local connection state and blocks all outbound HTTP.',
+			),
+			'network_calls' => array(
+				'allowed' => false,
+				'blocked_attempts' => $network_calls,
+			),
+		);
+		if (
+			true !== $result['module_state']['active_after_activation'] ||
+			false !== $result['module_state']['active_after_deactivation'] ||
+			true !== $result['owner_health']['before_role_drift_pass'] ||
+			false !== $result['owner_health']['after_role_drift_pass'] ||
+			! empty( $network_calls )
+		) {
+			throw new RuntimeException( 'Jetpack module-state fixture did not satisfy its local execution contract.' );
+		}
+	} catch ( Throwable $error ) {
+		$failure = $error;
+	} finally {
+		remove_filter( 'pre_http_request', $block_http, 10 );
+		foreach ( $snapshot as $option_name => $entry ) {
+			$restored = $entry['describe']['present']
+				? update_option( $option_name, $entry['value'] ) || get_option( $option_name ) === $entry['value']
+				: delete_option( $option_name ) || get_option( $option_name, $missing ) === $missing;
+			if ( ! $restored ) {
+				$cleanup_errors[] = "option:$option_name";
+			}
+		}
+		$manager->reset_connection_status();
+		if ( ! function_exists( 'wp_delete_user' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/user.php';
+		}
+		if ( $owner_id > 0 && ! wp_delete_user( $owner_id ) ) {
+			$cleanup_errors[] = 'fixture_owner';
+		}
+		wp_set_current_user( $previous_user_id );
+
+		$restored = array();
+		foreach ( $option_names as $option_name ) {
+			$restored[ $option_name ] = $describe( get_option( $option_name, $missing ), $missing );
+		}
+		$result['cleanup'] = array(
+			'options_restored' => $restored === array_map( static fn ( $entry ) => $entry['describe'], $snapshot ),
+			'fixture_owner_deleted' => $owner_id <= 0 || ! get_user_by( 'id', $owner_id ),
+			'errors' => $cleanup_errors,
+			'after_restoration' => $restored,
+		);
+	}
+
+	if ( $failure instanceof Throwable ) {
+		throw $failure;
+	}
+	if ( ! empty( $cleanup_errors ) || empty( $result['cleanup']['options_restored'] ) || empty( $result['cleanup']['fixture_owner_deleted'] ) ) {
+		throw new RuntimeException( 'Jetpack module-state fixture cleanup failed.' );
+	}
+
+	return array(
+		'metrics' => array(
+			'module_toggle_passed' => true,
+			'owner_health_passed_before_drift' => true,
+			'owner_health_failed_after_drift' => true,
+			'cleanup_passed' => true,
+		),
+		'metadata' => array(
+			'runner' => 'wp-codebox',
+			'workload' => 'jetpack-module-state-matrix',
+			'coverage_shape' => 'local module toggle, placeholder connection-owner health evaluation, state hashing, and restoration without outbound requests',
+		),
+		'artifacts' => array( 'module_state_matrix' => $result ),
+		'result' => $result,
+	);
+};

--- a/Automattic/jetpack/bench/jetpack-module-state-matrix.php
+++ b/Automattic/jetpack/bench/jetpack-module-state-matrix.php
@@ -80,7 +80,7 @@ return function (): array {
 		Jetpack_Options::update_option( 'id', 6950001 );
 		Jetpack_Options::update_option( 'blog_token', 'fixture.module-state.blog-token' );
 		Jetpack_Options::update_option( 'master_user', $owner_id );
-		Jetpack_Options::update_option( 'user_tokens', array( $owner_id => 'fixture.module-state.owner.' . $owner_id ) );
+		Jetpack_Options::update_option( 'user_tokens', array( $owner_id => 'module-state.owner.' . $owner_id ) );
 		update_option( 'jetpack_sync_settings', array( 'full_sync' => 'fixture-disabled', 'sent' => false ) );
 		$manager->reset_connection_status();
 

--- a/Automattic/jetpack/bench/jetpack-module-state-matrix.php
+++ b/Automattic/jetpack/bench/jetpack-module-state-matrix.php
@@ -49,6 +49,7 @@ return function (): array {
 	$result           = array();
 	$failure          = null;
 	$manager          = new \Automattic\Jetpack\Connection\Manager( 'jetpack' );
+	$modules          = new \Automattic\Jetpack\Modules();
 	$block_http       = static function ( $preempt, $args, $url ) use ( &$network_calls ) {
 		$network_calls[] = esc_url_raw( $url );
 		return new WP_Error( 'homeboy_jetpack_module_state_network_blocked', 'Outbound HTTP is blocked by the local module-state fixture.' );
@@ -68,7 +69,8 @@ return function (): array {
 		}
 
 		// Keep the fixture representative without using a real WordPress.com identity.
-		if ( ! \Jetpack::update_active_modules( array( 'markdown', 'shortcodes' ) ) ) {
+		$module_seed = array( 'markdown', 'shortcodes' );
+		if ( ! $modules->update_active( $module_seed ) && $module_seed !== get_option( 'jetpack_active_modules', array() ) ) {
 			throw new RuntimeException( 'Jetpack module-state fixture could not seed active modules.' );
 		}
 		Jetpack_Options::update_option( 'id', 6950001 );
@@ -94,16 +96,11 @@ return function (): array {
 		$health_tests   = new \Automattic\Jetpack\Connection\Connection_Health_Tests();
 		$healthy_result = $health_tests->run_test( 'test__master_user_can_manage_options' );
 
-		$available_modules = \Jetpack::get_available_modules();
-		$toggle_candidates = array_values( array_diff( array_intersect( array( 'contact-form', 'markdown', 'shortcodes' ), $available_modules ), $module_before ) );
-		if ( empty( $toggle_candidates ) ) {
-			throw new RuntimeException( 'No local Jetpack module toggle candidate is available.' );
-		}
-		$toggle_module = $toggle_candidates[0];
-		\Jetpack::activate_module( $toggle_module, false, false );
-		$active_after_activation = \Jetpack::is_module_active( $toggle_module );
-		\Jetpack::deactivate_module( $toggle_module );
-		$active_after_deactivation = \Jetpack::is_module_active( $toggle_module );
+		$toggle_module = 'contact-form';
+		$modules->update_active( array_merge( $module_before, array( $toggle_module ) ) );
+		$active_after_activation = in_array( $toggle_module, get_option( 'jetpack_active_modules', array() ), true );
+		$modules->update_active( $module_before );
+		$active_after_deactivation = in_array( $toggle_module, get_option( 'jetpack_active_modules', array() ), true );
 		$module_after = get_option( 'jetpack_active_modules', array() );
 
 		$owner = get_userdata( $owner_id );
@@ -124,7 +121,7 @@ return function (): array {
 		$result = array(
 			'schema' => 'homeboy-rigs/jetpack-module-state-matrix/v1',
 			'fixture' => array(
-				'module_seed' => array( 'markdown', 'shortcodes' ),
+				'module_seed' => $module_seed,
 				'placeholder_connection_owner_id' => $owner_id,
 				'connection' => 'local-placeholder-only',
 			),
@@ -159,6 +156,7 @@ return function (): array {
 		if (
 			true !== $result['module_state']['active_after_activation'] ||
 			false !== $result['module_state']['active_after_deactivation'] ||
+			$result['module_state']['before_value'] !== $result['module_state']['after_value'] ||
 			true !== $result['owner_health']['before_role_drift_pass'] ||
 			false !== $result['owner_health']['after_role_drift_pass'] ||
 			! empty( $network_calls )

--- a/Automattic/jetpack/bench/jetpack-module-state-matrix.php
+++ b/Automattic/jetpack/bench/jetpack-module-state-matrix.php
@@ -54,8 +54,12 @@ return function (): array {
 		$network_calls[] = esc_url_raw( $url );
 		return new WP_Error( 'homeboy_jetpack_module_state_network_blocked', 'Outbound HTTP is blocked by the local module-state fixture.' );
 	};
+	$register_fixture_modules = static function ( $available ): array {
+		return array_values( array_unique( array_merge( $available, array( 'markdown', 'shortcodes', 'contact-form' ) ) ) );
+	};
 
 	add_filter( 'pre_http_request', $block_http, 10, 3 );
+	add_filter( 'jetpack_get_available_standalone_modules', $register_fixture_modules );
 	try {
 		$owner_id = wp_insert_user(
 			array(
@@ -97,10 +101,10 @@ return function (): array {
 		$healthy_result = $health_tests->run_test( 'test__master_user_can_manage_options' );
 
 		$toggle_module = 'contact-form';
-		$modules->update_active( array_merge( $module_before, array( $toggle_module ) ) );
-		$active_after_activation = in_array( $toggle_module, get_option( 'jetpack_active_modules', array() ), true );
-		$modules->update_active( $module_before );
-		$active_after_deactivation = in_array( $toggle_module, get_option( 'jetpack_active_modules', array() ), true );
+		$modules->activate( $toggle_module, false, false );
+		$active_after_activation = $modules->is_active( $toggle_module );
+		$modules->deactivate( $toggle_module );
+		$active_after_deactivation = $modules->is_active( $toggle_module );
 		$module_after = get_option( 'jetpack_active_modules', array() );
 
 		$owner = get_userdata( $owner_id );
@@ -167,6 +171,7 @@ return function (): array {
 		$failure = $error;
 	} finally {
 		remove_filter( 'pre_http_request', $block_http, 10 );
+		remove_filter( 'jetpack_get_available_standalone_modules', $register_fixture_modules );
 		foreach ( $snapshot as $option_name => $entry ) {
 			$restored = $entry['describe']['present']
 				? update_option( $option_name, $entry['value'] ) || get_option( $option_name ) === $entry['value']

--- a/Automattic/jetpack/bench/jetpack-module-state-matrix.php
+++ b/Automattic/jetpack/bench/jetpack-module-state-matrix.php
@@ -157,15 +157,16 @@ return function (): array {
 				'blocked_attempts' => $network_calls,
 			),
 		);
-		if (
-			true !== $result['module_state']['active_after_activation'] ||
-			false !== $result['module_state']['active_after_deactivation'] ||
-			$result['module_state']['before_value'] !== $result['module_state']['after_value'] ||
-			true !== $result['owner_health']['before_role_drift_pass'] ||
-			false !== $result['owner_health']['after_role_drift_pass'] ||
-			! empty( $network_calls )
-		) {
-			throw new RuntimeException( 'Jetpack module-state fixture did not satisfy its local execution contract.' );
+		$result['contract_checks'] = array(
+			'module_activated' => true === $result['module_state']['active_after_activation'],
+			'module_deactivated' => false === $result['module_state']['active_after_deactivation'],
+			'module_state_restored' => $result['module_state']['before_value'] === $result['module_state']['after_value'],
+			'owner_healthy_before_drift' => true === $result['owner_health']['before_role_drift_pass'],
+			'owner_unhealthy_after_drift' => false === $result['owner_health']['after_role_drift_pass'],
+			'no_outbound_http_attempts' => empty( $network_calls ),
+		);
+		if ( in_array( false, $result['contract_checks'], true ) ) {
+			throw new RuntimeException( 'Jetpack module-state fixture contract checks failed: ' . wp_json_encode( $result['contract_checks'] ) );
 		}
 	} catch ( Throwable $error ) {
 		$failure = $error;

--- a/Automattic/jetpack/bench/jetpack-module-state-matrix.php
+++ b/Automattic/jetpack/bench/jetpack-module-state-matrix.php
@@ -80,7 +80,7 @@ return function (): array {
 		Jetpack_Options::update_option( 'id', 6950001 );
 		Jetpack_Options::update_option( 'blog_token', 'fixture.module-state.blog-token' );
 		Jetpack_Options::update_option( 'master_user', $owner_id );
-		Jetpack_Options::update_option( 'user_tokens', array( $owner_id => 'fixture.module-state.owner-token' ) );
+		Jetpack_Options::update_option( 'user_tokens', array( $owner_id => 'fixture.module-state.owner.' . $owner_id ) );
 		update_option( 'jetpack_sync_settings', array( 'full_sync' => 'fixture-disabled', 'sent' => false ) );
 		$manager->reset_connection_status();
 

--- a/Automattic/jetpack/fuzz/jetpack-module-state-matrix.json
+++ b/Automattic/jetpack/fuzz/jetpack-module-state-matrix.json
@@ -8,20 +8,19 @@
     "jetpack-settings"
   ],
   "operations": [
-    "module-discovery",
-    "module-group-inventory",
-    "module-activate-deactivate-disposable-mutation",
-    "settings-state-classification",
-    "dependency-classification",
-    "connected-state-blocker-classification",
-    "disposable-destructive-contract-classification"
+    "module-state-seed",
+    "module-activate-deactivate-local-mutation",
+    "settings-before-after-hash",
+    "connection-owner-health-evaluation",
+    "remote-connection-boundary-classification",
+    "fixture-state-restoration"
   ],
   "case_budget": 80,
   "duration_budget_seconds": 900,
   "metadata": {
     "kind": "wordpress-plugin-fuzz",
     "wordpress_runner": "wp-codebox",
-    "workload_path": "${package.root}/manifests/full-surface-coverage.json",
+    "workload_path": "${package.root}/bench/jetpack-module-state-matrix.php",
     "expected_artifact_role": "fuzz_report",
     "expected_artifact_semantic_key": "fuzz.report",
     "mutation_policy": "upstream_disposable_destructive_contract",
@@ -29,12 +28,12 @@
       "status": "required",
       "contract": "wordpress-disposable-destructive-contract",
       "fixture_scope": "wp-codebox-disposable-wordpress",
-      "rollback_required": false,
+      "rollback_required": true,
       "remote_state_allowed": false
     },
     "readiness": {
       "level": "executable",
-      "coverage_contract": "Jetpack module discovery, grouping, dependency, settings-state, connected-state blocker, and local disposable activation/deactivation through the upstream destructive contract. WP.com remote-state effects stay blocked until explicit provisioning exists.",
+      "coverage_contract": "Runs a PHP WP Codebox fixture that seeds non-empty local module and settings state, toggles one locally available module, evaluates placeholder connection-owner health before and after capability drift, records before/after values and hashes, and restores every option and user.",
       "upstream_blockers": [
         "true WP.com connected-state behavior requires an explicit OAuth app, sandbox blog, service account, or exact equivalent before remote-state effects can run"
       ],
@@ -53,32 +52,19 @@
         }
       },
       "mutation": {
-        "safety_boundary": "Executes local module state writes only in a disposable WP Codebox WordPress runtime through the upstream destructive contract. Connection-dependent remote effects are classified as provisioning-blocked.",
-        "rollback_required": false,
-        "disposable_sandbox_boundary_artifacts": ["disposable_sandbox_boundary"],
-        "mutation_isolation_artifacts": ["module_state_disposable_mutation_contract", "module_option_before_after_rows"],
-        "delete_boundary_artifacts": ["delete_boundary_artifact"],
-        "destructive_case_ledgers": ["destructive_case_ledger"],
-        "teardown_discard_evidence": ["sandbox_teardown_evidence"],
-        "artifact_bundle_refs": ["artifact_bundle_ref"],
-        "rollback_artifacts": [],
-        "disposable_contract_artifacts": [
-          "module_state_disposable_mutation_contract",
-          "module_option_before_after_rows"
-        ]
+        "safety_boundary": "Executes local module and placeholder connection-owner writes only in a disposable WP Codebox runtime. The PHP workload blocks outbound HTTP and restores all options and the temporary user before returning.",
+        "rollback_required": true,
+        "rollback_artifacts": ["module_state_matrix"],
+        "remote_connection_behavior": "provisioned_connected_state_required"
       }
     },
     "artifact_expectations": {
       "required": [
-        "module_matrix",
-        "module_group_rows",
-        "dependency_rows",
-        "connected_state_blockers",
-        "disposable_mutation_contract_rows"
+        "module_state_matrix"
       ],
       "optional": [
-        "settings_state_rows",
-        "executed_local_toggle_rows"
+        "module_and_settings_before_after_hashes",
+        "cleanup_assertion"
       ]
     }
   },
@@ -89,9 +75,9 @@
   },
   "workload": {
     "runner": "wp-codebox",
-    "type": "generic",
-    "path": "${package.root}/manifests/full-surface-coverage.json",
-    "entry": "wordpress-plugin-module-state-matrix"
+    "type": "php",
+    "path": "${package.root}/bench/jetpack-module-state-matrix.php",
+    "entry": "jetpack-module-state-matrix"
   },
   "cases": [
     {
@@ -101,87 +87,20 @@
         "jetpack-settings"
       ],
       "operations": [
-        "module-discovery",
-        "module-group-inventory",
-          "module-activate-deactivate-disposable-mutation",
-        "settings-state-classification",
-        "dependency-classification",
-        "connected-state-blocker-classification",
-          "disposable-destructive-contract-classification"
+        "module-state-seed",
+        "module-activate-deactivate-local-mutation",
+        "settings-before-after-hash",
+        "connection-owner-health-evaluation",
+        "remote-connection-boundary-classification",
+        "fixture-state-restoration"
       ],
       "inputs": {
-        "module_allowlist": [
-          "stats",
-          "publicize",
-          "related-posts",
-          "markdown",
-          "shortcodes",
-          "widget-visibility",
-          "photon",
-          "sitemaps",
-          "protect",
-          "monitor",
-          "subscriptions",
-          "comments",
-          "likes",
-          "carousel",
-          "contact-form",
-          "tiled-gallery"
-        ],
-        "module_groups": {
-          "traffic": [
-            "stats",
-            "related-posts",
-            "sitemaps"
-          ],
-          "sharing": [
-            "publicize",
-            "sharing",
-            "likes"
-          ],
-          "writing": [
-            "markdown",
-            "shortcodes",
-            "contact-form"
-          ],
-          "media": [
-            "photon",
-            "carousel",
-            "tiled-gallery"
-          ],
-          "security": [
-            "protect",
-            "monitor"
-          ],
-          "community": [
-            "subscriptions",
-            "comments",
-            "widget-visibility"
-          ]
-        },
-        "connected_state_blockers": [
-          "publicize",
-          "protect",
-          "monitor",
-          "stats",
-          "subscriptions"
-        ],
-        "connected_state_required_for_mutation": false,
-        "connected_remote_state_provisioning_required": true,
-        "runtime_isolation_required_for_mutation": true,
-        "external_dispatch": false,
-        "execute_mutations": true,
-        "mutation_mode": "upstream_disposable_destructive_contract",
-        "rollback_required": false,
-        "disposable_destructive_contract": [
-          "run only inside wp-codebox disposable WordPress",
-          "record module option before and after value shape",
-          "classify WP.com remote effects as provisioned_connected_state_required"
-        ],
-        "skip_reason_codes": [
-          "connection_required",
-          "credential_unavailable"
-        ]
+        "module_seed": ["markdown", "shortcodes"],
+        "toggle_candidates": ["markdown", "shortcodes", "contact-form"],
+        "settings_options": ["jetpack_options", "jetpack_private_options", "jetpack_sync_settings"],
+        "network_calls_allowed": false,
+        "real_wpcom_credentials_allowed": false,
+        "restore_original_values": true
       },
       "phases": {
         "setup": [
@@ -194,15 +113,10 @@
         ],
         "action": [
           {
-            "command": "wordpress.fuzz-plugin-module-state",
+            "command": "wordpress.run-workload",
             "args": [
-              "external_dispatch=false",
-              "execute_mutations=true",
-              "mutation_mode=upstream_disposable_destructive_contract",
-              "connected_state_required_for_mutation=false",
-              "connected_remote_state_provisioning_required=true",
-              "runtime_isolation_required_for_mutation=true",
-              "rollback_required=false"
+              "path=${package.root}/bench/jetpack-module-state-matrix.php",
+              "type=php"
             ]
           }
         ],
@@ -223,19 +137,23 @@
           "metadata": {
             "semantic_key": "fuzz.report"
           }
-        },
-        {
-          "name": "module_state_disposable_mutation_contract",
-          "path": "jetpack-module-state-matrix/module_state_disposable_mutation_contract.json",
-          "required": true,
-          "metadata": {
-              "semantic_key": "fuzz.disposable_destructive_contract"
-          }
         }
       ],
       "metadata": {
         "safety_class": "isolated_mutation",
         "mutation_policy": "upstream_disposable_destructive_contract"
+      },
+      "intent": {
+        "schema": "homeboy/fuzz-workload-intent/v1",
+        "type": "wordpress-plugin-workload",
+        "plugin": { "activation": "jetpack/jetpack.php" },
+        "execute": {
+          "workload_ref": "default",
+          "path": "${package.root}/bench/jetpack-module-state-matrix.php",
+          "type": "php",
+          "entry": "jetpack-module-state-matrix"
+        },
+        "collect": [{ "artifact": "module_state_matrix" }]
       }
     }
   ],
@@ -249,13 +167,12 @@
       "jetpack-settings"
     ],
     "operations": [
-      "module-discovery",
-      "module-group-inventory",
-      "module-activate-deactivate-disposable-mutation",
-      "settings-state-classification",
-      "dependency-classification",
-      "connected-state-blocker-classification",
-      "disposable-destructive-contract-classification"
+      "module-state-seed",
+      "module-activate-deactivate-local-mutation",
+      "settings-before-after-hash",
+      "connection-owner-health-evaluation",
+      "remote-connection-boundary-classification",
+      "fixture-state-restoration"
     ]
   },
   "artifacts": {
@@ -264,12 +181,6 @@
         "name": "module_state_matrix",
         "role": "fuzz_report",
         "semantic_key": "fuzz.report",
-        "required": true
-      },
-      {
-        "name": "module_state_disposable_mutation_contract",
-        "role": "disposable_destructive_contract",
-        "semantic_key": "fuzz.disposable_destructive_contract",
         "required": true
       }
     ]

--- a/scripts/product-full-surface-matrix.test.mjs
+++ b/scripts/product-full-surface-matrix.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -142,4 +142,22 @@ test('product matrices do not define generic runner or Codebox behavior', () => 
     const manifest = readJson(productManifest.file);
     visit(manifest.product_surface_matrix, [productManifest.product, 'product_surface_matrix']);
   }
+});
+
+test('Jetpack module-state matrix resolves to a real PHP Codebox workload', () => {
+  const workloadPath = 'Automattic/jetpack/fuzz/jetpack-module-state-matrix.json';
+  const workload = readJson(workloadPath);
+  const phpWorkload = '${package.root}/bench/jetpack-module-state-matrix.php';
+  const action = workload.cases[0].phases.action;
+
+  assert.equal(workload.metadata.workload_path, phpWorkload);
+  assert.equal(workload.workload.type, 'php');
+  assert.equal(workload.workload.path, phpWorkload);
+  assert.ok(existsSync(path.join(repoRoot, 'Automattic/jetpack/bench/jetpack-module-state-matrix.php')));
+  assert.deepEqual(action, [{
+    command: 'wordpress.run-workload',
+    args: [`path=${phpWorkload}`, 'type=php'],
+  }]);
+  assert.deepEqual(workload.artifacts.expected.map(({ name }) => name), ['module_state_matrix']);
+  assert.equal(workload.metadata.readiness.mutation.rollback_required, true);
 });


### PR DESCRIPTION
## Summary

- replace the declarative Jetpack module-state matrix placeholder with a real PHP WP Codebox workload
- seed non-empty module and settings state, toggle an available local module, and evaluate connection-owner health before and after capability drift
- block outbound HTTP, classify true remote-state behavior as provisioning-dependent, and restore all touched options and the fixture user
- add contract coverage requiring the manifest to resolve to the committed PHP workload

Closes #695.

Evidence anchor: [Zendesk #11206186](https://a8c.zendesk.com/agent/tickets/11206186).

## Validation

- `php -l Automattic/jetpack/bench/jetpack-module-state-matrix.php`
- JSON parse of `Automattic/jetpack/fuzz/jetpack-module-state-matrix.json`
- `homeboy rig lint Automattic/jetpack --all` (6/6)
- `node scripts/test-contracts.mjs --scope=wordpress-rigs` (19/19)
- `git diff --check`

Lab execution will follow after the committed revision is available to the runner.

## AI Assistance

OpenAI GPT-5.6-sol through OpenCode was used to inspect the existing Jetpack coverage, draft the executable workload and contract test, and run validation. Chris Huber reviewed the resulting diff and remains responsible for every line.